### PR TITLE
Add a conda recipe for pybind11

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
-include setup.py
 include include/pybind11/*.h

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+${PYTHON} setup.py install --single-version-externally-managed --record=record.txt;
+

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: pybind11
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  {% if environ.get('GIT_DESCRIBE_NUMBER', '0') == '0' %}string: py{{ environ.get('PY_VER').replace('.', '') }}_0
+  {% else %}string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', 'GIT_STUB') }}{% endif %}
+
+source:
+  git_url: ../
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - pybind11
+
+about:
+  home: https://github.com/wjakob/pybind11/
+  summary: Seamless operability between C++11 and Python


### PR DESCRIPTION
The crux is the `--single-version-externally-managed` argument that allows headers to be installed despite setuptools.

If you create a channel on anaconda.org for your package, people should be able to install it through.
```
conda install -c http://conda.anaconda.org/wjakob pybind11
```