### PR TITLE
Signature formatting for sphinx

### DIFF
--- a/example/example11.ref
+++ b/example/example11.ref
@@ -1,22 +1,22 @@
 Help on built-in function kw_func in module example
 
 kkww__ffuunncc(...)
-    kw_func(x : int, y : int)
+    kw_func(x : int, y : int) -> NoneType
 
 Help on built-in function kw_func2 in module example
 
 kkww__ffuunncc22(...)
-    kw_func2(x : int = 100L, y : int = 200L)
+    kw_func2(x : int = 100L, y : int = 200L) -> NoneType
 
 Help on built-in function kw_func3 in module example
 
 kkww__ffuunncc33(...)
-    kw_func3(data : unicode = u'Hello world!')
+    kw_func3(data : unicode = u'Hello world!') -> NoneType
 
 Help on built-in function kw_func4 in module example
 
 kkww__ffuunncc44(...)
-    kw_func4(myList : list<int> = [13L, 17L])
+    kw_func4(myList : list<int> = [13L, 17L]) -> NoneType
 
 kw_func(x=5, y=10)
 kw_func(x=5, y=10)
@@ -28,7 +28,7 @@ kw_func(x=100, y=10)
 kw_func(x=5, y=10)
 kw_func(x=5, y=10)
 Caught expected exception: Incompatible function arguments. The following argument types are supported:
-    1. (x : int = 100L, y : int = 200L)
+    1. (x : int = 100L, y : int = 200L) -> NoneType
 
 kw_func4: 13 17 
 kw_func4: 1 2 3 

--- a/example/example11.ref
+++ b/example/example11.ref
@@ -1,22 +1,22 @@
 Help on built-in function kw_func in module example
 
 kkww__ffuunncc(...)
-    Signature : (x : int, y : int) -> NoneType
+    kw_func(x : int, y : int)
 
 Help on built-in function kw_func2 in module example
 
 kkww__ffuunncc22(...)
-    Signature : (x : int = 100L, y : int = 200L) -> NoneType
+    kw_func2(x : int = 100L, y : int = 200L)
 
 Help on built-in function kw_func3 in module example
 
 kkww__ffuunncc33(...)
-    Signature : (data : unicode = u'Hello world!') -> NoneType
+    kw_func3(data : unicode = u'Hello world!')
 
 Help on built-in function kw_func4 in module example
 
 kkww__ffuunncc44(...)
-    Signature : (myList : list<int> = [13L, 17L]) -> NoneType
+    kw_func4(myList : list<int> = [13L, 17L])
 
 kw_func(x=5, y=10)
 kw_func(x=5, y=10)
@@ -28,7 +28,7 @@ kw_func(x=100, y=10)
 kw_func(x=5, y=10)
 kw_func(x=5, y=10)
 Caught expected exception: Incompatible function arguments. The following argument types are supported:
-    1. (x : int = 100L, y : int = 200L) -> NoneType
+    1. (x : int = 100L, y : int = 200L)
 
 kw_func4: 13 17 
 kw_func4: 1 2 3 

--- a/example/example5.ref
+++ b/example/example5.ref
@@ -13,7 +13,7 @@ Rabbit is a parrot
 Polly is a parrot
 Molly is a dog
 The following error is expected: Incompatible function arguments. The following argument types are supported:
-    1. (example.Dog) -> NoneType
+    1. (example.Dog)
 
 Callback function 1 called!
 False

--- a/example/example5.ref
+++ b/example/example5.ref
@@ -13,7 +13,7 @@ Rabbit is a parrot
 Polly is a parrot
 Molly is a dog
 The following error is expected: Incompatible function arguments. The following argument types are supported:
-    1. (example.Dog)
+    1. (example.Dog) -> NoneType
 
 Callback function 1 called!
 False

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -81,7 +81,7 @@ public:
 
         /* Generate a readable signature describing the function's arguments and return value types */
         using detail::descr;
-        PYBIND11_DESCR signature = cast_in::name() + detail::_(" -> ") + cast_out::name();
+        PYBIND11_DESCR signature = cast_in::name();
 
         /* Register the function with Python from generic (non-templated) code */
         initialize(rec, signature.text(), signature.types(), sizeof...(Args));
@@ -157,7 +157,7 @@ protected:
 
         /* Generate a readable signature describing the function's arguments and return value types */
         using detail::descr;
-        PYBIND11_DESCR signature = cast_in::name() + detail::_(" -> ") + cast_out::name();
+        PYBIND11_DESCR signature = cast_in::name();
 
         /* Register the function with Python from generic (non-templated) code */
         initialize(rec, signature.text(), signature.types(), sizeof...(Args));
@@ -298,7 +298,7 @@ protected:
         for (auto it = chain_start; it != nullptr; it = it->next) {
             if (chain)
                 signatures += std::to_string(++index) + ". ";
-            signatures += "Signature : ";
+            signatures += rec->name;
             signatures += it->signature;
             signatures += "\n";
             if (it->doc && strlen(it->doc) > 0) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -295,6 +295,13 @@ protected:
         int index = 0;
         /* Create a nice pydoc rec including all signatures and
            docstrings of the functions in the overload chain */
+        if (chain) {
+            // First a generic signature
+            signatures += rec->name;
+            signatures += "(*args, **kwargs)\n";
+            signatures += "Overloaded function.\n\n";
+        }
+        // Then specific overload signatures
         for (auto it = chain_start; it != nullptr; it = it->next) {
             if (chain)
                 signatures += std::to_string(++index) + ". ";

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -81,7 +81,7 @@ public:
 
         /* Generate a readable signature describing the function's arguments and return value types */
         using detail::descr;
-        PYBIND11_DESCR signature = cast_in::name();
+        PYBIND11_DESCR signature = cast_in::name() + detail::_(" -> ") + cast_out::name();
 
         /* Register the function with Python from generic (non-templated) code */
         initialize(rec, signature.text(), signature.types(), sizeof...(Args));
@@ -157,7 +157,7 @@ protected:
 
         /* Generate a readable signature describing the function's arguments and return value types */
         using detail::descr;
-        PYBIND11_DESCR signature = cast_in::name();
+        PYBIND11_DESCR signature = cast_in::name() + detail::_(" -> ") + cast_out::name();
 
         /* Register the function with Python from generic (non-templated) code */
         initialize(rec, signature.text(), signature.types(), sizeof...(Args));


### PR DESCRIPTION
Documentation tools like sphinx use the inspect module to fetch the signature of functions, which is why we don't usually need to embed it in the docstring for pure python functions. The first line normally contains one-line summary of what the function does, which is used by sphinx to create a one-liner when listing functions of a module.

However, this cannot work with C extension modules because introspection does not work with them.
Hence it is customary to embed the signature as the first line of the docstring in that case. This is what cython does too when we set the option `embedsignature` to True.

To handle this well, sphinx will parse the docstring and try to see if the first line *looks* like a signature and will use the *next* non-empty line as the one-line summary. However, it does not seem to work with pybind11' s formatting of signatures.

This PR removes the `Signature :` prefix and replaces it with the function name, and it removes the return type.

I made a simple test project for you here: https://github.com/SylvainCorlay/pbtest which you can pip install and generate the doc with `make html`. 

Here are the results before and after the change:

 - In the module summary:

   Before:
   <img width="669" alt="bad" src="https://cloud.githubusercontent.com/assets/2397974/13383770/5e5e4bee-de5c-11e5-9377-3db843d824c3.png">

   After:
   <img width="671" alt="good" src="https://cloud.githubusercontent.com/assets/2397974/13383769/5e5e01d4-de5c-11e5-9d16-24daa08d84a9.png">

- In the documentation for `add`:

  Before:
   <img width="671" alt="bad_docstring" src="https://cloud.githubusercontent.com/assets/2397974/13386997/73f1fdf6-de80-11e5-9055-b386d4b1a941.png">
   After:
   <img width="669" alt="good_docstring" src="https://cloud.githubusercontent.com/assets/2397974/13386994/660bc9a6-de80-11e5-8a6d-4ef9a42a9981.png">


  