### PR TITLE
Use emplace for casting to map

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -72,7 +72,7 @@ template <typename Type, typename Key, typename Value> struct map_caster {
             if (!kconv.load(it.first.ptr(), convert) ||
                 !vconv.load(it.second.ptr(), convert))
                 return false;
-            value[(Key) kconv] = (Value) vconv;
+            value.emplace((Key) kconv, (Value) vconv);
         }
         return true;
     }


### PR DESCRIPTION
This allows for use with maps where the mapped_type doesn't have a default constructor.