### PR TITLE
Update release instructions

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,13 +1,20 @@
 To release a new version of pybind11:
 
-- Update `pybind11/_version.py` (set release version, remove 'dev')
-- `git add` and `git commit`.
-- `python setup.py sdist upload`.
-- `python setup.py bdist_wheel upload`.
-- `git tag -a X.X -m 'Release tag comment'`.
-- Update `_version.py` (add 'dev' and increment minor).
-- Update version macros in `include/pybind11/common.h`
-- `git add` and `git commit`. `git push`. `git push --tags`.
+- Update the version number and push to pypi
+    - Update ``pybind11/_version.py`` (set release version, remove 'dev')
+    - ``git add`` and ``git commit``.
+    - ``python setup.py sdist upload``.
+    - ``python setup.py bdist_wheel upload``.
+- Tag the commit and push to anaconda.org
+    - ``git tag -a X.X -m '[Release comment]'``.
+    - ``conda-build conda.recipe --output``
+      This should ouput the path of the generated tar.bz2 for the package
+    - ``conda-convert --platform all [path/to/tar.bz2] -o .``
+    - For each platform name, ``anaconda-upload ./platform/tarfile.tar.bz2``
+- Get back to work
+    - Update ``_version.py`` (add 'dev' and increment minor).
+    - Update version macros in ``include/pybind11/common.h``
+    - ``git add`` and ``git commit``. ``git push``. ``git push --tags``.
 
-The remote for the last `git push --tags` should be the main repository for
+The remote for the last ``git push --tags`` should be the main repository for
 pybind11.


### PR DESCRIPTION
This worked for me (I did a test upload on https://anaconda.org/SylvainCorlay/pybind11).

If you want to release the current `v1.3` version on anaconda.org using these instructions, I recommend checking out the `v1.3` tag first.