### PR TITLE
Check for other callable python objects

### DIFF
--- a/example/example5.py
+++ b/example/example5.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from functools import partial
 import sys
 sys.path.append('.')
 
@@ -37,8 +38,13 @@ def func2(a, b, c, d):
     print('Callback function 2 called : ' + str(a) + ", " + str(b) + ", " + str(c) + ", "+ str(d))
     return d
 
+def func3(a):
+    print('Callback function 3 called : ' + str(a))
+
 print(test_callback1(func1))
 print(test_callback2(func2))
+print(test_callback1(partial(func2, "Hello", "from", "partial", "object")))
+print(test_callback1(partial(func3, "Partial object with one argument")))
 
 test_callback3(lambda i: i + 1)
 f = test_callback4()

--- a/example/example5.ref
+++ b/example/example5.ref
@@ -19,4 +19,8 @@ Callback function 1 called!
 False
 Callback function 2 called : Hello, x, True, 5
 5
+Callback function 2 called : Hello, from, partial, object
+False
+Callback function 3 called : Partial object with one argument
+False
 func(43) = 44

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -20,7 +20,7 @@ template <typename Return, typename... Args> struct type_caster<std::function<Re
 public:
     bool load(handle src_, bool) {
         src_ = detail::get_function(src_);
-        if (!src_ || !(PyFunction_Check(src_.ptr()) || PyCFunction_Check(src_.ptr())))
+        if (!src_ || !PyCallable_Check(src_.ptr()))
             return false;
         object src(src_, true);
         value = [src](Args... args) -> Return {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -428,7 +428,7 @@ public:
 
 class function : public object {
 public:
-    PYBIND11_OBJECT_DEFAULT(function, object, PyFunction_Check)
+    PYBIND11_OBJECT_DEFAULT(function, object, PyCallable_Check)
     bool is_cpp_function() const {
         handle fun = detail::get_function(m_ptr);
         return fun && PyCFunction_Check(fun.ptr());


### PR DESCRIPTION
This allows the pybind11 translator for std::function to handle other python callable objects. In particular, `functools.partial` can be used. I don't think there should be any other consequences.