### PR TITLE
Improve conda recipe

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pybind11
-  version: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '').replace('v', '') }}
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
@@ -22,5 +22,5 @@ test:
     - pybind11
 
 about:
-  home: https://github.com/wjakob/pybind11/
+  home: https://github.com/pybind/pybind11/
   summary: Seamless operability between C++11 and Python


### PR DESCRIPTION
The version number formed by the git tag is not a valid version number because of the `'v'` prefix. I am now manually removing the `v`.