### PR TITLE
Fixing gcc warnings when used with -pedantic switch

### DIFF
--- a/example/example12.cpp
+++ b/example/example12.cpp
@@ -52,7 +52,7 @@ public:
         PYBIND11_OVERLOAD_PURE(
             bool,
             Example12,
-            run_bool
+            run_bool,
         );
         throw std::runtime_error("this will never be reached");
     }
@@ -61,7 +61,7 @@ public:
         PYBIND11_OVERLOAD_PURE(
             void,         /* Return type */
             Example12,    /* Parent class */
-            pure_virtual  /* Name of function */
+            pure_virtual,  /* Name of function */
                           /* This function has no arguments */
         );
     }

--- a/example/example6.cpp
+++ b/example/example6.cpp
@@ -121,7 +121,7 @@ namespace {
         py::object ref; // keep a reference
         size_t index = 0;
     };
-};
+}
 
 void init_ex6(py::module &m) {
     py::class_<Sequence> seq(m, "Sequence");

--- a/example/example8.cpp
+++ b/example/example8.cpp
@@ -70,8 +70,8 @@ private:
 };
 
 /// Make pybind aware of the ref-counted wrapper type (s)
-PYBIND11_DECLARE_HOLDER_TYPE(T, ref<T>);
-PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
+PYBIND11_DECLARE_HOLDER_TYPE(T, ref<T>)
+PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
 
 Object *make_object_1() { return new MyObject1(1); }
 ref<Object> make_object_2() { return new MyObject1(2); }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -38,15 +38,6 @@ NAMESPACE_BEGIN(detail)
 template<typename A, typename B>
 A cast_any_ptr(B x) { return reinterpret_cast<A>(reinterpret_cast<uintptr_t>(x)); }
 
-/// Return (*)(Args...) -> void*
-template <typename Return, typename... Args>
-void * func_to_voidp(Return (*f)(Args...)) { return cast_any_ptr<void*>(f); }
-
-/// void* -> Return (*)(Args...)
-template <typename Return, typename... Args>
-Return (*voidp_to_func(void * f))(Args...) { return cast_any_ptr<Return (*)(Args...)>(f); }
-
-
 
 /// Additional type information which does not fit into the PyTypeObject
 struct type_info {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -34,6 +34,20 @@ private:
 
 NAMESPACE_BEGIN(detail)
 
+/// Convert from any type pointer to another avoding warnings about void* vs (void*()) incompatibility.
+template<typename A, typename B>
+A cast_any_ptr(B x) { return reinterpret_cast<A>(reinterpret_cast<uintptr_t>(x)); }
+
+/// Return (*)(Args...) -> void*
+template <typename Return, typename... Args>
+void * func_to_voidp(Return (*f)(Args...)) { return cast_any_ptr<void*>(f); }
+
+/// void* -> Return (*)(Args...)
+template <typename Return, typename... Args>
+Return (*voidp_to_func(void * f))(Args...) { return cast_any_ptr<Return (*)(Args...)>(f); }
+
+
+
 /// Additional type information which does not fit into the PyTypeObject
 struct type_info {
     PyTypeObject *type;

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -56,11 +56,11 @@ public:
             void **api_ptr = (void **) (c ? PyCObject_AsVoidPtr(c.ptr()) : nullptr);
 #endif
             API api;
-            api.PyArray_Type_          = (decltype(api.PyArray_Type_))          api_ptr[API_PyArray_Type];
-            api.PyArray_DescrFromType_ = (decltype(api.PyArray_DescrFromType_)) api_ptr[API_PyArray_DescrFromType];
-            api.PyArray_FromAny_       = (decltype(api.PyArray_FromAny_))       api_ptr[API_PyArray_FromAny];
-            api.PyArray_NewCopy_       = (decltype(api.PyArray_NewCopy_))       api_ptr[API_PyArray_NewCopy];
-            api.PyArray_NewFromDescr_  = (decltype(api.PyArray_NewFromDescr_))  api_ptr[API_PyArray_NewFromDescr];
+            api.PyArray_Type_          = detail::cast_any_ptr<decltype(api.PyArray_Type_)>          (api_ptr[API_PyArray_Type]);
+            api.PyArray_DescrFromType_ = detail::cast_any_ptr<decltype(api.PyArray_DescrFromType_)> (api_ptr[API_PyArray_DescrFromType]);
+            api.PyArray_FromAny_       = detail::cast_any_ptr<decltype(api.PyArray_FromAny_)>       (api_ptr[API_PyArray_FromAny]);
+            api.PyArray_NewCopy_       = detail::cast_any_ptr<decltype(api.PyArray_NewCopy_)>       (api_ptr[API_PyArray_NewCopy]);
+            api.PyArray_NewFromDescr_  = detail::cast_any_ptr<decltype(api.PyArray_NewFromDescr_)>  (api_ptr[API_PyArray_NewFromDescr]);
             return api;
         }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -49,7 +49,7 @@ public:
     template <typename Return, typename... Args, typename... Extra>
     cpp_function(Return (*f)(Args...), const Extra&... extra) {
         auto rec = new detail::function_record();
-        rec->data = detail::func_to_voidp(f);
+        rec->data = detail::cast_any_ptr<void*>(f);
 
         typedef arg_value_caster<Args...> cast_in;
         typedef return_value_caster<Return> cast_out;
@@ -67,7 +67,7 @@ public:
 
             /* Do the call and convert the return value back into the Python domain */
             handle result = cast_out::cast(
-                args.template call<Return>(detail::voidp_to_func<Return,Args...>(rec->data)),
+					   args.template call<Return>(detail::cast_any_ptr<Return (*)(Args...)>(rec->data)),
                 rec->policy, parent);
 
             /* Invoke call policy post-call hook */

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -49,7 +49,7 @@ public:
     template <typename Return, typename... Args, typename... Extra>
     cpp_function(Return (*f)(Args...), const Extra&... extra) {
         auto rec = new detail::function_record();
-        rec->data = (void *) f;
+        rec->data = detail::func_to_voidp(f);
 
         typedef arg_value_caster<Args...> cast_in;
         typedef return_value_caster<Return> cast_out;
@@ -67,7 +67,7 @@ public:
 
             /* Do the call and convert the return value back into the Python domain */
             handle result = cast_out::cast(
-                args.template call<Return>((Return (*) (Args...)) rec->data),
+                args.template call<Return>(detail::voidp_to_func<Return,Args...>(rec->data)),
                 rec->policy, parent);
 
             /* Invoke call policy post-call hook */

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -67,7 +67,7 @@ public:
 
             /* Do the call and convert the return value back into the Python domain */
             handle result = cast_out::cast(
-					   args.template call<Return>(detail::cast_any_ptr<Return (*)(Args...)>(rec->data)),
+                                           args.template call<Return>(detail::cast_any_ptr<Return (*)(Args...)>(rec->data)),
                 rec->policy, parent);
 
             /* Invoke call policy post-call hook */


### PR DESCRIPTION
Hi,

Thanks for pybind11 it's pretty awesome. I use it at work and it improved my c++ to python workflow tremendously. I compile stuff with gcc on Linux using -pedantic flag. There were two places in the library itself that generated warnings when using this mode. They are related to conversion of function pointer to object pointer and back, apparently it's not ok on some platforms and so "ISO C++ forbids casting between pointer-to-function and pointer-to-object". It is however perfectly fine on platforms where `sizeof(void*) == sizeof(void(*)())`.

So that's what I fixed (just the symptom not the reason). I also fixed different warnings in example code, some extra ';' and variadic macro related stuff.

I'm not including changes to cmake file, since I'm not sure if you want to use pedantic flag in a general case.

Regards,

Kirill
