### PR TITLE
Fix warnings in clang

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -338,7 +338,7 @@ public:
     static handle cast(void_type, return_value_policy /* policy */, handle /* parent */) {
         return handle(Py_None).inc_ref();
     }
-    PYBIND11_TYPE_CASTER(void_type, _("NoneType"));
+    PYBIND11_TYPE_CASTER(void_type, _("NoneType"))
 };
 
 template <> class type_caster<void> : public type_caster<void_type> {
@@ -382,7 +382,7 @@ public:
     static handle cast(bool src, return_value_policy /* policy */, handle /* parent */) {
         return handle(src ? Py_True : Py_False).inc_ref();
     }
-    PYBIND11_TYPE_CASTER(bool, _("bool"));
+    PYBIND11_TYPE_CASTER(bool, _("bool"))
 };
 
 template <> class type_caster<std::string> {
@@ -408,7 +408,7 @@ public:
         return PyUnicode_FromStringAndSize(src.c_str(), src.length());
     }
 
-    PYBIND11_TYPE_CASTER(std::string, _(PYBIND11_STRING_NAME));
+    PYBIND11_TYPE_CASTER(std::string, _(PYBIND11_STRING_NAME))
 protected:
     bool success = false;
 };
@@ -459,7 +459,7 @@ public:
         return PyUnicode_FromWideChar(src.c_str(), src.length());
     }
 
-    PYBIND11_TYPE_CASTER(std::wstring, _(PYBIND11_STRING_NAME));
+    PYBIND11_TYPE_CASTER(std::wstring, _(PYBIND11_STRING_NAME))
 protected:
     bool success = false;
 };
@@ -696,7 +696,7 @@ public:
     static handle cast(const handle &src, return_value_policy /* policy */, handle /* parent */) {
         return src.inc_ref();
     }
-    PYBIND11_TYPE_CASTER(type, handle_type_name<type>::name());
+    PYBIND11_TYPE_CASTER(type, handle_type_name<type>::name())
 };
 
 NAMESPACE_END(detail)

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -39,7 +39,7 @@ public:
         return PyComplex_FromDoubles((double) src.real(), (double) src.imag());
     }
 
-    PYBIND11_TYPE_CASTER(std::complex<T>, _("complex"));
+    PYBIND11_TYPE_CASTER(std::complex<T>, _("complex"))
 };
 NAMESPACE_END(detail)
 NAMESPACE_END(pybind11)

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -53,7 +53,7 @@ template <typename Type, typename Key> struct set_caster {
         return s.release();
     }
 
-    PYBIND11_TYPE_CASTER(type, _("set<") + key_conv::name() + _(">"));
+    PYBIND11_TYPE_CASTER(type, _("set<") + key_conv::name() + _(">"))
 };
 
 template <typename Type, typename Key, typename Value> struct map_caster {
@@ -89,7 +89,7 @@ template <typename Type, typename Key, typename Value> struct map_caster {
         return d.release();
     }
 
-    PYBIND11_TYPE_CASTER(type, _("dict<") + key_conv::name() + _(", ") + value_conv::name() + _(">"));
+    PYBIND11_TYPE_CASTER(type, _("dict<") + key_conv::name() + _(", ") + value_conv::name() + _(">"))
 };
 
 template <typename Type, typename Value> struct list_caster {
@@ -128,7 +128,8 @@ template <typename Type, typename Value> struct list_caster {
         return l.release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, _("list<") + value_conv::name() + _(">"));
+    PYBIND11_TYPE_CASTER(Type, _("list<") + value_conv::name() + _(">"))
+
 };
 
 template <typename Type, typename Alloc> struct type_caster<std::vector<Type, Alloc>>
@@ -168,7 +169,7 @@ template <typename Type, size_t Size> struct type_caster<std::array<Type, Size>>
         }
         return l.release();
     }
-    PYBIND11_TYPE_CASTER(array_type, _("list<") + value_conv::name() + _(">") + _("[") + _<Size>() + _("]"));
+    PYBIND11_TYPE_CASTER(array_type, _("list<") + value_conv::name() + _(">") + _("[") + _<Size>() + _("]"))
 };
 
 template <typename Key, typename Compare, typename Alloc> struct type_caster<std::set<Key, Compare, Alloc>>


### PR DESCRIPTION
When using pybind11 in clang I see warnings because of these extra semicolons.