### PR TITLE
I think iterator need a postfix op

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -250,6 +250,12 @@ public:
             value = object(PyIter_Next(m_ptr), false);
         return *this;
     }
+	iterator operator++(int)
+    {
+        auto tmp(*this); // copy
+        operator++(); // pre-increment
+        return tmp;   // return old value
+    }
     bool operator==(const iterator &it) const { return *it == **this; }
     bool operator!=(const iterator &it) const { return *it != **this; }
     const handle &operator*() const {


### PR DESCRIPTION
I'm almost certain this is probably wrong, I'm just getting back into c++, but the iterator class needed a postfix increment in order for this simple example to compile:

```cpp
py::iterator iter2iter(py::iterator s) {
    return py::make_iterator(std::begin(s), std::end(s));
}
```