### PR TITLE
mkdoc.py: fix typo in `__DOC5` macro

### DIFF
--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -239,7 +239,7 @@ if __name__ == '__main__':
 #define __DOC2(n1, n2)                           __doc_##n1##_##n2
 #define __DOC3(n1, n2, n3)                       __doc_##n1##_##n2##_##n3
 #define __DOC4(n1, n2, n3, n4)                   __doc_##n1##_##n2##_##n3##_##n4
-#define __DOC5(n1, n2, n3, n4, n5)               __doc_##n1##_##n2##_##n3##_##n4_##n5
+#define __DOC5(n1, n2, n3, n4, n5)               __doc_##n1##_##n2##_##n3##_##n4##_##n5
 #define DOC(...)                                 __EXPAND(__EXPAND(__CAT2(__DOC, __VA_SIZE(__VA_ARGS__)))(__VA_ARGS__))
 
 #if defined(__GNUG__)


### PR DESCRIPTION
This prevented `DOC(...)` calls with 5 arguments to resolve correctly.