### PR TITLE
constructor fix

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -201,6 +201,7 @@ struct buffer_info {
     std::vector<size_t> shape;   // Shape of the tensor (1 entry per dimension)
     std::vector<size_t> strides; // Number of entries between adjacent entries (for each per dimension)
 
+    buffer_info() : ptr(nullptr), view(nullptr) {}
     buffer_info(void *ptr, size_t itemsize, const std::string &format, int ndim,
                 const std::vector<size_t> &shape, const std::vector<size_t> &strides)
         : ptr(ptr), itemsize(itemsize), size(1), format(format),

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -128,6 +128,7 @@ template <typename T, int ExtraFlags = 0> class array_t : public array {
 public:
     PYBIND11_OBJECT_CVT(array_t, array, is_non_null, m_ptr = ensure(m_ptr));
     array_t() : array() { }
+    array_t(const buffer_info& info) : array(info) {}
     static bool is_non_null(PyObject *ptr) { return ptr != nullptr; }
     static PyObject *ensure(PyObject *ptr) {
         if (ptr == nullptr)


### PR DESCRIPTION
This adds constructors, which are required for a numpy arrays wrappers extension. This extension is meant to be its own project, however these changes in pybind are required for it, to not have to maintain a fork.