### PR TITLE
Fixed typo in NumPy example which prevented compilation

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1186,7 +1186,7 @@ simply using ``vectorize``).
         auto result = py::array(py::buffer_info(
             nullptr,            /* Pointer to data (nullptr -> ask NumPy to allocate!) */
             sizeof(double),     /* Size of one item */
-            py::format_descriptor<double>::value, /* Buffer format */
+            py::format_descriptor<double>::value(), /* Buffer format */
             buf1.ndim,          /* How many dimensions? */
             { buf1.shape[0] },  /* Number of elements for each dimension */
             { sizeof(double) }  /* Strides for each dimension */


### PR DESCRIPTION
There was a typo in the NumPy example which did not compile.