### PR TITLE
pybind11::args should have been derived from tuple

### DIFF
--- a/example/example11.cpp
+++ b/example/example11.cpp
@@ -27,8 +27,8 @@ py::object call_kw_func(py::function f) {
 }
 
 void args_function(py::args args) {
-    for (auto item : args)
-        std::cout << "got argument: " << item << std::endl;
+    for (size_t it=0; it<args.size(); ++it)
+        std::cout << "got argument: " << py::object(args[it]) << std::endl;
 }
 
 void args_kwargs_function(py::args args, py::kwargs kwargs) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -491,7 +491,7 @@ public:
         if (!m_ptr) pybind11_fail("Could not allocate tuple object!");
     }
     size_t size() const { return (size_t) PyTuple_Size(m_ptr); }
-    detail::tuple_accessor operator[](size_t index) const { return detail::tuple_accessor(ptr(), index); }
+    detail::tuple_accessor operator[](size_t index) const { return detail::tuple_accessor(*this, index); }
 };
 
 class dict : public object {
@@ -517,7 +517,7 @@ public:
     void append(const object &object) const { PyList_Append(m_ptr, object.ptr()); }
 };
 
-class args : public list { PYBIND11_OBJECT_DEFAULT(args, list, PyList_Check) };
+class args : public tuple { PYBIND11_OBJECT_DEFAULT(args, tuple, PyTuple_Check) };
 class kwargs : public dict { PYBIND11_OBJECT_DEFAULT(kwargs, dict, PyDict_Check)  };
 
 class set : public object {


### PR DESCRIPTION
args was derived from list, but cpp_function::dispatcher sends a tuple to it->impl (line [#346](https://github.com/pybind/pybind11/blob/1e3be73a521d6c888e09e554b8a239ce28fbf5a8/include/pybind11/pybind11.h#L346) and [#392](https://github.com/pybind/pybind11/blob/1e3be73a521d6c888e09e554b8a239ce28fbf5a8/include/pybind11/pybind11.h#L392) in pybind11.h).  As a result args::size() and args::operator[] don't work at all.  On my mac args::size() returns -1.  Making args a subclass of tuple fixes it.