### PR TITLE
Add support for Cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ cmake_install.cmake
 .DS_Store
 /example/example.so
 /example/example.pyd
+/example/example.dll
 *.sln
 *.sdf
 *.opensdf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     # Check for Link Time Optimization support
     # (GCC/Clang)
     CHECK_CXX_COMPILER_FLAG("-flto" HAS_LTO_FLAG)
-    if (HAS_LTO_FLAG)
+    if (HAS_LTO_FLAG AND NOT CYGWIN)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
     endif()
 
@@ -149,6 +149,9 @@ add_library(example SHARED
   ${PYBIND11_EXAMPLES}
 )
 
+# Link against the Python shared library
+target_link_libraries(example ${PYTHON_LIBRARY})
+
 # Don't add a 'lib' prefix to the shared library
 set_target_properties(example PROPERTIES PREFIX "")
 
@@ -182,9 +185,6 @@ if (WIN32)
 
   # .PYD file extension on Windows
   set_target_properties(example PROPERTIES SUFFIX ".pyd")
-
-  # Link against the Python shared library
-  target_link_libraries(example ${PYTHON_LIBRARY})
 elseif (UNIX)
   # It's quite common to have multiple copies of the same Python version
   # installed on one's system. E.g.: one copy from the OS and another copy
@@ -200,8 +200,13 @@ elseif (UNIX)
   # missing symbols, but that's perfectly fine -- they will be resolved at
   # import time.
 
-  # .SO file extension on Linux/Mac OS
-  set_target_properties(example PROPERTIES SUFFIX ".so")
+  # .DLL file extension on Cygwin, .SO file extension on Linux/Mac OS
+  if (CYGWIN)
+    set(SUFFIX ".dll")
+  else()
+    set(SUFFIX ".so")
+  endif()
+  set_target_properties(example PROPERTIES SUFFIX ${SUFFIX})
 
   # Optimize for a small binary size
   if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
@@ -213,11 +218,11 @@ elseif (UNIX)
     set_target_properties(example PROPERTIES MACOSX_RPATH ".")
     set_target_properties(example PROPERTIES LINK_FLAGS "-undefined dynamic_lookup ")
     if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
-      add_custom_command(TARGET example POST_BUILD COMMAND strip -u -r ${PROJECT_SOURCE_DIR}/example/example.so)
+      add_custom_command(TARGET example POST_BUILD COMMAND strip -u -r ${PROJECT_SOURCE_DIR}/example/example${SUFFIX})
     endif()
   else()
     if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
-      add_custom_command(TARGET example POST_BUILD COMMAND strip ${PROJECT_SOURCE_DIR}/example/example.so)
+      add_custom_command(TARGET example POST_BUILD COMMAND strip ${PROJECT_SOURCE_DIR}/example/example${SUFFIX})
     endif()
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
   endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wconversion")
 endif()
 
 

--- a/example/example10.cpp
+++ b/example/example10.cpp
@@ -13,7 +13,7 @@
 
 double my_func(int x, float y, double z) {
     std::cout << "my_func(x:int=" << x << ", y:float=" << y << ", z:float=" << z << ")" << std::endl;
-    return x*y*z;
+    return (float) x*y*z;
 }
 
 std::complex<double> my_func3(std::complex<double> c) {

--- a/example/example4.cpp
+++ b/example/example4.cpp
@@ -38,7 +38,7 @@ void test_function2(EMyEnumeration k) {
 
 float test_function3(int i) {
     std::cout << "test_function(" << i << ")" << std::endl;
-    return i / 2.f;
+    return (float) i / 2.f;
 }
 
 py::bytes return_bytes() {

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -262,7 +262,7 @@ struct internals {
     std::unordered_map<const void *, void*> registered_instances;    // void * -> PyObject*
     std::unordered_set<std::pair<const PyObject *, const char *>, overload_hash> inactive_overload_cache;
 #if defined(WITH_THREAD)
-    long tstate = 0;
+    decltype(PyThread_create_key()) tstate = 0; // Usually an int but a long on Cygwin64 with Python 3.x
     PyInterpreterState *istate = nullptr;
 #endif
 };

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -262,7 +262,7 @@ struct internals {
     std::unordered_map<const void *, void*> registered_instances;    // void * -> PyObject*
     std::unordered_set<std::pair<const PyObject *, const char *>, overload_hash> inactive_overload_cache;
 #if defined(WITH_THREAD)
-    int tstate = 0;
+    long tstate = 0;
     PyInterpreterState *istate = nullptr;
 #endif
 };

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1115,7 +1115,7 @@ public:
     gil_scoped_release(bool disassoc = false) : disassoc(disassoc) {
         tstate = PyEval_SaveThread();
         if (disassoc) {
-            int key = detail::get_internals().tstate;
+            auto key = detail::get_internals().tstate;
             #if PY_MAJOR_VERSION < 3
                 PyThread_delete_key_value(key);
             #else
@@ -1128,7 +1128,7 @@ public:
             return;
         PyEval_RestoreThread(tstate);
         if (disassoc) {
-            int key = detail::get_internals().tstate;
+            auto key = detail::get_internals().tstate;
             #if PY_MAJOR_VERSION < 3
                 PyThread_delete_key_value(key);
             #endif


### PR DESCRIPTION
The 64-bit version of Cygwin defines PyThread_create_key() with a return type of long (instead of int; [some background information](https://cygwin.com/ml/cygwin-apps/2013-07/msg00362.html) can be found on the cygwin-apps mailing list). This pull request makes pybind11 use decltype() to deduce the type to use for pybind11::detail::internals::tstate. I also added the flag -Wconversion to CMakeLists.txt to help detect this kind of problems in the future. 

I tested pybind11 with the changes on Cygwin (only 64-bit version), Linux (g++) and Windows (VS2015). 