### PR TITLE
A few smaller fixes and a test output improvement

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,8 +19,6 @@ install:
 build_script:
   - echo Running cmake...
   - cd c:\projects\pybind11
-  - cmake -G "%CMAKE_PLATFORM%" -DPYTHON_INCLUDE_DIR:PATH=%PYTHON_DIR%/include -DPYTHON_LIBRARY:FILEPATH=%PYTHON_DIR%/libs/python34.lib -DPYTHON_EXECUTABLE:FILEPATH=%PYTHON_DIR%/python.exe
+  - cmake -G "%CMAKE_PLATFORM%" -DPYTHON_EXECUTABLE:FILEPATH=%PYTHON_DIR%/python.exe
   - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-  - set MSBuildOptions=/v:m /p:Configuration=%Configuration% /logger:%MSBuildLogger%
-  - msbuild %MSBuildOptions% pybind11.sln
-  - ctest -C %Configuration%
+  - cmake --build . --config %Configuration% --target check -- /v:m /logger:%MSBuildLogger%

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,18 @@ matrix:
   include:
     - os: linux
       compiler: gcc-4.8
-      script:
+      install:
         - pyvenv-3.5 venv
-        - cmake -DPYBIND11_PYTHON_VERSION=3.5 -DPYTHON_INCLUDE_DIR:PATH=/usr/include/python3.5m -DPYTHON_LIBRARY:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython3.5m.so -DPYTHON_EXECUTABLE:FILEPATH=`pwd`/venv/bin/python3.5 -DCMAKE_CXX_COMPILER=g++-4.8
-        - make -j 2
         - source venv/bin/activate
         - pip install numpy
-        - CTEST_OUTPUT_ON_FAILURE=TRUE make test
+      script:
+        - CXX=g++-4.8 cmake -DPYBIND11_PYTHON_VERSION=3.5
+        - CTEST_OUTPUT_ON_FAILURE=TRUE make check -j 2
     - os: osx
       compiler: clang
       script:
         - cmake -DPYBIND11_PYTHON_VERSION=2.7
-        - make -j 2
-        - CTEST_OUTPUT_ON_FAILURE=TRUE make test
+        - CTEST_OUTPUT_ON_FAILURE=TRUE make check -j 2
     #- os: linux
       #compiler: gcc-4.8
       #script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
       install:
         - pyvenv-3.5 venv
         - source venv/bin/activate
+        - pip install -U pip wheel
         - pip install numpy
       script:
         - CXX=g++-4.8 cmake -DPYBIND11_PYTHON_VERSION=3.5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ endfunction()
 if (PYBIND11_TEST)
   enable_testing()
   add_subdirectory(example)
+  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION> DEPENDS example)
 endif()
 
 if (PYBIND11_INSTALL)

--- a/example/example2.cpp
+++ b/example/example2.cpp
@@ -154,7 +154,7 @@ void init_ex2(py::module &m) {
         .def("get_list", &Example2::get_list, "Return a Python list")
         .def("get_list_2", &Example2::get_list_2, "Return a C++ list")
         .def("get_set", &Example2::get_set, "Return a Python set")
-        .def("get_set2", &Example2::get_set, "Return a C++ set")
+        .def("get_set2", &Example2::get_set_2, "Return a C++ set")
         .def("get_array", &Example2::get_array, "Return a C++ array")
         .def("print_dict", &Example2::print_dict, "Print entries of a Python dictionary")
         .def("print_dict_2", &Example2::print_dict_2, "Print entries of a C++ dictionary")

--- a/example/issues.cpp
+++ b/example/issues.cpp
@@ -135,7 +135,7 @@ void init_issues(py::module &m) {
     try {
         py::class_<Placeholder>(m2, "Placeholder");
         throw std::logic_error("Expected an exception!");
-    } catch (std::runtime_error &e) {
+    } catch (std::runtime_error &) {
         /* All good */
     }
 }

--- a/example/run_test.py
+++ b/example/run_test.py
@@ -2,6 +2,7 @@ import sys
 import os
 import re
 import subprocess
+import difflib
 
 remove_unicode_marker = re.compile(r'u(\'[^\']*\')')
 remove_long_marker    = re.compile(r'([0-9])L')
@@ -36,11 +37,7 @@ def sanitize(lines):
                 line = ""
         lines[i] = line
 
-    lines = '\n'.join(sorted([l for l in lines if l != ""]))
-
-    print('==================')
-    print(lines)
-    return lines
+    return '\n'.join(sorted([l for l in lines if l != ""]))
 
 path = os.path.dirname(__file__)
 if path != '':
@@ -69,4 +66,8 @@ elif output == reference:
     exit(0)
 else:
     print('Test "%s" FAILED!' % name)
+    print('--- output')
+    print('+++ reference')
+    print(''.join(difflib.ndiff(output.splitlines(keepends=True),
+                                reference.splitlines(keepends=True))))
     exit(-1)

--- a/include/pybind11/descr.h
+++ b/include/pybind11/descr.h
@@ -139,7 +139,7 @@ protected:
         const T *it = ptr;
         while (*it++ != (T) 0)
             ;
-        return it - ptr;
+        return static_cast<size_t>(it - ptr);
     }
 
     const std::type_info **m_types = nullptr;


### PR DESCRIPTION
The fixes are described in the first two commit messages.

The skipped test bug silently passes when it shouldn't. It came up as an error while I was working on another feature (I'll submit a separate PR later), but it gave me a bit of trouble. That was the motivation for the third commit: diff output for failed tests. For example, with the change a failure report would look like this:
```
Test "example2" FAILED!
--- output
+++ reference
  ('test', True)
  (5, 'test', True)
  15
  5
  Destructing Example2
  Entry at positon 0: value
  Example2: No constructor defined!
  Help on class Example2 in module example
  This exception was intentionally thrown.
  ['array entry 1', 'array entry 2']
  __module__(Example2) = example
  __module__(Example2.get_set) = example
  __name__(Example2) = Example2
  __name__(Example2.get_set) = get_set
  __name__(example) = example
  array item 0: array entry 1
  array item 1: array entry 2
  can't set attribute
  class EExxaammppllee22(builtins.object)
  key: key, value=value
- key: key, value=value_bug
?                      ----
+ key: key, value=value
  key: key1
  key: key1
  key: key2
```
This is a [Differ-style delta from difflib](https://docs.python.org/3.5/library/difflib.html#difflib.ndiff).

The last commit adds a `make check` target to CMake which will rebuild as needed and test, unlike `make test` which only tests. This is more useful when there are multiple targets in a project, but the tests only rely on a subset. This is not the case for pybind11, but it's still nice to have for two reasons: 1) With `make test` it's possible to forget to rebuild first, with `make check` it's not. 2) For integration with some IDEs.