### PR TITLE
Syntax sugar: user-defined literals for arg and str

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -177,6 +177,21 @@ The keyword names also appear in the function signatures within the documentatio
 
             A function which adds two numbers
 
+A shorter notation for named arguments is also available:
+
+.. code-block:: cpp
+    
+    // regular notation
+    m.def("add1", &add, py::arg("i"), py::arg("j"));
+    // shorthand
+    using namespace pybind11::literals;
+    m.def("add2", &add, "i"_a, "j"_a);
+
+The :var:`_a` suffix forms a C++11 literal which is equivalent to :class:`arg`. 
+Note that the literal operator must first be made visible with the directive 
+``using namespace pybind11::literals``. This does not bring in anything else 
+from the ``pybind11`` namespace except for literals.
+
 .. _default_args:
 
 Default arguments
@@ -212,6 +227,15 @@ The default values also appear within the documentation.
             Signature : (i: int = 1, j: int = 2) -> int
 
             A function which adds two numbers
+
+The shorthand notation is also available for default arguments:
+
+.. code-block:: cpp
+    
+    // regular notation
+    m.def("add1", &add, py::arg("i") = 1, py::arg("j") = 2);
+    // shorthand
+    m.def("add2", &add, "i"_a=1, "j"_a=2);
 
 .. _supported_types:
 
@@ -283,4 +307,3 @@ as arguments and return values, refer to the section on binding :ref:`classes`.
 
 .. [#f1] In practice, implementation and binding code will generally be located
          in separate files.
-

--- a/example/example11.cpp
+++ b/example/example11.cpp
@@ -55,4 +55,7 @@ void init_ex11(py::module &m) {
 
     m.def("args_function", &args_function);
     m.def("args_kwargs_function", &args_kwargs_function);
+
+    using namespace py::literals;
+    m.def("kw_func_udl", &kw_func, "x"_a, "y"_a=300);
 }

--- a/example/example11.py
+++ b/example/example11.py
@@ -6,12 +6,13 @@ import pydoc
 sys.path.append('.')
 
 from example import kw_func, kw_func2, kw_func3, kw_func4, call_kw_func
-from example import args_function, args_kwargs_function
+from example import args_function, args_kwargs_function, kw_func_udl
 
 print(pydoc.render_doc(kw_func, "Help on %s"))
 print(pydoc.render_doc(kw_func2, "Help on %s"))
 print(pydoc.render_doc(kw_func3, "Help on %s"))
 print(pydoc.render_doc(kw_func4, "Help on %s"))
+print(pydoc.render_doc(kw_func_udl, "Help on %s"))
 
 kw_func(5, 10)
 kw_func(5, y=10)
@@ -39,3 +40,5 @@ call_kw_func(kw_func2)
 
 args_function('arg1_value', 'arg2_value', 3)
 args_kwargs_function('arg1_value', 'arg2_value', arg3='arg3_value', arg4=4)
+
+kw_func_udl(x=5, y=10)

--- a/example/example11.ref
+++ b/example/example11.ref
@@ -18,6 +18,11 @@ Help on built-in function kw_func4 in module example
 kkww__ffuunncc44(...)
     kw_func4(myList : list<int> = [13L, 17L]) -> NoneType
 
+Help on built-in function kw_func_udl in module example
+
+kkww__ffuunncc__uuddll(...)
+    kw_func_udl(x : int, y : int = 300L) -> NoneType
+
 kw_func(x=5, y=10)
 kw_func(x=5, y=10)
 kw_func(x=5, y=10)
@@ -40,3 +45,5 @@ got argument: arg1_value
 got argument: arg2_value
 got keyword argument: arg3 -> arg3_value
 got keyword argument: arg4 -> 4
+
+kw_func(x=5, y=10)

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -18,23 +18,29 @@ template <typename T> struct arg_t;
 
 /// Annotation for keyword arguments
 struct arg {
-    arg(const char *name) : name(name) { }
-    template <typename T> arg_t<T> operator=(const T &value);
-    template <typename T, size_t N> arg_t<const T *> operator=(T const (&value)[N]);
+    constexpr arg(const char *name) : name(name) { }
+
+    template <typename T>
+    constexpr arg_t<T> operator=(const T &value) const { return {name, value}; }
+    template <typename T, size_t N>
+    constexpr arg_t<const T *> operator=(T const (&value)[N]) const {
+        return operator=((const T *) value);
+    };
+
     const char *name;
 };
 
 /// Annotation for keyword arguments with default values
 template <typename T> struct arg_t : public arg {
-    arg_t(const char *name, const T &value, const char *descr = nullptr)
+    constexpr arg_t(const char *name, const T &value, const char *descr = nullptr)
         : arg(name), value(value), descr(descr) { }
     T value;
     const char *descr;
 };
 
-template <typename T> arg_t<T> arg::operator=(const T &value) { return arg_t<T>(name, value); }
-template <typename T, size_t N> arg_t<const T *> arg::operator=(T const (&value)[N]) {
-    return operator=((const T *) value);
+inline namespace literals {
+/// String literal version of arg
+constexpr arg operator"" _a(const char *name, size_t) { return {name}; }
 }
 
 /// Annotation for methods


### PR DESCRIPTION
Pure sugar here. This PR proposes using C++11 [UDLs](http://en.cppreference.com/w/cpp/language/user_literal) for `py::arg` and `py::str`. Here is an example for named arguments:
```c++
// regular version
m.def("foo", &foo, py::arg("required"), py::arg("optional")=value);
// using literals
m.def("foo", &foo, "required"_a, "optional"_a=value);
```
where `_a` is the proposed literal suffix for `py::arg`. I intentionally omit the spaces in `_a=value` as this matches the usual Python style for default values.

This is similar for `py::str` with the `_s` suffix:
```c++
py::set set;
set.add(py::str("key1"));
set.add("key2"_s);
```

Some notes:

* The literals are in an inline namespace as is the `std` library convention. Before use, they must be imported with `using namespace pybind11::literals`. This will bring in only the `_a` and `_s` names, but nothing else from the `pybind11` namespace. Alternatively, `using namespace pybind11` can be used which will import everything including the literals thanks to the inline namespace.

* I wasn't sure if I should mix the inline keyword with the existing `NAMESPACE_BEGIN/END` macros, so I just wrote the plain `namespace {}`. I'm also not quite sure why the namespace macros are needed. Let me know if I should change anything here.

* I haven't added anything to the docs yet (in case the feature isn't desired) but I can add a little note for the literals.
