### PR TITLE
Check the number of named arguments at compile time

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -321,5 +321,18 @@ template <typename... Args> struct process_attributes {
     }
 };
 
+/// Compile-time integer sum
+constexpr size_t constexpr_sum() { return 0; }
+template <typename T, typename... Ts>
+constexpr size_t constexpr_sum(T n, Ts... ns) { return n + constexpr_sum(ns...); }
+
+/// Check the number of named arguments at compile time
+template <typename... Extra,
+          size_t named = constexpr_sum(std::is_base_of<arg, Extra>::value...),
+          size_t self  = constexpr_sum(std::is_same<is_method, Extra>::value...)>
+constexpr bool expected_num_args(size_t nargs) {
+    return named == 0 || (self + named) == nargs;
+}
+
 NAMESPACE_END(detail)
 NAMESPACE_END(pybind11)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -72,6 +72,9 @@ protected:
     /// Special internal constructor for functors, lambda functions, etc.
     template <typename Func, typename Return, typename... Args, typename... Extra>
     void initialize(Func &&f, Return (*)(Args...), const Extra&... extra) {
+        static_assert(detail::expected_num_args<Extra...>(sizeof...(Args)),
+                      "The number of named arguments does not match the function signature");
+
         struct capture { typename std::remove_reference<Func>::type f; };
 
         /* Store the function including any extra state it might have (e.g. a lambda capture object) */
@@ -205,12 +208,6 @@ protected:
             rec->name = strdup("__nonzero__");
         }
 #endif
-
-        if (!rec->args.empty() && (int) rec->args.size() != args)
-            pybind11_fail(
-                "cpp_function(): function \"" + std::string(rec->name) + "\" takes " +
-                std::to_string(args) + " arguments, but " + std::to_string(rec->args.size()) +
-                " pybind11::arg entries were specified!");
 
         rec->signature = strdup(signature.c_str());
         rec->args.shrink_to_fit();


### PR DESCRIPTION
This moves the runtime check to compile time. Here is a sample error message (clang) - 3 arguments were named instead of the expected 2:
```
In file included from pybind11/example/example11.cpp:10:
In file included from pybind11/example/example.h:1:
pybind11/include/pybind11/pybind11.h:75:9: error: static_assert failed "The number of named arguments does not match the function signature"
        static_assert(detail::expected_num_args<Extra...>(sizeof...(Args)),
        ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pybind11/include/pybind11/pybind11.h:44:9: note: in instantiation of function template specialization 'pybind11::cpp_function::initialize<void (*&)(int, int), void, int, int, pybind11::name, pybind11::sibling, pybind11::scope, pybind11::arg, pybind11::arg, pybind11::arg>' requested here
        initialize(f, f, extra...);
        ^
pybind11/include/pybind11/pybind11.h:475:22: note: in instantiation of function template specialization 'pybind11::cpp_function::cpp_function<void, int, int, pybind11::name, pybind11::sibling, pybind11::scope, pybind11::arg, pybind11::arg, pybind11::arg>' requested here
        cpp_function func(std::forward<Func>(f), name(name_),
                     ^
pybind11/example/example11.cpp:44:7: note: in instantiation of function template specialization 'pybind11::module::def<void (*)(int, int), pybind11::arg, pybind11::arg, pybind11::arg>' requested here
    m.def("kw_func", &kw_func, py::arg("x"), py::arg("y"), py::arg("z"));
      ^
```

It doesn't indicate the expected number of arguments like the runtime check, but I think the compile-time error is a huge advantage.

The implementation actually contains only a minimal amount of template gore. `constexpr_sum` will instantiate recursively, but after the first time the instantiations will just be reused, so it doesn't really affect compilation speed.