### PR TITLE
Detection of PYBIND11 python version logic tweak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,11 @@ option(PYBIND11_INSTALL "Install pybind11 header files?" ${PYBIND11_MASTER_PROJE
 option(PYBIND11_TEST    "Build pybind11 test suite?"     ${PYBIND11_MASTER_PROJECT})
 
 # Add a CMake parameter for choosing a desired Python version
-set(PYBIND11_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling the example application")
+if(DEFINED PYBIND11_PYTHON_VERSION)
+  set(PYBIND11_PYTHON_VERSION ${PYBIND11_PYTHON_VERSION} CACHE STRING "Python version to use for compiling the example application")
+else()
+  set(PYBIND11_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling the example application")
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/tools")
 set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6 3.7)


### PR DESCRIPTION
Using `set(PYBIND11_PYTHON_VERSION` in a parent project was failing because it is overwritten in `pybind11/CMakeLists.txt`. This PR fixes overriding the variable if it is already defined, and defaults to the original initialization if it was undefined.

Tested by successfully compiling my project with pybind11 bindings and running its test (failed when finding wrong python version) in addition to running `pybind11` tests. I think this is related to functionality included in PR #207