### PR TITLE
Use prefix increment in make_iterator

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -116,7 +116,7 @@
 extern "C" {
     struct _Py_atomic_address { void *value; };
     PyAPI_DATA(_Py_atomic_address) _PyThreadState_Current;
-};
+}
 #endif
 
 #define PYBIND11_TRY_NEXT_OVERLOAD ((PyObject *) 1) // special failure return code


### PR DESCRIPTION
This patch switches to using prefix increment for iterators returned by `make_iterator`. This is generally a good idea since postfix increment involves creating a temporary object which may sometimes be expensive.

Btw I've just noticed there's been another related PR (#183) which seems to have been abandoned.