### PR TITLE
Allow std::enable_shared_from_this when using const element type

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -887,7 +887,7 @@ private:
     template <typename T>
     static void init_holder_helper(instance_type *inst, const holder_type * /* unused */, const std::enable_shared_from_this<T> * /* dummy */) {
         try {
-            new (&inst->holder) holder_type(std::static_pointer_cast<type>(inst->value->shared_from_this()));
+            new (&inst->holder) holder_type(std::static_pointer_cast<typename holder_type::element_type>(inst->value->shared_from_this()));
         } catch (const std::bad_weak_ptr &) {
             new (&inst->holder) holder_type(inst->value);
         }


### PR DESCRIPTION
The call to `std::static_pointer_cast` for a `std::enable_shared_from_this holder` should probably use the type as declared in the binding holder (as opposed to the type itself). This allows a `std::shared_ptr` to be used even if the element type is not identical, such as when it is `const` and/or derived (our particular use case).

This is related to #131, and commit 309a85ba5