### PR TITLE
Fix test diff output under python2.7

### DIFF
--- a/example/run_test.py
+++ b/example/run_test.py
@@ -68,6 +68,6 @@ else:
     print('Test "%s" FAILED!' % name)
     print('--- output')
     print('+++ reference')
-    print(''.join(difflib.ndiff(output.splitlines(keepends=True),
-                                reference.splitlines(keepends=True))))
+    print('\n'.join(difflib.ndiff(output.splitlines(),
+                                reference.splitlines())))
     exit(-1)


### PR DESCRIPTION
PR #220 broke failed test output under python2.7, which doesn't support the keepends argument to splitlines.