### PR TITLE
Tighten check() test in eigen.py

### DIFF
--- a/example/eigen.py
+++ b/example/eigen.py
@@ -24,6 +24,8 @@ ref = np.array(
 def check(mat):
     return 'OK' if np.sum(mat - ref) == 0 else 'NOT OK'
 
+print("should_give_NOT_OK = %s" % check(ref[:, ::-1]))
+
 print("fixed_r = %s" % check(fixed_r()))
 print("fixed_c = %s" % check(fixed_c()))
 print("pt_r(fixed_r) = %s" % check(fixed_passthrough_r(fixed_r())))

--- a/example/eigen.py
+++ b/example/eigen.py
@@ -22,7 +22,7 @@ ref = np.array(
 
 
 def check(mat):
-    return 'OK' if np.sum(mat - ref) == 0 else 'NOT OK'
+    return 'OK' if np.sum(abs(mat - ref)) == 0 else 'NOT OK'
 
 print("should_give_NOT_OK = %s" % check(ref[:, ::-1]))
 

--- a/example/eigen.ref
+++ b/example/eigen.ref
@@ -1,3 +1,4 @@
+should_give_NOT_OK = NOT OK
 fixed_r = OK
 fixed_c = OK
 pt_r(fixed_r) = OK


### PR DESCRIPTION
The `check()` function in `example/eigen.py` does not catch cases where the given matrix has the correct sum-of-elements but is otherwise wrong.  This PR adds an initially-failing test to check that a re-arranged matrix gives a `NOT OK` result, and then tightens `check()` to make the test pass.