### PR TITLE
Fix gcc6 placement new warning

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -82,7 +82,14 @@ protected:
 
         /* Store the capture object directly in the function record if there is enough space */
         if (sizeof(capture) <= sizeof(rec->data)) {
+#if defined(__GNUG__) && !defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wplacement-new"
+#endif
             new ((capture *) &rec->data) capture { std::forward<Func>(f) };
+#if defined(__GNUG__) && !defined(__clang__)
+#  pragma GCC diagnostic pop
+#endif
             if (!std::is_trivially_destructible<Func>::value)
                 rec->free_data = [](detail::function_record *r) { ((capture *) &r->data)->~capture(); };
         } else {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -82,12 +82,12 @@ protected:
 
         /* Store the capture object directly in the function record if there is enough space */
         if (sizeof(capture) <= sizeof(rec->data)) {
-#if defined(__GNUG__) && !defined(__clang__)
+#if defined(__GNUG__) && !defined(__clang__) && __GNUC__ >= 6
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wplacement-new"
 #endif
             new ((capture *) &rec->data) capture { std::forward<Func>(f) };
-#if defined(__GNUG__) && !defined(__clang__)
+#if defined(__GNUG__) && !defined(__clang__) && __GNUC__ >= 6
 #  pragma GCC diagnostic pop
 #endif
             if (!std::is_trivially_destructible<Func>::value)


### PR DESCRIPTION
GCC 6 adds a -Wplacement-new warning that warns for placement-new into a space that is too small, which is sometimes being triggered here (e.g. example5.cpp and example17.cpp trigger it).  It's a false warning, however: the line immediately before just checked the size, and so this line is never going to actually be reached in the cases where the warning is being triggered.

This localizes the warning disabling just to this one spot rather than add it to the list of disabled warnings at the top of the file as there are other placement-new uses in pybind11 where this warning could warn about legitimate (future) problems.