### PR TITLE
Skip eigen test when eigen header available but NumPy not

### DIFF
--- a/example/eigen.py
+++ b/example/eigen.py
@@ -11,7 +11,11 @@ from example import sparse_r, sparse_c
 from example import sparse_passthrough_r, sparse_passthrough_c
 from example import double_row, double_col
 from example import double_mat_cm, double_mat_rm
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    # NumPy missing: skip test
+    exit(99)
 
 ref = np.array(
     [[0, 3, 0, 0, 0, 11],

--- a/example/example10.py
+++ b/example/example10.py
@@ -7,8 +7,8 @@ import example
 try:
     import numpy as np
 except ImportError:
-    print('NumPy missing')
-    exit(0)
+    # NumPy missing: skip test
+    exit(99)
 
 from example import vectorized_func
 from example import vectorized_func2

--- a/example/example7.py
+++ b/example/example7.py
@@ -8,8 +8,8 @@ from example import Matrix
 try:
     import numpy as np
 except ImportError:
-    print('NumPy missing')
-    exit(0)
+    # NumPy missing: skip test
+    exit(99)
 
 m = Matrix(5, 5)
 

--- a/example/run_test.py
+++ b/example/run_test.py
@@ -52,16 +52,20 @@ if len(sys.argv) == 3 and sys.argv[1] == '--relaxed':
     relaxed = True
 
 name = sys.argv[1]
-output_bytes = subprocess.check_output([sys.executable, name + ".py"],
-                                       stderr=subprocess.STDOUT)
+try:
+    output_bytes = subprocess.check_output([sys.executable, name + ".py"],
+                                           stderr=subprocess.STDOUT)
+except subprocess.CalledProcessError as e:
+    if e.returncode == 99:
+        print('Test "%s" could not be run.' % name)
+        exit(0)
+    else:
+        raise
 
 output    = sanitize(output_bytes.decode('utf-8'))
 reference = sanitize(open(name + '.ref', 'r').read())
 
-if 'NumPy missing' in output:
-    print('Test "%s" could not be run.' % name)
-    exit(0)
-elif output == reference:
+if output == reference:
     print('Test "%s" succeeded.' % name)
     exit(0)
 else:


### PR DESCRIPTION
When NumPy isn't available, some tests (example7 and example10) don't actually run, but still report "passed" in the test output, and the eigen test fails.

This branch has two commits: the first enables test skipping via CMake (but only for cmake >= 3, when the test error skipping code was added), the second skips the eigen test when NumPy isn't available.

One effect of this is that "make test" will treat skipped tests as test failures in the overall summary and exit code, as shown below.  That's probably actually a good thing for automated testing, as skipped tests means part of the code isn't being tested.

```
Test project /home/jagerman/src/pybind11/build
      Start  1: example1
 1/20 Test  #1: example1 .........................   Passed    0.05 sec
      Start  2: example2
 2/20 Test  #2: example2 .........................   Passed    0.08 sec
      Start  3: example3
 3/20 Test  #3: example3 .........................   Passed    0.05 sec
      Start  4: example4
 4/20 Test  #4: example4 .........................   Passed    0.05 sec
      Start  5: example5
 5/20 Test  #5: example5 .........................   Passed    0.05 sec
      Start  6: example6
 6/20 Test  #6: example6 .........................   Passed    0.05 sec
      Start  7: example7
 7/20 Test  #7: example7 .........................***Skipped   0.05 sec
      Start  8: example8
 8/20 Test  #8: example8 .........................   Passed    0.05 sec
      Start  9: example9
 9/20 Test  #9: example9 .........................   Passed    0.05 sec
      Start 10: example10
10/20 Test #10: example10 ........................***Skipped   0.05 sec
      Start 11: example11
11/20 Test #11: example11 ........................   Passed    0.07 sec
      Start 12: example12
12/20 Test #12: example12 ........................   Passed    0.05 sec
      Start 13: example13
13/20 Test #13: example13 ........................   Passed    0.05 sec
      Start 14: example14
14/20 Test #14: example14 ........................   Passed    0.05 sec
      Start 15: example15
15/20 Test #15: example15 ........................   Passed    0.05 sec
      Start 16: example16
16/20 Test #16: example16 ........................   Passed    0.05 sec
      Start 17: example17
17/20 Test #17: example17 ........................   Passed    0.05 sec
      Start 18: example18
18/20 Test #18: example18 ........................   Passed    0.05 sec
      Start 19: issues
19/20 Test #19: issues ...........................   Passed    0.05 sec
      Start 20: eigen
20/20 Test #20: eigen ............................***Skipped   0.05 sec

85% tests passed, 3 tests failed out of 20

Total Test time (real) =   1.00 sec

The following tests FAILED:
	  7 - example7 (Not Run)
	 10 - example10 (Not Run)
	 20 - eigen (Not Run)
Errors while running CTest
Makefile:127: recipe for target 'test' failed
make: *** [test] Error 8
```