### PR TITLE
generic_type::initialize(): Set tp_flags earlier

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -547,8 +547,16 @@ protected:
                           "\" is already registered!");
 
         object type_holder(PyType_Type.tp_alloc(&PyType_Type, 0), false);
-        object name(PYBIND11_FROM_STRING(rec->name), false);
         auto type = (PyHeapTypeObject*) type_holder.ptr();
+
+        /* Flags */
+        type->ht_type.tp_flags |= Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
+#if PY_MAJOR_VERSION < 3
+        type->ht_type.tp_flags |= Py_TPFLAGS_CHECKTYPES;
+#endif
+        type->ht_type.tp_flags &= ~Py_TPFLAGS_HAVE_GC;
+
+        object name(PYBIND11_FROM_STRING(rec->name), false);
 
         if (!type_holder || !name)
             pybind11_fail("generic_type: unable to create type object!");
@@ -603,13 +611,6 @@ protected:
 
         /* Support weak references (needed for the keep_alive feature) */
         type->ht_type.tp_weaklistoffset = offsetof(instance_essentials<void>, weakrefs);
-
-        /* Flags */
-        type->ht_type.tp_flags |= Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
-#if PY_MAJOR_VERSION < 3
-        type->ht_type.tp_flags |= Py_TPFLAGS_CHECKTYPES;
-#endif
-        type->ht_type.tp_flags &= ~Py_TPFLAGS_HAVE_GC;
 
         if (rec->doc) {
             /* Allocate memory for docstring (using PyObject_MALLOC, since


### PR DESCRIPTION
This is very much for discussion: I was experiencing strange and difficult-to-reproduce coredumps on importing a pybind-defined module.  Error message was

```
Fatal Python error: type_traverse() called for non-heap type '(null)'
```

and backtrace was of the form (addresses etc. snipped)

```
#0  __GI_raise (sig=sig@entry=6)
#1  __GI_abort ()
#2  Py_FatalError (msg=<optimized out>) at Python/pylifecycle.c:1370
#3  type_traverse (type=0x2b64118, visit=0x7f68f94f41b0 <visit_decref>, arg=0x0) at Objects/typeobject.c:3224
#4  subtract_refs (containers=0x7f68f9801180 <generations>) at Modules/gcmodule.c:398
#5  collect (generation=0, n_collected=0x7fff8a7d7648, n_uncollectable=0x7fff8a7d7640, nofail=0) at Modules/gcmodule.c:951
#6  collect_with_callback (generation=0) at Modules/gcmodule.c:1119
#7  collect_generations () at Modules/gcmodule.c:1142
#8  _PyObject_GC_Alloc (use_calloc=<optimized out>, basicsize=<optimized out>) at Modules/gcmodule.c:1708
#9  PyType_GenericAlloc (type=0x7f68f97d76a0 <_PyExc_AttributeError>, nitems=0) at Objects/typeobject.c:941
#10 BaseException_new (type=<optimized out>, args=0x7f68f4ee15f8, kwds=<optimized out>) at Objects/exceptions.c:36
#11 type_call (type=0x7f68f97d76a0 <_PyExc_AttributeError>, args=0x7f68f4ee15f8, kwds=0x0) at Objects/typeobject.c:908
#12 PyObject_Call (func=0x7f68f97d76a0 <_PyExc_AttributeError>, arg=<optimized out>, kw=<optimized out>) at Objects/abstract.c:2165
#13 PyEval_CallObjectWithKeywords (func=0x7f68f97d76a0 <_PyExc_AttributeError>, arg=0x7f68f4ee15f8, kw=<optimized out>) at Python/ceval.c:4530
#14 PyErr_SetObject (exception=0x7f68f97d76a0 <_PyExc_AttributeError>, value=0x7f68f3f6e5d0) at Python/errors.c:91
#15 PyErr_FormatV (exception=0x7f68f97d76a0 <_PyExc_AttributeError>, format=<optimized out>, vargs=0x7fff8a7d77c0) at Python/errors.c:787
#16 PyErr_Format (exception=<optimized out>, format=<optimized out>) at Python/errors.c:802
#17 _PyObject_GenericGetAttrWithDict (obj=0x7f68f4ec5818, name=0x7f68f3f20f30, dict=0x7f68f4cc6cc8) at Objects/object.c:1107
#18 module_getattro (m=0x7f68f4ec5818, name=0x7f68f3f20f30) at Objects/moduleobject.c:659
#19 pybind11::detail::accessor::operator pybind11::object (this=<optimized out>) at [...]/pybind11/pytypes.h:129
#20 handle (ptr=0x0, this=0x7fff8a7d7a18) at [...]/pybind11/pytypes.h:27
#21 object (borrowed=false, ptr=0x0, this=0x7fff8a7d7a18) at [...]/pybind11/pytypes.h:66
#22 accessor (attr=true, key=0x7f68ee21b41b "__module__", obj=..., this=0x7fff8a7d7a10) at [...]/pybind11/pytypes.h:112
#23 attr (key=0x7f68ee21b41b "__module__", this=0x7fff8a7d7d50) at [...]/pybind11/pytypes.h:332
#24 pybind11::detail::generic_type::initialize (this=this@entry=0x7fff8a7d7c30, rec=rec@entry=0x7fff8a7d7d50) at [...]/pybind11/pybind11.h:553
#25 class_<> (name=0x7f68ee21b66e "AccurateConvergenceState", scope=..., this=0x7fff8a7d7c30) at [...]/pybind11/pybind11.h:750
...
```

Although I'm not familiar with the details of the Python runtime in this regard, some digging around prompted by the above suggested that setting the flags earlier, before any Python runtime activity, might fix the problem.  With the commit of this PR, my coredump went away, but it was difficult to reproduce in the first place so I would not be completely confident I've understood and/or fixed the problem correctly.

Including

```python
import gc
gc.set_threshold(1)
```

made the problem occur much more reliably, supporting the above idea.

Maybe somebody who understands this area of the code better can review?