### PR TITLE
Add missing scipy run-time dep to eigen test

### DIFF
--- a/example/eigen.py
+++ b/example/eigen.py
@@ -13,6 +13,7 @@ from example import double_row, double_col
 from example import double_mat_cm, double_mat_rm
 try:
     import numpy as np
+    import scipy
 except ImportError:
     # NumPy missing: skip test
     exit(99)


### PR DESCRIPTION
Very minor PR: scipy is imported in pybind11/eigen.h when it encounters a sparse matrix, which gets tested in the eigen test, but ends up failing halfway through the test if numpy is available but scipy isn't.