### PR TITLE
Add pybind11::make_key_iterator for map iteration

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -957,6 +957,12 @@ exceptions:
 |                                      | indicate wrong value passed  |
 |                                      | in ``container.remove(...)`` |
 +--------------------------------------+------------------------------+
+| :class:`pybind11::key_error`         | ``KeyError`` (used to        |
+|                                      | indicate out of bounds       |
+|                                      | accesses in ``__getitem__``, |
+|                                      | ``__setitem__`` in dict-like |
+|                                      | objects, etc.)               |
++--------------------------------------+------------------------------+
 | :class:`pybind11::error_already_set` | Indicates that the Python    |
 |                                      | exception flag has already   |
 |                                      | been initialized             |

--- a/example/example-sequences-and-iterators.py
+++ b/example/example-sequences-and-iterators.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import sys
 sys.path.append('.')
 
-from example import Sequence
+from example import Sequence, StringMap
 
 s = Sequence(5)
 print("s = " + str(s))
@@ -28,6 +28,24 @@ rev[0::2] = Sequence([2.0, 2.0, 2.0])
 for i in rev:
     print(i, end=' ')
 print('')
+
+m = StringMap({ 'hi': 'bye', 'black': 'white' })
+print(m['hi'])
+print(len(m))
+print(m['black'])
+try:
+    print(m['orange'])
+    print('Error: should have thrown exception')
+except KeyError:
+    pass
+m['orange'] = 'banana'
+print(m['orange'])
+
+for k in m:
+    print("key = %s, value = %s" % (k, m[k]))
+
+for k,v in m.items():
+    print("item: (%s, %s)" % (k,v))
 
 from example import ConstructorStats
 cstats = ConstructorStats.get(Sequence)

--- a/example/example-sequences-and-iterators.ref
+++ b/example/example-sequences-and-iterators.ref
@@ -13,9 +13,19 @@ rev[0], rev[1], rev[2], rev[3], rev[4] = 0.000000 56.779999 0.000000 0.000000 12
 0.0 56.779998779296875 0.0 0.0 12.34000015258789 
 0.0 56.779998779296875 0.0 0.0 12.34000015258789 
 True
-### Sequence @ 0x153c4b0 created of size 3  from std::vector
-### Sequence @ 0x153c4b0 destroyed
+### Sequence @ 0x1b4d1f0 created of size 3 from std::vector
+### Sequence @ 0x1b4d1f0 destroyed
 2.0 56.779998779296875 2.0 0.0 2.0 
+bye
+2
+white
+banana
+key = orange, value = banana
+key = hi, value = bye
+key = black, value = white
+item: (orange, banana)
+item: (hi, bye)
+item: (black, white)
 Instances not destroyed: 3
 ### Sequence @ 0x1535b00 destroyed
 Instances not destroyed: 2

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -55,6 +55,7 @@ PYBIND11_NOINLINE inline internals &get_internals() {
                     if (p) std::rethrow_exception(p);
                 } catch (const error_already_set &)      {                                                 return;
                 } catch (const index_error &e)           { PyErr_SetString(PyExc_IndexError,    e.what()); return;
+                } catch (const key_error &e)             { PyErr_SetString(PyExc_KeyError,      e.what()); return;
                 } catch (const value_error &e)           { PyErr_SetString(PyExc_ValueError,    e.what()); return;
                 } catch (const stop_iteration &e)        { PyErr_SetString(PyExc_StopIteration, e.what()); return;
                 } catch (const std::bad_alloc &e)        { PyErr_SetString(PyExc_MemoryError,   e.what()); return;

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -314,6 +314,7 @@ NAMESPACE_END(detail)
 class error_already_set : public std::runtime_error { public: error_already_set() : std::runtime_error(detail::error_string())  {} };
 PYBIND11_RUNTIME_EXCEPTION(stop_iteration)
 PYBIND11_RUNTIME_EXCEPTION(index_error)
+PYBIND11_RUNTIME_EXCEPTION(key_error)
 PYBIND11_RUNTIME_EXCEPTION(value_error)
 PYBIND11_RUNTIME_EXCEPTION(cast_error) /// Thrown when pybind11::cast or handle::call fail due to a type casting error
 PYBIND11_RUNTIME_EXCEPTION(reference_cast_error) /// Used internally


### PR DESCRIPTION
This allows exposing a dict-like interface to python code, allowing iteration over keys via:

```
for k in custommapping:
    ...
```

It does this via a new function, rather than overloading `py::make_iterator` for pair containers, so that you can still expose iteration over pairs, allowing you to also provide a `dict.items()`-compatible functionality, allowing:

```
for k, v in custommapping.items():
    ...
```

by defining an `__iter__` method that returns `pybind11::make_key_iterator` and a `items` method that returns `pybind11::make_iterator`.

example6 is updated with an example class providing both types of iteration.