### PR TITLE
Added py::register_exception for simple case

### DIFF
--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -46,6 +46,18 @@ private:
     std::string message = "";
 };
 
+
+// Like the above, but declared via the helper function
+class MyException5 : public std::logic_error {
+public:
+    explicit MyException5(const std::string &what) : std::logic_error(what) {}
+};
+
+// Inherits from MyException5
+class MyException5_1 : public MyException5 {
+    using MyException5::MyException5;
+};
+
 void throws1() {
     throw MyException("this error should go to a custom type");
 }
@@ -60,6 +72,14 @@ void throws3() {
 
 void throws4() {
     throw MyException4("this error is rethrown");
+}
+
+void throws5() {
+    throw MyException5("this is a helper-defined translated exception");
+}
+
+void throws5_1() {
+    throw MyException5_1("MyException5 subclass");
 }
 
 void throws_logic_error() {
@@ -80,7 +100,8 @@ test_initializer custom_exceptions([](py::module &m) {
         try {
             if (p) std::rethrow_exception(p);
         } catch (const MyException &e) {
-            PyErr_SetString(ex.ptr(), e.what());
+            // Set MyException as the active python error
+            ex(e.what());
         }
     });
 
@@ -91,6 +112,7 @@ test_initializer custom_exceptions([](py::module &m) {
         try {
             if (p) std::rethrow_exception(p);
         } catch (const MyException2 &e) {
+            // Translate this exception to a standard RuntimeError
             PyErr_SetString(PyExc_RuntimeError, e.what());
         }
     });
@@ -106,10 +128,17 @@ test_initializer custom_exceptions([](py::module &m) {
         }
     });
 
+    // A simple exception translation:
+    auto ex5 = py::register_exception<MyException5>(m, "MyException5");
+    // A slightly more complicated one that declares MyException5_1 as a subclass of MyException5
+    py::register_exception<MyException5_1>(m, "MyException5_1", ex5.ptr());
+
     m.def("throws1", &throws1);
     m.def("throws2", &throws2);
     m.def("throws3", &throws3);
     m.def("throws4", &throws4);
+    m.def("throws5", &throws5);
+    m.def("throws5_1", &throws5_1);
     m.def("throws_logic_error", &throws_logic_error);
 
     m.def("throw_already_set", [](bool err) {

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -22,7 +22,8 @@ def test_python_call_in_catch():
 
 
 def test_custom(msg):
-    from pybind11_tests import (MyException, throws1, throws2, throws3, throws4,
+    from pybind11_tests import (MyException, MyException5, MyException5_1,
+                                throws1, throws2, throws3, throws4, throws5, throws5_1,
                                 throws_logic_error)
 
     # Can we catch a MyException?"
@@ -49,3 +50,25 @@ def test_custom(msg):
     with pytest.raises(RuntimeError) as excinfo:
         throws_logic_error()
     assert msg(excinfo.value) == "this error should fall through to the standard handler"
+
+    # Can we handle a helper-declared exception?
+    with pytest.raises(MyException5) as excinfo:
+        throws5()
+    assert msg(excinfo.value) == "this is a helper-defined translated exception"
+
+    # Exception subclassing:
+    with pytest.raises(MyException5) as excinfo:
+        throws5_1()
+    assert msg(excinfo.value) == "MyException5 subclass"
+    assert isinstance(excinfo.value, MyException5_1)
+
+    with pytest.raises(MyException5_1) as excinfo:
+        throws5_1()
+    assert msg(excinfo.value) == "MyException5 subclass"
+
+    with pytest.raises(MyException5) as excinfo:
+        try:
+            throws5()
+        except MyException5_1 as e:
+            raise RuntimeError("Exception error: caught child from parent")
+    assert msg(excinfo.value) == "this is a helper-defined translated exception"


### PR DESCRIPTION
Addresses #295.

The custom exception handling added in PR #273 is robust, but is overly complex for declaring the most common simple C++ -> Python exception mapping that needs only to copy `what()`.  This add a simple
`py::register_exception<CppException>(module, "PythonException");` function that greatly simplifies the basic case of translation of a simple CppException into a simple PythonException.