### PR TITLE
Improve CI test coverage: eigen, numpy and C++14

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,26 +1,33 @@
 version: 1.0.{build}
 os: Visual Studio 2015
-clone_folder: C:\projects\pybind11
 test: off
-configuration:
-    - Release
-    - Debug
-branches:
-  only:
-    - master
+platform:
+- x86
+- x64
 environment:
+  CTEST_OUTPUT_ON_FAILURE: 1
   matrix:
-    - CMAKE_PLATFORM: "Visual Studio 14 2015"
-      PYTHON_DIR: "C:\\Python34"
-      CTEST_OUTPUT_ON_FAILURE: 1
-    - CMAKE_PLATFORM: "Visual Studio 14 2015 Win64"
-      PYTHON_DIR: "C:\\Python34-x64"
-      CTEST_OUTPUT_ON_FAILURE: 1
+  - CONDA: 27
+  - CONDA: 35
 install:
-  - cinstall: python
+- ps: |
+    if ($env:PLATFORM -eq "x64") { $env:CMAKE_ARCH = "x64" }
+    if ($env:PYTHON) {
+      if ($env:PLATFORM -eq "x64") { $env:PYTHON = "$env:PYTHON-x64" }
+      $env:PATH = "C:\Python$env:PYTHON\;C:\Python$env:PYTHON\Scripts\;$env:PATH"
+      pip install --disable-pip-version-check --user --upgrade pip wheel
+      pip install numpy scipy
+    } elseif ($env:CONDA) {
+      if ($env:CONDA -eq "27") { $env:CONDA = "" }
+      if ($env:PLATFORM -eq "x64") { $env:CONDA = "$env:CONDA-x64" }
+      $env:PATH = "C:\Miniconda$env:CONDA\;C:\Miniconda$env:CONDA\Scripts\;$env:PATH"
+      conda install -y -q numpy scipy
+    }
+- ps: |
+    Start-FileDownload 'http://bitbucket.org/eigen/eigen/get/3.2.9.zip'
+    7z x 3.2.9.zip -y > $null
+    $env:CMAKE_INCLUDE_PATH = "eigen-eigen-dc6cfdf9bcec"
 build_script:
-  - echo Running cmake...
-  - cd c:\projects\pybind11
-  - cmake -G "%CMAKE_PLATFORM%" -DPYTHON_EXECUTABLE:FILEPATH=%PYTHON_DIR%/python.exe
-  - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-  - cmake --build . --config %Configuration% --target check -- /v:m /logger:%MSBuildLogger%
+- cmake -A "%CMAKE_ARCH%"
+- set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- cmake --build . --config Release --target check -- /v:m /logger:%MSBuildLogger%

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,12 @@ install:
     pip install --user --upgrade pip virtualenv
     virtualenv -p python$PYTHON venv
   elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    if [ "${PYTHON:0:1}" = "3" ]; then PMAJOR=3; fi
-    brew update; brew install python$PMAJOR;
+    if [ "${PYTHON:0:1}" = "3" ]; then
+      PMAJOR=3; brew update; brew install python$PMAJOR;
+    else
+      curl -fsSL -O https://bootstrap.pypa.io/get-pip.py
+      sudo -H python get-pip.py
+    fi
     pip$PMAJOR install --user --upgrade pip virtualenv
     python$PMAJOR -m virtualenv venv
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,19 @@
 language: cpp
 sudo: false
+matrix:
+  include:
+  - os: linux
+    compiler: gcc-4.8
+    env: PYTHON=2.7 CPP=11
+  - os: linux
+    compiler: gcc-4.8
+    env: PYTHON=3.5 CPP=11
+  - os: osx
+    osx_image: xcode7.3
+    env: PYTHON=2.7 CPP=14
+  - os: osx
+    osx_image: xcode7.3
+    env: PYTHON=3.5 CPP=14
 cache:
   directories:
   - $HOME/.cache/pip
@@ -12,33 +26,27 @@ addons:
       - kubuntu-backports # cmake 2.8.12
     packages:
       - g++-4.8
-      - g++-4.8-multilib
-      - g++-multilib
       - python3.5
       - python3.5-dev
-      - python3.5-venv
-      - python3.5-dev:i386
       - cmake
-matrix:
-  include:
-    - os: linux
-      compiler: gcc-4.8
-      install:
-        - pyvenv-3.5 venv
-        - source venv/bin/activate
-        - pip install -U pip wheel
-        - pip install numpy
-      script:
-        - CXX=g++-4.8 cmake -DPYBIND11_PYTHON_VERSION=3.5
-        - CTEST_OUTPUT_ON_FAILURE=TRUE make check -j 2
-    - os: osx
-      compiler: clang
-      script:
-        - cmake -DPYBIND11_PYTHON_VERSION=2.7
-        - CTEST_OUTPUT_ON_FAILURE=TRUE make check -j 2
-    #- os: linux
-      #compiler: gcc-4.8
-      #script:
-        #- pyvenv-3.5 venv
-        #- cmake -DPYBIND11_PYTHON_VERSION=3.5 -DPYTHON_INCLUDE_DIR:PATH=/usr/include/python3.5m -DPYTHON_LIBRARY:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython3.5m.so -DPYTHON_EXECUTABLE:FILEPATH=`pwd`/venv/bin/python3.5 -DCMAKE_CXX_COMPILER=g++-4.8 -DCMAKE_CXX_FLAGS=-m32
-        #- make -j 2
+install:
+- |
+  if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+    export CXX=g++-4.8 CC=gcc-4.8;
+    pip install --user --upgrade pip virtualenv
+    virtualenv -p python$PYTHON venv
+  elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    if [ "${PYTHON:0:1}" = "3" ]; then PMAJOR=3; fi
+    brew update; brew install python$PMAJOR;
+    pip$PMAJOR install --user --upgrade pip virtualenv
+    python$PMAJOR -m virtualenv venv
+  fi
+  source venv/bin/activate
+  pip install numpy scipy
+- |
+  wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz
+  tar xzf eigen.tar.gz
+  export CMAKE_INCLUDE_PATH=eigen-eigen-dc6cfdf9bcec
+script:
+- cmake -DPYBIND11_PYTHON_VERSION=$PYTHON -DPYBIND11_CPP_STANDARD=-std=c++$CPP
+- CTEST_OUTPUT_ON_FAILURE=TRUE make check -j 2

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(Eigen3 QUIET)
 
 if(EIGEN3_FOUND)
   list(APPEND PYBIND11_EXAMPLES eigen.cpp)
-  message(STATUS "Building Eigen testcase")
+  message(STATUS "Building Eigen v${EIGEN3_VERSION} testcase")
 else()
   message(STATUS "NOT Building Eigen testcase")
 endif()


### PR DESCRIPTION
This PR configures Travis and AppVeyor to install eigen, numpy and scipy on all 3 operating systems. It also updates the OS X image on Travis with a C++14 compliant version of clang.

**Added**:
* Run eigen and numpy tests on all platforms
* Compile with C++14 on OS X/clang and C++11 on Linux/gcc
* Test Python 2.7 on Windows

**Removed**:
* The unused/commented-out 32-bit Travis config
* Windows debug config (in favor of Python 2.7)

**Notes**:

All platforms install numpy and scipy binaries, so the installation is relatively fast. OS X has had wheels for a while already, but the `manylinux` binary wheels are new.

Windows recently got a wheel install for numpy as well. Unfortunately, scipy is not available yet. This is why the AppVeyor install uses `conda` instead of `pip`. However, I have left the regular `pip install` in there so this can be an easy switch when a scipy wheel becomes available.