### PR TITLE
Changes accessor::operator=() to throw error_already_set() instead of using pybind11_fail().

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -117,10 +117,10 @@ public:
     void operator=(const handle &value) {
         if (attr) {
             if (PyObject_SetAttr(obj.ptr(), key.ptr(), value.ptr()) == -1)
-                pybind11_fail("Unable to set object attribute");
+                throw error_already_set();
         } else {
             if (PyObject_SetItem(obj.ptr(), key.ptr(), value.ptr()) == -1)
-                pybind11_fail("Unable to set object item");
+                throw error_already_set();
         }
     }
 


### PR DESCRIPTION
PyObject_SetItem and PyObject_SetAttr both throws an exception on
failure so this will show the underlying exception instead of masking
it.

Fixes #303.