### PR TITLE
Improve function signatures for IDEs and static analysis tools

### DIFF
--- a/example/eigen.py
+++ b/example/eigen.py
@@ -106,3 +106,9 @@ for i in range(4):
 
 print("symmetric_lower %s" % ("OK" if (symmetric_lower(asymm) == symm_lower).all() else "FAILED"))
 print("symmetric_upper %s" % ("OK" if (symmetric_upper(asymm) == symm_upper).all() else "FAILED"))
+
+print(double_col.__doc__)
+print(double_row.__doc__)
+print(double_mat_rm.__doc__)
+print(sparse_passthrough_r.__doc__)
+print(sparse_passthrough_c.__doc__)

--- a/example/eigen.ref
+++ b/example/eigen.ref
@@ -53,3 +53,8 @@ block(1,4,3,2) OK
 incr_diag OK
 symmetric_lower OK
 symmetric_upper OK
+double_col(arg0: numpy.ndarray[float32[m, 1]]) -> numpy.ndarray[float32[m, 1]]
+double_row(arg0: numpy.ndarray[float32[1, n]]) -> numpy.ndarray[float32[1, n]]
+double_mat_rm(arg0: numpy.ndarray[float32[m, n]]) -> numpy.ndarray[float32[m, n]]
+sparse_passthrough_r(arg0: scipy.sparse.csr_matrix[float32]) -> scipy.sparse.csr_matrix[float32]
+sparse_passthrough_c(arg0: scipy.sparse.csc_matrix[float32]) -> scipy.sparse.csc_matrix[float32]

--- a/example/example-arg-keywords-and-defaults.cpp
+++ b/example/example-arg-keywords-and-defaults.cpp
@@ -40,8 +40,13 @@ void args_kwargs_function(py::args args, py::kwargs kwargs) {
     }
 }
 
+struct KWClass {
+    void foo(int, float) {}
+};
+
 void init_ex_arg_keywords_and_defaults(py::module &m) {
-    m.def("kw_func", &kw_func, py::arg("x"), py::arg("y"));
+    m.def("kw_func0", &kw_func);
+    m.def("kw_func1", &kw_func, py::arg("x"), py::arg("y"));
     m.def("kw_func2", &kw_func, py::arg("x") = 100, py::arg("y") = 200);
     m.def("kw_func3", [](const char *) { }, py::arg("data") = std::string("Hello world!"));
 
@@ -59,4 +64,8 @@ void init_ex_arg_keywords_and_defaults(py::module &m) {
     using namespace py::literals;
     m.def("kw_func_udl", &kw_func, "x"_a, "y"_a=300);
     m.def("kw_func_udl_z", &kw_func, "x"_a, "y"_a=0);
+    
+    py::class_<KWClass>(m, "KWClass")
+        .def("foo0", &KWClass::foo)
+        .def("foo1", &KWClass::foo, "x"_a, "y"_a);
 }

--- a/example/example-arg-keywords-and-defaults.py
+++ b/example/example-arg-keywords-and-defaults.py
@@ -5,19 +5,26 @@ import pydoc
 
 sys.path.append('.')
 
-from example import kw_func, kw_func2, kw_func3, kw_func4, call_kw_func
+from example import kw_func0, kw_func1, kw_func2, kw_func3, kw_func4, call_kw_func
 from example import args_function, args_kwargs_function, kw_func_udl, kw_func_udl_z
+from example import KWClass
 
-print(pydoc.render_doc(kw_func, "Help on %s"))
+print(pydoc.render_doc(kw_func0, "Help on %s"))
+print(pydoc.render_doc(kw_func1, "Help on %s"))
 print(pydoc.render_doc(kw_func2, "Help on %s"))
 print(pydoc.render_doc(kw_func3, "Help on %s"))
 print(pydoc.render_doc(kw_func4, "Help on %s"))
 print(pydoc.render_doc(kw_func_udl, "Help on %s"))
 print(pydoc.render_doc(kw_func_udl_z, "Help on %s"))
+print(pydoc.render_doc(args_function, "Help on %s"))
+print(pydoc.render_doc(args_kwargs_function, "Help on %s"))
 
-kw_func(5, 10)
-kw_func(5, y=10)
-kw_func(y=10, x=5)
+print(KWClass.foo0.__doc__)
+print(KWClass.foo1.__doc__)
+
+kw_func1(5, 10)
+kw_func1(5, y=10)
+kw_func1(y=10, x=5)
 
 kw_func2()
 

--- a/example/example-arg-keywords-and-defaults.ref
+++ b/example/example-arg-keywords-and-defaults.ref
@@ -1,32 +1,52 @@
-Help on built-in function kw_func in module example
+Help on built-in function kw_func0 in module example
 
-kkww__ffuunncc(...)
-    kw_func(x : int, y : int) -> NoneType
+kkww__ffuunncc00(...)
+    kw_func0(arg0: int, arg1: int) -> NoneType
+
+Help on built-in function kw_func1 in module example
+
+kkww__ffuunncc11(...)
+    kw_func1(x: int, y: int) -> NoneType
 
 Help on built-in function kw_func2 in module example
 
 kkww__ffuunncc22(...)
-    kw_func2(x : int = 100L, y : int = 200L) -> NoneType
+    kw_func2(x: int=100L, y: int=200L) -> NoneType
 
 Help on built-in function kw_func3 in module example
 
 kkww__ffuunncc33(...)
-    kw_func3(data : unicode = u'Hello world!') -> NoneType
+    kw_func3(data: unicode=u'Hello world!') -> NoneType
 
 Help on built-in function kw_func4 in module example
 
 kkww__ffuunncc44(...)
-    kw_func4(myList : list<int> = [13L, 17L]) -> NoneType
+    kw_func4(myList: list<int>=[13L, 17L]) -> NoneType
 
 Help on built-in function kw_func_udl in module example
 
 kkww__ffuunncc__uuddll(...)
-    kw_func_udl(x : int, y : int = 300L) -> NoneType
+    kw_func_udl(x: int, y: int=300L) -> NoneType
 
 Help on built-in function kw_func_udl_z in module example
 
 kkww__ffuunncc__uuddll__zz(...)
-    kw_func_udl_z(x : int, y : int = 0L) -> NoneType
+    kw_func_udl_z(x: int, y: int=0L) -> NoneType
+
+Help on built-in function args_function in module example
+
+aarrggss__ffuunnccttiioonn(...)
+    args_function(*args) -> NoneType
+
+Help on built-in function args_kwargs_function in module example
+
+aarrggss__kkwwaarrggss__ffuunnccttiioonn(...)
+    args_kwargs_function(*args, **kwargs) -> NoneType
+
+
+foo0(self: KWClass, arg0: int, arg1: float) -> NoneType
+foo1(self: KWClass, x: int, y: float) -> NoneType
+
 
 kw_func(x=5, y=10)
 kw_func(x=5, y=10)
@@ -38,7 +58,7 @@ kw_func(x=100, y=10)
 kw_func(x=5, y=10)
 kw_func(x=5, y=10)
 Caught expected exception: Incompatible function arguments. The following argument types are supported:
-    1. (x : int = 100L, y : int = 200L) -> NoneType
+    1. (x: int=100L, y: int=200L) -> NoneType
     Invoked with:
 kw_func4: 13 17 
 kw_func4: 1 2 3 

--- a/example/example-arg-keywords-and-defaults.ref
+++ b/example/example-arg-keywords-and-defaults.ref
@@ -1,51 +1,51 @@
 Help on built-in function kw_func0 in module example
 
 kkww__ffuunncc00(...)
-    kw_func0(arg0: int, arg1: int) -> NoneType
+    kw_func0(arg0: int, arg1: int) -> None
 
 Help on built-in function kw_func1 in module example
 
 kkww__ffuunncc11(...)
-    kw_func1(x: int, y: int) -> NoneType
+    kw_func1(x: int, y: int) -> None
 
 Help on built-in function kw_func2 in module example
 
 kkww__ffuunncc22(...)
-    kw_func2(x: int=100L, y: int=200L) -> NoneType
+    kw_func2(x: int=100L, y: int=200L) -> None
 
 Help on built-in function kw_func3 in module example
 
 kkww__ffuunncc33(...)
-    kw_func3(data: unicode=u'Hello world!') -> NoneType
+    kw_func3(data: unicode=u'Hello world!') -> None
 
 Help on built-in function kw_func4 in module example
 
 kkww__ffuunncc44(...)
-    kw_func4(myList: list<int>=[13L, 17L]) -> NoneType
+    kw_func4(myList: List[int]=[13L, 17L]) -> None
 
 Help on built-in function kw_func_udl in module example
 
 kkww__ffuunncc__uuddll(...)
-    kw_func_udl(x: int, y: int=300L) -> NoneType
+    kw_func_udl(x: int, y: int=300L) -> None
 
 Help on built-in function kw_func_udl_z in module example
 
 kkww__ffuunncc__uuddll__zz(...)
-    kw_func_udl_z(x: int, y: int=0L) -> NoneType
+    kw_func_udl_z(x: int, y: int=0L) -> None
 
 Help on built-in function args_function in module example
 
 aarrggss__ffuunnccttiioonn(...)
-    args_function(*args) -> NoneType
+    args_function(*args) -> None
 
 Help on built-in function args_kwargs_function in module example
 
 aarrggss__kkwwaarrggss__ffuunnccttiioonn(...)
-    args_kwargs_function(*args, **kwargs) -> NoneType
+    args_kwargs_function(*args, **kwargs) -> None
 
 
-foo0(self: KWClass, arg0: int, arg1: float) -> NoneType
-foo1(self: KWClass, x: int, y: float) -> NoneType
+foo0(self: KWClass, arg0: int, arg1: float) -> None
+foo1(self: KWClass, x: int, y: float) -> None
 
 
 kw_func(x=5, y=10)
@@ -58,10 +58,10 @@ kw_func(x=100, y=10)
 kw_func(x=5, y=10)
 kw_func(x=5, y=10)
 Caught expected exception: Incompatible function arguments. The following argument types are supported:
-    1. (x: int=100L, y: int=200L) -> NoneType
+    1. (x: int=100L, y: int=200L) -> None
     Invoked with:
-kw_func4: 13 17 
-kw_func4: 1 2 3 
+kw_func4: 13 17
+kw_func4: 1 2 3
 kw_func(x=1234, y=5678)
 got argument: arg1_value
 got argument: arg2_value

--- a/example/example-callbacks.py
+++ b/example/example-callbacks.py
@@ -82,3 +82,6 @@ except Exception as e:
         print("All OK!")
     else:
         print("Problem!")
+
+print(test_callback3.__doc__)
+print(test_callback4.__doc__)

--- a/example/example-callbacks.ref
+++ b/example/example-callbacks.ref
@@ -6,7 +6,7 @@ Molly is a dog
 Molly is a dog
 Woof!
 The following error is expected: Incompatible function arguments. The following argument types are supported:
-    1. (example.Dog) -> NoneType
+    1. (arg0: example.Dog) -> NoneType
     Invoked with: <example.Pet object at 0>
 Callback function 1 called!
 False

--- a/example/example-callbacks.ref
+++ b/example/example-callbacks.ref
@@ -6,7 +6,7 @@ Molly is a dog
 Molly is a dog
 Woof!
 The following error is expected: Incompatible function arguments. The following argument types are supported:
-    1. (arg0: example.Dog) -> NoneType
+    1. (arg0: example.Dog) -> None
     Invoked with: <example.Pet object at 0>
 Callback function 1 called!
 False
@@ -36,3 +36,6 @@ could not convert to a function pointer.
 All OK!
 could not convert to a function pointer.
 All OK!
+
+test_callback3(arg0: Callable[[int], int]) -> None
+test_callback4() -> Callable[[int], int]

--- a/example/example-numpy-vectorize.py
+++ b/example/example-numpy-vectorize.py
@@ -32,3 +32,5 @@ from example import selective_func
 selective_func(np.array([1], dtype=np.int32))
 selective_func(np.array([1.0], dtype=np.float32))
 selective_func(np.array([1.0j], dtype=np.complex64))
+
+print(vectorized_func.__doc__)

--- a/example/example-numpy-vectorize.ref
+++ b/example/example-numpy-vectorize.ref
@@ -76,3 +76,4 @@ my_func(x:int=6, y:float=3, z:float=2)
 Int branch taken. 
 Float branch taken. 
 Complex float branch taken. 
+vectorized_func(arg0: numpy.ndarray[int], arg1: numpy.ndarray[float], arg2: numpy.ndarray[float]) -> object

--- a/example/example-opaque-types.ref
+++ b/example/example-opaque-types.ref
@@ -10,7 +10,7 @@ Called ExampleMandA default constructor..
 Got void ptr : 0x7f9ba0f3c430
 Called ExampleMandA destructor (0)
 Caught expected exception: Incompatible function arguments. The following argument types are supported:
-    1. (capsule) -> NoneType
+    1. (arg0: capsule) -> None
     Invoked with: [1, 2, 3]
 None
 Got null str : 0x0

--- a/example/example-python-types.ref
+++ b/example/example-python-types.ref
@@ -34,8 +34,8 @@ class EExxaammpplleePPyytthhoonnTTyyppeess(__builtin__.object)
  |      x.__init__(...) initializes x; see help(type(x)) for signature
  |  
  |  ggeett__aarrrraayy(...)
- |      Signature : (example.ExamplePythonTypes) -> list<unicode>[2]
  |      
+ |      Signature : (example.ExamplePythonTypes) -> List[unicode[2]]
  |      Return a C++ array
  |  
  |  ggeett__ddiicctt(...)
@@ -44,8 +44,8 @@ class EExxaammpplleePPyytthhoonnTTyyppeess(__builtin__.object)
  |      Return a Python dictionary
  |  
  |  ggeett__ddiicctt__22(...)
- |      Signature : (example.ExamplePythonTypes) -> dict<unicode, unicode>
  |      
+ |      Signature : (example.ExamplePythonTypes) -> Dict[unicode, unicode]
  |      Return a C++ dictionary
  |  
  |  ggeett__lliisstt(...)
@@ -54,8 +54,8 @@ class EExxaammpplleePPyytthhoonnTTyyppeess(__builtin__.object)
  |      Return a Python list
  |  
  |  ggeett__lliisstt__22(...)
- |      Signature : (example.ExamplePythonTypes) -> list<unicode>
  |      
+ |      Signature : (example.ExamplePythonTypes) -> List[unicode]
  |      Return a C++ list
  |  
  |  ggeett__sseett(...)
@@ -69,53 +69,53 @@ class EExxaammpplleePPyytthhoonnTTyyppeess(__builtin__.object)
  |      Return a C++ set
  |  
  |  ppaaiirr__ppaasssstthhrroouugghh(...)
- |      Signature : (example.ExamplePythonTypes, (bool, unicode)) -> (unicode, bool)
  |      
+ |      Signature : (example.ExamplePythonTypes, Tuple[bool, unicode]) -> Tuple[unicode, bool]
  |      Return a pair in reversed order
  |  
  |  pprriinntt__aarrrraayy(...)
- |      Signature : (example.ExamplePythonTypes, list<unicode>[2]) -> NoneType
  |      
+ |      Signature : (example.ExamplePythonTypes, List[unicode[2]]) -> None
  |      Print entries of a C++ array
  |  
  |  pprriinntt__ddiicctt(...)
- |      Signature : (example.ExamplePythonTypes, dict) -> NoneType
  |      
+ |      Signature : (example.ExamplePythonTypes, dict) -> None
  |      Print entries of a Python dictionary
  |  
  |  pprriinntt__ddiicctt__22(...)
- |      Signature : (example.ExamplePythonTypes, dict<unicode, unicode>) -> NoneType
  |      
+ |      Signature : (example.ExamplePythonTypes, Dict[unicode, unicode]) -> None
  |      Print entries of a C++ dictionary
  |  
  |  pprriinntt__lliisstt(...)
- |      Signature : (example.ExamplePythonTypes, list) -> NoneType
  |      
+ |      Signature : (example.ExamplePythonTypes, list) -> None
  |      Print entries of a Python list
  |  
  |  pprriinntt__lliisstt__22(...)
- |      Signature : (example.ExamplePythonTypes, list<unicode>) -> NoneType
  |      
+ |      Signature : (example.ExamplePythonTypes, List[unicode]) -> None
  |      Print entries of a C++ list
  |  
  |  pprriinntt__sseett(...)
- |      Signature : (example.ExamplePythonTypes, set) -> NoneType
  |      
+ |      Signature : (example.ExamplePythonTypes, set) -> None
  |      Print entries of a Python set
  |  
  |  pprriinntt__sseett__22(...)
- |      Signature : (example.ExamplePythonTypes, set<unicode>) -> NoneType
  |      
+ |      Signature : (example.ExamplePythonTypes, Set[unicode]) -> None
  |      Print entries of a C++ set
  |  
  |  tthhrrooww__eexxcceeppttiioonn(...)
- |      Signature : (example.ExamplePythonTypes) -> NoneType
  |      
+ |      Signature : (example.ExamplePythonTypes) -> None
  |      Throw an exception
  |  
  |  ttuuppllee__ppaasssstthhrroouugghh(...)
- |      Signature : (example.ExamplePythonTypes, (bool, unicode, int)) -> (int, unicode, bool)
  |      
+ |      Signature : (example.ExamplePythonTypes, Tuple[bool, unicode, int]) -> Tuple[int, unicode, bool]
  |      Return a triple in reversed order
  |  
  |  ----------------------------------------------------------------------

--- a/example/issues.ref
+++ b/example/issues.ref
@@ -6,7 +6,7 @@ Yay..
 [3, 5, 7, 9, 11, 13, 15]
 0==0, 1==1, 2==2, 3==3, 4==4, 5==5, 6==6, 7==7, 8==8, 9==9, 
 Failed as expected: Incompatible function arguments. The following argument types are supported:
-    1. (arg0: example.issues.ElementA) -> NoneType
+    1. (arg0: example.issues.ElementA) -> None
     Invoked with: None
 Failed as expected: Incompatible function arguments. The following argument types are supported:
     1. (arg0: int) -> int

--- a/example/issues.ref
+++ b/example/issues.ref
@@ -6,10 +6,10 @@ Yay..
 [3, 5, 7, 9, 11, 13, 15]
 0==0, 1==1, 2==2, 3==3, 4==4, 5==5, 6==6, 7==7, 8==8, 9==9, 
 Failed as expected: Incompatible function arguments. The following argument types are supported:
-    1. (example.issues.ElementA) -> NoneType
+    1. (arg0: example.issues.ElementA) -> NoneType
     Invoked with: None
 Failed as expected: Incompatible function arguments. The following argument types are supported:
-    1. (int) -> int
+    1. (arg0: int) -> int
     Invoked with: 5.2
 12.0
 C++ version
@@ -21,6 +21,6 @@ In python f()
 StrIssue.__str__ called
 StrIssue[3]
 Failed as expected: Incompatible constructor arguments. The following argument types are supported:
-    1. example.issues.StrIssue(int)
+    1. example.issues.StrIssue(arg0: int)
     2. example.issues.StrIssue()
     Invoked with: no, such, constructor

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -399,7 +399,7 @@ public:
     static handle cast(void_type, return_value_policy /* policy */, handle /* parent */) {
         return handle(Py_None).inc_ref();
     }
-    PYBIND11_TYPE_CASTER(void_type, _("NoneType"));
+    PYBIND11_TYPE_CASTER(void_type, _("None"));
 };
 
 template <> class type_caster<void> : public type_caster<void_type> {
@@ -440,7 +440,7 @@ public:
 
     template <typename T> using cast_op_type = void*&;
     operator void *&() { return value; }
-    static PYBIND11_DESCR name() { return _("capsule"); }
+    static PYBIND11_DESCR name() { return type_descr(_("capsule")); }
 private:
     void *value = nullptr;
 };
@@ -615,8 +615,8 @@ public:
 
     static PYBIND11_DESCR name() {
         return type_descr(
-            _("(") + type_caster<typename intrinsic_type<T1>::type>::name() +
-            _(", ") + type_caster<typename intrinsic_type<T2>::type>::name() + _(")"));
+            _("Tuple[") + type_caster<typename intrinsic_type<T1>::type>::name() +
+            _(", ") + type_caster<typename intrinsic_type<T2>::type>::name() + _("]"));
     }
 
     template <typename T> using cast_op_type = type;
@@ -671,11 +671,12 @@ public:
         return cast(src, policy, parent, typename make_index_sequence<size>::type());
     }
 
+    static PYBIND11_DESCR element_names() {
+        return detail::concat(type_caster<typename intrinsic_type<Tuple>::type>::name()...);
+    }
+    
     static PYBIND11_DESCR name() {
-        return type_descr(
-               _("(") +
-               detail::concat(type_caster<typename intrinsic_type<Tuple>::type>::name()...) +
-               _(")"));
+        return type_descr(_("Tuple[") + element_names() + _("]"));
     }
 
     template <typename ReturnValue, typename Func> typename std::enable_if<!std::is_void<ReturnValue>::value, ReturnValue>::type call(Func &&f) {

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -161,8 +161,8 @@ struct type_caster<Type, typename std::enable_if<is_eigen_dense<Type>::value && 
         }
     }
 
-    PYBIND11_TYPE_CASTER(Type, _("numpy.ndarray[dtype=") + npy_format_descriptor<Scalar>::name() +
-            _(", shape=(") + rows() + _(", ") + cols() + _(")]"));
+    PYBIND11_TYPE_CASTER(Type, _("numpy.ndarray[") + npy_format_descriptor<Scalar>::name() +
+            _("[") + rows() + _(", ") + cols() + _("]]"));
 
 protected:
     template <typename T = Type, typename std::enable_if<T::RowsAtCompileTime == Eigen::Dynamic, int>::type = 0>
@@ -321,7 +321,7 @@ struct type_caster<Type, typename std::enable_if<is_eigen_sparse<Type>::value>::
         ).release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, _<(Type::Flags & Eigen::RowMajorBit) != 0>("scipy.sparse.csr_matrix[dtype=", "scipy.sparse.csc_matrix[dtype=")
+    PYBIND11_TYPE_CASTER(Type, _<(Type::Flags & Eigen::RowMajorBit) != 0>("scipy.sparse.csr_matrix[", "scipy.sparse.csc_matrix[")
             + npy_format_descriptor<Scalar>::name() + _("]"));
 };
 

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -65,10 +65,10 @@ public:
             return cpp_function(std::forward<Func>(f_), policy).release();
     }
 
-    PYBIND11_TYPE_CASTER(type, _("function<") +
-            type_caster<std::tuple<Args...>>::name() + _(" -> ") +
+    PYBIND11_TYPE_CASTER(type, _("Callable[[") +
+            type_caster<std::tuple<Args...>>::element_names() + _("], ") +
             type_caster<retval_type>::name() +
-            _(">"));
+            _("]"));
 };
 
 NAMESPACE_END(detail)

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -385,7 +385,7 @@ struct vectorize_helper {
 };
 
 template <typename T, int Flags> struct handle_type_name<array_t<T, Flags>> {
-    static PYBIND11_DESCR name() { return _("numpy.ndarray[dtype=") + type_caster<T>::name() + _("]"); }
+    static PYBIND11_DESCR name() { return _("numpy.ndarray[") + type_caster<T>::name() + _("]"); }
 };
 
 NAMESPACE_END(detail)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -135,8 +135,8 @@ protected:
         detail::process_attributes<Extra...>::init(extra..., rec);
 
         /* Generate a readable signature describing the function's arguments and return value types */
-        using detail::descr;
-        PYBIND11_DESCR signature = cast_in::name() + detail::_(" -> ") + cast_out::name();
+        using detail::descr; using detail::_;
+        PYBIND11_DESCR signature = _("(") + cast_in::element_names() + _(") -> ") + cast_out::name();
 
         /* Register the function with Python from generic (non-templated) code */
         initialize_generic(rec, signature.text(), signature.types(), sizeof...(Args));
@@ -183,7 +183,7 @@ protected:
 
             if (c == '{') {
                 // Write arg name for everything except *args, **kwargs and return type.
-                if (type_depth == 1 && text[char_index] != '*' && arg_index < args) {
+                if (type_depth == 0 && text[char_index] != '*' && arg_index < args) {
                     if (!rec->args.empty()) {
                         signature += rec->args[arg_index].name;
                     } else if (arg_index == 0 && rec->class_) {
@@ -196,7 +196,7 @@ protected:
                 ++type_depth;
             } else if (c == '}') {
                 --type_depth;
-                if (type_depth == 1) {
+                if (type_depth == 0) {
                     if (arg_index < rec->args.size() && rec->args[arg_index].descr) {
                         signature += "=";
                         signature += rec->args[arg_index].descr;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -157,7 +157,7 @@ protected:
 
     /// Register a function call with Python (generic non-templated code goes here)
     void initialize_generic(detail::function_record *rec, const char *text,
-                            const std::type_info *const *types, int args) {
+                            const std::type_info *const *types, size_t args) {
 
         /* Create copies of all referenced C-style strings */
         rec->name = strdup(rec->name ? rec->name : "");
@@ -182,16 +182,23 @@ protected:
                 break;
 
             if (c == '{') {
-                if (type_depth == 1 && arg_index < rec->args.size()) {
-                    signature += rec->args[arg_index].name;
-                    signature += " : ";
+                // Write arg name for everything except *args, **kwargs and return type.
+                if (type_depth == 1 && text[char_index] != '*' && arg_index < args) {
+                    if (!rec->args.empty()) {
+                        signature += rec->args[arg_index].name;
+                    } else if (arg_index == 0 && rec->class_) {
+                        signature += "self";
+                    } else {
+                        signature += "arg" + std::to_string(arg_index - (rec->class_ ? 1 : 0));
+                    }
+                    signature += ": ";
                 }
                 ++type_depth;
             } else if (c == '}') {
                 --type_depth;
-                if (type_depth == 1 && arg_index < rec->args.size()) {
-                    if (rec->args[arg_index].descr) {
-                        signature += " = ";
+                if (type_depth == 1) {
+                    if (arg_index < rec->args.size() && rec->args[arg_index].descr) {
+                        signature += "=";
                         signature += rec->args[arg_index].descr;
                     }
                     arg_index++;
@@ -453,9 +460,9 @@ protected:
 
                 bool wrote_sig = false;
                 if (overloads->is_constructor) {
-                    // For a constructor, rewrite `(Object, arg0, ...) -> NoneType` as `Object(arg0, ...)`
+                    // For a constructor, rewrite `(self: Object, arg0, ...) -> NoneType` as `Object(arg0, ...)`
                     std::string sig = it2->signature;
-                    size_t start = sig.find('(') + 1;
+                    size_t start = sig.find('(') + 7; // skip "(self: "
                     if (start < sig.size()) {
                         // End at the , for the next argument
                         size_t end = sig.find(", "), next = end + 2;

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -53,7 +53,7 @@ template <typename Type, typename Key> struct set_caster {
         return s.release();
     }
 
-    PYBIND11_TYPE_CASTER(type, _("set<") + key_conv::name() + _(">"));
+    PYBIND11_TYPE_CASTER(type, _("Set[") + key_conv::name() + _("]"));
 };
 
 template <typename Type, typename Key, typename Value> struct map_caster {
@@ -89,7 +89,7 @@ template <typename Type, typename Key, typename Value> struct map_caster {
         return d.release();
     }
 
-    PYBIND11_TYPE_CASTER(type, _("dict<") + key_conv::name() + _(", ") + value_conv::name() + _(">"));
+    PYBIND11_TYPE_CASTER(type, _("Dict[") + key_conv::name() + _(", ") + value_conv::name() + _("]"));
 };
 
 template <typename Type, typename Value> struct list_caster {
@@ -128,7 +128,7 @@ template <typename Type, typename Value> struct list_caster {
         return l.release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, _("list<") + value_conv::name() + _(">"));
+    PYBIND11_TYPE_CASTER(Type, _("List[") + value_conv::name() + _("]"));
 };
 
 template <typename Type, typename Alloc> struct type_caster<std::vector<Type, Alloc>>
@@ -168,7 +168,7 @@ template <typename Type, size_t Size> struct type_caster<std::array<Type, Size>>
         }
         return l.release();
     }
-    PYBIND11_TYPE_CASTER(array_type, _("list<") + value_conv::name() + _(">") + _("[") + _<Size>() + _("]"));
+    PYBIND11_TYPE_CASTER(array_type, _("List[") + value_conv::name() + _("[") + _<Size>() + _("]]"));
 };
 
 template <typename Key, typename Compare, typename Alloc> struct type_caster<std::set<Key, Compare, Alloc>>


### PR DESCRIPTION
This PR concerns IDEs (like [PyCharm](https://www.jetbrains.com/pycharm/)) and static analysis tools (like [Jedi](http://jedi.jedidjah.ch/en/latest/)) which deal with binary extensions by parsing the docstring and trying to reconstruct the function definition. I believe a few tweaks can be made in pybind11's signature generation to improve compatibility with these tools.

I've divided the proposal here in 3 parts. The first part is implemented already in this commit. The second and third part require a bit more work so I'm just outlining the intentions first.

### Part 1: Uniform `name: type=default_value` parameter signatures

When exporting a function without any named arguments, pybind11 will just write the types in the docstring. For example, for a method:
```python
"""foo(Object, int, int)"""  # self + 2 args
```
I ran into this problem with PyCharm, where it would look at that docstring and reconstruct the function incorrectly as 
```python
def foo(self, object, p_int0, p_int1):  # self + 3 args -- wrong reconstruction
```
This is because some binary modules like `numpy` established the convention that `self` should be added implicitly for methods if the first argument isn't already called `self`. Note also that it interprets `int` as an arg name and tries to reconstruct the function with valid unique identifiers.

This PR changes the way unnamed arguments are documented to:
```python
"""foo(self: Object, arg0: int, arg1: int)"""
```
This matches named arguments and makes for easier parsing for static analysis. See the commit message for details.

### Part 2: Use PEP 484 type hints

[PEP 484](https://www.python.org/dev/peps/pep-0484/) defines a standard way for annotating types in Python. It would be nice if this was adopted in pybind11. For example, this would replace the current `list<int>` type annotation with the PEP484-style `List[int]`. This would essentially be a style change, but hopefully one that should be broadly adopted.

If this is acceptable, I can quickly add the changes to this PR.

### Part 3: Signature object

[PEP 362](https://www.python.org/dev/peps/pep-0362/) defines a common way to express function signatures in Python. Builtins and binary parts of the library have started to adopt this convention by adding the `__signature__` attribute. If pybind11 adopted this, analysis tools could simply use Python's `inspect` module to get function signatures and there wouldn't be any need to parse the docstring.

This last part would be a bit more involved and I'd probably like to separate it into a different PR if there is interest.