### PR TITLE
Fix zero valued enum comparison error

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1019,7 +1019,7 @@ public:
         this->def("__init__", [](Type& value, UnderlyingType i) { new (&value) Type((Type) i); });
         this->def("__int__", [](Type value) { return (UnderlyingType) value; });
         this->def("__eq__", [](const Type &value, Type *value2) { return value2 && value == *value2; });
-        this->def("__eq__", [](const Type &value, UnderlyingType value2) { return value2 && value == value2; });
+        this->def("__eq__", [](const Type &value, UnderlyingType value2) { return value == value2; });
         this->def("__ne__", [](const Type &value, Type *value2) { return !value2 || value != *value2; });
         this->def("__ne__", [](const Type &value, UnderlyingType value2) { return value != value2; });
         this->def("__hash__", [](const Type &value) { return (UnderlyingType) value; });


### PR DESCRIPTION
Unfortunately a copy-and-paste error crept in my previous PR. This caused comparisons of enums with zero value to fail. This commit fixes that problem.
Sorry.