### PR TITLE
Add support for Eigen::Ref<...> function arguments

### DIFF
--- a/example/eigen.cpp
+++ b/example/eigen.cpp
@@ -9,6 +9,7 @@
 
 #include "example.h"
 #include <pybind11/eigen.h>
+#include <Eigen/Cholesky>
 
 Eigen::VectorXf double_col(const Eigen::VectorXf& x)
 { return 2.0f * x; }
@@ -18,6 +19,14 @@ Eigen::RowVectorXf double_row(const Eigen::RowVectorXf& x)
 
 Eigen::MatrixXf double_mat_cm(const Eigen::MatrixXf& x)
 { return 2.0f * x; }
+
+// Different ways of passing via Eigen::Ref; the first and second are the Eigen-recommended
+Eigen::MatrixXd cholesky1(Eigen::Ref<Eigen::MatrixXd> &x) { return x.llt().matrixL(); }
+Eigen::MatrixXd cholesky2(const Eigen::Ref<const Eigen::MatrixXd> &x) { return x.llt().matrixL(); }
+Eigen::MatrixXd cholesky3(const Eigen::Ref<Eigen::MatrixXd> &x) { return x.llt().matrixL(); }
+Eigen::MatrixXd cholesky4(Eigen::Ref<const Eigen::MatrixXd> &x) { return x.llt().matrixL(); }
+Eigen::MatrixXd cholesky5(Eigen::Ref<Eigen::MatrixXd> x) { return x.llt().matrixL(); }
+Eigen::MatrixXd cholesky6(Eigen::Ref<const Eigen::MatrixXd> x) { return x.llt().matrixL(); }
 
 typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> MatrixXfRowMajor;
 MatrixXfRowMajor double_mat_rm(const MatrixXfRowMajor& x)
@@ -40,6 +49,12 @@ void init_eigen(py::module &m) {
     m.def("double_row", &double_row);
     m.def("double_mat_cm", &double_mat_cm);
     m.def("double_mat_rm", &double_mat_rm);
+    m.def("cholesky1", &cholesky1);
+    m.def("cholesky2", &cholesky2);
+    m.def("cholesky3", &cholesky3);
+    m.def("cholesky4", &cholesky4);
+    m.def("cholesky5", &cholesky5);
+    m.def("cholesky6", &cholesky6);
 
     m.def("fixed_r", [mat]() -> FixedMatrixR { 
         return FixedMatrixR(mat);

--- a/example/eigen.py
+++ b/example/eigen.py
@@ -11,6 +11,7 @@ from example import sparse_r, sparse_c
 from example import sparse_passthrough_r, sparse_passthrough_c
 from example import double_row, double_col
 from example import double_mat_cm, double_mat_rm
+from example import cholesky1, cholesky2, cholesky3, cholesky4, cholesky5, cholesky6
 try:
     import numpy as np
     import scipy
@@ -70,3 +71,10 @@ slices = [counting_3d[0, :, :], counting_3d[:, 0, :], counting_3d[:, :, 0]]
 for slice_idx, ref_mat in enumerate(slices):
     print("double_mat_cm(%d) = %s" % (slice_idx, check_got_vs_ref(double_mat_cm(ref_mat), 2.0 * ref_mat)))
     print("double_mat_rm(%d) = %s" % (slice_idx, check_got_vs_ref(double_mat_rm(ref_mat), 2.0 * ref_mat)))
+
+i = 1
+for chol in [cholesky1, cholesky2, cholesky3, cholesky4, cholesky5, cholesky6]:
+    mymat = chol(np.array([[1,2,4], [2,13,23], [4,23,77]]))
+    print("cholesky" + str(i) + " " + ("OK" if (mymat == np.array([[1,0,0], [2,3,0], [4,5,6]])).all() else "NOT OKAY"))
+    i += 1
+

--- a/example/eigen.ref
+++ b/example/eigen.ref
@@ -27,3 +27,9 @@ double_mat_cm(1) = OK
 double_mat_rm(1) = OK
 double_mat_cm(2) = OK
 double_mat_rm(2) = OK
+cholesky1 OK
+cholesky2 OK
+cholesky3 OK
+cholesky4 OK
+cholesky5 OK
+cholesky6 OK


### PR DESCRIPTION
Eigen::Ref is a common way to pass eigen dense types without needing a template, e.g. the single definition `void func(const Eigen::Ref<const Eigen::MatrixXd> &x)` is a useful signature to accept any double-coefficient matrix-like object/block/etc. (without needing the implementation in a template.)

The current pybind11 eigen support fails with internal errors if attempting to bind a function with an Eigen::Ref<...> argument because, while Eigen::Ref<...> satisfies the "is_eigen_dense" requirement, it can't compile if used: Eigen::Ref<...> itself is not default constructible, and so the argument loader can't default construct an std::tuple containing an Eigen::Ref<...>, which results in compilation failure.

This commit adds support for Eigen::Ref<...> arguments by giving it its own type_caster implementation which basically is just a wrapper around the type_caster for the referenced type with a unique_ptr storing the required Ref object (which itself references the wrapped type_caster).

There is, of course, no performance advantage for pybind11-using code of using Eigen::Ref<...>--we are allocating a matrix of the derived type when loading it--this is mainly about allowing pybind11 to bind transparently to C++ methods taking Eigen::Refs.