### PR TITLE
Added advanced doc section on virtual methods + inheritance

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -470,10 +470,6 @@ can now create a python class that inherits from ``Dog``:
     See the file :file:`example-virtual-functions.cpp` for complete examples
     using both the duplication and templated trampoline approaches.
 
-    The file also contains a more intrusive approach using multiple
-    inheritance, which may be useful in special situations with deep class
-    hierarchies to avoid code generation.
-
 .. _macro_notes:
 
 General notes regarding convenience macros

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -232,7 +232,7 @@ code).
 
     class Dog : public Animal {
     public:
-        std::string go(int n_times) {
+        std::string go(int n_times) override {
             std::string result;
             for (int i=0; i<n_times; ++i)
                 result += "woof! ";
@@ -283,7 +283,7 @@ helper class that is defined as follows:
         using Animal::Animal;
 
         /* Trampoline (need one for each virtual function) */
-        std::string go(int n_times) {
+        std::string go(int n_times) override {
             PYBIND11_OVERLOAD_PURE(
                 std::string, /* Return type */
                 Animal,      /* Parent class */
@@ -328,6 +328,11 @@ by specifying it as the *third* template argument to :class:`class_`. The
 second argument with the unique pointer is simply the default holder type used
 by pybind11. Following this, we are able to define a constructor as usual.
 
+Note, however, that the above is sufficient for allowing python classes to
+extend ``Animal``, but not ``Dog``: see ref:`virtual_and_inheritance` for the
+necessary steps required to providing proper overload support for inherited
+classes.
+
 The Python session below shows how to override ``Animal::go`` and invoke it via
 a virtual method call.
 
@@ -353,6 +358,121 @@ Please take a look at the :ref:`macro_notes` before using this feature.
     example that demonstrates how to override virtual functions using pybind11
     in more detail.
 
+.. _virtual_and_inheritance:
+
+Combining virtual functions and inheritance
+===========================================
+
+When combining virtual methods with inheritance, you need to be sure to provide
+an override for each method for which you want to allow overrides from derived
+python classes.  For example, suppose we extend the above ``Animal``/``Dog``
+example as follows:
+
+.. code-block:: cpp
+    class Animal {
+    public:
+        virtual std::string go(int n_times) = 0;
+        virtual std::string name() { return "unknown"; }
+    };
+    class Dog : public class Animal {
+    public:
+        std::string go(int n_times) override {
+            std::string result;
+            for (int i=0; i<n_times; ++i)
+                result += bark() + " ";
+            return result;
+        }
+        virtual std::string bark() { return "woof!"; }
+    };
+
+then the trampoline class for ``Animal`` must, as described in the previous
+section, override ``go()`` and ``name()``, but in order to allow python code to
+inherit properly from ``Dog``, we also need a trampoline class for ``Dog`` that
+overrides both the added ``bark()`` method *and* the ``go()`` and ``name()``
+methods inherited from ``Animal`` (even though ``Dog`` doesn't directly
+override the ``name()`` method):
+
+.. code-block:: cpp
+    class PyAnimal : public Animal {
+    public:
+        using Animal::Animal; // Inherit constructors
+        std::string go(int n_times) override { PYBIND11_OVERLOAD_PURE(std::string, Animal, go, n_times); }
+        std::string name() override { PYBIND11_OVERLOAD(std::string, Animal, name, ); }
+    };
+    class PyDog : public Dog {
+    public:
+        using Dog::Dog; // Inherit constructors
+        std::string go(int n_times) override { PYBIND11_OVERLOAD_PURE(std::string, Dog, go, n_times); }
+        std::string name() override { PYBIND11_OVERLOAD(std::string, Dog, name, ); }
+        std::string bark() override { PYBIND11_OVERLOAD(std::string, Dog, bark, ); }
+    };
+
+A registered class derived from a pybind11-registered class with virtual
+methods requires a similar trampoline class, *even if* it doesn't explicitly
+declare or override any virtual methods itself:
+
+.. code-block:: cpp
+    class Husky : public Dog {};
+    class PyHusky : public Husky {
+        using Dog::Dog; // Inherit constructors
+        std::string go(int n_times) override { PYBIND11_OVERLOAD_PURE(std::string, Husky, go, n_times); }
+        std::string name() override { PYBIND11_OVERLOAD(std::string, Husky, name, ); }
+        std::string bark() override { PYBIND11_OVERLOAD(std::string, Husky, bark, ); }
+    };
+
+There is, however, a technique that can be used to avoid this duplication
+(which can be especially helpful for a base class with several virtual
+methods).  The technique involves using template trampoline classes, as
+follows:
+
+.. code-block:: cpp
+    template <class AnimalBase = Animal> class PyAnimal : public AnimalBase {
+        using AnimalBase::AnimalBase; // Inherit constructors
+        std::string go(int n_times) override { PYBIND11_OVERLOAD_PURE(std::string, AnimalBase, go, n_times); }
+        std::string name() override { PYBIND11_OVERLOAD(std::string, AnimalBase, name, ); }
+    };
+    template <class DogBase = Dog> class PyDog : public PyAnimal<DogBase> {
+        using PyAnimal<DogBase>::PyAnimal; // Inherit constructors
+        // Override PyAnimal's pure virtual go() with a non-pure one:
+        std::string go(int n_times) override { PYBIND11_OVERLOAD(std::string, DogBase, go, n_times); }
+        std::string bark() override { PYBIND11_OVERLOAD(std::string, DogBase, bark, ); }
+    };
+
+This technique has the advantage of requiring just one trampoline method to be
+declared per virtual method and pure virtual method override.  It does,
+however, require the compiler to generate at least as many methods (and
+possibly more, if both pure virtual and overridden pure virtual methods are
+exposed, as above).
+
+The classes are then registered with pybind11 using:
+
+.. code-block:: cpp
+    py::class_<Animal, std::unique_ptr<Animal>, PyAnimal<>> animal(m, "Animal");
+    py::class_<Dog, std::unique_ptr<Dog>, PyDog<>> dog(m, "Dog");
+    py::class_<Husky, std::unique_ptr<Husky>, PyDog<Husky>> husky(m, "Husky");
+    // ... add animal, dog, husky definitions
+
+Note that ``Husky`` did not require a dedicated trampoline template class at
+all, since it neither declares any new virtual methods nor provides any pure
+virtual method implementations.
+
+With either the repeated-virtuals or templated trampoline methods in place, you
+can now create a python class that inherits from ``Dog``:
+
+.. code-block:: python
+
+    class ShihTzu(Dog):
+        def bark(self):
+            return "yip!"
+
+.. seealso::
+
+    See the file :file:`example-virtual-functions.cpp` for complete examples
+    using both the duplication and templated trampoline approaches.
+
+    The file also contains a more intrusive approach using multiple
+    inheritance, which may be useful in special situations with deep class
+    hierarchies to avoid code generation.
 
 .. _macro_notes:
 

--- a/example/example-virtual-functions.py
+++ b/example/example-virtual-functions.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append('.')
 
 from example import ExampleVirt, runExampleVirt, runExampleVirtVirtual, runExampleVirtBool
-from example import A_Repeat, B_Repeat, C_Repeat, D_Repeat, A_MI, B_MI, C_MI, D_MI, A_Tpl, B_Tpl, C_Tpl, D_Tpl
+from example import A_Repeat, B_Repeat, C_Repeat, D_Repeat, A_Tpl, B_Tpl, C_Tpl, D_Tpl
 
 class ExtendedExampleVirt(ExampleVirt):
     def __init__(self, state):
@@ -40,11 +40,6 @@ sys.stdout.flush()
 class VI_AR(A_Repeat):
     def unlucky_number(self):
         return 99
-class VI_AMI(A_MI):
-    def unlucky_number(self):
-        return 990
-    def say_something(self, times):
-        return A_MI.say_something(self, 2*times)
 class VI_AT(A_Tpl):
     def unlucky_number(self):
         return 999
@@ -52,17 +47,11 @@ class VI_AT(A_Tpl):
 class VI_CR(C_Repeat):
     def lucky_number(self):
         return C_Repeat.lucky_number(self) + 1.25
-class VI_CMI(C_MI):
-    def lucky_number(self):
-        return 1.75
 class VI_CT(C_Tpl):
     pass
 class VI_CCR(VI_CR):
     def lucky_number(self):
         return VI_CR.lucky_number(self) * 10
-class VI_CCMI(VI_CMI):
-    def lucky_number(self):
-        return VI_CMI.lucky_number(self) * 100
 class VI_CCT(VI_CT):
     def lucky_number(self):
         return VI_CT.lucky_number(self) * 1000
@@ -73,11 +62,6 @@ class VI_DR(D_Repeat):
         return 123
     def lucky_number(self):
         return 42.0
-class VI_DMI(D_MI):
-    def unlucky_number(self):
-        return 1230
-    def lucky_number(self):
-        return -9.5
 class VI_DT(D_Tpl):
     def say_something(self, times):
         print("VI_DT says:" + (' quack' * times))
@@ -87,12 +71,12 @@ class VI_DT(D_Tpl):
         return -4.25
 
 classes = [
-    # A_Repeat, A_MI, A_Tpl, # abstract (they have a pure virtual unlucky_number)
-    VI_AR, VI_AMI, VI_AT,
-    B_Repeat, B_MI, B_Tpl,
-    C_Repeat, C_MI, C_Tpl,
-    VI_CR, VI_CMI, VI_CT, VI_CCR, VI_CCMI, VI_CCT,
-    D_Repeat, D_MI, D_Tpl, VI_DR, VI_DMI, VI_DT
+    # A_Repeat, A_Tpl, # abstract (they have a pure virtual unlucky_number)
+    VI_AR, VI_AT,
+    B_Repeat, B_Tpl,
+    C_Repeat, C_Tpl,
+    VI_CR, VI_CT, VI_CCR, VI_CCT,
+    D_Repeat, D_Tpl, VI_DR, VI_DT
 ]
 
 for cl in classes:

--- a/example/example-virtual-functions.py
+++ b/example/example-virtual-functions.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append('.')
 
 from example import ExampleVirt, runExampleVirt, runExampleVirtVirtual, runExampleVirtBool
-
+from example import A_Repeat, B_Repeat, C_Repeat, D_Repeat, A_MI, B_MI, C_MI, D_MI, A_Tpl, B_Tpl, C_Tpl, D_Tpl
 
 class ExtendedExampleVirt(ExampleVirt):
     def __init__(self, state):
@@ -34,3 +34,72 @@ ex12p = ExtendedExampleVirt(10)
 print(runExampleVirt(ex12p, 20))
 print(runExampleVirtBool(ex12p))
 runExampleVirtVirtual(ex12p)
+
+sys.stdout.flush()
+
+class VI_AR(A_Repeat):
+    def unlucky_number(self):
+        return 99
+class VI_AMI(A_MI):
+    def unlucky_number(self):
+        return 990
+    def say_something(self, times):
+        return A_MI.say_something(self, 2*times)
+class VI_AT(A_Tpl):
+    def unlucky_number(self):
+        return 999
+
+class VI_CR(C_Repeat):
+    def lucky_number(self):
+        return C_Repeat.lucky_number(self) + 1.25
+class VI_CMI(C_MI):
+    def lucky_number(self):
+        return 1.75
+class VI_CT(C_Tpl):
+    pass
+class VI_CCR(VI_CR):
+    def lucky_number(self):
+        return VI_CR.lucky_number(self) * 10
+class VI_CCMI(VI_CMI):
+    def lucky_number(self):
+        return VI_CMI.lucky_number(self) * 100
+class VI_CCT(VI_CT):
+    def lucky_number(self):
+        return VI_CT.lucky_number(self) * 1000
+
+
+class VI_DR(D_Repeat):
+    def unlucky_number(self):
+        return 123
+    def lucky_number(self):
+        return 42.0
+class VI_DMI(D_MI):
+    def unlucky_number(self):
+        return 1230
+    def lucky_number(self):
+        return -9.5
+class VI_DT(D_Tpl):
+    def say_something(self, times):
+        print("VI_DT says:" + (' quack' * times))
+    def unlucky_number(self):
+        return 1234
+    def lucky_number(self):
+        return -4.25
+
+classes = [
+    # A_Repeat, A_MI, A_Tpl, # abstract (they have a pure virtual unlucky_number)
+    VI_AR, VI_AMI, VI_AT,
+    B_Repeat, B_MI, B_Tpl,
+    C_Repeat, C_MI, C_Tpl,
+    VI_CR, VI_CMI, VI_CT, VI_CCR, VI_CCMI, VI_CCT,
+    D_Repeat, D_MI, D_Tpl, VI_DR, VI_DMI, VI_DT
+]
+
+for cl in classes:
+    print("\n%s:" % cl.__name__)
+    obj = cl()
+    obj.say_something(3)
+    print("Unlucky = %d" % obj.unlucky_number())
+    if hasattr(obj, "lucky_number"):
+        print("Lucky = %.2f" % obj.lucky_number())
+

--- a/example/example-virtual-functions.ref
+++ b/example/example-virtual-functions.ref
@@ -14,20 +14,11 @@ VI_AR:
 hihihi
 Unlucky = 99
 
-VI_AMI:
-hihihihihihi
-Unlucky = 990
-
 VI_AT:
 hihihi
 Unlucky = 999
 
 B_Repeat:
-B says hi 3 times
-Unlucky = 13
-Lucky = 7.00
-
-B_MI:
 B says hi 3 times
 Unlucky = 13
 Lucky = 7.00
@@ -42,11 +33,6 @@ B says hi 3 times
 Unlucky = 4444
 Lucky = 888.00
 
-C_MI:
-B says hi 3 times
-Unlucky = 4444
-Lucky = 888.00
-
 C_Tpl:
 B says hi 3 times
 Unlucky = 4444
@@ -56,11 +42,6 @@ VI_CR:
 B says hi 3 times
 Unlucky = 4444
 Lucky = 889.25
-
-VI_CMI:
-B says hi 3 times
-Unlucky = 4444
-Lucky = 1.75
 
 VI_CT:
 B says hi 3 times
@@ -72,22 +53,12 @@ B says hi 3 times
 Unlucky = 4444
 Lucky = 8892.50
 
-VI_CCMI:
-B says hi 3 times
-Unlucky = 4444
-Lucky = 175.00
-
 VI_CCT:
 B says hi 3 times
 Unlucky = 4444
 Lucky = 888000.00
 
 D_Repeat:
-B says hi 3 times
-Unlucky = 4444
-Lucky = 888.00
-
-D_MI:
 B says hi 3 times
 Unlucky = 4444
 Lucky = 888.00
@@ -101,11 +72,6 @@ VI_DR:
 B says hi 3 times
 Unlucky = 123
 Lucky = 42.00
-
-VI_DMI:
-B says hi 3 times
-Unlucky = 1230
-Lucky = -9.50
 
 VI_DT:
 VI_DT says: quack quack quack

--- a/example/example-virtual-functions.ref
+++ b/example/example-virtual-functions.ref
@@ -9,5 +9,107 @@ Original implementation of ExampleVirt::run(state=11, value=21)
 ExtendedExampleVirt::run_bool()
 False
 ExtendedExampleVirt::pure_virtual(): Hello world
+
+VI_AR:
+hihihi
+Unlucky = 99
+
+VI_AMI:
+hihihihihihi
+Unlucky = 990
+
+VI_AT:
+hihihi
+Unlucky = 999
+
+B_Repeat:
+B says hi 3 times
+Unlucky = 13
+Lucky = 7.00
+
+B_MI:
+B says hi 3 times
+Unlucky = 13
+Lucky = 7.00
+
+B_Tpl:
+B says hi 3 times
+Unlucky = 13
+Lucky = 7.00
+
+C_Repeat:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 888.00
+
+C_MI:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 888.00
+
+C_Tpl:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 888.00
+
+VI_CR:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 889.25
+
+VI_CMI:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 1.75
+
+VI_CT:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 888.00
+
+VI_CCR:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 8892.50
+
+VI_CCMI:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 175.00
+
+VI_CCT:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 888000.00
+
+D_Repeat:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 888.00
+
+D_MI:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 888.00
+
+D_Tpl:
+B says hi 3 times
+Unlucky = 4444
+Lucky = 888.00
+
+VI_DR:
+B says hi 3 times
+Unlucky = 123
+Lucky = 42.00
+
+VI_DMI:
+B says hi 3 times
+Unlucky = 1230
+Lucky = -9.50
+
+VI_DT:
+VI_DT says: quack quack quack
+Unlucky = 1234
+Lucky = -4.25
 Destructing ExampleVirt..
 Destructing ExampleVirt..


### PR DESCRIPTION
As discussed in #320.

The adds a documentation block that mentions that the trampoline classes must provide overrides for both the classes' own virtual methods *and* any inherited virtual methods.  It also provides a templated solution to avoiding method duplication.

The example includes a third method (only mentioned in the "see also" section of the documentation addition), using multiple inheritance. While this approach works, and avoids code generation in deep hierarchies, it is intrusive by requiring that the wrapped classes use virtual inheritance, which itself is more instrusive if any of the virtual base classes need anything other than default constructors.  As per the discussion in #320, it is kept as an example, but not suggested in the documentation.