### PR TITLE
Decay types before passing to is_pod_struct<> / npy_format_descriptor<>

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -29,8 +29,6 @@ NAMESPACE_BEGIN(pybind11)
 namespace detail {
 template <typename type, typename SFINAE = void> struct npy_format_descriptor { };
 template <typename type> struct is_pod_struct;
-template <typename T> using decay_cv_ref =
-    typename std::remove_cv<typename std::remove_reference<T>::type>::type;
 
 struct npy_api {
     enum constants {
@@ -148,7 +146,7 @@ public:
     }
 
     template <typename T> static dtype of() {
-        return detail::npy_format_descriptor<T>::dtype();
+        return detail::npy_format_descriptor<typename std::remove_cv<T>::type>::dtype();
     }
 
     size_t itemsize() const {
@@ -306,7 +304,9 @@ public:
 
 template <typename T>
 struct format_descriptor<T, typename std::enable_if<detail::is_pod_struct<T>::value>::type> {
-    static std::string format() { return detail::npy_format_descriptor<T>::format(); }
+    static std::string format() {
+        return detail::npy_format_descriptor<typename std::remove_cv<T>::type>::format();
+    }
 };
 
 template <size_t N> struct format_descriptor<char[N]> {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -29,6 +29,8 @@ NAMESPACE_BEGIN(pybind11)
 namespace detail {
 template <typename type, typename SFINAE = void> struct npy_format_descriptor { };
 template <typename type> struct is_pod_struct;
+template <typename T> using decay_cv_ref =
+    typename std::remove_cv<typename std::remove_reference<T>::type>::type;
 
 struct npy_api {
     enum constants {
@@ -321,14 +323,15 @@ template <typename T, size_t N> struct is_std_array<std::array<T, N>> : std::tru
 template <typename T>
 struct is_pod_struct {
     enum { value = std::is_pod<T>::value && // offsetof only works correctly for POD types
+           !std::is_reference<T>::value &&
            !std::is_array<T>::value &&
            !is_std_array<T>::value &&
            !std::is_integral<T>::value &&
-           !std::is_same<T, float>::value &&
-           !std::is_same<T, double>::value &&
-           !std::is_same<T, bool>::value &&
-           !std::is_same<T, std::complex<float>>::value &&
-           !std::is_same<T, std::complex<double>>::value };
+           !std::is_same<typename std::remove_cv<T>::type, float>::value &&
+           !std::is_same<typename std::remove_cv<T>::type, double>::value &&
+           !std::is_same<typename std::remove_cv<T>::type, bool>::value &&
+           !std::is_same<typename std::remove_cv<T>::type, std::complex<float>>::value &&
+           !std::is_same<typename std::remove_cv<T>::type, std::complex<double>>::value };
 };
 
 template <typename T> struct npy_format_descriptor<T, typename std::enable_if<std::is_integral<T>::value>::type> {


### PR DESCRIPTION
I was trying to simplify some code in `eigen.h` using the new array ctors when I noticed that `is_pod_struct` didn't behave properly when given `const float` as argument, so the types need to be decayed first (`std::decay` won't cut it though, hence remove_reference/remove_cv).

The same issue applies to `npy_format_descriptor` (likely to have been a problem previously as well, just went unnoticed); in addition this fix should avoid some potential code bloat.

This PR basically decays all types before passing them to `is_pod_struct<>` and `npy_format_descriptor<>`. These should not be used manually outside of `numpy.h` anyway.

Note: this is to be merged in only after #334 is merged and I'll rebase this (this branch is branched off there, so contains the format descriptor commit).