### PR TITLE
Add g++-6 builds to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,53 +4,89 @@ matrix:
   include:
   - os: linux
     compiler: gcc-4.8
-    env: PYTHON=2.7 CPP=11
+    env: PYTHON=2.7 CPP=11 GCC=4.8
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - kubuntu-backports # cmake 2.8.12
+        packages:
+        - g++-4.8
+        - cmake
   - os: linux
     compiler: gcc-4.8
-    env: PYTHON=3.5 CPP=11
+    env: PYTHON=3.5 CPP=11 GCC=4.8
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - deadsnakes
+        - kubuntu-backports # cmake 2.8.12
+        packages:
+        - g++-4.8
+        - python3.5-dev
+        - cmake
   - os: osx
     osx_image: xcode7.3
     env: PYTHON=2.7 CPP=14
   - os: osx
     osx_image: xcode7.3
     env: PYTHON=3.5 CPP=14
+  - compiler: gcc-6
+    services: docker
+    sudo: true
+    env: PYTHON=2.7 CPP=14 DOCKER=debian:testing NATIVE_DEPS=1
+    install:
+    - docker exec --tty "$containerid" apt-get -y --no-install-recommends install python2.7-dev python-scipy libeigen3-dev cmake make g++
+  - compiler: gcc-6
+    services: docker
+    sudo: true
+    env: PYTHON=3.5 CPP=14 DOCKER=debian:testing NATIVE_DEPS=1
+    install:
+    - docker exec --tty "$containerid" apt-get -y --no-install-recommends install python3.5-dev python3-scipy libeigen3-dev cmake make g++
 cache:
   directories:
   - $HOME/.cache/pip
   - ccache
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - deadsnakes
-      - kubuntu-backports # cmake 2.8.12
-    packages:
-      - g++-4.8
-      - python3.5
-      - python3.5-dev
-      - cmake
+before_install:
+- |
+  if [ -n "$DOCKER" ]; then
+    docker pull $DOCKER
+    export containerid=$(docker run --detach --tty \
+      --volume="$PWD":/pybind11 --workdir=/pybind11 \
+      --env="CC=$CC" --env="CXX=$CXX" --env="DEBIAN_FRONTEND=$DEBIAN_FRONTEND" \
+      --env=GCC_COLORS=\  \
+      $DOCKER)
+    docker exec --tty "$containerid" apt-get update
+    docker exec --tty "$containerid" apt-get -y upgrade
+    export SCRIPT_RUN_PREFIX="docker exec --tty $containerid"
+  fi
 install:
 - |
-  if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    export CXX=g++-4.8 CC=gcc-4.8;
-    pip install --user --upgrade pip virtualenv
-    virtualenv -p python$PYTHON venv
-  elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    if [ "${PYTHON:0:1}" = "3" ]; then
-      PMAJOR=3; brew update; brew install python$PMAJOR;
-    else
-      curl -fsSL -O https://bootstrap.pypa.io/get-pip.py
-      sudo -H python get-pip.py
+  if [ -z "$NATIVE_DEPS" ]; then
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      if [ -n "$GCC" ]; then export CXX=g++-$GCC CC=gcc-$GCC; fi
+      pip install --user --upgrade pip virtualenv
+      virtualenv -p python$PYTHON venv
+    elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      if [ "${PYTHON:0:1}" = "3" ]; then
+        PMAJOR=3; brew update; brew install python$PMAJOR;
+      else
+        curl -fsSL -O https://bootstrap.pypa.io/get-pip.py
+        sudo -H python get-pip.py
+      fi
+      pip$PMAJOR install --user --upgrade pip virtualenv
+      python$PMAJOR -m virtualenv venv
     fi
-    pip$PMAJOR install --user --upgrade pip virtualenv
-    python$PMAJOR -m virtualenv venv
+    source venv/bin/activate
+    pip install numpy scipy
+
+    wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz
+    tar xzf eigen.tar.gz
+    export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=eigen-eigen-dc6cfdf9bcec"
   fi
-  source venv/bin/activate
-  pip install numpy scipy
-- |
-  wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz
-  tar xzf eigen.tar.gz
-  export CMAKE_INCLUDE_PATH=eigen-eigen-dc6cfdf9bcec
 script:
-- cmake -DPYBIND11_PYTHON_VERSION=$PYTHON -DPYBIND11_CPP_STANDARD=-std=c++$CPP
-- CTEST_OUTPUT_ON_FAILURE=TRUE make check -j 2
+- $SCRIPT_RUN_PREFIX cmake ${CMAKE_EXTRA_ARGS} -DPYBIND11_PYTHON_VERSION=$PYTHON -DPYBIND11_CPP_STANDARD=-std=c++$CPP
+- $SCRIPT_RUN_PREFIX make CTEST_OUTPUT_ON_FAILURE=TRUE check -j 2
+after_script:
+- if [ -n "$DOCKER" ]; then docker stop "$containerid"; docker rm "$containerid"; fi


### PR DESCRIPTION
The current linux/g++ testing (using a backported g++-4.8 on a 4-year-old Ubuntu) is quite ancient.  It's good as a baseline level of support, but it means we aren't testing g++'s C++14 support at all (which is why #334 happened).

This commit adds a docker-based travis-ci build using the debian "testing" distribution, which will give us both another test system (with different versions of build tools), while, more importantly, also adding a build and test run using g++ in C++14 mode.