### PR TITLE
Report warnings as errors on Travis and AppVeyor (-Werror)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,6 +28,6 @@ install:
     7z x 3.2.9.zip -y > $null
     $env:CMAKE_INCLUDE_PATH = "eigen-eigen-dc6cfdf9bcec"
 build_script:
-- cmake -A "%CMAKE_ARCH%"
+- cmake -A "%CMAKE_ARCH%" -DPYBIND11_WERROR=ON
 - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - cmake --build . --config Release --target check -- /v:m /logger:%MSBuildLogger%

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,10 @@ install:
     export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=eigen-eigen-dc6cfdf9bcec"
   fi
 script:
-- $SCRIPT_RUN_PREFIX cmake ${CMAKE_EXTRA_ARGS} -DPYBIND11_PYTHON_VERSION=$PYTHON -DPYBIND11_CPP_STANDARD=-std=c++$CPP
+- $SCRIPT_RUN_PREFIX cmake ${CMAKE_EXTRA_ARGS}
+    -DPYBIND11_PYTHON_VERSION=$PYTHON
+    -DPYBIND11_CPP_STANDARD=-std=c++$CPP
+    -DPYBIND11_WERROR=ON
 - $SCRIPT_RUN_PREFIX make CTEST_OUTPUT_ON_FAILURE=TRUE check -j 2
 after_script:
 - if [ -n "$DOCKER" ]; then docker stop "$containerid"; docker rm "$containerid"; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 option(PYBIND11_INSTALL "Install pybind11 header files?" ${PYBIND11_MASTER_PROJECT})
 option(PYBIND11_TEST    "Build pybind11 test suite?"     ${PYBIND11_MASTER_PROJECT})
+option(PYBIND11_WERROR  "Report all warnings as errors"  OFF)
 
 # Add a CMake parameter for choosing a desired Python version
 set(PYBIND11_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling the example application")
@@ -141,6 +142,14 @@ function(pybind11_enable_warnings target_name)
     target_compile_options(${target_name} PRIVATE /W4)
   else()
     target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wconversion)
+  endif()
+
+  if(PYBIND11_WERROR)
+    if(MSVC)
+        target_compile_options(${target_name} PRIVATE /WX)
+    else()
+        target_compile_options(${target_name} PRIVATE -Werror)
+    endif()
   endif()
 endfunction()
 

--- a/example/example-methods-and-attributes.cpp
+++ b/example/example-methods-and-attributes.cpp
@@ -8,8 +8,6 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include <unordered_map>
-#include <list>
 #include "example.h"
 #include "constructor-stats.h"
 


### PR DESCRIPTION
Warnings sometimes go unnoticed because they require manually looking through all the CI logs. This PR turns on `-Werror` (`/WX`) to make warnings easily noticeable. This only applies to the Travis/AppVeyor builds -- the offline default is normal warnings.

The second commit fixed [this warning on Python 2.7](https://travis-ci.org/pybind/pybind11/jobs/152310057#L425).