### PR TITLE
Allow optional callback as function argument

### DIFF
--- a/example/example-callbacks.cpp
+++ b/example/example-callbacks.cpp
@@ -35,6 +35,13 @@ py::cpp_function test_callback5() {
        py::arg("number"));
 }
 
+void test_callback6(const std::function<int(int)> *func = nullptr) {
+    if (func != nullptr && *func)
+        cout << "func(21) = " << (*func)(21) << std::endl;
+    else
+        cout << "func not provided" << std::endl;
+}
+
 int dummy_function(int i) { return i + 1; }
 int dummy_function2(int i, int j) { return i + j; }
 std::function<int(int)> roundtrip(std::function<int(int)> f) { 
@@ -79,6 +86,7 @@ void init_ex_callbacks(py::module &m) {
     m.def("test_callback3", &test_callback3);
     m.def("test_callback4", &test_callback4);
     m.def("test_callback5", &test_callback5);
+    m.def("test_callback6", &test_callback6, py::arg("func") = (std::function<int(int)> *)nullptr);
 
     /* Test cleanup of lambda closure */
 

--- a/example/example-callbacks.py
+++ b/example/example-callbacks.py
@@ -30,6 +30,7 @@ from example import test_callback2
 from example import test_callback3
 from example import test_callback4
 from example import test_callback5
+from example import test_callback6
 from example import test_cleanup
 
 def func1():
@@ -52,6 +53,9 @@ f = test_callback4()
 print("func(43) = %i" % f(43))
 f = test_callback5()
 print("func(number=43) = %i" % f(number=43))
+test_callback6(lambda i: i + 2)
+test_callback6()
+test_callback6(None)
 
 test_cleanup()
 

--- a/example/example-callbacks.ref
+++ b/example/example-callbacks.ref
@@ -16,6 +16,9 @@ Callback function 2 called : Hello, from, partial, object
 False
 Callback function 3 called : Partial object with one argument
 False
+func not provided
+func not provided
+func(21) = 23
 func(43) = 44
 func(43) = 44
 func(number=43) = 44

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -20,6 +20,7 @@ template <typename Return, typename... Args> struct type_caster<std::function<Re
     typedef typename std::conditional<std::is_same<Return, void>::value, void_type, Return>::type retval_type;
 public:
     bool load(handle src_, bool) {
+        if (src_.ptr() == Py_None) return true;
         src_ = detail::get_function(src_);
         if (!src_ || !PyCallable_Check(src_.ptr()))
             return false;
@@ -54,6 +55,12 @@ public:
             return (retval.template cast<Return>());
         };
         return true;
+    }
+
+    template <typename Func>
+    static handle cast(Func *f_, return_value_policy policy, handle parent) {
+        if(f_ == nullptr) return handle(Py_None).inc_ref();
+        return cast(*f_, policy, parent);
     }
 
     template <typename Func>


### PR DESCRIPTION
This is required to avoid a std::bad_function_call when attempting to use an empty std::function as the default value for a function argument