### PR TITLE
Build docs just once, in a dedicated build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,8 @@ matrix:
     language: docs
     compiler: sphinx
     env: PYTHON=2.7 DOCS=1
-    script: $SCRIPT_RUN_PREFIX make -C docs html SPHINX_OPTIONS=-W
+    install: pip install sphinx sphinx_rtd_theme
+    script: make -C docs html SPHINX_OPTIONS=-W
 cache:
   directories:
   - $HOME/.cache/pip
@@ -73,7 +74,6 @@ before_install:
     docker exec --tty "$containerid" apt-get -y upgrade
     export SCRIPT_RUN_PREFIX="docker exec --tty $containerid"
   fi
-install:
 - |
   if [ -z "$NATIVE_DEPS" ]; then
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
@@ -92,16 +92,13 @@ install:
     fi
     source venv/bin/activate
   fi
+install:
 - |
-  if [ -n "$DOCS" ] && [ -z "$NATIVE_DEPS" ]; then pip install sphinx sphinx_rtd_theme; fi
-- |
-  if [ -z "$NATIVE_DEPS" ] && [ -z "$DOCS" ]; then
-    pip install numpy scipy 
+  pip install numpy scipy
 
-    wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz
-    tar xzf eigen.tar.gz
-    export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=eigen-eigen-dc6cfdf9bcec"
-  fi
+  wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz
+  tar xzf eigen.tar.gz
+  export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=eigen-eigen-dc6cfdf9bcec"
 script:
 - $SCRIPT_RUN_PREFIX cmake ${CMAKE_EXTRA_ARGS}
     -DPYBIND11_PYTHON_VERSION=$PYTHON

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     install:
     - >
       docker exec --tty "$containerid" apt-get -y --no-install-recommends install
-      python2.7-dev python-scipy libeigen3-dev python-sphinx python-sphinx-rtd-theme
+      python2.7-dev python-scipy libeigen3-dev
       cmake make g++
   - compiler: gcc-6
     services: docker
@@ -48,8 +48,14 @@ matrix:
     install:
     - >
       docker exec --tty "$containerid" apt-get -y --no-install-recommends install
-      python3.5-dev python3-scipy libeigen3-dev python3-sphinx python3-sphinx-rtd-theme
+      python3.5-dev python3-scipy libeigen3-dev
       cmake make g++
+  # Documentation build:
+  - os: linux
+    language: docs
+    compiler: sphinx
+    env: PYTHON=2.7 DOCS=1
+    script: $SCRIPT_RUN_PREFIX make -C docs html SPHINX_OPTIONS=-W
 cache:
   directories:
   - $HOME/.cache/pip
@@ -85,7 +91,12 @@ install:
       python$PMAJOR -m virtualenv venv
     fi
     source venv/bin/activate
-    pip install numpy scipy sphinx sphinx_rtd_theme
+  fi
+- |
+  if [ -n "$DOCS" ] && [ -z "$NATIVE_DEPS" ]; then pip install sphinx sphinx_rtd_theme; fi
+- |
+  if [ -z "$NATIVE_DEPS" ] && [ -z "$DOCS" ]; then
+    pip install numpy scipy 
 
     wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz
     tar xzf eigen.tar.gz
@@ -97,6 +108,5 @@ script:
     -DPYBIND11_CPP_STANDARD=-std=c++$CPP
     -DPYBIND11_WERROR=ON
 - $SCRIPT_RUN_PREFIX make CTEST_OUTPUT_ON_FAILURE=TRUE check -j 2
-- $SCRIPT_RUN_PREFIX make -C docs html SPHINX_OPTIONS=-W
 after_script:
 - if [ -n "$DOCKER" ]; then docker stop "$containerid"; docker rm "$containerid"; fi


### PR DESCRIPTION
This switches the travis-ci build to build the docs in a dedicated build rather than as part of the regular linux/osx builds.