### PR TITLE
Enable keep_alive for def_property_readonly

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -666,8 +666,12 @@ argument with index ``Patient`` should be kept alive at least until the
 argument with index ``Nurse`` is freed by the garbage collector. Argument
 indices start at one, while zero refers to the return value. For methods, index
 ``1`` refers to the implicit ``this`` pointer, while regular arguments begin at
-index ``2``. Arbitrarily many call policies can be specified. When a ``Nurse``
-with value ``None`` is detected at runtime, the call policy does nothing.
+index ``2``. A ``keep_alive`` policy may be supplied when creating properties
+using def_property_readonly, for properties created using any other
+``def_property_*`` methods it is necessary to manually construct cpp_function
+instances using the desired ``keep_alive`` policy. Arbitrarily many call policies
+can be specified. When a ``Nurse`` with value ``None`` is detected at runtime,
+the call policy does nothing.
 
 This feature internally relies on the ability to create a *weak reference* to
 the nurse object, which is permitted by all classes exposed via pybind11. When

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -920,6 +920,14 @@ public:
         return *this;
     }
 
+    template <typename Func, typename... Extra,
+              typename std::enable_if<std::is_convertible<Func, cpp_function>::value, int>::type = 0>
+    class_ &def_property_readonly(const char *name, Func&& fget, const Extra& ...extra) {
+        cpp_function cfget(std::forward<Func>(fget), extra...);
+        def_property(name, cfget, cpp_function(), extra...);
+        return *this;
+    }
+
     template <typename... Extra>
     class_ &def_property_readonly_static(const char *name, const cpp_function &fget, const Extra& ...extra) {
         def_property_static(name, fget, cpp_function(), extra...);


### PR DESCRIPTION
Currently any keep_alive policy provided to a def_property_* method is silently ignored. Mostly this makes sense:
* For the static def_property_* methods a keep_alive policy has no obvious use case
* For def_readwrite and def_readonly return value policies control object lifetimes safely
* For def_property it is not clear how a keep_alive policy should apply to both the getter and setter functions with differing argument indices

However for def_property_readonly it does make sense to allow a keep_alive policy to be specified. This update enables keep_alive policies supplied to def_property_readonly, and clarifies the handling in advanced.rst