### PR TITLE
Workaround for random failure of pytest capture on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,4 +29,5 @@ install:
 build_script:
 - cmake -A "%CMAKE_ARCH%" -DPYBIND11_WERROR=ON
 - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- set PYTEST_ADDOPTS="-s"  # workaround for pytest capture issue, see #351
 - cmake --build . --config Release --target pytest -- /v:m /logger:%MSBuildLogger%


### PR DESCRIPTION
See the issue and AppVeyor failure logs [here](https://github.com/pybind/pybind11/pull/296#issuecomment-241463939). I managed to semi-reproduce it on my Windows VM. It's slightly annoying to debug as it happens only about once every 10 runs. This quick workaround should make sure that other PRs don't get false failure reports from AppVeyor. I'll see about a real fix in the meantime.

pytest can capture test output both globally (controlled by the cmd line flag `--capture`) or locally (`capsys` and `capfd` fixtures). Enabling both methods at the same time causes problems on Windows: test output is not captured sometimes, resulting in test failure. This happens seemingly at random.

This workaround disables global output capture (`-s`, i.e. `--capture=no`) leaving only the local capture fixtures. As a side-effect test output on AppVeyor CI is a little messy, but this will have to do until a better solution is found.