### PR TITLE
Add support for iterators with different begin/end types

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,8 @@ Breaking changes queued for v2.0.0 (Not yet released)
 * ``std::enable_shared_from_this<>`` now also works for ``const`` values
 * A return value policy can now be passed to ``handle::operator()``
 * ``make_iterator()`` improvements for better compatibility with various types
-  (now uses prefix increment operator)
+  (now uses prefix increment operator); it now also accepts iterators with
+  different begin/end types as long as they are equality comparable.
 * ``arg()`` now accepts a wider range of argument types for default values
 * Added ``repr()`` method to the ``handle`` class.
 * Added support for registering structured dtypes via ``PYBIND11_NUMPY_DTYPE()`` macro.

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1117,8 +1117,10 @@ PYBIND11_NOINLINE inline void keep_alive_impl(int Nurse, int Patient, handle arg
     keep_alive_impl(nurse, patient);
 }
 
-template <typename Iterator, bool KeyIterator = false> struct iterator_state {
-    Iterator it, end;
+template <typename Iterator, typename Sentinel, bool KeyIterator = false>
+struct iterator_state {
+    Iterator it;
+    Sentinel end;
     bool first;
 };
 
@@ -1127,10 +1129,11 @@ NAMESPACE_END(detail)
 template <typename... Args> detail::init<Args...> init() { return detail::init<Args...>(); }
 
 template <typename Iterator,
+          typename Sentinel,
           typename ValueType = decltype(*std::declval<Iterator>()),
           typename... Extra>
-iterator make_iterator(Iterator first, Iterator last, Extra &&... extra) {
-    typedef detail::iterator_state<Iterator> state;
+iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
+    typedef detail::iterator_state<Iterator, Sentinel> state;
 
     if (!detail::get_type_info(typeid(state))) {
         class_<state>(handle(), "")
@@ -1149,10 +1152,11 @@ iterator make_iterator(Iterator first, Iterator last, Extra &&... extra) {
     return (iterator) cast(state { first, last, true });
 }
 template <typename Iterator,
+          typename Sentinel,
           typename KeyType = decltype((*std::declval<Iterator>()).first),
           typename... Extra>
-iterator make_key_iterator(Iterator first, Iterator last, Extra &&... extra) {
-    typedef detail::iterator_state<Iterator, true> state;
+iterator make_key_iterator(Iterator first, Sentinel last, Extra &&... extra) {
+    typedef detail::iterator_state<Iterator, Sentinel, true> state;
 
     if (!detail::get_type_info(typeid(state))) {
         class_<state>(handle(), "")

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1149,7 +1149,7 @@ iterator make_iterator(Iterator first, Iterator last, Extra &&... extra) {
     return (iterator) cast(state { first, last, true });
 }
 template <typename Iterator,
-          typename KeyType = decltype(std::declval<Iterator>()->first),
+          typename KeyType = decltype((*std::declval<Iterator>()).first),
           typename... Extra>
 iterator make_key_iterator(Iterator first, Iterator last, Extra &&... extra) {
     typedef detail::iterator_state<Iterator, true> state;
@@ -1164,7 +1164,7 @@ iterator make_key_iterator(Iterator first, Iterator last, Extra &&... extra) {
                     s.first = false;
                 if (s.it == s.end)
                     throw stop_iteration();
-                return s.it->first;
+                return (*s.it).first;
             }, return_value_policy::reference_internal, std::forward<Extra>(extra)...);
     }
 

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -245,7 +245,7 @@ pybind11::class_<std::vector<T, Allocator>, holder_type> bind_vector(pybind11::m
 
     cl.def("__iter__",
         [](Vector &v) {
-            return pybind11::make_iterator<ItType, T>(v.begin(), v.end());
+            return pybind11::make_iterator<ItType, ItType, T>(v.begin(), v.end());
         },
         pybind11::keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
     );

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -10,6 +10,18 @@ def allclose(a_list, b_list, rel_tol=1e-05, abs_tol=0.0):
     return all(isclose(a, b, rel_tol=rel_tol, abs_tol=abs_tol) for a, b in zip(a_list, b_list))
 
 
+def test_generalized_iterators():
+    from pybind11_tests import IntPairs
+
+    assert list(IntPairs([(1, 2), (3, 4), (0, 5)]).nonzero()) == [(1, 2), (3, 4)]
+    assert list(IntPairs([(1, 2), (2, 0), (0, 3), (4, 5)]).nonzero()) == [(1, 2)]
+    assert list(IntPairs([(0, 3), (1, 2), (3, 4)]).nonzero()) == []
+
+    assert list(IntPairs([(1, 2), (3, 4), (0, 5)]).nonzero_keys()) == [1, 3]
+    assert list(IntPairs([(1, 2), (2, 0), (0, 3), (4, 5)]).nonzero_keys()) == [1]
+    assert list(IntPairs([(0, 3), (1, 2), (3, 4)]).nonzero_keys()) == []
+
+
 def test_sequence():
     from pybind11_tests import Sequence, ConstructorStats
 


### PR DESCRIPTION
Clang 3.9 ([PR](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0184r0.html)) and gcc 6.1 (https://github.com/gcc-mirror/gcc/commit/39e2f1a461b97f5bba555a4577cf7c265bb8e99d) have support for generalized range-based for in c++1z, so why not support it too. This PR makes `make_iterator` and `make_key_iterator` work with generalized ranges, e.g. those from [ranges-v3](https://github.com/ericniebler/range-v3) library, as long as the iterator type is equality comparable to the sentinel type.
