### PR TITLE
Fix dtype::strip_padding() on Intel compiler

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -191,7 +191,7 @@ private:
 
         std::sort(field_descriptors.begin(), field_descriptors.end(),
                   [](const field_descr& a, const field_descr& b) {
-                      return (int) a.offset < (int) b.offset;
+                      return a.offset.cast<int>() < b.offset.cast<int>();
                   });
 
         list names, formats, offsets;


### PR DESCRIPTION
Idk why but it fixes it on icpc. Shouldn't it work the same?