### PR TITLE
Don't install pytest from cmake, just fail instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       apt:
         sources: [ubuntu-toolchain-r-test, kubuntu-backports]
         packages: [g++-4.8, cmake]
-    install: false
+    install: pip install pytest
   # Documentation build:
   - os: linux
     language: docs
@@ -90,10 +90,10 @@ install:
   # Install dependencies
   if [ -n "$DOCKER" ]; then
     docker exec --tty "$containerid" apt-get -y --no-install-recommends install \
-      python$PYTHON-dev python$PY-pip python$PY-setuptools python$PY-scipy \
+      python$PYTHON-dev python$PY-pytest python$PY-scipy \
       libeigen3-dev cmake make g++
   else
-    pip install numpy scipy
+    pip install numpy scipy pytest
 
     wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz
     tar xzf eigen.tar.gz

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,7 +58,7 @@ if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
   endforeach()
 endif()
 
-# Make sure pytest is found or try to install it if it's not found
+# Make sure pytest is found or produce a fatal error
 macro(pybind11_execute_python)
   execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ${ARGN} OUTPUT_QUIET ERROR_QUIET
                   RESULT_VARIABLE pybind11_execute_python_error)
@@ -67,17 +67,7 @@ endmacro()
 if(NOT PYBIND11_PYTEST_FOUND)
   pybind11_execute_python(pytest --version --noconftest)
   if(pybind11_execute_python_error)
-    message(STATUS "Installing pytest using pip")
-    pybind11_execute_python(pip install pytest)
-    if(pybind11_execute_python_error)
-      message(STATUS "Installing pytest using pip --user (fallback)")
-      pybind11_execute_python(pip install --user pytest)
-    endif()
-
-    pybind11_execute_python(pytest --version --noconftest)
-    if(pybind11_execute_python_error)
-      message(FATAL_ERROR "Running the tests requires pytest. Please install it manually.")
-    endif()
+    message(FATAL_ERROR "Running the tests requires pytest.  Please install it manually (try: ${PYTHON_EXECUTABLE} -m pip install pytest)")
   endif()
 
   set(PYBIND11_PYTEST_FOUND TRUE CACHE INTERAL "")


### PR DESCRIPTION
Fixes #363 

Installing something outside the project directory from a cmake invocation is overly intrusive; this changes tests/CMakeLists.txt to just fail with an informative message instead, and changes the travis-ci builds to install pytest via pip or apt-get instead of via CMake.