### PR TITLE
Check for style issues during docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,11 @@ matrix:
   # Documentation build:
   - os: linux
     language: docs
-    env: DOCS
+    env: DOCS STYLE
     install: pip install sphinx sphinx_rtd_theme
-    script: make -C docs html SPHINX_OPTIONS=-W
+    script:
+    - make -C docs html SPHINX_OPTIONS=-W
+    - tools/check-style.sh
 cache:
   directories:
   - $HOME/.cache/pip

--- a/tests/object.h
+++ b/tests/object.h
@@ -13,32 +13,32 @@ public:
     /// Copy constructor
     Object(const Object &) : m_refCount(0) { print_copy_created(this); }
 
-	/// Return the current reference count
-	int getRefCount() const { return m_refCount; };
+    /// Return the current reference count
+    int getRefCount() const { return m_refCount; };
 
-	/// Increase the object's reference count by one
-	void incRef() const { ++m_refCount; }
+    /// Increase the object's reference count by one
+    void incRef() const { ++m_refCount; }
 
-	/** \brief Decrease the reference count of
-	 * the object and possibly deallocate it.
-	 *
-	 * The object will automatically be deallocated once
-	 * the reference count reaches zero.
-	 */
-	void decRef(bool dealloc = true) const {
-	    --m_refCount;
-	    if (m_refCount == 0 && dealloc)
+    /** \brief Decrease the reference count of
+     * the object and possibly deallocate it.
+     *
+     * The object will automatically be deallocated once
+     * the reference count reaches zero.
+     */
+    void decRef(bool dealloc = true) const {
+        --m_refCount;
+        if (m_refCount == 0 && dealloc)
             delete this;
         else if (m_refCount < 0)
-	        throw std::runtime_error("Internal error: reference count < 0!");
+            throw std::runtime_error("Internal error: reference count < 0!");
     }
 
     virtual std::string toString() const = 0;
 protected:
-	/** \brief Virtual protected deconstructor.
-	 * (Will only be called by \ref ref)
-	 */
-	virtual ~Object() { print_destroyed(this); }
+    /** \brief Virtual protected deconstructor.
+     * (Will only be called by \ref ref)
+     */
+    virtual ~Object() { print_destroyed(this); }
 private:
     mutable std::atomic<int> m_refCount { 0 };
 };
@@ -61,18 +61,18 @@ class ref_tag {};
  */
 template <typename T> class ref {
 public:
-	/// Create a nullptr reference
+    /// Create a nullptr reference
     ref() : m_ptr(nullptr) { print_default_created(this); track_default_created((ref_tag*) this); }
 
     /// Construct a reference from a pointer
-	ref(T *ptr) : m_ptr(ptr) {
-	    if (m_ptr) ((Object *) m_ptr)->incRef();
+    ref(T *ptr) : m_ptr(ptr) {
+        if (m_ptr) ((Object *) m_ptr)->incRef();
 
         print_created(this, "from pointer", m_ptr); track_created((ref_tag*) this, "from pointer");
 
-	}
+    }
 
-	/// Copy constructor
+    /// Copy constructor
     ref(const ref &r) : m_ptr(r.m_ptr) {
         if (m_ptr)
             ((Object *) m_ptr)->incRef();
@@ -96,80 +96,80 @@ public:
     }
 
     /// Move another reference into the current one
-	ref& operator=(ref&& r) {
+    ref& operator=(ref&& r) {
         print_move_assigned(this, "pointer", r.m_ptr); track_move_assigned((ref_tag*) this);
 
-		if (*this == r)
-			return *this;
-		if (m_ptr)
-			((Object *) m_ptr)->decRef();
-		m_ptr = r.m_ptr;
-		r.m_ptr = nullptr;
-		return *this;
-	}
+        if (*this == r)
+            return *this;
+        if (m_ptr)
+            ((Object *) m_ptr)->decRef();
+        m_ptr = r.m_ptr;
+        r.m_ptr = nullptr;
+        return *this;
+    }
 
-	/// Overwrite this reference with another reference
-	ref& operator=(const ref& r) {
+    /// Overwrite this reference with another reference
+    ref& operator=(const ref& r) {
         print_copy_assigned(this, "pointer", r.m_ptr); track_copy_assigned((ref_tag*) this);
 
-		if (m_ptr == r.m_ptr)
-			return *this;
-		if (m_ptr)
-			((Object *) m_ptr)->decRef();
-		m_ptr = r.m_ptr;
-		if (m_ptr)
-			((Object *) m_ptr)->incRef();
-		return *this;
-	}
+        if (m_ptr == r.m_ptr)
+            return *this;
+        if (m_ptr)
+            ((Object *) m_ptr)->decRef();
+        m_ptr = r.m_ptr;
+        if (m_ptr)
+            ((Object *) m_ptr)->incRef();
+        return *this;
+    }
 
-	/// Overwrite this reference with a pointer to another object
-	ref& operator=(T *ptr) {
+    /// Overwrite this reference with a pointer to another object
+    ref& operator=(T *ptr) {
         print_values(this, "assigned pointer"); track_values((ref_tag*) this, "assigned pointer");
 
-		if (m_ptr == ptr)
-			return *this;
-		if (m_ptr)
-			((Object *) m_ptr)->decRef();
-		m_ptr = ptr;
-		if (m_ptr)
-			((Object *) m_ptr)->incRef();
-		return *this;
-	}
+        if (m_ptr == ptr)
+            return *this;
+        if (m_ptr)
+            ((Object *) m_ptr)->decRef();
+        m_ptr = ptr;
+        if (m_ptr)
+            ((Object *) m_ptr)->incRef();
+        return *this;
+    }
 
-	/// Compare this reference with another reference
-	bool operator==(const ref &r) const { return m_ptr == r.m_ptr; }
+    /// Compare this reference with another reference
+    bool operator==(const ref &r) const { return m_ptr == r.m_ptr; }
 
-	/// Compare this reference with another reference
-	bool operator!=(const ref &r) const { return m_ptr != r.m_ptr; }
+    /// Compare this reference with another reference
+    bool operator!=(const ref &r) const { return m_ptr != r.m_ptr; }
 
-	/// Compare this reference with a pointer
-	bool operator==(const T* ptr) const { return m_ptr == ptr; }
+    /// Compare this reference with a pointer
+    bool operator==(const T* ptr) const { return m_ptr == ptr; }
 
-	/// Compare this reference with a pointer
-	bool operator!=(const T* ptr) const { return m_ptr != ptr; }
+    /// Compare this reference with a pointer
+    bool operator!=(const T* ptr) const { return m_ptr != ptr; }
 
-	/// Access the object referenced by this reference
-	T* operator->() { return m_ptr; }
+    /// Access the object referenced by this reference
+    T* operator->() { return m_ptr; }
 
-	/// Access the object referenced by this reference
-	const T* operator->() const { return m_ptr; }
+    /// Access the object referenced by this reference
+    const T* operator->() const { return m_ptr; }
 
-	/// Return a C++ reference to the referenced object
-	T& operator*() { return *m_ptr; }
+    /// Return a C++ reference to the referenced object
+    T& operator*() { return *m_ptr; }
 
-	/// Return a const C++ reference to the referenced object
-	const T& operator*() const { return *m_ptr; }
+    /// Return a const C++ reference to the referenced object
+    const T& operator*() const { return *m_ptr; }
 
-	/// Return a pointer to the referenced object
-	operator T* () { return m_ptr; }
+    /// Return a pointer to the referenced object
+    operator T* () { return m_ptr; }
 
-	/// Return a const pointer to the referenced object
-	T* get() { return m_ptr; }
+    /// Return a const pointer to the referenced object
+    T* get() { return m_ptr; }
 
-	/// Return a pointer to the referenced object
-	const T* get() const { return m_ptr; }
+    /// Return a pointer to the referenced object
+    const T* get() const { return m_ptr; }
 private:
-	T *m_ptr;
+    T *m_ptr;
 };
 
 #endif /* __OBJECT_H */

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -13,25 +13,25 @@
 
 class El {
 public:
-	El() = delete;
-	El(int v) : a(v) { }
+    El() = delete;
+    El(int v) : a(v) { }
 
-	int a;
+    int a;
 };
 
 std::ostream & operator<<(std::ostream &s, El const&v) {
-	s << "El{" << v.a << '}';
-	return s;
+    s << "El{" << v.a << '}';
+    return s;
 }
 
 void init_ex_stl_binder_vector(py::module &m) {
-	py::class_<El>(m, "El")
-		.def(py::init<int>());
+    py::class_<El>(m, "El")
+        .def(py::init<int>());
 
-	py::bind_vector<unsigned int>(m, "VectorInt");
-	py::bind_vector<bool>(m, "VectorBool");
+    py::bind_vector<unsigned int>(m, "VectorInt");
+    py::bind_vector<bool>(m, "VectorBool");
 
-	py::bind_vector<El>(m, "VectorEl");
+    py::bind_vector<El>(m, "VectorEl");
 
     py::bind_vector<std::vector<El>>(m, "VectorVectorEl");
 }

--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -6,14 +6,28 @@
 # Invoke as: tools/check-style.sh
 #
 
-found=0
-for f in `grep $'\t' include/ tests/ docs/*.rst -rl`; do
-    if [ "$found" -eq 0 ]; then
+errors=0
+IFS=$'\n'
+found=
+grep $'\t' include/ tests/ docs/*.rst -rl | while read f; do
+    if [ -z "$found" ]; then
         echo -e '\e[31m\e[01mError: found tabs instead of spaces in the following files:\e[0m'
         found=1
+        errors=1
     fi
 
     echo "    $f"
 done
 
-exit $found
+found=
+grep '\<\(if\|for\|while\)(' include/ tests/* -r --color=always | while read line; do
+    if [ -z "$found" ]; then
+        echo -e '\e[31m\e[01mError: found the following coding style problems:\e[0m'
+        found=1
+        errors=1
+    fi
+
+    echo "    $line"
+done
+
+exit $errors

--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# 
+# Script to check include/test code for common pybind11 code style errors.
+# Currently just checks for tabs used instead of spaces.
+# 
+# Invoke as: tools/check-style.sh
+#
+
+found=0
+for f in `grep $'\t' include/ tests/ docs/*.rst -rl`; do
+    if [ "$found" -eq 0 ]; then
+        echo -e '\e[31m\e[01mError: found tabs instead of spaces in the following files:\e[0m'
+        found=1
+    fi
+
+    echo "    $f"
+done
+
+exit $found


### PR DESCRIPTION
I've noticed a few code comments in commits about using tabs vs spaces, and thought it would be pretty easy to automate this in the travis-ci builds.

This PR adds a bash script into `tools/` that checks for tabs/spaces in source files (`include/`, `tests/`, and `docs/*.rst`), outputting an error message and exiting with a bad status if tabs are found, and then calls it during the docs build.  The second commit changes some failing tabs that I found in a couple of the `tests/` source files.

Here's an example of a build failure when tabs are found (i.e. before the second commit): https://travis-ci.org/jagerman/pybind11/jobs/155765929