### PR TITLE
Fix check-style exit status and improve failure messages

### DIFF
--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -9,7 +9,8 @@
 errors=0
 IFS=$'\n'
 found=
-grep $'\t' include/ tests/ docs/*.rst -rl | while read f; do
+exec 3< <(grep $'\t' include/ tests/ docs/*.rst -rl)
+while read -u 3 f; do
     if [ -z "$found" ]; then
         echo -e '\e[31m\e[01mError: found tabs instead of spaces in the following files:\e[0m'
         found=1
@@ -20,7 +21,8 @@ grep $'\t' include/ tests/ docs/*.rst -rl | while read f; do
 done
 
 found=
-grep '\<\(if\|for\|while\)(' include/ tests/* -r --color=always | while read line; do
+exec 3< <(grep '\<\(if\|for\|while\)(' include/ tests/*.{cpp,py,h} -r --color=always)
+while read -u 3 line; do
     if [ -z "$found" ]; then
         echo -e '\e[31m\e[01mError: found the following coding style problems:\e[0m'
         found=1

--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -9,7 +9,8 @@
 errors=0
 IFS=$'\n'
 found=
-exec 3< <(grep $'\t' include/ tests/ docs/*.rst -rl)
+# The mt=41 sets a red background for matched tabs:
+exec 3< <(GREP_COLORS='mt=41' grep $'\t' include/ tests/ docs/*.rst -rn --color=always)
 while read -u 3 f; do
     if [ -z "$found" ]; then
         echo -e '\e[31m\e[01mError: found tabs instead of spaces in the following files:\e[0m'
@@ -21,7 +22,7 @@ while read -u 3 f; do
 done
 
 found=
-exec 3< <(grep '\<\(if\|for\|while\)(' include/ tests/*.{cpp,py,h} -r --color=always)
+exec 3< <(grep '\<\(if\|for\|while\)(' include/ tests/*.{cpp,py,h} -rn --color=always)
 while read -u 3 line; do
     if [ -z "$found" ]; then
         echo -e '\e[31m\e[01mError: found the following coding style problems:\e[0m'


### PR DESCRIPTION
The check-style script added in #369 wasn't propagated its failure exit status properly (because the loops were in a pipe and thus running in a subshell).  This fixes it by running the greps in subshells and the loops in the main shell.

This also avoids the `if(`/`for(`/`while(` style check on `tests/CMakeLists.txt`, since it *does* have `if()` statements with no space that are producing error messages, but that's the preferred CMake style.  (These aren't triggering build failures, currently, because of the first problem).