### PR TITLE
Make buffer_info movable and not copyable

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -235,12 +235,10 @@ struct buffer_info {
         }
     }
 
-    ~buffer_info() {
-        if (view) { PyBuffer_Release(view); delete view; }
-    }
+    struct ViewDeleter { void operator()(Py_buffer *view) const { PyBuffer_Release(view); delete view; } };
 
 private:
-    Py_buffer *view = nullptr;
+    std::unique_ptr<Py_buffer, ViewDeleter> view;
 };
 
 NAMESPACE_BEGIN(detail)


### PR DESCRIPTION
`buffer_info` currently gets a default copy constructor and copy assignment operator, but not a default move constructor or move assignment operator.  Nevertheless it is not actually copy-safe (a copy will result in two pointers to `view`, which will result in a double-free during deletion (as reported in #377)).

I think this was technically broken already: any code returning a `buffer_info` constructed from a view was implicitly depending on return value copy elision, but a non-eliding compiler (which is probably rare in practice) should result in double frees.

This commit changes `view` to a unique_ptr, and moves the `view` destruction code into a custom deleter of that unique_ptr (so that move assignment destroys the old value properly).  These two changes have
two effects:

- we get a default, implicit move constructor and move assignment operator (they were not present before because of the user-declared destructor).
- we no longer have (broken) default copy constructor/copy assignment (because `view`, now a unique_ptr instead of a raw pointer, is no longer copyable).

It would be easy enough to also make it copyable by changing the unique_ptr to a shared_ptr, but I'm not sure that that makes sense, conceptually.