### PR TITLE
Numpy improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ set(PYBIND11_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/tools")
 set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6 3.7)
 find_package(PythonLibsNew ${PYBIND11_PYTHON_VERSION} REQUIRED)
+find_package(Numpy)
+if(PYTHON_NUMPY_FOUND)
+    list(APPEND PYTHON_INCLUDE_DIRS ${PYTHON_NUMPY_INCLUDE_DIR})
+endif()
 
 include(CheckCXXCompilerFlag)
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -208,7 +208,7 @@ class array : public buffer {
 public:
     PYBIND11_OBJECT_DEFAULT(array, buffer, detail::npy_api::get().PyArray_Check_)
 
-    enum {
+    enum : int{
         c_style = detail::npy_api::NPY_C_CONTIGUOUS_,
         f_style = detail::npy_api::NPY_F_CONTIGUOUS_,
         forcecast = detail::npy_api::NPY_ARRAY_FORCECAST_

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -20,6 +20,14 @@
 #include <string>
 #include <initializer_list>
 
+#ifndef PYBIND_DONT_INCLUDE_NUMPY
+#include <Python.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/ndarrayobject.h>
+#include <numpy/ndarraytypes.h>
+#undef NPY_NO_DEPRECATED_API
+#endif
+
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
@@ -153,12 +161,80 @@ public:
         return attr("itemsize").cast<size_t>();
     }
 
-    bool has_fields() const {
-        return attr("fields").cast<object>().ptr() != Py_None;
-    }
-
     std::string kind() const {
         return (std::string) attr("kind").cast<pybind11::str>();
+    }
+
+    bool check_scalar() const{
+        return PyArray_CheckScalar(m_ptr);
+    }
+
+    bool is_any_scalar() const{
+        return PyArray_CheckScalar(m_ptr);
+    }
+
+    bool is_unsigned() const{
+        return PyDataType_ISUNSIGNED(m_ptr);
+    }
+
+    bool is_signed() const{
+        return PyDataType_ISSIGNED(m_ptr);
+    }
+
+    bool is_integer() const{
+        return PyDataType_ISINTEGER(m_ptr);
+    }
+
+    bool is_float() const{
+        return PyDataType_ISFLOAT(m_ptr);
+    }
+
+    bool is_complex() const{
+        return PyDataType_ISCOMPLEX(m_ptr);
+    }
+
+    bool is_number() const{
+        return PyDataType_ISNUMBER(m_ptr);
+    }
+
+    bool is_string() const{
+        return PyDataType_ISSTRING(m_ptr);
+    }
+
+    bool is_python() const{
+        return PyDataType_ISPYTHON(m_ptr);
+    }
+
+    bool is_flexible() const{
+        return PyDataType_ISFLEXIBLE(m_ptr);
+    }
+
+    bool is_userdef() const{
+        return PyDataType_ISUSERDEF(m_ptr);
+    }
+
+    bool is_extended() const{
+        return PyDataType_ISEXTENDED(m_ptr);
+    }
+
+    bool is_object() const{
+        return PyDataType_ISOBJECT(m_ptr);
+    }
+
+    bool is_bool() const{
+        return PyTypeNum_ISBOOL(((PyArray_Descr*)(m_ptr))->type_num);//bool has bitrotted, see https://mail.scipy.org/pipermail/numpy-discussion/2013-August/067549.html
+    }
+
+    bool has_fields() const{
+        return PyDataType_HASFIELDS(m_ptr);
+    }
+
+    bool is_swapped() const{
+        return PyDataType_ISBYTESWAPPED(m_ptr);
+    }
+
+    bool operator==(const dtype &rhs) const{
+        return PyArray_EquivTypes((PyArray_Descr *) m_ptr, (PyArray_Descr *) rhs.m_ptr);
     }
 
 private:
@@ -251,7 +327,87 @@ public:
     : array(pybind11::dtype(info), info.shape, info.strides, info.ptr) { }
 
     pybind11::dtype dtype() {
-        return attr("dtype").cast<pybind11::dtype>();
+        return object((PyObject *) PyArray_DTYPE((PyArrayObject *) m_ptr), true).cast<pybind11::dtype>();
+    }
+    int ndims() const{
+        return PyArray_NDIM((PyArrayObject *) m_ptr);
+    }
+    npy_intp dim(int d) const{
+        return PyArray_DIM((PyArrayObject *) m_ptr, d);
+    }
+    const npy_intp* shape() const{
+        return PyArray_SHAPE((PyArrayObject *) m_ptr);
+    }
+    const npy_intp* strides() const{
+        return PyArray_STRIDES((PyArrayObject *) m_ptr);
+    }
+    npy_intp stride(int d) const{
+        return PyArray_STRIDE((PyArrayObject *) m_ptr, d);
+    }
+    uint8_t *data() {
+        return reinterpret_cast<uint8_t *>(PyArray_DATA((PyArrayObject *) m_ptr));
+    }
+    uint8_t *data() const{
+        return reinterpret_cast<uint8_t *>(PyArray_DATA((PyArrayObject *) m_ptr));
+    }
+    object base() const{
+        return object(PyArray_BASE((PyArrayObject *) m_ptr), true);
+    }
+    int type() const{
+        return PyArray_TYPE((PyArrayObject *) m_ptr);
+    }
+    int flags() const{
+        return PyArray_FLAGS((PyArrayObject *) m_ptr);
+    }
+    size_t itemsize() const{
+        return PyArray_ITEMSIZE((PyArrayObject *) m_ptr);
+    }
+    size_t size() const{
+        return PyArray_SIZE((PyArrayObject *) m_ptr);
+    }
+    size_t nbytes() const{
+        return PyArray_NBYTES((PyArrayObject *) m_ptr);
+    }
+
+    template<typename... Args>
+    uint8_t* data_at(Args&&... indices){
+        const int nterms = sizeof...(indices);
+        const uint32_t _indices[] = { uint32_t(indices)... };
+        auto *strides = this->strides();
+        assert(nterms < this->ndims());
+        uint8_t *p = this->data();
+        for(int i = 0; i < nterms; ++i){
+            p += _indices[i] * strides[i];
+        }
+        return p;
+    }
+    template<typename... Args>
+    const uint8_t* data_at(Args&&... indices) const{
+        return const_cast<array *>(this)->data_at(indices...);
+    }
+
+    template<int N>
+    static array empty(const std::array<int, N> &shape, const pybind11::dtype &type, int order = 'C'){
+        npy_intp _shape[N];
+        for(int i = 0; i < N; ++i){
+            _shape[i] = shape[i];
+        }
+        object result(PyArray_Empty(N, _shape, type, order == 'f' || order == 'F' ), false);
+        if (!result)
+            pybind11_fail("NumPy: unable to create array!");
+        return result;
+    }
+
+    template<int N>
+    static array zeros(const std::array<int, N> &shape, const pybind11::dtype &type, int order = 'C'){
+        npy_intp _shape[N];
+        for(int i = 0; i < N; ++i){
+            _shape[i] = shape[i];
+        }
+        object result(PyArray_Zeros(N, _shape, type, order == 'f' || order == 'F' ), false);
+        if (!result)
+            pybind11_fail("NumPy: unable to create array!");
+        return result;
     }
 
 protected:
@@ -286,6 +442,51 @@ public:
 
     array_t(size_t size, T* ptr = nullptr)
     : array(size, ptr) { }
+
+    T *data() {
+        return reinterpret_cast<T *>(PyArray_DATA((PyArrayObject *) m_ptr));
+    }
+    const T *data() const{
+        return reinterpret_cast<T *>(PyArray_DATA((PyArrayObject *) m_ptr));
+    }
+
+    template<typename... Args>
+    T* data_at(Args&&... indices){
+        const int nterms = sizeof...(indices);
+        const uint32_t _indices[] = { uint32_t(indices)... };
+        auto *strides = this->strides();
+        assert(nterms < this->ndims());
+        uint8_t *p = this->data();
+        for(int i = 0; i < nterms; ++i){
+            p += _indices[i] * strides[i];
+        }
+        return p;
+    }
+    template<typename... Args>
+    T* data_at(Args&&... indices) const{
+        return const_cast<array *>(this)->data_at(indices...);
+    }
+
+    template<typename... Args>
+    T* at(Args&&... indices){
+        assert(sizeof...(indices) == this->ndims());
+        return *this->data_at(indices...);
+    }
+    template<typename... Args>
+    const T* at(Args&&... indices) const{
+        assert(sizeof...(indices) == this->ndims());
+        return const_cast<array_t<T, ExtraFlags> *>(this)->at(indices...);
+    }
+
+    template<int N>
+    static array_t<T> empty(const std::array<int, N> &shape, int order = 'C'){
+        return empty(shape, dtype::of<T>(), order);
+    }
+
+    template<int N>
+    static array_t<T> zeros(const std::array<int, N> &shape, int order = 'C'){
+        return zeros(shape, dtype::of<T>(), order);
+    }
 
     static bool is_non_null(PyObject *ptr) { return ptr != nullptr; }
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -280,6 +280,26 @@ private:
     }
 };
 
+class dtype_record_builder {
+    list names;
+    list offsets;
+    list types;
+    size_t itemsize;
+
+    dtype_record_builder(size_t itemsize):itemsize(itemsize){}
+
+    dtype_record_builder& add(const std::string &name, size_t offset, dtype &type){
+        names.append(str(name));
+        offsets.append(int_(offset));
+        types.append(type);
+        return *this;
+    }
+
+    dtype build(){
+        return dtype(names, types, offsets, itemsize);
+    }
+};
+
 class array : public buffer {
 public:
     PYBIND11_OBJECT_DEFAULT(array, buffer, detail::npy_api::get().PyArray_Check_)

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -10,6 +10,10 @@
 #include "pybind11_tests.h"
 #include "constructor_stats.h"
 
+#include <Python.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/ndarrayobject.h>
+
 void init_ex_methods_and_attributes(py::module &);
 void init_ex_python_types(py::module &);
 void init_ex_operator_overloading(py::module &);
@@ -50,6 +54,7 @@ void bind_ConstructorStats(py::module &m) {
 }
 
 PYBIND11_PLUGIN(pybind11_tests) {
+    import_array(); //import numpy
     py::module m("pybind11_tests", "pybind example plugin");
 
     bind_ConstructorStats(m);

--- a/tools/FindNumpy.cmake
+++ b/tools/FindNumpy.cmake
@@ -1,0 +1,64 @@
+#Unless otherwise noted in the file, all files in this repository are
+#licensed under the BSD license, reproduced below.
+#
+#Redistribution and use in source and binary forms, with or without
+#modification, are permitted provided that the following conditions are met:
+#
+#- Redistributions of source code must retain the above copyright notice, this
+#  list of conditions and the following disclaimer.
+#- Redistributions in binary form must reproduce the above copyright notice,
+#  this list of conditions and the following disclaimer in the documentation
+#  and/or other materials provided with the distribution.
+#- Neither the name of Eyescale Software GmbH nor the names of its
+#  contributors may be used to endorse or promote products derived from this
+#  software without specific prior written permission.
+#
+#THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required(VERSION 2.6)
+
+if(NOT PYTHON_EXECUTABLE)
+  if(NumPy_FIND_QUIETLY)
+    find_package(PythonInterp QUIET)
+  else()
+    find_package(PythonInterp)
+    set(__numpy_out 1)
+  endif()
+endif()
+
+if (PYTHON_EXECUTABLE)
+  # Find out the include path
+  execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}" -c
+            "from __future__ import print_function\ntry: import numpy; print(numpy.get_include(), end='')\nexcept:pass\n"
+            OUTPUT_VARIABLE __numpy_path)
+  # And the version
+  execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}" -c
+            "from __future__ import print_function\ntry: import numpy; print(numpy.__version__, end='')\nexcept:pass\n"
+    OUTPUT_VARIABLE __numpy_version)
+elseif(__numpy_out)
+  message(STATUS "Python executable not found.")
+endif(PYTHON_EXECUTABLE)
+
+find_path(PYTHON_NUMPY_INCLUDE_DIR numpy/arrayobject.h
+  HINTS "${__numpy_path}" "${PYTHON_INCLUDE_PATH}" NO_DEFAULT_PATH)
+
+if(PYTHON_NUMPY_INCLUDE_DIR)
+  set(PYTHON_NUMPY_FOUND 1 CACHE INTERNAL "Python numpy found")
+endif(PYTHON_NUMPY_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NumPy REQUIRED_VARS PYTHON_NUMPY_INCLUDE_DIR
+                                        VERSION_VAR __numpy_version)
+


### PR DESCRIPTION
It is clear pains were taken to avoid bringing in numpy's c-api, but I don't think this was the correct choice - going at it pure python half-defeats the productivity promises pybind11 gives and is something others including myself wish worked better.

Instead we should embrace the c-api, which greatly simplifies typical array usage and improves performance by not jumping needlessly back into python land.  The cost is a warning that we might get fixed up stream having to do with the _import_module symbol, and calling that function in the appropriate (initialization) places.

Various other improvements were made such as allowing "mapped" arrays and supporting array creation flags.