### PR TITLE
Cache return types of called functions

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -106,6 +106,9 @@ struct function_record {
     /// Number of arguments
     uint16_t nargs;
 
+    /// Cached detail::type_info pointer for return value
+    const detail::type_info *ret_type_cache = nullptr;
+
     /// Python method object
     PyMethodDef *def = nullptr;
 


### PR DESCRIPTION
Each time a function is called, we currently do a type lookup in registered_types_cpp to figure out the python type info associated with the return value.  This hash lookup adds to the overhead, which can be a small but noticeable overhead for functions called in a tight python loop (one of the two main issues reported in #376).  It can, however, be easily cached since the lookup is going to return an identical value each time (since pybind11 doesn't support de-registering types).

This commit adds an (optional) cache parameter to the lookup for generic types (i.e. those inheriting from type_caster_generic) so that these lookups can be cached.

Of course, adding a cache variable isn't free either: there is a small (0.93%) increase in the test .so size (on linux/g++6), but it seems worthwhile for a noticeable overhead reduction.