### PR TITLE
Fix ref heap casts

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -259,24 +259,25 @@ using cast_op_type = typename std::conditional<std::is_pointer<typename std::rem
 
 /// Generic type caster for objects stored on the heap
 template <typename type> class type_caster_base : public type_caster_generic {
+    using itype = intrinsic_t<type>;
 public:
     static PYBIND11_DESCR name() { return type_descr(_<type>()); }
 
     type_caster_base() : type_caster_generic(typeid(type)) { }
 
-    static handle cast(const type &src, return_value_policy policy, handle parent) {
+    static handle cast(const itype &src, return_value_policy policy, handle parent) {
         if (policy == return_value_policy::automatic || policy == return_value_policy::automatic_reference)
             policy = return_value_policy::copy;
         return cast(&src, policy, parent);
     }
 
-    static handle cast(type &&src, return_value_policy policy, handle parent) {
+    static handle cast(itype &&src, return_value_policy policy, handle parent) {
         if (policy == return_value_policy::automatic || policy == return_value_policy::automatic_reference)
             policy = return_value_policy::move;
         return cast(&src, policy, parent);
     }
 
-    static handle cast(const type *src, return_value_policy policy, handle parent) {
+    static handle cast(const itype *src, return_value_policy policy, handle parent) {
         return type_caster_generic::cast(
             src, policy, parent, src ? &typeid(*src) : nullptr, &typeid(type),
             make_copy_constructor(src), make_move_constructor(src));
@@ -284,8 +285,8 @@ public:
 
     template <typename T> using cast_op_type = pybind11::detail::cast_op_type<T>;
 
-    operator type*() { return (type *) value; }
-    operator type&() { if (!value) throw reference_cast_error(); return *((type *) value); }
+    operator itype*() { return (type *) value; }
+    operator itype&() { if (!value) throw reference_cast_error(); return *((itype *) value); }
 
 protected:
     typedef void *(*Constructor)(const void *stream);

--- a/tests/test_issues.cpp
+++ b/tests/test_issues.cpp
@@ -208,7 +208,9 @@ void init_issues(py::module &m) {
     public:
         using OverrideTest::OverrideTest;
         int int_value() override { PYBIND11_OVERLOAD(int, OverrideTest, int_value); }
-        int &int_ref() override { PYBIND11_OVERLOAD(int &, OverrideTest, int_ref); }
+        // Not allowed (uncommenting should hit a static_assert failure): we can't get a reference
+        // to a python numeric value, since we only copy values in the numeric type caster:
+//      int &int_ref() override { PYBIND11_OVERLOAD(int &, OverrideTest, int_ref); }
         A A_value() override { PYBIND11_OVERLOAD(A, OverrideTest, A_value); }
         A &A_ref() override { PYBIND11_OVERLOAD(A &, OverrideTest, A_ref); }
     };
@@ -217,9 +219,10 @@ void init_issues(py::module &m) {
     py::class_<OverrideTest, PyOverrideTest>(m2, "OverrideTest")
         .def(py::init<int>())
         .def("int_value", &OverrideTest::int_value)
-        .def("int_ref", &OverrideTest::int_ref)
+//      .def("int_ref", &OverrideTest::int_ref)
         .def("A_value", &OverrideTest::A_value)
         .def("A_ref", &OverrideTest::A_ref);
+
 }
 
 // MSVC workaround: trying to use a lambda here crashes MSCV

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -171,9 +171,10 @@ def test_override_ref():
     from pybind11_tests.issues import OverrideTest
     o = OverrideTest(42)
 
-    i = o.int_ref()
+    # Not allowed (see associated .cpp comment)
+    #i = o.int_ref()
+    #assert o.int_ref() == 42
     assert o.int_value() == 42
-    assert o.int_ref() == 42
 
     assert o.A_value().value == 99
     a = o.A_ref()

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -166,3 +166,17 @@ def test_move_fallback():
     assert m2.value == 2
     m1 = get_moveissue1(1)
     assert m1.value == 1
+
+def test_override_ref():
+    from pybind11_tests.issues import OverrideTest
+    o = OverrideTest(42)
+
+    i = o.int_ref()
+    assert o.int_value() == 42
+    assert o.int_ref() == 42
+
+    assert o.A_value().value == 99
+    a = o.A_ref()
+    assert a.value == 99
+    a.value = 7
+    assert a.value == 7


### PR DESCRIPTION
This fixes #392 and #219.  For the former, `type_caster_base` should be using `primitive_t<type>`, instead of `type`.  That, however, exposes the second issue (triggered in #392, originally reported in #219) that attempting to get a reference to a numeric type is returning a reference to a local variable; this prevents that with a failing static_assert.