### PR TITLE
Fixed a "deallocating None" issue which caused by corrupted reference…

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -475,11 +475,12 @@ inline str::str(const bytes& b) {
     m_ptr = obj.release().ptr();
 }
 
-class none : public object {
-public:
-    PYBIND11_OBJECT(none, object, detail::PyNone_Check)
-    none() : object(Py_None, true) { }
-};
+inline const handle& none()
+{
+    const static handle NONE_OBJECT(Py_None);
+
+    return NONE_OBJECT.inc_ref();
+}
 
 class bool_ : public object {
 public:


### PR DESCRIPTION
Dear all,

This pull request contains a fix to a corrupted reference count issue.
The reference count is increased and decreased immediately every time the "**return none();**" is called. This ends with a corrupted reference count.

Best Regards,
Po