### PR TITLE
Add a way to deal with copied value references

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -298,13 +298,11 @@ helper class that is defined as follows:
 
 The macro :func:`PYBIND11_OVERLOAD_PURE` should be used for pure virtual
 functions, and :func:`PYBIND11_OVERLOAD` should be used for functions which have
-a default implementation.
-
-There are also two alternate macros :func:`PYBIND11_OVERLOAD_PURE_NAME` and
-:func:`PYBIND11_OVERLOAD_NAME` which take a string-valued name argument between
-the *Parent class* and *Name of the function* slots. This is useful when the
-C++ and Python versions of the function have different names, e.g.
-``operator()`` vs ``__call__``.
+a default implementation.  There are also two alternate macros
+:func:`PYBIND11_OVERLOAD_PURE_NAME` and :func:`PYBIND11_OVERLOAD_NAME` which
+take a string-valued name argument between the *Parent class* and *Name of the
+function* slots. This is useful when the C++ and Python versions of the
+function have different names, e.g.  ``operator()`` vs ``__call__``.
 
 The binding code also needs a few minor adaptations (highlighted):
 
@@ -356,6 +354,25 @@ a virtual method call.
     u'meow! meow! meow! '
 
 Please take a look at the :ref:`macro_notes` before using this feature.
+
+.. note::
+
+    When the overridden type returns a reference or pointer to a type that
+    pybind11 converts from Python (for example, numeric values, std::string,
+    and other built-in value-converting types), there are some limitations to
+    be aware of:
+
+    - because in these cases there is no C++ variable to reference (the value
+      is stored in the referenced Python variable), pybind11 provides one in
+      the PYBIND11_OVERLOAD macros (when needed) with static storage duration.
+      Note that this means that invoking the overloaded method on *any*
+      instance will change the referenced value stored in *all* instances of
+      that type.
+
+    - Attempts to modify a non-const reference will not have the desired
+      effect: it will change only the static cache variable, but this change
+      will not propagate to underlying Python instance, and the change will be
+      replaced the next time the overload is invoked.
 
 .. seealso::
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -327,10 +327,10 @@ The binding code also needs a few minor adaptations (highlighted):
         return m.ptr();
     }
 
-Importantly, pybind11 is made aware of the trampoline trampoline helper class
-by specifying it as an extra template argument to :class:`class_`.  (This can
-also be combined with other template arguments such as a custom holder type;
-the order of template types does not matter).  Following this, we are able to
+Importantly, pybind11 is made aware of the trampoline helper class by
+specifying it as an extra template argument to :class:`class_`.  (This can also
+be combined with other template arguments such as a custom holder type; the
+order of template types does not matter).  Following this, we are able to
 define a constructor as usual.
 
 Note, however, that the above is sufficient for allowing python classes to

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -935,9 +935,6 @@ template <typename T> detail::enable_if_t<detail::move_if_unreferenced<T>::value
 template <typename T> detail::enable_if_t<detail::move_never<T>::value, T> cast(object &&object) {
     return cast<T>(object);
 }
-// Provide a ref_cast() with move support for objects (only participates for moveable types)
-template <typename T> detail::enable_if_t<detail::move_is_plain_type<T>::value, T>
-ref_cast(object &&object) { return cast<T>(std::move(object)); }
 
 template <typename T> T object::cast() const & { return pybind11::cast<T>(*this); }
 template <typename T> T object::cast() && { return pybind11::cast<T>(std::move(*this)); }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1486,10 +1486,10 @@ template <class T> function get_overload(const T *this_ptr, const char *name) {
         pybind11::gil_scoped_acquire gil; \
         pybind11::function overload = pybind11::get_overload(static_cast<const cname *>(this), name); \
         if (overload) { \
-            pybind11::object o = overload(__VA_ARGS__); \
+            auto o = overload(__VA_ARGS__); \
             if (pybind11::detail::cast_is_temporary_value_reference<ret_type>::value) { \
-                static pybind11::detail::overload_local_t<ret_type> local_value; \
-                return pybind11::detail::cast_ref<ret_type>(std::move(o), local_value); \
+                static pybind11::detail::overload_caster_t<ret_type> caster; \
+                return pybind11::detail::cast_ref<ret_type>(std::move(o), caster); \
             } \
             else return pybind11::detail::cast_safe<ret_type>(std::move(o)); \
         } \

--- a/tests/test_virtual_functions.cpp
+++ b/tests/test_virtual_functions.cpp
@@ -36,7 +36,7 @@ class PyExampleVirt : public ExampleVirt {
 public:
     using ExampleVirt::ExampleVirt; /* Inherit constructors */
 
-    virtual int run(int value) {
+    int run(int value) override {
         /* Generate wrapping code that enables native function overloading */
         PYBIND11_OVERLOAD(
             int,         /* Return type */
@@ -46,7 +46,7 @@ public:
         );
     }
 
-    virtual bool run_bool() {
+    bool run_bool() override {
         PYBIND11_OVERLOAD_PURE(
             bool,         /* Return type */
             ExampleVirt,  /* Parent class */
@@ -56,7 +56,7 @@ public:
         );
     }
 
-    virtual void pure_virtual() {
+    void pure_virtual() override {
         PYBIND11_OVERLOAD_PURE(
             void,         /* Return type */
             ExampleVirt,  /* Parent class */
@@ -107,11 +107,11 @@ public:
 };
 class NCVirtTrampoline : public NCVirt {
 #if !defined(__INTEL_COMPILER)
-    virtual NonCopyable get_noncopyable(int a, int b) {
+    NonCopyable get_noncopyable(int a, int b) override {
         PYBIND11_OVERLOAD(NonCopyable, NCVirt, get_noncopyable, a, b);
     }
 #endif
-    virtual Movable get_movable(int a, int b) {
+    Movable get_movable(int a, int b) override {
         PYBIND11_OVERLOAD_PURE(Movable, NCVirt, get_movable, a, b);
     }
 };


### PR DESCRIPTION
This PR adds `PYBIND11_OVERLOAD_REF*` macros (`PYBIND11_OVERLOAD_REF`, `PYBIND11_OVERLOAD_REF_PURE`, etc.) that work like the non-_REF versions, but store a value in a given variable instead of returning it when an overload is found, which is what we need to do when dealing with overridden functions that return a reference or pointer to a pybind11 converting type (e.g. numbers, strings, pairs, tuples, and any other types casters using `PYBIND11_TYPE_CASTER`).

Intended use is:

```C++
    class PyClass : public Class {
        public:
            using Class::Class;
            const int& vmethod() override {
                PYBIND11_OVERLOAD_REF(_tmp_value, Class, vmethod)
                return _tmp_value;
            }
        protected:
            int _tmp_value;
    };
```

Note that the `return _tmp_value;` is only reached if we find an overload; if there is no overload, this returns the parent's return value (or throws, for the _PURE variants).