### PR TITLE
Add array methods via C API

### DIFF
--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -83,12 +83,11 @@ struct type_caster<Type, typename std::enable_if<is_eigen_dense<Type>::value && 
     static constexpr bool isVector = Type::IsVectorAtCompileTime;
 
     bool load(handle src, bool) {
-       array_t<Scalar> buffer(src, true);
-       if (!buffer.check())
-           return false;
+        array_t<Scalar> buf(src, true);
+        if (!buf.check())
+            return false;
 
-        auto info = buffer.request();
-        if (info.ndim == 1) {
+        if (buf.ndim() == 1) {
             typedef Eigen::InnerStride<> Strides;
             if (!isVector &&
                 !(Type::RowsAtCompileTime == Eigen::Dynamic &&
@@ -96,31 +95,32 @@ struct type_caster<Type, typename std::enable_if<is_eigen_dense<Type>::value && 
                 return false;
 
             if (Type::SizeAtCompileTime != Eigen::Dynamic &&
-                info.shape[0] != (size_t) Type::SizeAtCompileTime)
+                buf.shape(0) != (size_t) Type::SizeAtCompileTime)
                 return false;
 
-            auto strides = Strides(info.strides[0] / sizeof(Scalar));
-
-            Strides::Index n_elts = (Strides::Index) info.shape[0];
+            Strides::Index n_elts = (Strides::Index) buf.shape(0);
             Strides::Index unity = 1;
 
             value = Eigen::Map<Type, 0, Strides>(
-                (Scalar *) info.ptr, rowMajor ? unity : n_elts, rowMajor ? n_elts : unity, strides);
-        } else if (info.ndim == 2) {
+                buf.mutable_data(),
+                rowMajor ? unity : n_elts,
+                rowMajor ? n_elts : unity,
+                Strides(buf.strides(0) / sizeof(Scalar))
+            );
+        } else if (buf.ndim() == 2) {
             typedef Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic> Strides;
 
-            if ((Type::RowsAtCompileTime != Eigen::Dynamic && info.shape[0] != (size_t) Type::RowsAtCompileTime) ||
-                (Type::ColsAtCompileTime != Eigen::Dynamic && info.shape[1] != (size_t) Type::ColsAtCompileTime))
+            if ((Type::RowsAtCompileTime != Eigen::Dynamic && buf.shape(0) != (size_t) Type::RowsAtCompileTime) ||
+                (Type::ColsAtCompileTime != Eigen::Dynamic && buf.shape(1) != (size_t) Type::ColsAtCompileTime))
                 return false;
 
-            auto strides = Strides(
-                info.strides[rowMajor ? 0 : 1] / sizeof(Scalar),
-                info.strides[rowMajor ? 1 : 0] / sizeof(Scalar));
-
             value = Eigen::Map<Type, 0, Strides>(
-                (Scalar *) info.ptr,
-                typename Strides::Index(info.shape[0]),
-                typename Strides::Index(info.shape[1]), strides);
+                buf.mutable_data(),
+                typename Strides::Index(buf.shape(0)),
+                typename Strides::Index(buf.shape(1)),
+                Strides(buf.strides(rowMajor ? 0 : 1) / sizeof(Scalar),
+                        buf.strides(rowMajor ? 1 : 0) / sizeof(Scalar))
+            );
         } else {
             return false;
         }
@@ -222,28 +222,18 @@ struct type_caster<Type, typename std::enable_if<is_eigen_sparse<Type>::value>::
             }
         }
 
-        auto valuesArray = array_t<Scalar>((object) obj.attr("data"));
-        auto innerIndicesArray = array_t<StorageIndex>((object) obj.attr("indices"));
-        auto outerIndicesArray = array_t<StorageIndex>((object) obj.attr("indptr"));
+        auto values = array_t<Scalar>((object) obj.attr("data"));
+        auto innerIndices = array_t<StorageIndex>((object) obj.attr("indices"));
+        auto outerIndices = array_t<StorageIndex>((object) obj.attr("indptr"));
         auto shape = pybind11::tuple((pybind11::object) obj.attr("shape"));
         auto nnz = obj.attr("nnz").cast<Index>();
 
-        if (!valuesArray.check() || !innerIndicesArray.check() ||
-            !outerIndicesArray.check())
+        if (!values.check() || !innerIndices.check() || !outerIndices.check())
             return false;
 
-        auto outerIndices = outerIndicesArray.request();
-        auto innerIndices = innerIndicesArray.request();
-        auto values = valuesArray.request();
-
         value = Eigen::MappedSparseMatrix<Scalar, Type::Flags, StorageIndex>(
-            shape[0].cast<Index>(),
-            shape[1].cast<Index>(),
-            nnz,
-            static_cast<StorageIndex *>(outerIndices.ptr),
-            static_cast<StorageIndex *>(innerIndices.ptr),
-            static_cast<Scalar *>(values.ptr)
-        );
+            shape[0].cast<Index>(), shape[1].cast<Index>(), nnz,
+            outerIndices.mutable_data(), innerIndices.mutable_data(), values.mutable_data());
 
         return true;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PYBIND11_TEST_FILES
   test_kwargs_and_defaults.cpp
   test_methods_and_attributes.cpp
   test_modules.cpp
+  test_numpy_array.cpp
   test_numpy_dtypes.cpp
   test_numpy_vectorize.cpp
   test_opaque_types.cpp

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -8,38 +8,87 @@
 */
 
 #include "pybind11_tests.h"
+
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
+#include <cstdint>
+#include <vector>
+
+using arr = py::array;
+using arr_t = py::array_t<uint16_t, 0>;
+
+template<typename... Ix> arr data(const arr& a, Ix&&... index) {
+    return arr(a.nbytes() - a.offset_at(index...), (const uint8_t *) a.data(index...));
+}
+
+template<typename... Ix> arr data_t(const arr_t& a, Ix&&... index) {
+    return arr(a.size() - a.index_at(index...), a.data(index...));
+}
+
+arr& mutate_data(arr& a) {
+    auto ptr = (uint8_t *) a.mutable_data();
+    for (size_t i = 0; i < a.nbytes(); i++)
+        ptr[i] = (uint8_t) (ptr[i] * 2);
+    return a;
+}
+
+arr_t& mutate_data_t(arr_t& a) {
+    auto ptr = a.mutable_data();
+    for (size_t i = 0; i < a.size(); i++)
+        ptr[i]++;
+    return a;
+}
+
+template<typename... Ix> arr& mutate_data(arr& a, Ix&&... index) {
+    auto ptr = (uint8_t *) a.mutable_data(index...);
+    for (size_t i = 0; i < a.nbytes() - a.offset_at(index...); i++)
+        ptr[i] = (uint8_t) (ptr[i] * 2);
+    return a;
+}
+
+template<typename... Ix> arr_t& mutate_data_t(arr_t& a, Ix&&... index) {
+    auto ptr = a.mutable_data(index...);
+    for (size_t i = 0; i < a.size() - a.index_at(index...); i++)
+        ptr[i]++;
+    return a;
+}
+
+template<typename... Ix> size_t index_at(const arr& a, Ix&&... idx) { return a.index_at(idx...); }
+template<typename... Ix> size_t index_at_t(const arr_t& a, Ix&&... idx) { return a.index_at(idx...); }
+template<typename... Ix> size_t offset_at(const arr& a, Ix&&... idx) { return a.offset_at(idx...); }
+template<typename... Ix> size_t offset_at_t(const arr_t& a, Ix&&... idx) { return a.offset_at(idx...); }
+template<typename... Ix> size_t at_t(const arr_t& a, Ix&&... idx) { return a.at(idx...); }
+template<typename... Ix> arr_t& mutate_at_t(arr_t& a, Ix&&... idx) { a.mutable_at(idx...)++; return a; }
+
+#define def_index_fn(name, type) \
+    sm.def(#name, [](type a) { return name(a); }); \
+    sm.def(#name, [](type a, int i) { return name(a, i); }); \
+    sm.def(#name, [](type a, int i, int j) { return name(a, i, j); }); \
+    sm.def(#name, [](type a, int i, int j, int k) { return name(a, i, j, k); });
+
 test_initializer numpy_array([](py::module &m) {
-    m.def("get_arr_ndim", [](const py::array& arr) {
-        return arr.ndim();
-    });
-    m.def("get_arr_shape", [](const py::array& arr) {
-        return std::vector<size_t>(arr.shape(), arr.shape() + arr.ndim());
-    });
-    m.def("get_arr_shape", [](const py::array& arr, size_t dim) {
-        return arr.shape(dim);
-    });
-    m.def("get_arr_strides", [](const py::array& arr) {
-        return std::vector<size_t>(arr.strides(), arr.strides() + arr.ndim());
-    });
-    m.def("get_arr_strides", [](const py::array& arr, size_t dim) {
-        return arr.strides(dim);
-    });
-    m.def("get_arr_writeable", [](const py::array& arr) {
-        return arr.writeable();
-    });
-    m.def("get_arr_size", [](const py::array& arr) {
-        return arr.size();
-    });
-    m.def("get_arr_itemsize", [](const py::array& arr) {
-        return arr.itemsize();
-    });
-    m.def("get_arr_nbytes", [](const py::array& arr) {
-        return arr.nbytes();
-    });
-    m.def("get_arr_owndata", [](const py::array& arr) {
-        return arr.owndata();
-    });
+    auto sm = m.def_submodule("array");
+
+    sm.def("ndim", [](const arr& a) { return a.ndim(); });
+    sm.def("shape", [](const arr& a) { return arr(a.ndim(), a.shape()); });
+    sm.def("shape", [](const arr& a, size_t dim) { return a.shape(dim); });
+    sm.def("strides", [](const arr& a) { return arr(a.ndim(), a.strides()); });
+    sm.def("strides", [](const arr& a, size_t dim) { return a.strides(dim); });
+    sm.def("writeable", [](const arr& a) { return a.writeable(); });
+    sm.def("size", [](const arr& a) { return a.size(); });
+    sm.def("itemsize", [](const arr& a) { return a.itemsize(); });
+    sm.def("nbytes", [](const arr& a) { return a.nbytes(); });
+    sm.def("owndata", [](const arr& a) { return a.owndata(); });
+
+    def_index_fn(data, const arr&);
+    def_index_fn(data_t, const arr_t&);
+    def_index_fn(index_at, const arr&);
+    def_index_fn(index_at_t, const arr_t&);
+    def_index_fn(offset_at, const arr&);
+    def_index_fn(offset_at_t, const arr_t&);
+    def_index_fn(mutate_data, arr&);
+    def_index_fn(mutate_data_t, arr_t&);
+    def_index_fn(at_t, const arr_t&);
+    def_index_fn(mutate_at_t, arr_t&);
 });

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -1,0 +1,45 @@
+/*
+    tests/test_numpy_array.cpp -- test core array functionality
+
+    Copyright (c) 2016 Ivan Smirnov <i.s.smirnov@gmail.com>
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#include "pybind11_tests.h"
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+test_initializer numpy_array([](py::module &m) {
+    m.def("get_arr_ndim", [](const py::array& arr) {
+        return arr.ndim();
+    });
+    m.def("get_arr_shape", [](const py::array& arr) {
+        return std::vector<size_t>(arr.shape(), arr.shape() + arr.ndim());
+    });
+    m.def("get_arr_shape", [](const py::array& arr, size_t dim) {
+        return arr.shape(dim);
+    });
+    m.def("get_arr_strides", [](const py::array& arr) {
+        return std::vector<size_t>(arr.strides(), arr.strides() + arr.ndim());
+    });
+    m.def("get_arr_strides", [](const py::array& arr, size_t dim) {
+        return arr.strides(dim);
+    });
+    m.def("get_arr_writeable", [](const py::array& arr) {
+        return arr.writeable();
+    });
+    m.def("get_arr_size", [](const py::array& arr) {
+        return arr.size();
+    });
+    m.def("get_arr_itemsize", [](const py::array& arr) {
+        return arr.itemsize();
+    });
+    m.def("get_arr_nbytes", [](const py::array& arr) {
+        return arr.nbytes();
+    });
+    m.def("get_arr_owndata", [](const py::array& arr) {
+        return arr.owndata();
+    });
+});

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -1,0 +1,43 @@
+import pytest
+
+with pytest.suppress(ImportError):
+    import numpy as np
+
+
+@pytest.requires_numpy
+def test_array_attributes():
+    from pybind11_tests import (get_arr_ndim, get_arr_shape, get_arr_strides, get_arr_writeable,
+                                get_arr_size, get_arr_itemsize, get_arr_nbytes, get_arr_owndata)
+
+    a = np.array(0, 'f8')
+    assert get_arr_ndim(a) == 0
+    assert get_arr_shape(a) == []
+    assert get_arr_strides(a) == []
+    with pytest.raises(RuntimeError):
+        get_arr_shape(a, 1)
+    with pytest.raises(RuntimeError):
+        get_arr_strides(a, 0)
+    assert get_arr_writeable(a)
+    assert get_arr_size(a) == 1
+    assert get_arr_itemsize(a) == 8
+    assert get_arr_nbytes(a) == 8
+    assert get_arr_owndata(a)
+
+    a = np.array([[1, 2, 3], [4, 5, 6]], 'u2').view()
+    a.flags.writeable = False
+    assert get_arr_ndim(a) == 2
+    assert get_arr_shape(a) == [2, 3]
+    assert get_arr_shape(a, 0) == 2
+    assert get_arr_shape(a, 1) == 3
+    assert get_arr_strides(a) == [6, 2]
+    assert get_arr_strides(a, 0) == 6
+    assert get_arr_strides(a, 1) == 2
+    with pytest.raises(RuntimeError):
+        get_arr_shape(a, 2)
+    with pytest.raises(RuntimeError):
+        get_arr_strides(a, 2)
+    assert not get_arr_writeable(a)
+    assert get_arr_size(a) == 6
+    assert get_arr_itemsize(a) == 2
+    assert get_arr_nbytes(a) == 12
+    assert not get_arr_owndata(a)

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -4,40 +4,147 @@ with pytest.suppress(ImportError):
     import numpy as np
 
 
+@pytest.fixture(scope='function')
+def arr():
+    return np.array([[1, 2, 3], [4, 5, 6]], '<u2')
+
+
 @pytest.requires_numpy
 def test_array_attributes():
-    from pybind11_tests import (get_arr_ndim, get_arr_shape, get_arr_strides, get_arr_writeable,
-                                get_arr_size, get_arr_itemsize, get_arr_nbytes, get_arr_owndata)
+    from pybind11_tests.array import (
+        ndim, shape, strides, writeable, size, itemsize, nbytes, owndata
+    )
 
     a = np.array(0, 'f8')
-    assert get_arr_ndim(a) == 0
-    assert get_arr_shape(a) == []
-    assert get_arr_strides(a) == []
-    with pytest.raises(RuntimeError):
-        get_arr_shape(a, 1)
-    with pytest.raises(RuntimeError):
-        get_arr_strides(a, 0)
-    assert get_arr_writeable(a)
-    assert get_arr_size(a) == 1
-    assert get_arr_itemsize(a) == 8
-    assert get_arr_nbytes(a) == 8
-    assert get_arr_owndata(a)
+    assert ndim(a) == 0
+    assert all(shape(a) == [])
+    assert all(strides(a) == [])
+    with pytest.raises(IndexError) as excinfo:
+        shape(a, 0)
+    assert str(excinfo.value) == 'invalid axis: 0 (ndim = 0)'
+    with pytest.raises(IndexError) as excinfo:
+        strides(a, 0)
+    assert str(excinfo.value) == 'invalid axis: 0 (ndim = 0)'
+    assert writeable(a)
+    assert size(a) == 1
+    assert itemsize(a) == 8
+    assert nbytes(a) == 8
+    assert owndata(a)
 
     a = np.array([[1, 2, 3], [4, 5, 6]], 'u2').view()
     a.flags.writeable = False
-    assert get_arr_ndim(a) == 2
-    assert get_arr_shape(a) == [2, 3]
-    assert get_arr_shape(a, 0) == 2
-    assert get_arr_shape(a, 1) == 3
-    assert get_arr_strides(a) == [6, 2]
-    assert get_arr_strides(a, 0) == 6
-    assert get_arr_strides(a, 1) == 2
-    with pytest.raises(RuntimeError):
-        get_arr_shape(a, 2)
-    with pytest.raises(RuntimeError):
-        get_arr_strides(a, 2)
-    assert not get_arr_writeable(a)
-    assert get_arr_size(a) == 6
-    assert get_arr_itemsize(a) == 2
-    assert get_arr_nbytes(a) == 12
-    assert not get_arr_owndata(a)
+    assert ndim(a) == 2
+    assert all(shape(a) == [2, 3])
+    assert shape(a, 0) == 2
+    assert shape(a, 1) == 3
+    assert all(strides(a) == [6, 2])
+    assert strides(a, 0) == 6
+    assert strides(a, 1) == 2
+    with pytest.raises(IndexError) as excinfo:
+        shape(a, 2)
+    assert str(excinfo.value) == 'invalid axis: 2 (ndim = 2)'
+    with pytest.raises(IndexError) as excinfo:
+        strides(a, 2)
+    assert str(excinfo.value) == 'invalid axis: 2 (ndim = 2)'
+    assert not writeable(a)
+    assert size(a) == 6
+    assert itemsize(a) == 2
+    assert nbytes(a) == 12
+    assert not owndata(a)
+
+
+@pytest.requires_numpy
+@pytest.mark.parametrize('args, ret', [([], 0), ([0], 0), ([1], 3), ([0, 1], 1), ([1, 2], 5)])
+def test_index_offset(arr, args, ret):
+    from pybind11_tests.array import index_at, index_at_t, offset_at, offset_at_t
+    assert index_at(arr, *args) == ret
+    assert index_at_t(arr, *args) == ret
+    assert offset_at(arr, *args) == ret * arr.dtype.itemsize
+    assert offset_at_t(arr, *args) == ret * arr.dtype.itemsize
+
+
+@pytest.requires_numpy
+def test_dim_check_fail(arr):
+    from pybind11_tests.array import (index_at, index_at_t, offset_at, offset_at_t, data, data_t,
+                                      mutate_data, mutate_data_t)
+    for func in (index_at, index_at_t, offset_at, offset_at_t, data, data_t,
+                 mutate_data, mutate_data_t):
+        with pytest.raises(IndexError) as excinfo:
+            func(arr, 1, 2, 3)
+        assert str(excinfo.value) == 'too many indices for an array: 3 (ndim = 2)'
+
+
+@pytest.requires_numpy
+@pytest.mark.parametrize('args, ret',
+                         [([], [1, 2, 3, 4, 5, 6]),
+                          ([1], [4, 5, 6]),
+                          ([0, 1], [2, 3, 4, 5, 6]),
+                          ([1, 2], [6])])
+def test_data(arr, args, ret):
+    from pybind11_tests.array import data, data_t
+    assert all(data_t(arr, *args) == ret)
+    assert all(data(arr, *args)[::2] == ret)
+    assert all(data(arr, *args)[1::2] == 0)
+
+
+@pytest.requires_numpy
+def test_mutate_readonly(arr):
+    from pybind11_tests.array import mutate_data, mutate_data_t, mutate_at_t
+    arr.flags.writeable = False
+    for func, args in (mutate_data, ()), (mutate_data_t, ()), (mutate_at_t, (0, 0)):
+        with pytest.raises(RuntimeError) as excinfo:
+            func(arr, *args)
+        assert str(excinfo.value) == 'array is not writeable'
+
+
+@pytest.requires_numpy
+@pytest.mark.parametrize('dim', [0, 1, 3])
+def test_at_fail(arr, dim):
+    from pybind11_tests.array import at_t, mutate_at_t
+    for func in at_t, mutate_at_t:
+        with pytest.raises(IndexError) as excinfo:
+            func(arr, *([0] * dim))
+        assert str(excinfo.value) == 'index dimension mismatch: {} (ndim = 2)'.format(dim)
+
+
+@pytest.requires_numpy
+def test_at(arr):
+    from pybind11_tests.array import at_t, mutate_at_t
+
+    assert at_t(arr, 0, 2) == 3
+    assert at_t(arr, 1, 0) == 4
+
+    assert all(mutate_at_t(arr, 0, 2).ravel() == [1, 2, 4, 4, 5, 6])
+    assert all(mutate_at_t(arr, 1, 0).ravel() == [1, 2, 4, 5, 5, 6])
+
+
+@pytest.requires_numpy
+def test_mutate_data(arr):
+    from pybind11_tests.array import mutate_data, mutate_data_t
+
+    assert all(mutate_data(arr).ravel() == [2, 4, 6, 8, 10, 12])
+    assert all(mutate_data(arr).ravel() == [4, 8, 12, 16, 20, 24])
+    assert all(mutate_data(arr, 1).ravel() == [4, 8, 12, 32, 40, 48])
+    assert all(mutate_data(arr, 0, 1).ravel() == [4, 16, 24, 64, 80, 96])
+    assert all(mutate_data(arr, 1, 2).ravel() == [4, 16, 24, 64, 80, 192])
+
+    assert all(mutate_data_t(arr).ravel() == [5, 17, 25, 65, 81, 193])
+    assert all(mutate_data_t(arr).ravel() == [6, 18, 26, 66, 82, 194])
+    assert all(mutate_data_t(arr, 1).ravel() == [6, 18, 26, 67, 83, 195])
+    assert all(mutate_data_t(arr, 0, 1).ravel() == [6, 19, 27, 68, 84, 196])
+    assert all(mutate_data_t(arr, 1, 2).ravel() == [6, 19, 27, 68, 84, 197])
+
+
+@pytest.requires_numpy
+def test_bounds_check(arr):
+    from pybind11_tests.array import (index_at, index_at_t, data, data_t,
+                                      mutate_data, mutate_data_t, at_t, mutate_at_t)
+    funcs = (index_at, index_at_t, data, data_t,
+             mutate_data, mutate_data_t, at_t, mutate_at_t)
+    for func in funcs:
+        with pytest.raises(IndexError) as excinfo:
+            index_at(arr, 2, 0)
+        assert str(excinfo.value) == 'index 2 is out of bounds for axis 0 with size 2'
+        with pytest.raises(IndexError) as excinfo:
+            index_at(arr, 0, 4)
+        assert str(excinfo.value) == 'index 4 is out of bounds for axis 1 with size 3'


### PR DESCRIPTION
Working with NumPy data structures is a very limited experience unless you can access the underlying C objects directly, this PR partially addresses that.

`PyArray_Proxy` and `PyArrayDescr_Proxy` are headers of the corresponding NumPy C objects. Those haven't changed at least since v1.5 and are unlikely to change in the future (although NumPy devs mentioned that it's possible in release 2.0 -- hence why they changed most macros to functions to avoid potential ABI breakage; if that ever occurs, the only way to handle it for us would be to include numpy headers at compile time).

- A few methods on `dtype` now use C API -- `has_fields`, `kind`, `itemsize`
- Add various methods to array like `ndim`, `shape`, `strides`, `itemsize`, `nbytes`, `size`, all matching the existing NumPy C/Python API
- Add `data` / `mutable_data` -- direct access without having to request a buffer
- Add a few indexing routines (`index_at`, `data_at`) -- for `array` the pointers are `uint8_t` (index is counted in bytes), for `array_t` it's the underlying type `T` (index is in elements). This could serve like a good precursor for eventually implementing tensors with fixed number of dimensions (e.g. 1-D, 2-D) -- some checks could be made at compile-time then.

Notes / a few open questions:
- If the API is considered to be too redundant (e.g. all kinds of `*_at` and `mutable_*` methods), a few methods could be probably axed. For instance, `data/data_at` could be merged into a single method, etc.
- Can we assume that `Py_intptr_t` is of same size as `size_t`? On all flat address space platforms (= all sane platforms) this would be true, I think.
- Should `array::data()` return `uint8_t*` or `void*`? (the former makes more sense to me)
- In `check_ndim`, should a check be made only when `NDEBUG` is not defined, like a debug assert, or should it be there always? Maybe it could always be done for general class of arrays, and removed for fixed-ndim arrays if we ever get to implement them.
- Should the out-of-bounds access be also checked the same way when using `*_at` and `at` methods? Maybe `!NDEBUG` only. It's not currently checked at all.
- Should `writeable` flag be only checked when not `NDEBUG` or should it be done always? Unlike bounds checking, I'm thinking it should always be done (unless we know for sure an array is writeable because its ctor/caster ensures that, see below).
- The reason `mutable_*` methods exist is that (generally) we only know if the array is writeable or not at runtime, even for `array_t`, so we need to ensure we can write to buffer. It's [explicitly stated](https://github.com/numpy/numpy/blob/b91e8d8f164731bb710cc1e5173cc8ec3f8fadf5/doc/source/reference/c-api.array.rst#data-access) in NumPy C API guide that this flag must be respected. If we choose to split array types into a hierarchy as I suggested earlier (e.g. `array_in`, `array_out`) and writeable flag is enforced for "out" arrays, this check can be bypassed for those types -- I'm planning to address this in another PR.