### PR TITLE
operators should return NotImplemented given unsupported input (fixes #393)

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -90,10 +90,13 @@ is really just short hand notation for
 
     .def("__mul__", [](const Vector2 &a, float b) {
         return a * b;
-    })
+    }, py::is_operator())
 
 This can be useful for exposing additional operators that don't exist on the
-C++ side, or to perform other types of customization.
+C++ side, or to perform other types of customization. The ``py::is_operator``
+flag marker is needed to inform pybind11 that this is an operator, which
+returns ``NotImplemented`` when invoked with incompatible arguments rather than
+throwing a type error.
 
 .. note::
 

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -17,6 +17,9 @@ NAMESPACE_BEGIN(pybind11)
 /// Annotation for methods
 struct is_method { handle class_; is_method(const handle &c) : class_(c) { } };
 
+/// Annotation for operators
+struct is_operator { };
+
 /// Annotation for parent scope
 struct scope { handle value; scope(const handle &s) : value(s) { } };
 
@@ -57,6 +60,10 @@ struct argument_record {
 
 /// Internal data structure which holds metadata about a bound function (signature, overloads, etc.)
 struct function_record {
+    function_record()
+        : is_constructor(false), is_stateless(false), is_operator(false),
+          has_args(false), has_kwargs(false) { }
+
     /// Function name
     char *name = nullptr; /* why no C++ strings? They generate heavier code.. */
 
@@ -86,6 +93,9 @@ struct function_record {
 
     /// True if this is a stateless function pointer
     bool is_stateless : 1;
+
+    /// True if this is an operator (__add__), etc.
+    bool is_operator : 1;
 
     /// True if the function has a '*args' argument
     bool has_args : 1;
@@ -198,6 +208,10 @@ template <> struct process_attribute<scope> : process_attribute_default<scope> {
     static void init(const scope &s, function_record *r) { r->scope = s.value; }
 };
 
+/// Process an attribute which indicates that this function is an operator
+template <> struct process_attribute<is_operator> : process_attribute_default<is_operator> {
+    static void init(const is_operator &, function_record *r) { r->is_operator = true; }
+};
 
 /// Process a keyword argument attribute (*without* a default value)
 template <> struct process_attribute<arg> : process_attribute_default<arg> {

--- a/include/pybind11/operators.h
+++ b/include/pybind11/operators.h
@@ -54,14 +54,14 @@ template <op_id id, op_type ot, typename L, typename R> struct op_ {
         typedef typename std::conditional<std::is_same<L, self_t>::value, Base, L>::type L_type;
         typedef typename std::conditional<std::is_same<R, self_t>::value, Base, R>::type R_type;
         typedef op_impl<id, ot, Base, L_type, R_type> op;
-        cl.def(op::name(), &op::execute, extra...);
+        cl.def(op::name(), &op::execute, is_operator(), extra...);
     }
     template <typename Class, typename... Extra> void execute_cast(Class &cl, const Extra&... extra) const {
         typedef typename Class::type Base;
         typedef typename std::conditional<std::is_same<L, self_t>::value, Base, L>::type L_type;
         typedef typename std::conditional<std::is_same<R, self_t>::value, Base, R>::type R_type;
         typedef op_impl<id, ot, Base, L_type, R_type> op;
-        cl.def(op::name(), &op::execute_cast, extra...);
+        cl.def(op::name(), &op::execute_cast, is_operator(), extra...);
     }
 };
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -181,3 +181,16 @@ def test_override_ref():
     assert a.value == "hi"
     a.value = "bye"
     assert a.value == "bye"
+
+def test_operators_notimplemented(capture):
+    from pybind11_tests.issues import OpTest1, OpTest2
+    with capture:
+        C1, C2 = OpTest1(), OpTest2()
+        C1 + C1
+        C2 + C2
+        C2 + C1
+        C1 + C2
+    assert capture == """Add OpTest1 with OpTest1
+Add OpTest2 with OpTest2
+Add OpTest2 with OpTest1
+Add OpTest2 with OpTest1"""


### PR DESCRIPTION
Operators like __add__ should return NotImplemented given invalid inputs rather than throwing an exception. This PR adds a new flag ``is_operator`` that can be used to indicate that this behavior is requested.

There is also a minor space optimization that reduces the size of the generated binary by 3% :)