### PR TITLE
parameterize iterators by return value policy (fixes #388)

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -246,10 +246,12 @@ pybind11::class_<Vector, holder_type> bind_vector(pybind11::module &m, std::stri
     cl.def("__len__", &Vector::size);
 
     cl.def("__iter__",
-        [](Vector &v) {
-            return pybind11::make_iterator<ItType, ItType, T>(v.begin(), v.end());
-        },
-        pybind11::keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
+           [](Vector &v) {
+               return pybind11::make_iterator<
+                   return_value_policy::reference_internal, ItType, ItType, T>(
+                   v.begin(), v.end());
+           },
+           pybind11::keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
     );
 
     /// Slicing protocol

--- a/tests/test_issues.cpp
+++ b/tests/test_issues.cpp
@@ -233,6 +233,11 @@ void init_issues(py::module &m) {
         .def(py::self + py::self)
         .def("__add__", [](const OpTest2& c2, const OpTest1& c1) { return c2 + c1; })
         .def("__radd__", [](const OpTest2& c2, const OpTest1& c1) { return c2 + c1; });
+
+    // Issue 388: Can't make iterators via make_iterator() with different r/v policies
+    static std::vector<int> list = { 1, 2, 3 };
+    m2.def("make_iterator_1", []() { return py::make_iterator<py::return_value_policy::copy>(list); });
+    m2.def("make_iterator_2", []() { return py::make_iterator<py::return_value_policy::automatic>(list); });
 }
 
 // MSVC workaround: trying to use a lambda here crashes MSCV

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -170,3 +170,12 @@ def test_operators_notimplemented(capture):
 Add OpTest2 with OpTest2
 Add OpTest2 with OpTest1
 Add OpTest2 with OpTest1"""
+
+def test_iterator_rvpolicy():
+    """ Issue 388: Can't make iterators via make_iterator() with different r/v policies """
+    from pybind11_tests.issues import make_iterator_1
+    from pybind11_tests.issues import make_iterator_2
+
+    assert list(make_iterator_1()) == [1, 2, 3]
+    assert list(make_iterator_2()) == [1, 2, 3]
+    assert(type(make_iterator_1()) != type(make_iterator_2()))


### PR DESCRIPTION
This PR fixes the issue with ``make_iterator`` by introducing an extra template parameter. I also played with extracting it from the argument list, but that (of course) does not work since they are not constexpr.

Thoughts?