### PR TITLE
Fix Python C API calls in desctuctors triggered by error_already_set

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -54,11 +54,7 @@ PYBIND11_NOINLINE inline internals &get_internals() {
                 try {
                     if (p) std::rethrow_exception(p);
                 } catch (error_already_set &e)           { e.restore();                                    return;
-                } catch (const index_error &e)           { PyErr_SetString(PyExc_IndexError,    e.what()); return;
-                } catch (const key_error &e)             { PyErr_SetString(PyExc_KeyError,      e.what()); return;
-                } catch (const value_error &e)           { PyErr_SetString(PyExc_ValueError,    e.what()); return;
-                } catch (const type_error &e)            { PyErr_SetString(PyExc_TypeError,     e.what()); return;
-                } catch (const stop_iteration &e)        { PyErr_SetString(PyExc_StopIteration, e.what()); return;
+                } catch (const builtin_exception &e)     { e.set_error();                                  return;
                 } catch (const std::bad_alloc &e)        { PyErr_SetString(PyExc_MemoryError,   e.what()); return;
                 } catch (const std::domain_error &e)     { PyErr_SetString(PyExc_ValueError,    e.what()); return;
                 } catch (const std::invalid_argument &e) { PyErr_SetString(PyExc_ValueError,    e.what()); return;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -53,7 +53,7 @@ PYBIND11_NOINLINE inline internals &get_internals() {
             [](std::exception_ptr p) -> void {
                 try {
                     if (p) std::rethrow_exception(p);
-                } catch (const error_already_set &)      {                                                 return;
+                } catch (error_already_set &e)           { e.restore();                                    return;
                 } catch (const index_error &e)           { PyErr_SetString(PyExc_IndexError,    e.what()); return;
                 } catch (const key_error &e)             { PyErr_SetString(PyExc_KeyError,      e.what()); return;
                 } catch (const value_error &e)           { PyErr_SetString(PyExc_ValueError,    e.what()); return;

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -217,7 +217,6 @@ struct type_caster<Type, typename std::enable_if<is_eigen_sparse<Type>::value>::
             try {
                 obj = matrix_type(obj);
             } catch (const error_already_set &) {
-                PyErr_Clear();
                 return false;
             }
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -426,7 +426,8 @@ protected:
                 if (result.ptr() != PYBIND11_TRY_NEXT_OVERLOAD)
                     break;
             }
-        } catch (const error_already_set &) {
+        } catch (error_already_set &e) {
+            e.restore();
             return nullptr;
         } catch (...) {
             /* When an exception is caught, give each registered exception
@@ -1309,7 +1310,6 @@ NAMESPACE_END(detail)
 
 template <return_value_policy policy = return_value_policy::automatic_reference, typename... Args>
 void print(Args &&...args) {
-    error_scope scope; // Preserve error state
     auto c = detail::collect_arguments<policy>(std::forward<Args>(args)...);
     detail::print(c.args(), c.kwargs());
 }

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -63,7 +63,6 @@ test_initializer eval([](py::module &m) {
         try {
             py::eval("nonsense code ...");
         } catch (py::error_already_set &) {
-            PyErr_Clear();
             return true;
         }
         return false;

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -13,6 +13,14 @@ def test_error_already_set(msg):
     assert msg(excinfo.value) == "foo"
 
 
+def test_python_call_in_catch():
+    from pybind11_tests import python_call_in_destructor
+
+    d = {}
+    assert python_call_in_destructor(d) is True
+    assert d["good"] is True
+
+
 def test_custom(msg):
     from pybind11_tests import (MyException, throws1, throws2, throws3, throws4,
                                 throws_logic_error)


### PR DESCRIPTION
Find #404 for the original issue.

While this was exposed by calling `py::print` in a C++ destructor, the underlying issue affects any calls to the Python C API made in destructors which are triggered by throwing `error_already_set`. This is because the Python C API expects all Python errors to be cleared before any new API calls are made. The solution in #404 was to temporarily pop the error for the `py::print` call, but to fully resolve the issue, this would need to be done for every C API call.

This PR changes the behavior of `error_already_set` so that it fetches and holds the Python error. That way Python calls can be made in exception-triggered destructors and there is no need for `error_scope` everywhere.

This effectively flips the behavior of `error_already_set`. Previously, it was assumed that the error stays in Python, so handling the exception in C++ would require explicitly calling `PyErr_Clear()`, but nothing was needed to propagate the error to Python. With this change, handling the error in C++ does not require a `PyErr_Clear()` call, but propagating the error to Python requires an explicit `error_already_set::restore()`.

The change does not break old code which explicitly calls `PyErr_Clear()` for cleanup, which should be the majority of user code. The need for an explicit `restore()` does break old code, but this should be mostly confined to the library and not user code.