### PR TITLE
Fix missing smart_ptr test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(PYBIND11_TEST_FILES
   test_kwargs_and_defaults.cpp
   test_methods_and_attributes.cpp
   test_modules.cpp
+  test_multiple_inheritance.cpp
   test_numpy_array.cpp
   test_numpy_dtypes.cpp
   test_numpy_vectorize.cpp
@@ -29,9 +30,9 @@ set(PYBIND11_TEST_FILES
   test_pickling.cpp
   test_python_types.cpp
   test_sequences_and_iterators.cpp
+  test_smart_ptr.cpp
   test_stl_binders.cpp
   test_virtual_functions.cpp
-  test_multiple_inheritance.cpp
 )
 
 string(REPLACE ".cpp" ".py" PYBIND11_PYTEST_FILES "${PYBIND11_TEST_FILES}")


### PR DESCRIPTION
Looks like `test_smart_ptr` was accidentally left out of the build list after #410, so it wasn't being tested.