### PR TITLE
enable IDEs such as Qt Creator to list headers files in the project tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,23 +157,24 @@ if (PYBIND11_TEST)
   add_subdirectory(tests)
 endif()
 
-if (PYBIND11_INSTALL)
-  set(PYBIND11_HEADERS
-    include/pybind11/attr.h
-    include/pybind11/cast.h
-    include/pybind11/common.h
-    include/pybind11/complex.h
-    include/pybind11/descr.h
-    include/pybind11/eigen.h
-    include/pybind11/functional.h
-    include/pybind11/numpy.h
-    include/pybind11/operators.h
-    include/pybind11/pybind11.h
-    include/pybind11/pytypes.h
-    include/pybind11/stl.h
-    include/pybind11/stl_bind.h
-    include/pybind11/typeid.h
-  )
+set(PYBIND11_HEADERS
+  include/pybind11/attr.h
+  include/pybind11/cast.h
+  include/pybind11/common.h
+  include/pybind11/complex.h
+  include/pybind11/descr.h
+  include/pybind11/eigen.h
+  include/pybind11/functional.h
+  include/pybind11/numpy.h
+  include/pybind11/operators.h
+  include/pybind11/pybind11.h
+  include/pybind11/pytypes.h
+  include/pybind11/stl.h
+  include/pybind11/stl_bind.h
+  include/pybind11/typeid.h
+)
+add_custom_target(headers SOURCES ${PYBIND11_HEADERS})
 
+if (PYBIND11_INSTALL)
   install(FILES ${PYBIND11_HEADERS} DESTINATION include/pybind11)
 endif()


### PR DESCRIPTION
Keep headers files as a source only target in order to enable IDEs to list them in the project tree. See [1] for more details.

[1] http://stackoverflow.com/questions/28384935/qtcreator-cmake-project-how-to-show-all-project-files