### PR TITLE
Make header files viewable in IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,27 +153,27 @@ function(pybind11_enable_warnings target_name)
   endif()
 endfunction()
 
+set(PYBIND11_HEADERS
+  include/pybind11/attr.h
+  include/pybind11/cast.h
+  include/pybind11/common.h
+  include/pybind11/complex.h
+  include/pybind11/descr.h
+  include/pybind11/eigen.h
+  include/pybind11/functional.h
+  include/pybind11/numpy.h
+  include/pybind11/operators.h
+  include/pybind11/pybind11.h
+  include/pybind11/pytypes.h
+  include/pybind11/stl.h
+  include/pybind11/stl_bind.h
+  include/pybind11/typeid.h
+)
+
 if (PYBIND11_TEST)
   add_subdirectory(tests)
 endif()
 
 if (PYBIND11_INSTALL)
-  set(PYBIND11_HEADERS
-    include/pybind11/attr.h
-    include/pybind11/cast.h
-    include/pybind11/common.h
-    include/pybind11/complex.h
-    include/pybind11/descr.h
-    include/pybind11/eigen.h
-    include/pybind11/functional.h
-    include/pybind11/numpy.h
-    include/pybind11/operators.h
-    include/pybind11/pybind11.h
-    include/pybind11/pytypes.h
-    include/pybind11/stl.h
-    include/pybind11/stl_bind.h
-    include/pybind11/typeid.h
-  )
-
   install(FILES ${PYBIND11_HEADERS} DESTINATION include/pybind11)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ set(PYBIND11_HEADERS
   include/pybind11/complex.h
   include/pybind11/descr.h
   include/pybind11/eigen.h
+  include/pybind11/eval.h
   include/pybind11/functional.h
   include/pybind11/numpy.h
   include/pybind11/operators.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,7 +53,7 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
 endif()
 
 # Create the binding library
-file(GLOB PYBIND11_HEADERS ../include/pybind11/*.h)
+string(REPLACE "include/" "${CMAKE_SOURCE_DIR}/include/" PYBIND11_HEADERS "${PYBIND11_HEADERS}")
 pybind11_add_module(pybind11_tests pybind11_tests.cpp ${PYBIND11_TEST_FILES} ${PYBIND11_HEADERS})
 pybind11_enable_warnings(pybind11_tests)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,7 +53,8 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
 endif()
 
 # Create the binding library
-pybind11_add_module(pybind11_tests pybind11_tests.cpp ${PYBIND11_TEST_FILES})
+file(GLOB PYBIND11_HEADERS ../include/pybind11/*.h)
+pybind11_add_module(pybind11_tests pybind11_tests.cpp ${PYBIND11_TEST_FILES} ${PYBIND11_HEADERS})
 pybind11_enable_warnings(pybind11_tests)
 
 if(EIGEN3_FOUND)


### PR DESCRIPTION
Add header files to the target created in pybind11_add_module in order to make them viewable in the project tree of IDEs.