### PR TITLE
Make the accessor interface more complete

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -53,6 +53,8 @@ Breaking changes queued for v2.0.0 (Not yet released)
 * Added ``py::dict`` keyword constructor:``auto d = dict("number"_a=42, "name"_a="World");``
 * Added ``py::str::format()`` method and ``_s`` literal:
   ``py::str s = "1 + 2 = {}"_s.format(3);``
+* Attribute and item accessors now have a more complete interface which makes it possible
+  to chain attributes ``obj.attr("a")[key].attr("b").attr("method")(1, 2, 3)```.
 * Various minor improvements of library internals (no user-visible changes)
 
 1.8.1 (July 12, 2016)

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -276,7 +276,7 @@ template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
 
 /// Process a parent class attribute
 template <typename T>
-struct process_attribute<T, enable_if_t<std::is_base_of<handle, T>::value>> : process_attribute_default<handle> {
+struct process_attribute<T, enable_if_t<is_pyobject<T>::value>> : process_attribute_default<handle> {
     static void init(const handle &h, type_record *r) { r->bases.append(h); }
 };
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -39,7 +39,10 @@ PYBIND11_NOINLINE inline internals &get_internals() {
         return *internals_ptr;
     handle builtins(PyEval_GetBuiltins());
     const char *id = PYBIND11_INTERNALS_ID;
-    capsule caps(builtins[id]);
+    capsule caps;
+    if (builtins.contains(id)) {
+        caps = builtins[id];
+    }
     if (caps.check()) {
         internals_ptr = caps;
     } else {
@@ -1221,7 +1224,7 @@ private:
     }
 
     void process(list &/*args_list*/, arg_v a) {
-        if (m_kwargs[a.name]) {
+        if (m_kwargs.contains(a.name)) {
 #if defined(NDEBUG)
             multiple_values_error();
 #else
@@ -1240,7 +1243,7 @@ private:
 
     void process(list &/*args_list*/, detail::kwargs_proxy kp) {
         for (const auto &k : dict(kp, true)) {
-            if (m_kwargs[k.first]) {
+            if (m_kwargs.contains(k.first)) {
 #if defined(NDEBUG)
                 multiple_values_error();
 #else

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1219,7 +1219,7 @@ private:
 
     void process(list &args_list, detail::args_proxy ap) {
         for (const auto &a : ap) {
-            args_list.append(a.cast<object>());
+            args_list.append(a);
         }
     }
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -125,11 +125,11 @@ private:
 
     static npy_api lookup() {
         module m = module::import("numpy.core.multiarray");
-        object c = (object) m.attr("_ARRAY_API");
+        auto c = m.attr("_ARRAY_API").cast<object>();
 #if PY_MAJOR_VERSION >= 3
-        void **api_ptr = (void **) (c ? PyCapsule_GetPointer(c.ptr(), NULL) : nullptr);
+        void **api_ptr = (void **) PyCapsule_GetPointer(c.ptr(), NULL);
 #else
-        void **api_ptr = (void **) (c ? PyCObject_AsVoidPtr(c.ptr()) : nullptr);
+        void **api_ptr = (void **) PyCObject_AsVoidPtr(c.ptr());
 #endif
         npy_api api;
 #define DECL_NPY_API(Func) api.Func##_ = (decltype(api.Func##_)) api_ptr[API_##Func];

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -125,7 +125,7 @@ private:
 
     static npy_api lookup() {
         module m = module::import("numpy.core.multiarray");
-        auto c = m.attr("_ARRAY_API").cast<object>();
+        auto c = m.attr("_ARRAY_API");
 #if PY_MAJOR_VERSION >= 3
         void **api_ptr = (void **) PyCapsule_GetPointer(c.ptr(), NULL);
 #else
@@ -220,9 +220,7 @@ private:
         struct field_descr { PYBIND11_STR_TYPE name; object format; pybind11::int_ offset; };
         std::vector<field_descr> field_descriptors;
 
-        auto fields = attr("fields").cast<object>();
-        auto items = fields.attr("items").cast<object>();
-        for (auto field : items()) {
+        for (auto field : attr("fields").attr("items")()) {
             auto spec = object(field, true).cast<tuple>();
             auto name = spec[0].cast<pybind11::str>();
             auto format = spec[1].cast<tuple>()[0].cast<dtype>();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1338,7 +1338,7 @@ NAMESPACE_BEGIN(detail)
 PYBIND11_NOINLINE inline void print(tuple args, dict kwargs) {
     auto strings = tuple(args.size());
     for (size_t i = 0; i < args.size(); ++i) {
-        strings[i] = args[i].cast<object>().str();
+        strings[i] = args[i].str();
     }
     auto sep = kwargs.contains("sep") ? kwargs["sep"] : cast(" ");
     auto line = sep.attr("join")(strings);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -18,6 +18,7 @@
 #  pragma warning(disable: 4800) // warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
 #  pragma warning(disable: 4996) // warning C4996: The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name
 #  pragma warning(disable: 4702) // warning C4702: unreachable code
+#  pragma warning(disable: 4522) // warning C4522: multiple assignment operators specified
 #elif defined(__INTEL_COMPILER)
 #  pragma warning(push)
 #  pragma warning(disable: 186)   // pointless comparison of unsigned integer with zero

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -176,7 +176,7 @@ protected:
             if (a.descr)
                 a.descr = strdup(a.descr);
             else if (a.value)
-                a.descr = strdup(((std::string) ((object) handle(a.value).attr("__repr__"))().str()).c_str());
+                a.descr = strdup(a.value.attr("__repr__")().cast<std::string>().c_str());
         }
 
         auto const &registered_types = detail::get_internals().registered_types_cpp;
@@ -723,8 +723,7 @@ protected:
         if (ob_type == &PyType_Type) {
             std::string name_ = std::string(ht_type.tp_name) + "__Meta";
 #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
-            object ht_qualname(PyUnicode_FromFormat(
-                "%U__Meta", ((object) attr("__qualname__")).ptr()), false);
+            object ht_qualname(PyUnicode_FromFormat("%U__Meta", attr("__qualname__").ptr()), false);
 #endif
             object name(PYBIND11_FROM_STRING(name_.c_str()), false);
             object type_holder(PyType_Type.tp_alloc(&PyType_Type, 0), false);
@@ -1342,16 +1341,16 @@ PYBIND11_NOINLINE inline void print(tuple args, dict kwargs) {
         strings[i] = args[i].cast<object>().str();
     }
     auto sep = kwargs.contains("sep") ? kwargs["sep"] : cast(" ");
-    auto line = sep.attr("join").cast<object>()(strings);
+    auto line = sep.attr("join")(strings);
 
     auto file = kwargs.contains("file") ? kwargs["file"].cast<object>()
                                         : module::import("sys").attr("stdout");
-    auto write = file.attr("write").cast<object>();
+    auto write = file.attr("write");
     write(line);
     write(kwargs.contains("end") ? kwargs["end"] : cast("\n"));
 
     if (kwargs.contains("flush") && kwargs["flush"].cast<bool>()) {
-        file.attr("flush").cast<object>()();
+        file.attr("flush")();
     }
 }
 NAMESPACE_END(detail)

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -16,50 +16,72 @@
 NAMESPACE_BEGIN(pybind11)
 
 /* A few forward declarations */
-class object; class str; class iterator;
+class handle; class object;
+class str; class iterator;
 struct arg; struct arg_v;
-namespace detail { class accessor; class args_proxy; class kwargs_proxy; }
+
+NAMESPACE_BEGIN(detail)
+class accessor; class args_proxy;
+
+/// Tag and check to identify a class which implements the Python object API
+class pyobject_tag { };
+template <typename T> using is_pyobject = std::is_base_of<pyobject_tag, T>;
+
+/// Mixin which adds common functions to handle, object and various accessors.
+/// The only requirement for `Derived` is to implement `PyObject *Derived::ptr() const`.
+template <typename Derived>
+class object_api : public pyobject_tag {
+    const Derived &derived() const { return static_cast<const Derived &>(*this); }
+
+public:
+    iterator begin() const;
+    iterator end() const;
+    accessor operator[](handle key) const;
+    accessor operator[](const char *key) const;
+    accessor attr(handle key) const;
+    accessor attr(const char *key) const;
+    args_proxy operator*() const;
+
+    template <return_value_policy policy = return_value_policy::automatic_reference, typename... Args>
+    object operator()(Args &&...args) const;
+    template <return_value_policy policy = return_value_policy::automatic_reference, typename... Args>
+    PYBIND11_DEPRECATED("call(...) was deprecated in favor of operator()(...)")
+        object call(Args&&... args) const;
+
+    bool is_none() const { return derived().ptr() == Py_None; }
+    pybind11::str str() const;
+    pybind11::str repr() const;
+
+    int ref_count() const { return static_cast<int>(Py_REFCNT(derived().ptr())); }
+    handle get_type() const;
+};
+
+NAMESPACE_END(detail)
 
 /// Holds a reference to a Python object (no reference counting)
-class handle {
+class handle : public detail::object_api<handle> {
 public:
-    handle() : m_ptr(nullptr) { }
-    handle(const handle &other) : m_ptr(other.m_ptr) { }
+    handle() = default;
     handle(PyObject *ptr) : m_ptr(ptr) { }
+
     PyObject *ptr() const { return m_ptr; }
     PyObject *&ptr() { return m_ptr; }
     const handle& inc_ref() const { Py_XINCREF(m_ptr); return *this; }
     const handle& dec_ref() const { Py_XDECREF(m_ptr); return *this; }
-    int ref_count() const { return (int) Py_REFCNT(m_ptr); }
-    handle get_type() const { return handle((PyObject *) Py_TYPE(m_ptr)); }
-    inline iterator begin() const;
-    inline iterator end() const;
-    inline detail::accessor operator[](handle key) const;
-    inline detail::accessor operator[](const char *key) const;
-    inline detail::accessor attr(handle key) const;
-    inline detail::accessor attr(const char *key) const;
-    inline pybind11::str str() const;
-    inline pybind11::str repr() const;
-    bool is_none() const { return m_ptr == Py_None; }
+
     template <typename T> T cast() const;
-    template <return_value_policy policy = return_value_policy::automatic_reference, typename ... Args>
-    PYBIND11_DEPRECATED("call(...) was deprecated in favor of operator()(...)")
-        object call(Args&&... args) const;
-    template <return_value_policy policy = return_value_policy::automatic_reference, typename ... Args>
-    object operator()(Args&&... args) const;
     operator bool() const { return m_ptr != nullptr; }
     bool operator==(const handle &h) const { return m_ptr == h.m_ptr; }
     bool operator!=(const handle &h) const { return m_ptr != h.m_ptr; }
     bool check() const { return m_ptr != nullptr; }
-    inline detail::args_proxy operator*() const;
 protected:
-    PyObject *m_ptr;
+    PyObject *m_ptr = nullptr;
 };
 
 /// Holds a reference to a Python object (with reference counting)
 class object : public handle {
 public:
-    object() { }
+    object() = default;
     object(const object &o) : handle(o) { inc_ref(); }
     object(const handle &h, bool borrowed) : handle(h) { if (borrowed) inc_ref(); }
     object(PyObject *ptr, bool borrowed) : handle(ptr) { if (borrowed) inc_ref(); }
@@ -347,14 +369,6 @@ public:
     PYBIND11_OBJECT_DEFAULT(iterable, object, detail::PyIterable_Check)
 };
 
-inline detail::accessor handle::operator[](handle key) const { return detail::accessor(*this, key, false); }
-inline detail::accessor handle::operator[](const char *key) const { return detail::accessor(*this, key, false); }
-inline detail::accessor handle::attr(handle key) const { return detail::accessor(*this, key, true); }
-inline detail::accessor handle::attr(const char *key) const { return detail::accessor(*this, key, true); }
-inline iterator handle::begin() const { return iterator(PyObject_GetIter(ptr()), false); }
-inline iterator handle::end() const { return iterator(nullptr, false); }
-inline detail::args_proxy handle::operator*() const { return detail::args_proxy(*this); }
-
 class bytes;
 
 class str : public object {
@@ -398,24 +412,6 @@ public:
 inline namespace literals {
 /// String literal version of str
 inline str operator"" _s(const char *s, size_t size) { return {s, size}; }
-}
-
-inline pybind11::str handle::str() const {
-    PyObject *strValue = PyObject_Str(m_ptr);
-#if PY_MAJOR_VERSION < 3
-    PyObject *unicode = PyUnicode_FromEncodedObject(strValue, "utf-8", nullptr);
-    Py_XDECREF(strValue); strValue = unicode;
-#endif
-    return pybind11::str(strValue, false);
-}
-
-inline pybind11::str handle::repr() const {
-    PyObject *strValue = PyObject_Repr(m_ptr);
-#if PY_MAJOR_VERSION < 3
-    PyObject *unicode = PyUnicode_FromEncodedObject(strValue, "utf-8", nullptr);
-    Py_XDECREF(strValue); strValue = unicode;
-#endif
-    return pybind11::str(strValue, false);
 }
 
 class bytes : public object {
@@ -691,4 +687,37 @@ inline size_t len(handle h) {
     return (size_t) result;
 }
 
+NAMESPACE_BEGIN(detail)
+template <typename D> iterator object_api<D>::begin() const { return {PyObject_GetIter(derived().ptr()), false}; }
+template <typename D> iterator object_api<D>::end() const { return {nullptr, false}; }
+template <typename D> accessor object_api<D>::operator[](handle key) const { return {derived(), key, false}; }
+template <typename D> accessor object_api<D>::operator[](const char *key) const { return {derived(), key, false}; }
+template <typename D> accessor object_api<D>::attr(handle key) const { return {derived(), key, true}; }
+template <typename D> accessor object_api<D>::attr(const char *key) const { return {derived(), key, true}; }
+template <typename D> args_proxy object_api<D>::operator*() const { return {derived().ptr()}; }
+
+template <typename D>
+pybind11::str object_api<D>::str() const {
+    PyObject *str_value = PyObject_Str(derived().ptr());
+#if PY_MAJOR_VERSION < 3
+    PyObject *unicode = PyUnicode_FromEncodedObject(str_value, "utf-8", nullptr);
+    Py_XDECREF(str_value); str_value = unicode;
+#endif
+    return {str_value, false};
+}
+
+template <typename D>
+pybind11::str object_api<D>::repr() const {
+    PyObject *str_value = PyObject_Repr(derived().ptr());
+#if PY_MAJOR_VERSION < 3
+    PyObject *unicode = PyUnicode_FromEncodedObject(str_value, "utf-8", nullptr);
+    Py_XDECREF(str_value); str_value = unicode;
+#endif
+    return {str_value, false};
+}
+
+template <typename D>
+handle object_api<D>::get_type() const { return (PyObject *) Py_TYPE(derived().ptr()); }
+
+NAMESPACE_END(detail)
 NAMESPACE_END(pybind11)

--- a/tests/constructor_stats.h
+++ b/tests/constructor_stats.h
@@ -103,7 +103,7 @@ public:
 
     int alive() {
         // Force garbage collection to ensure any pending destructors are invoked:
-        py::module::import("gc").attr("collect").operator py::object()();
+        py::module::import("gc").attr("collect")();
         int total = 0;
         for (const auto &p : _instances) if (p.second > 0) total += p.second;
         return total;

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -39,7 +39,7 @@ PYBIND11_PLUGIN(pybind11_tests) {
     for (const auto &initializer : initializers())
         initializer(m);
 
-    if (!m.attr("have_eigen")) m.attr("have_eigen") = py::cast(false);
+    if (!py::hasattr(m, "have_eigen")) m.attr("have_eigen") = py::cast(false);
 
     return m.ptr();
 }

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -272,4 +272,21 @@ test_initializer python_types([](py::module &m) {
         }
         return py::tuple();
     });
+
+    m.def("test_accessor_assignment", []() {
+        auto l = py::list(1);
+        l[0] = py::cast(0);
+
+        auto d = py::dict();
+        d["get"] = l[0];
+        auto var = l[0];
+        d["deferred_get"] = var;
+        l[0] = py::cast(1);
+        d["set"] = l[0];
+        var = py::cast(99); // this assignment should not overwrite l[0]
+        d["deferred_set"] = l[0];
+        d["var"] = var;
+
+        return d;
+    });
 });

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -60,7 +60,7 @@ public:
     py::list get_list() {
         py::list list;
         list.append(py::str("value"));
-        py::print("Entry at position 0:", py::object(list[0]));
+        py::print("Entry at position 0:", list[0]);
         list[0] = py::str("overwritten");
         return list;
     }
@@ -256,5 +256,20 @@ test_initializer python_types([](py::module &m) {
         d["operator*"] = o.attr("func")(*o.attr("begin_end"));
 
         return d;
+    });
+
+    m.def("test_tuple_accessor", [](py::tuple existing_t) {
+        try {
+            existing_t[0] = py::cast(1);
+        } catch (const py::error_already_set &) {
+            // --> Python system error
+            // Only new tuples (refcount == 1) are mutable
+            auto new_t = py::tuple(3);
+            for (size_t i = 0; i < new_t.size(); ++i) {
+                new_t[i] = py::cast(i);
+            }
+            return new_t;
+        }
+        return py::tuple();
     });
 });

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -251,7 +251,7 @@ def test_dict_api():
 
 
 def test_accessors():
-    from pybind11_tests import test_accessor_api
+    from pybind11_tests import test_accessor_api, test_tuple_accessor
 
     class SubTestObject:
         attr_obj = 1
@@ -278,3 +278,5 @@ def test_accessors():
     assert d["is_none"] is False
     assert d["operator()"] == 2
     assert d["operator*"] == 7
+
+    assert test_tuple_accessor(tuple()) == (0, 1, 2)

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -251,7 +251,7 @@ def test_dict_api():
 
 
 def test_accessors():
-    from pybind11_tests import test_accessor_api, test_tuple_accessor
+    from pybind11_tests import test_accessor_api, test_tuple_accessor, test_accessor_assignment
 
     class SubTestObject:
         attr_obj = 1
@@ -280,3 +280,10 @@ def test_accessors():
     assert d["operator*"] == 7
 
     assert test_tuple_accessor(tuple()) == (0, 1, 2)
+
+    d = test_accessor_assignment()
+    assert d["get"] == 0
+    assert d["deferred_get"] == 0
+    assert d["set"] == 1
+    assert d["deferred_set"] == 1
+    assert d["var"] == 99

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -248,3 +248,33 @@ def test_dict_api():
     from pybind11_tests import test_dict_keyword_constructor
 
     assert test_dict_keyword_constructor() == {"x": 1, "y": 2, "z": 3}
+
+
+def test_accessors():
+    from pybind11_tests import test_accessor_api
+
+    class SubTestObject:
+        attr_obj = 1
+        attr_char = 2
+
+    class TestObject:
+        basic_attr = 1
+        begin_end = [1, 2, 3]
+        d = {"operator[object]": 1, "operator[char *]": 2}
+        sub = SubTestObject()
+
+        def func(self, x, *args):
+            return self.basic_attr + x + sum(args)
+
+    d = test_accessor_api(TestObject())
+    assert d["basic_attr"] == 1
+    assert d["begin_end"] == [1, 2, 3]
+    assert d["operator[object]"] == 1
+    assert d["operator[char *]"] == 2
+    assert d["attr(object)"] == 1
+    assert d["attr(char *)"] == 2
+    assert d["missing_attr_ptr"] == "raised"
+    assert d["missing_attr_chain"] == "raised"
+    assert d["is_none"] is False
+    assert d["operator()"] == 2
+    assert d["operator*"] == 7


### PR DESCRIPTION
As discussed in #265, this PR completes the accessor interface to match `object`. (This does not include the more drastic changes of `object`/`handle` mentioned there. This PR only affects accessors.)

With the more complete accessors in this PR there is no need for an additional cast to `object` when working with attributes and items:
```c++
// before
obj.attr("foo").cast<object>().attr("bar").cast<object>();
// after
obj.attr("foo").attr("bar");
```
All accessor support the full interface, so any kind of chain can be made without intermediate casts:
```c++
auto var = obj.attr("a")[key].attr("b").attr("method")(1, 2, 3)
```

### Breaking change

This is a breaking change for `handle::attr` and `handle::operator[]`. They will throw `error_aleady_set` with the original Python error message instead of returning `nullptr`. This may not be too bad as the previous behavior was not documented as far as I can see. It's also possible to do this without a breaking change, but it would require checking for errors in 3 places instead of 1 and reconstructing the Python's error messages from scratch.

### Extra

The first two commits here actually reduce the binary size of the test module by ~3%, which is nice. The last 3 commits then increase the size but that's because of the new tests.