### PR TITLE
Re-add accessor bool operator

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -206,6 +206,18 @@ public:
     void operator=(handle value) && { Policy::set(obj, key, value); }
     void operator=(handle value) & { get_cache() = object(value, true); }
 
+    template <typename T = Policy>
+    PYBIND11_DEPRECATED("Use of obj.attr(...) as bool is deprecated in favor of pybind11::hasattr(obj, ...)")
+    operator enable_if_t<std::is_same<T, accessor_policies::str_attr>::value ||
+            std::is_same<T, accessor_policies::obj_attr>::value, bool>() const {
+        return hasattr(obj, key);
+    }
+    template <typename T = Policy>
+    PYBIND11_DEPRECATED("Use of obj[key] as bool is deprecated in favor of obj.contains(key)")
+    operator enable_if_t<std::is_same<T, accessor_policies::generic_item>::value, bool>() const {
+        return obj.contains(key);
+    }
+
     operator object() const { return get_cache(); }
     PyObject *ptr() const { return get_cache().ptr(); }
     template <typename T> T cast() const { return get_cache().template cast<T>(); }


### PR DESCRIPTION
PR #425 removed the `bool` operator from attribute accessors.  This was quite useful, and moreover it was the only way before #425 added the `hasattr` function to check for the existence of an attribute, via:

```C++
if (obj.attr("foo")) { ... }
```

and as such is probably in use by more pybind11 users than just me.  Since nothing in the PR #425 discussion or commit messages indicates that this was intentionally removed, I assume the removal was an oversight.