### PR TITLE
Add dynamic attribute support

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -44,6 +44,9 @@ template <int Nurse, int Patient> struct keep_alive { };
 /// Annotation indicating that a class is involved in a multiple inheritance relationship
 struct multiple_inheritance { };
 
+/// Annotation which enables dynamic attributes, i.e. adds `__dict__` to a class
+struct dynamic_attr { };
+
 NAMESPACE_BEGIN(detail)
 /* Forward declarations */
 enum op_id : int;
@@ -161,6 +164,9 @@ struct type_record {
 
     /// Multiple inheritance marker
     bool multiple_inheritance = false;
+
+    /// Does the class manage a __dict__?
+    bool dynamic_attr = false;
 
     PYBIND11_NOINLINE void add_base(const std::type_info *base, void *(*caster)(void *)) {
         auto base_info = detail::get_type_info(*base, false);
@@ -290,6 +296,11 @@ struct process_attribute<base<T>> : process_attribute_default<base<T>> {
 template <>
 struct process_attribute<multiple_inheritance> : process_attribute_default<multiple_inheritance> {
     static void init(const multiple_inheritance &, type_record *r) { r->multiple_inheritance = true; }
+};
+
+template <>
+struct process_attribute<dynamic_attr> : process_attribute_default<dynamic_attr> {
+    static void init(const dynamic_attr &, type_record *r) { r->dynamic_attr = true; }
 };
 
 /***

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -297,7 +297,6 @@ inline std::string error_string();
 template <typename type> struct instance_essentials {
     PyObject_HEAD
     type *value;
-    PyObject *dict;
     PyObject *weakrefs;
     bool owned : 1;
     bool constructed : 1;

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -297,6 +297,7 @@ inline std::string error_string();
 template <typename type> struct instance_essentials {
     PyObject_HEAD
     type *value;
+    PyObject *dict;
     PyObject *weakrefs;
     bool owned : 1;
     bool constructed : 1;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -573,6 +573,33 @@ public:
 };
 
 NAMESPACE_BEGIN(detail)
+extern "C" inline PyObject *get_dict(PyObject *op, void *) {
+    auto *self = (instance<void> *) op;
+    if (!self->dict) {
+        self->dict = PyDict_New();
+    }
+    Py_XINCREF(self->dict);
+    return self->dict;
+}
+
+extern "C" inline int set_dict(PyObject *op, PyObject *dict, void *) {
+    if (!PyDict_Check(dict)) {
+        PyErr_Format(PyExc_TypeError, "__dict__ must be set to a dictionary, not a '%.200s'",
+                     Py_TYPE(dict)->tp_name);
+        return -1;
+    }
+    auto *self = (instance<void> *) op;
+    Py_INCREF(dict);
+    Py_CLEAR(self->dict);
+    self->dict = dict;
+    return 0;
+}
+
+static PyGetSetDef generic_getset[] = {
+    {const_cast<char*>("__dict__"), get_dict, set_dict, nullptr, nullptr},
+    {nullptr, nullptr, nullptr, nullptr, nullptr}
+};
+
 /// Generic support for creating new Python heap types
 class generic_type : public object {
     template <typename...> friend class class_;
@@ -684,6 +711,15 @@ protected:
 #endif
         type->ht_type.tp_flags &= ~Py_TPFLAGS_HAVE_GC;
 
+        /* Support dynamic attributes */
+        if (rec->dynamic_attr) {
+            type->ht_type.tp_flags |= Py_TPFLAGS_HAVE_GC;
+            type->ht_type.tp_dictoffset = offsetof(instance_essentials<void>, dict);
+            type->ht_type.tp_getset = generic_getset;
+            type->ht_type.tp_traverse = traverse;
+            type->ht_type.tp_clear = clear;
+        }
+
         type->ht_type.tp_doc = tp_doc;
 
         if (PyType_Ready(&type->ht_type) < 0)
@@ -785,8 +821,22 @@ protected:
 
             if (self->weakrefs)
                 PyObject_ClearWeakRefs((PyObject *) self);
+
+            Py_CLEAR(self->dict);
         }
         Py_TYPE(self)->tp_free((PyObject*) self);
+    }
+
+    static int traverse(PyObject *op, visitproc visit, void *arg) {
+        auto *self = (instance<void> *) op;
+        Py_VISIT(self->dict);
+        return 0;
+    }
+
+    static int clear(PyObject *op) {
+        auto *self = (instance<void> *) op;
+        Py_CLEAR(self->dict);
+        return 0;
     }
 
     void install_buffer_funcs(

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -53,6 +53,12 @@ public:
     int value = 0;
 };
 
+class DynamicClass {
+public:
+    DynamicClass() { print_default_created(this); }
+    ~DynamicClass() { print_destroyed(this); }
+};
+
 test_initializer methods_and_attributes([](py::module &m) {
     py::class_<ExampleMandA>(m, "ExampleMandA")
         .def(py::init<>())
@@ -81,4 +87,7 @@ test_initializer methods_and_attributes([](py::module &m) {
         .def("__str__", &ExampleMandA::toString)
         .def_readwrite("value", &ExampleMandA::value)
         ;
+
+    py::class_<DynamicClass>(m, "DynamicClass", py::dynamic_attr())
+        .def(py::init());
 });

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -3,10 +3,10 @@ try:
 except ImportError:
     import pickle
 
-from pybind11_tests import Pickleable
-
 
 def test_roundtrip():
+    from pybind11_tests import Pickleable
+
     p = Pickleable("test_value")
     p.setExtra1(15)
     p.setExtra2(48)
@@ -16,3 +16,17 @@ def test_roundtrip():
     assert p2.value() == p.value()
     assert p2.extra1() == p.extra1()
     assert p2.extra2() == p.extra2()
+
+
+def test_roundtrip_with_dict():
+    from pybind11_tests import PickleableWithDict
+
+    p = PickleableWithDict("test_value")
+    p.extra = 15
+    p.dynamic = "Attribute"
+
+    data = pickle.dumps(p, pickle.HIGHEST_PROTOCOL)
+    p2 = pickle.loads(data)
+    assert p2.value == p.value
+    assert p2.extra == p.extra
+    assert p2.dynamic == p.dynamic


### PR DESCRIPTION
This makes it possible for pybind11 classes to pick up new attributes on the fly, just like regular Python classes. The feature is enabled using `py::dynamic_attr`:
```c++
// C++
py::class_<Foo>("Foo", py::dynamic_attr());
```
```python
# Python
foo = Foo()
assert not hasattr(foo, 'n')
foo.n = 42
assert hasattr(foo, 'n')
```

Previous discussions about dynamic attributes: #180, #270, #275. Compared to before, this PR adds `tp_traverse` and `tp_clear` in order to let Python's garbage collector resolve any reference cycles. `test_cyclic_gc` specifically tests a situation which would fail without opting into the GC.

The addition of `__dict__` also means that pickling needs to be handled differently for these classes. The `PickleableWithDict` test was added for this reason.

If the implementation looks good, I'll add a section to the documentation.

Question about function linkage: This may be a little off-topic, but I noticed it while adding `traverse` and `clear`. The existing functions which are passed to Python (`generic_type::init`, `generic_type::new_instance` and similar) are all just regular C++ functions. I was under the impression that these needed to be marked with `extern "C"` in order to get the correct linkage before being passed to Python's C API. Obviously, it works as it is now, but are there any portability concerns since it shouldn't technically be allowed to call a function with C++ linkage from C?