### PR TITLE
Accept any sequence type as std::vector (or std::list)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ set(PYBIND11_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/tools")
 set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6 3.7)
 find_package(PythonLibsNew ${PYBIND11_PYTHON_VERSION} REQUIRED)
-message(${PYTHONLIBS_FOUND})
 
 include(CheckCXXCompilerFlag)
 

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -97,13 +97,13 @@ template <typename Type, typename Value> struct list_caster {
     using value_conv = make_caster<Value>;
 
     bool load(handle src, bool convert) {
-        list l(src, true);
-        if (!l.check())
+        sequence s(src, true);
+        if (!s.check())
             return false;
         value_conv conv;
         value.clear();
-        reserve_maybe(l, &value);
-        for (auto it : l) {
+        reserve_maybe(s, &value);
+        for (auto it : s) {
             if (!conv.load(it, convert))
                 return false;
             value.push_back((Value) conv);
@@ -113,8 +113,8 @@ template <typename Type, typename Value> struct list_caster {
 
     template <typename T = Type,
               enable_if_t<std::is_same<decltype(std::declval<T>().reserve(0)), void>::value, int> = 0>
-    void reserve_maybe(list l, Type *) { value.reserve(l.size()); }
-    void reserve_maybe(list, void *) { }
+    void reserve_maybe(sequence s, Type *) { value.reserve(s.size()); }
+    void reserve_maybe(sequence, void *) { }
 
     static handle cast(const Type &src, return_value_policy policy, handle parent) {
         list l(src.size());

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -71,6 +71,14 @@ def test_instance(capture):
         list item 0: value
         list item 1: value2
     """
+    with capture:
+        list_result = instance.get_list_2()
+        list_result.append('value2')
+        instance.print_list_2(tuple(list_result))
+    assert capture.unordered == """
+        list item 0: value
+        list item 1: value2
+    """
     array_result = instance.get_array()
     assert array_result == ['array entry 1', 'array entry 2']
     with capture:


### PR DESCRIPTION
In the current implementation of the STL container casters functions which take `std::vector` or `std::list` arguments in C++ will only accept `list` in Python. This is not very Pythonic. Users will expect the functions to be callable with any other sequence type (e.g. `tuple`).

This PR implements that capability. It only affects `std::vector` and `std::list` to not complicate overloading on `std::tuple` or `std::pair` arguments, but could potentially be extended to cover those as well.

Note that this only affects `load`, functions returning `std::vector` or `std::list` will still return a Python `list`.