### PR TITLE
Disable most implicit conversion constructors

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -248,7 +248,7 @@ struct buffer_info {
     : buffer_info(ptr, itemsize, format, 1, std::vector<size_t> { size },
                   std::vector<size_t> { itemsize }) { }
 
-    buffer_info(Py_buffer *view, bool ownview = true)
+    explicit buffer_info(Py_buffer *view, bool ownview = true)
         : ptr(view->buf), itemsize((size_t) view->itemsize), size(1), format(view->format),
           ndim((size_t) view->ndim), shape((size_t) view->ndim), strides((size_t) view->ndim), view(view), ownview(ownview) {
         for (size_t i = 0; i < (size_t) view->ndim; ++i) {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -165,16 +165,16 @@ class dtype : public object {
 public:
     PYBIND11_OBJECT_DEFAULT(dtype, object, detail::npy_api::get().PyArrayDescr_Check_);
 
-    dtype(const buffer_info &info) {
+    explicit dtype(const buffer_info &info) {
         dtype descr(_dtype_from_pep3118()(PYBIND11_STR_TYPE(info.format)));
         m_ptr = descr.strip_padding().release().ptr();
     }
 
-    dtype(std::string format) {
+    explicit dtype(std::string format) {
         m_ptr = from_args(pybind11::str(format)).release().ptr();
     }
 
-    dtype(const char *format) : dtype(std::string(format)) { }
+    explicit dtype(const char *format) : dtype(std::string(format)) { }
 
     dtype(list names, list formats, list offsets, size_t itemsize) {
         dict args;
@@ -317,7 +317,7 @@ public:
     array(size_t count, const T *ptr, handle base = handle())
         : array(std::vector<size_t>{ count }, ptr, base) { }
 
-    array(const buffer_info &info)
+    explicit array(const buffer_info &info)
     : array(pybind11::dtype(info), info.shape, info.strides, info.ptr) { }
 
     /// Array descriptor (dtype)
@@ -477,18 +477,18 @@ public:
 
     array_t() : array() { }
 
-    array_t(const buffer_info& info) : array(info) { }
+    explicit array_t(const buffer_info& info) : array(info) { }
 
     array_t(const std::vector<size_t> &shape,
             const std::vector<size_t> &strides, const T *ptr = nullptr,
             handle base = handle())
         : array(shape, strides, ptr, base) { }
 
-    array_t(const std::vector<size_t> &shape, const T *ptr = nullptr,
+    explicit array_t(const std::vector<size_t> &shape, const T *ptr = nullptr,
             handle base = handle())
         : array(shape, ptr, base) { }
 
-    array_t(size_t count, const T *ptr = nullptr, handle base = handle())
+    explicit array_t(size_t count, const T *ptr = nullptr, handle base = handle())
         : array(count, ptr, base) { }
 
     constexpr size_t itemsize() const {
@@ -607,7 +607,7 @@ DECL_FMT(std::complex<double>, NPY_CDOUBLE_, "complex128");
 
 #define DECL_CHAR_FMT \
     static PYBIND11_DESCR name() { return _("S") + _<N>(); } \
-    static pybind11::dtype dtype() { return std::string("S") + std::to_string(N); }
+    static pybind11::dtype dtype() { return pybind11::dtype(std::string("S") + std::to_string(N)); }
 template <size_t N> struct npy_format_descriptor<char[N]> { DECL_CHAR_FMT };
 template <size_t N> struct npy_format_descriptor<std::array<char, N>> { DECL_CHAR_FMT };
 #undef DECL_CHAR_FMT
@@ -883,7 +883,7 @@ struct vectorize_helper {
     typename std::remove_reference<Func>::type f;
 
     template <typename T>
-    vectorize_helper(T&&f) : f(std::forward<T>(f)) { }
+    explicit vectorize_helper(T&&f) : f(std::forward<T>(f)) { }
 
     object operator()(array_t<Args, array::c_style | array::forcecast>... args) {
         return run(args..., typename make_index_sequence<sizeof...(Args)>::type());

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -44,12 +44,12 @@ public:
 
     /// Construct a cpp_function from a vanilla function pointer
     template <typename Return, typename... Args, typename... Extra>
-    cpp_function(Return (*f)(Args...), const Extra&... extra) {
+    explicit cpp_function(Return (*f)(Args...), const Extra&... extra) {
         initialize(f, f, extra...);
     }
 
     /// Construct a cpp_function from a lambda function (possibly with internal state)
-    template <typename Func, typename... Extra> cpp_function(Func &&f, const Extra&... extra) {
+    template <typename Func, typename... Extra> explicit cpp_function(Func &&f, const Extra&... extra) {
         initialize(std::forward<Func>(f),
                    (typename detail::remove_class<decltype(
                        &std::remove_reference<Func>::type::operator())>::type *) nullptr, extra...);
@@ -57,14 +57,14 @@ public:
 
     /// Construct a cpp_function from a class method (non-const)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
-            cpp_function(Return (Class::*f)(Arg...), const Extra&... extra) {
+            explicit cpp_function(Return (Class::*f)(Arg...), const Extra&... extra) {
         initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(args...); },
                    (Return (*) (Class *, Arg...)) nullptr, extra...);
     }
 
     /// Construct a cpp_function from a class method (const)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
-            cpp_function(Return (Class::*f)(Arg...) const, const Extra&... extra) {
+            explicit cpp_function(Return (Class::*f)(Arg...) const, const Extra&... extra) {
         initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(args...); },
                    (Return (*)(const Class *, Arg ...)) nullptr, extra...);
     }
@@ -528,7 +528,7 @@ class module : public object {
 public:
     PYBIND11_OBJECT_DEFAULT(module, object, PyModule_Check)
 
-    module(const char *name, const char *doc = nullptr) {
+    explicit module(const char *name, const char *doc = nullptr) {
 #if PY_MAJOR_VERSION >= 3
         PyModuleDef *def = new PyModuleDef();
         memset(def, 0, sizeof(PyModuleDef));
@@ -1524,7 +1524,7 @@ private:
 
 class gil_scoped_release {
 public:
-    gil_scoped_release(bool disassoc = false) : disassoc(disassoc) {
+    explicit gil_scoped_release(bool disassoc = false) : disassoc(disassoc) {
         tstate = PyEval_SaveThread();
         if (disassoc) {
             auto key = detail::get_internals().tstate;


### PR DESCRIPTION
We have various classes that have non-explicit constructors that accept a single argument (either taking just one, or taking multiple with the remainder defaulted), which is implicitly making them implicitly convertible from the argument.  In a few cases, this is desirable (e.g. being able to pass a `std::string` as a `py::str` argument, or a `double` as a `py::float_` argument); in many others, however, it is unintended (e.g. implicit conversion of size_t to a py::array_t<T> type).

This disables most of the unwanted implicit conversions by marking them `explicit`, and comments the ones that are deliberately left implicit.

Comments/suggestions welcome, though: some of the `explicit`s may be undesirable, and vice versa for the non-`explicit`s.