### PR TITLE
Bugfix: bad delete if no copy ctor

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(PYBIND11_TEST_FILES
   test_chrono.cpp
   test_class_args.cpp
   test_constants_and_functions.cpp
+  test_copy_move_policies.cpp
   test_eigen.cpp
   test_enum.cpp
   test_eval.cpp

--- a/tests/test_copy_move_policies.cpp
+++ b/tests/test_copy_move_policies.cpp
@@ -1,0 +1,41 @@
+/*
+    tests/test_copy_move_policies.cpp -- 'copy' and 'move'
+                                         return value policies
+
+    Copyright (c) 2016 Ben North <ben@redfrontdoor.org>
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#include "pybind11_tests.h"
+
+template <typename derived>
+struct empty {
+    static const derived& get_one() { return instance_; }
+    static derived instance_;
+};
+
+struct lacking_copy_ctor : public empty<lacking_copy_ctor> {
+    lacking_copy_ctor() {}
+    lacking_copy_ctor(const lacking_copy_ctor& other) = delete;
+};
+
+template <> lacking_copy_ctor empty<lacking_copy_ctor>::instance_ {};
+
+struct lacking_move_ctor : public empty<lacking_move_ctor> {
+    lacking_move_ctor() {}
+    lacking_move_ctor(const lacking_move_ctor& other) = delete;
+    lacking_move_ctor(lacking_move_ctor&& other) = delete;
+};
+
+template <> lacking_move_ctor empty<lacking_move_ctor>::instance_ {};
+
+test_initializer copy_move_policies([](py::module &m) {
+    py::class_<lacking_copy_ctor>(m, "lacking_copy_ctor")
+        .def_static("get_one", &lacking_copy_ctor::get_one,
+                    py::return_value_policy::copy);
+    py::class_<lacking_move_ctor>(m, "lacking_move_ctor")
+        .def_static("get_one", &lacking_move_ctor::get_one,
+                    py::return_value_policy::move);
+});

--- a/tests/test_copy_move_policies.py
+++ b/tests/test_copy_move_policies.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+def test_lacking_copy_ctor():
+    from pybind11_tests import lacking_copy_ctor
+    with pytest.raises(RuntimeError) as excinfo:
+        lacking_copy_ctor.get_one()
+    assert "the object is non-copyable!" in str(excinfo.value)
+
+
+def test_lacking_move_ctor():
+    from pybind11_tests import lacking_move_ctor
+    with pytest.raises(RuntimeError) as excinfo:
+        lacking_move_ctor.get_one()
+    assert "the object is neither movable nor copyable!" in str(excinfo.value)
+
+


### PR DESCRIPTION
I encountered a core dump which I believe I have tracked down the cause of.  If there is no copy ctor, but the return-value-policy for some function is 'copy', the state of `wrapper->value` and `wrapper->owned` are left in an incorrect state.  Pybind believes it owns somebody else's object, and then bad things happen when pybind attempts to delete that object.

This PR re-writes the handling of `policy` in `type_caster_generic::cast()` as a `switch` to clarify exactly which cases lead to which states of `value`/`owned`.  The new tests generate a core dump without the change to `cast.h`.