### PR TITLE
Typed iterators

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -736,7 +736,7 @@ public:
 
 class sequence : public object {
 public:
-    PYBIND11_OBJECT(sequence, object, PySequence_Check)
+    PYBIND11_OBJECT_DEFAULT(sequence, object, PySequence_Check)
     size_t size() const { return (size_t) PySequence_Size(m_ptr); }
     detail::sequence_accessor operator[](size_t index) const { return {*this, index}; }
 };

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -749,6 +749,14 @@ public:
     detail::sequence_accessor operator[](size_t index) const { return {*this, index}; }
 };
 
+template<typename T> class sequence_t : public sequence {
+public:
+    using sequence::sequence;
+
+    iterator_t<T> begin() { return {PyObject_GetIter(ptr()), false}; }
+    iterator_t<T> end() { return {nullptr, false}; }
+};
+
 class list : public object {
 public:
     PYBIND11_OBJECT(list, object, PyList_Check)

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -403,6 +403,9 @@ private:
     friend Derived;
 
 public:
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::input_iterator_tag;
+
     base_iterator() : value(), ready(false) { }
     base_iterator(const base_iterator<Derived>&) = default;
     base_iterator(base_iterator<Derived>&&) = default;
@@ -454,6 +457,7 @@ NAMESPACE_END(detail)
 class iterator : public object, public detail::base_iterator<iterator> {
     PYBIND11_OBJECT_CVT(iterator, object, PyIter_Check, this->reset())
     using base_t = detail::base_iterator<iterator>;
+    using reference = handle; using value_type = handle; using pointer = handle*;
 
     iterator() : object(), base_t() { }
     iterator(const iterator& it) : object(it), base_t(it) { }
@@ -471,6 +475,7 @@ class iterator : public object, public detail::base_iterator<iterator> {
 template<typename T> class iterator_t : public object, public detail::base_iterator<iterator_t<T>> {
     PYBIND11_OBJECT_CVT(iterator_t<T>, object, PyIter_Check, this->reset())
     using base_t = detail::base_iterator<iterator_t<T>>;
+    using reference = T; using value_type = T; using pointer = T*;
 
     iterator_t() : object(), base_t() { }
     iterator_t(const iterator_t<T>& it) : object(it), base_t(it) { }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -495,6 +495,14 @@ public:
     PYBIND11_OBJECT_DEFAULT(iterable, object, detail::PyIterable_Check)
 };
 
+template<typename T> class iterable_t : public iterable {
+public:
+    using iterable::iterable;
+
+    iterator_t<T> begin() { return {PyObject_GetIter(ptr()), false}; }
+    iterator_t<T> end() { return {nullptr, false}; }
+};
+
 class bytes;
 
 class str : public object {

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -92,7 +92,7 @@ template <typename Type, typename Key, typename Value> struct map_caster {
     PYBIND11_TYPE_CASTER(type, _("Dict[") + key_conv::name() + _(", ") + value_conv::name() + _("]"));
 };
 
-template <typename Type, typename Value> struct list_caster {
+template <typename Type, typename Value> struct sequence_caster {
     using type = Type;
     using value_conv = make_caster<Value>;
 
@@ -132,10 +132,10 @@ template <typename Type, typename Value> struct list_caster {
 };
 
 template <typename Type, typename Alloc> struct type_caster<std::vector<Type, Alloc>>
- : list_caster<std::vector<Type, Alloc>, Type> { };
+ : sequence_caster<std::vector<Type, Alloc>, Type> { };
 
 template <typename Type, typename Alloc> struct type_caster<std::list<Type, Alloc>>
- : list_caster<std::list<Type, Alloc>, Type> { };
+ : sequence_caster<std::list<Type, Alloc>, Type> { };
 
 template <typename Type, size_t Size> struct type_caster<std::array<Type, Size>> {
     using array_type = std::array<Type, Size>;

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -142,7 +142,7 @@ template <typename Type, size_t Size> struct type_caster<std::array<Type, Size>>
     using value_conv = make_caster<Type>;
 
     bool load(handle src, bool convert) {
-        list l(src, true);
+        sequence l(src, true);
         if (!l.check())
             return false;
         if (l.size() != Size)

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -8,10 +8,13 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
+
 #include "pybind11_tests.h"
 #include "constructor_stats.h"
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
+
+#include <algorithm>
 
 class Sequence {
 public:
@@ -216,6 +219,14 @@ test_initializer sequences_and_iterators([](py::module &m) {
        .def(py::self == py::self)
        .def(py::self != py::self);
        // Could also define py::self + py::self for concatenation, etc.
+
+    m.def("sort_iterable_t", [](py::iterable_t<std::string> it) {
+        auto v = std::vector<std::string>(it.begin(), it.end());
+        std::sort(v.begin(), v.end()); return v;
+    }).def("sort_sequence_t", [](py::sequence_t<std::string> it) {
+        auto v = std::vector<std::string>(it.begin(), it.end());
+        std::sort(v.begin(), v.end()); return v;
+    });
 
     py::class_<StringMap> map(m, "StringMap");
 

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -88,3 +88,26 @@ def test_map_iterator():
         assert m[k] == expected[k]
     for k, v in m.items():
         assert v == expected[k]
+
+
+@pytest.mark.parametrize('funcname', ['sort_iterable_t', 'sort_sequence_t'])
+def test_typed_iterables(funcname):
+    import pybind11_tests
+    func = getattr(pybind11_tests, funcname)
+
+    seq1 = ['b', 'c', 'a']
+    assert func(seq1) == ['a', 'b', 'c']
+
+    assert func([]) == []
+
+    with pytest.raises(RuntimeError) as excinfo:
+        func([1, 2])
+    assert 'Unable to cast' in str(excinfo.value)
+
+    seq2 = (s * 2 for s in seq1)  # generator, ok for iterables but not sequences
+    if funcname == 'sort_iterable_t':
+        assert func(seq2) == ['aa', 'bb', 'cc']
+    else:
+        with pytest.raises(TypeError) as excinfo:
+            func(seq2)
+        assert 'incompatible function arguments' in str(excinfo.value)


### PR DESCRIPTION
This has turned out to be quite a bit more work than I initially expected it to be, but here goes.
- `iterator_t<T>` is a typed iterator that casts each item to `T`
- `iterable_t<T>` is a typed iterable
- `sequence_t<T>` is a sized typed iterable
- Iterators can now be passed directly to STL (see the test example)
- `sequence` / `sequence_t` can now be used as a function argument
- `array<T, n>` is now loadable from sequences 

Previous discussion: in #360.
