### PR TITLE
Add default and converting constructors for all concrete Python types

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,7 +28,7 @@ Breaking changes queued for v2.0.0 (Not yet released)
   (now uses prefix increment operator); it now also accepts iterators with
   different begin/end types as long as they are equality comparable.
 * ``arg()`` now accepts a wider range of argument types for default values
-* Added ``repr()`` method to the ``handle`` class.
+* Added ``py::repr()`` function which is equivalent to Python's builtin ``repr()``.
 * Added support for registering structured dtypes via ``PYBIND11_NUMPY_DTYPE()`` macro.
 * Added ``PYBIND11_STR_TYPE`` macro which maps to the ``builtins.str`` type.
 * Added a simplified ``buffer_info`` constructor for 1-dimensional buffers.

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -265,9 +265,9 @@ template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
             auto descr = "'" + std::string(a.name) + ": " + a.type + "'";
             if (r->class_) {
                 if (r->name)
-                    descr += " in method '" + (std::string) r->class_.str() + "." + (std::string) r->name + "'";
+                    descr += " in method '" + (std::string) str(r->class_) + "." + (std::string) r->name + "'";
                 else
-                    descr += " in method of '" + (std::string) r->class_.str() + "'";
+                    descr += " in method of '" + (std::string) str(r->class_) + "'";
             } else if (r->name) {
                 descr += " in function named '" + (std::string) r->name + "'";
             }

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -111,7 +111,6 @@
 #define PYBIND11_BYTES_FROM_STRING_AND_SIZE PyBytes_FromStringAndSize
 #define PYBIND11_BYTES_AS_STRING_AND_SIZE PyBytes_AsStringAndSize
 #define PYBIND11_BYTES_AS_STRING PyBytes_AsString
-#define PYBIND11_BYTES_CHECK PyBytes_Check
 #define PYBIND11_LONG_CHECK(o) PyLong_Check(o)
 #define PYBIND11_LONG_AS_LONGLONG(o) PyLong_AsLongLong(o)
 #define PYBIND11_LONG_AS_UNSIGNED_LONGLONG(o) PyLong_AsUnsignedLongLong(o)
@@ -130,7 +129,6 @@
 #define PYBIND11_BYTES_FROM_STRING_AND_SIZE PyString_FromStringAndSize
 #define PYBIND11_BYTES_AS_STRING_AND_SIZE PyString_AsStringAndSize
 #define PYBIND11_BYTES_AS_STRING PyString_AsString
-#define PYBIND11_BYTES_CHECK PyString_Check
 #define PYBIND11_LONG_CHECK(o) (PyInt_Check(o) || PyLong_Check(o))
 #define PYBIND11_LONG_AS_LONGLONG(o) (PyInt_Check(o) ? (long long) PyLong_AsLong(o) : PyLong_AsLongLong(o))
 #define PYBIND11_LONG_AS_UNSIGNED_LONGLONG(o) (PyInt_Check(o) ? (unsigned long long) PyLong_AsUnsignedLong(o) : PyLong_AsUnsignedLongLong(o))

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -182,7 +182,7 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
         if (!src)
             return false;
 
-        object obj(src, true);
+        auto obj = reinterpret_borrow<object>(src);
         object sparse_module = module::import("scipy.sparse");
         object matrix_type = sparse_module.attr(
             rowMajor ? "csr_matrix" : "csc_matrix");

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -55,7 +55,7 @@ struct type_caster<Type, enable_if_t<is_eigen_dense<Type>::value && !is_eigen_re
 
     bool load(handle src, bool) {
         array_t<Scalar> buf(src, true);
-        if (!buf.check())
+        if (!buf)
             return false;
 
         if (buf.ndim() == 1) {
@@ -201,7 +201,7 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
         auto shape = pybind11::tuple((pybind11::object) obj.attr("shape"));
         auto nnz = obj.attr("nnz").cast<Index>();
 
-        if (!values.check() || !innerIndices.check() || !outerIndices.check())
+        if (!values || !innerIndices || !outerIndices)
             return false;
 
         value = Eigen::MappedSparseMatrix<Scalar, Type::Flags, StorageIndex>(

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -54,7 +54,7 @@ struct type_caster<Type, enable_if_t<is_eigen_dense<Type>::value && !is_eigen_re
     static constexpr bool isVector = Type::IsVectorAtCompileTime;
 
     bool load(handle src, bool) {
-        array_t<Scalar> buf(src, true);
+        auto buf = array_t<Scalar>::ensure(src);
         if (!buf)
             return false;
 

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -36,7 +36,7 @@ public:
            captured variables), in which case the roundtrip can be avoided.
          */
         if (PyCFunction_Check(src_.ptr())) {
-            capsule c(PyCFunction_GetSelf(src_.ptr()), true);
+            auto c = reinterpret_borrow<capsule>(PyCFunction_GetSelf(src_.ptr()));
             auto rec = (function_record *) c;
             using FunctionType = Return (*) (Args...);
 
@@ -47,7 +47,7 @@ public:
             }
         }
 
-        object src(src_, true);
+        auto src = reinterpret_borrow<object>(src_);
         value = [src](Args... args) -> Return {
             gil_scoped_acquire acq;
             object retval(src(std::move(args)...));

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -540,9 +540,11 @@ protected:
 
 template <typename T, int ExtraFlags = array::forcecast> class array_t : public array {
 public:
-    PYBIND11_OBJECT_CVT(array_t, array, is_non_null, m_ptr = ensure_(m_ptr));
-
     array_t() : array() { }
+
+    array_t(handle h, bool borrowed) : array(h, borrowed) { m_ptr = ensure_(m_ptr); }
+
+    array_t(const object &o) : array(o) { m_ptr = ensure_(m_ptr); }
 
     explicit array_t(const buffer_info& info) : array(info) { }
 
@@ -587,8 +589,6 @@ public:
             fail_dim_check(sizeof...(index), "index dimension mismatch");
         return *(static_cast<T*>(array::mutable_data()) + byte_offset(size_t(index)...) / itemsize());
     }
-
-    static bool is_non_null(PyObject *ptr) { return ptr != nullptr; }
 
     static PyObject *ensure_(PyObject *ptr) {
         if (ptr == nullptr)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -504,7 +504,7 @@ protected:
             msg += "\nInvoked with: ";
             tuple args_(args, true);
             for (size_t ti = overloads->is_constructor ? 1 : 0; ti < args_.size(); ++ti) {
-                msg += static_cast<std::string>(static_cast<object>(args_[ti]).str());
+                msg += static_cast<std::string>(pybind11::str(args_[ti]));
                 if ((ti + 1) != args_.size() )
                     msg += ", ";
             }
@@ -665,11 +665,9 @@ protected:
 #endif
 
         size_t num_bases = rec->bases.size();
-        tuple bases(num_bases);
-        for (size_t i = 0; i < num_bases; ++i)
-            bases[i] = rec->bases[i];
+        auto bases = tuple(rec->bases);
 
-        std::string full_name = (scope_module ? ((std::string) scope_module.str() + "." + rec->name)
+        std::string full_name = (scope_module ? ((std::string) pybind11::str(scope_module) + "." + rec->name)
                                               : std::string(rec->name));
 
         char *tp_doc = nullptr;
@@ -1470,7 +1468,7 @@ NAMESPACE_BEGIN(detail)
 PYBIND11_NOINLINE inline void print(tuple args, dict kwargs) {
     auto strings = tuple(args.size());
     for (size_t i = 0; i < args.size(); ++i) {
-        strings[i] = args[i].str();
+        strings[i] = str(args[i]);
     }
     auto sep = kwargs.contains("sep") ? kwargs["sep"] : cast(" ");
     auto line = sep.attr("join")(strings);
@@ -1654,7 +1652,7 @@ inline function get_type_overload(const void *this_ptr, const detail::type_info 
 
     /* Don't call dispatch code if invoked from overridden function */
     PyFrameObject *frame = PyThreadState_Get()->frame;
-    if (frame && (std::string) pybind11::handle(frame->f_code->co_name).str() == name &&
+    if (frame && (std::string) str(frame->f_code->co_name) == name &&
         frame->f_code->co_argcount > 0) {
         PyFrame_FastToLocals(frame);
         PyObject *self_caller = PyDict_GetItem(

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -45,9 +45,9 @@ template <typename Type, typename Key> struct set_caster {
     using key_conv = make_caster<Key>;
 
     bool load(handle src, bool convert) {
-        pybind11::set s(src, true);
-        if (!s.check())
+        if (!isinstance<pybind11::set>(src))
             return false;
+        pybind11::set s(src, true);
         value.clear();
         key_conv conv;
         for (auto entry : s) {
@@ -77,9 +77,9 @@ template <typename Type, typename Key, typename Value> struct map_caster {
     using value_conv = make_caster<Value>;
 
     bool load(handle src, bool convert) {
-        dict d(src, true);
-        if (!d.check())
+        if (!isinstance<dict>(src))
             return false;
+        dict d(src, true);
         key_conv kconv;
         value_conv vconv;
         value.clear();
@@ -112,9 +112,9 @@ template <typename Type, typename Value> struct list_caster {
     using value_conv = make_caster<Value>;
 
     bool load(handle src, bool convert) {
-        sequence s(src, true);
-        if (!s.check())
+        if (!isinstance<sequence>(src))
             return false;
+        sequence s(src, true);
         value_conv conv;
         value.clear();
         reserve_maybe(s, &value);
@@ -157,9 +157,9 @@ template <typename Type, size_t Size> struct type_caster<std::array<Type, Size>>
     using value_conv = make_caster<Type>;
 
     bool load(handle src, bool convert) {
-        list l(src, true);
-        if (!l.check())
+        if (!isinstance<list>(src))
             return false;
+        list l(src, true);
         if (l.size() != Size)
             return false;
         value_conv conv;

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -248,7 +248,7 @@ template<> struct type_caster<std::experimental::nullopt_t>
 NAMESPACE_END(detail)
 
 inline std::ostream &operator<<(std::ostream &os, const handle &obj) {
-    os << (std::string) obj.str();
+    os << (std::string) str(obj);
     return os;
 }
 

--- a/tests/test_inheritance.cpp
+++ b/tests/test_inheritance.cpp
@@ -83,4 +83,18 @@ test_initializer inheritance([](py::module &m) {
         return new BaseClass();
     });
     m.def("return_none", []() -> BaseClass* { return nullptr; });
+
+    m.def("test_isinstance", [](py::list l) {
+        struct Unregistered { }; // checks missing type_info code path
+
+        return py::make_tuple(
+            py::isinstance<py::tuple>(l[0]),
+            py::isinstance<py::dict>(l[1]),
+            py::isinstance<Pet>(l[2]),
+            py::isinstance<Pet>(l[3]),
+            py::isinstance<Dog>(l[4]),
+            py::isinstance<Rabbit>(l[5]),
+            py::isinstance<Unregistered>(l[6])
+        );
+    });
 });

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -45,3 +45,11 @@ def test_automatic_upcasting():
     assert type(return_class_n(2)).__name__ == "DerivedClass2"
     assert type(return_class_n(0)).__name__ == "BaseClass"
     assert type(return_class_n(1)).__name__ == "DerivedClass1"
+
+
+def test_isinstance():
+    from pybind11_tests import test_isinstance, Pet, Dog
+
+    objects = [tuple(), dict(), Pet("Polly", "parrot")] + [Dog("Molly")] * 4
+    expected = (True, True, True, True, True, False, False)
+    assert test_isinstance(objects) == expected

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -126,4 +126,28 @@ test_initializer numpy_array([](py::module &m) {
     );
 
     sm.def("function_taking_uint64", [](uint64_t) { });
+
+    sm.def("isinstance_untyped", [](py::object yes, py::object no) {
+        return py::isinstance<py::array>(yes) && !py::isinstance<py::array>(no);
+    });
+
+    sm.def("isinstance_typed", [](py::object o) {
+        return py::isinstance<py::array_t<double>>(o) && !py::isinstance<py::array_t<int>>(o);
+    });
+
+    sm.def("default_constructors", []() {
+        return py::dict(
+            "array"_a=py::array(),
+            "array_t<int32>"_a=py::array_t<std::int32_t>(),
+            "array_t<double>"_a=py::array_t<double>()
+        );
+    });
+
+    sm.def("converting_constructors", [](py::object o) {
+        return py::dict(
+            "array"_a=py::array(o),
+            "array_t<int32>"_a=py::array_t<std::int32_t>(o),
+            "array_t<double>"_a=py::array_t<double>(o)
+        );
+    });
 });

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -245,3 +245,30 @@ def test_cast_numpy_int64_to_uint64():
     from pybind11_tests.array import function_taking_uint64
     function_taking_uint64(123)
     function_taking_uint64(np.uint64(123))
+
+
+@pytest.requires_numpy
+def test_isinstance():
+    from pybind11_tests.array import isinstance_untyped, isinstance_typed
+
+    assert isinstance_untyped(np.array([1, 2, 3]), "not an array")
+    assert isinstance_typed(np.array([1.0, 2.0, 3.0]))
+
+
+@pytest.requires_numpy
+def test_constructors():
+    from pybind11_tests.array import default_constructors, converting_constructors
+
+    defaults = default_constructors()
+    for a in defaults.values():
+        assert a.size == 0
+    assert defaults["array"].dtype == np.array([]).dtype
+    assert defaults["array_t<int32>"].dtype == np.int32
+    assert defaults["array_t<double>"].dtype == np.float64
+
+    results = converting_constructors([1, 2, 3])
+    for a in results.values():
+        np.testing.assert_array_equal(a, [1, 2, 3])
+    assert results["array"].dtype == np.int_
+    assert results["array_t<int32>"].dtype == np.int32
+    assert results["array_t<double>"].dtype == np.float64

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -196,14 +196,14 @@ py::list print_format_descriptors() {
 
 py::list print_dtypes() {
     const auto dtypes = {
-        py::dtype::of<SimpleStruct>().str(),
-        py::dtype::of<PackedStruct>().str(),
-        py::dtype::of<NestedStruct>().str(),
-        py::dtype::of<PartialStruct>().str(),
-        py::dtype::of<PartialNestedStruct>().str(),
-        py::dtype::of<StringStruct>().str(),
-        py::dtype::of<EnumStruct>().str(),
-        py::dtype::of<StructWithUglyNames>().str()
+        py::str(py::dtype::of<SimpleStruct>()),
+        py::str(py::dtype::of<PackedStruct>()),
+        py::str(py::dtype::of<NestedStruct>()),
+        py::str(py::dtype::of<PartialStruct>()),
+        py::str(py::dtype::of<PartialNestedStruct>()),
+        py::str(py::dtype::of<StringStruct>()),
+        py::str(py::dtype::of<EnumStruct>()),
+        py::str(py::dtype::of<StructWithUglyNames>())
     };
     auto l = py::list();
     for (const auto &s : dtypes) {

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -153,8 +153,8 @@ public:
     }
 
     void test_print(const py::object& obj) {
-        py::print(obj.str());
-        py::print(obj.repr());
+        py::print(py::str(obj));
+        py::print(py::repr(obj));
     }
 
     static int value;
@@ -321,4 +321,46 @@ test_initializer python_types([](py::module &m) {
 
     m.attr("has_optional") = py::cast(has_optional);
     m.attr("has_exp_optional") = py::cast(has_exp_optional);
+
+    m.def("test_default_constructors", []() {
+        return py::dict(
+            "str"_a=py::str(),
+            "bool"_a=py::bool_(),
+            "int"_a=py::int_(),
+            "float"_a=py::float_(),
+            "tuple"_a=py::tuple(),
+            "list"_a=py::list(),
+            "dict"_a=py::dict(),
+            "set"_a=py::set()
+        );
+    });
+
+    m.def("test_converting_constructors", [](py::dict d) {
+        return py::dict(
+            "str"_a=py::str(d["str"]),
+            "bool"_a=py::bool_(d["bool"]),
+            "int"_a=py::int_(d["int"]),
+            "float"_a=py::float_(d["float"]),
+            "tuple"_a=py::tuple(d["tuple"]),
+            "list"_a=py::list(d["list"]),
+            "dict"_a=py::dict(d["dict"]),
+            "set"_a=py::set(d["set"]),
+            "memoryview"_a=py::memoryview(d["memoryview"])
+        );
+    });
+
+    m.def("test_cast_functions", [](py::dict d) {
+        // When converting between Python types, obj.cast<T>() should be the same as T(obj)
+        return py::dict(
+            "str"_a=d["str"].cast<py::str>(),
+            "bool"_a=d["bool"].cast<py::bool_>(),
+            "int"_a=d["int"].cast<py::int_>(),
+            "float"_a=d["float"].cast<py::float_>(),
+            "tuple"_a=d["tuple"].cast<py::tuple>(),
+            "list"_a=d["list"].cast<py::list>(),
+            "dict"_a=d["dict"].cast<py::dict>(),
+            "set"_a=d["set"].cast<py::set>(),
+            "memoryview"_a=d["memoryview"].cast<py::memoryview>()
+        );
+    });
 });

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -330,3 +330,29 @@ def test_exp_optional():
     assert test_nullopt_exp(None) == 42
     assert test_nullopt_exp(42) == 42
     assert test_nullopt_exp(43) == 43
+
+
+def test_constructors():
+    """C++ default and converting constructors are equivalent to type calls in Python"""
+    from pybind11_tests import (test_default_constructors, test_converting_constructors,
+                                test_cast_functions)
+
+    types = [str, bool, int, float, tuple, list, dict, set]
+    expected = {t.__name__: t() for t in types}
+    assert test_default_constructors() == expected
+
+    data = {
+        str: 42,
+        bool: "Not empty",
+        int: "42",
+        float: "+1e3",
+        tuple: range(3),
+        list: range(3),
+        dict: [("two", 2), ("one", 1), ("three", 3)],
+        set: [4, 4, 5, 6, 6, 6],
+        memoryview: b'abc'
+    }
+    inputs = {k.__name__: v for k, v in data.items()}
+    expected = {k.__name__: k(v) for k, v in data.items()}
+    assert test_converting_constructors(inputs) == expected
+    assert test_cast_functions(inputs) == expected


### PR DESCRIPTION
There is currently a functionality split between `py::str()` and `py::object::str()` which can be surprising:

``` c++
const char *c_string = ...;
auto s1 = pt::str(c_string); // convert to str
std::string std_string = ...;
auto s2 = pt::str(std_string); // convert to str
py::object obj = ...;
auto s3 = pt::str(obj); // --> no conversion <--
auto s4 = obj.str(); // convert to str
```

This PR makes case `s3` do the expected conversion (if needed). Case `s4` is deprecated.

### Update

This was extended to all concrete Python types represented in pybind11. New `reinterpret_*` functions were also added to streamline taking raw `PyObject *`. For example:
```c++
// New constructors
auto l1 = list(); // default construct empty list
auto l2 = list(obj); // convert `obj` to a list (throw on error)

// DEPRECATED
auto l3 = list(ptr, true/false); // borrow or steal `PyObject *` without any conversion

// In favor of
auto lb = reinterpret_borrow<list>(ptr);
auto ls = reinterpret_steal<list>(ptr);
```

### Deprecations

- `obj.str()` is deprecated in favor of `str(obj)`.
- `T obj = ...; obj.check()` is deprecated in favor of `isinstance<T>(obj)`.
- The `T(handle, bool)` constructor is deprecated in favor of `reinterpret_borrow<T>()` and `reinterpret_steal<T>()`.
- `obj.repr()` is **removed** in favor of `repr(obj)`. There is no deprecation warning since this hasn't actually made it to a stable version yet.


### Implementation

Making this work required changing the usual type check order, e.g.:

``` c++
auto l = list(ptr, true);
if (l.check())
   // ...
```

The above check happens after a `py::object` type is created, however this would not work correctly with a converting constructor since `py::str` would be able to make a string representation of any object which would essentially make its `.check()` always true. This would also make using `py::str` as a function parameter very difficult since it would shadow every other overload.

To overcome this, type creation and checking are reversed with the following syntax:

``` c++
if (isinstance<list>(ptr)) {
    auto l = reinterpret_borrow<list>(ptr);
    // ...
}
```

The `py::isinstance<T>(obj)` syntax was chosen because it can work uniformly for types derived from `py::object` as well as user types wrapped with `py:class_`.

``` c++
class Pet { ... };
py::class_<Pet>(...);

m.def("is_pet", [](py::object obj) {
    return py::isinstance<Pet>(obj); // works as expected
});
```

Note that `py::isinstance` takes a shortcut and calls the usual `Py*_Check()` functions for `py::object` classes, while user classes go the long way with `detail::get_type_info()` and `PyObject_IsInstance()`.