### PR TITLE
Prevent overwriting previous declarations

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -182,3 +182,8 @@ def test_iterator_rvpolicy():
     assert list(make_iterator_1()) == [1, 2, 3]
     assert list(make_iterator_2()) == [1, 2, 3]
     assert(type(make_iterator_1()) != type(make_iterator_2()))
+
+def test_dupe_assignment():
+    """ Issue 461: overwriting a class with a function """
+    from pybind11_tests.issues import dupe_exception_failures
+    assert dupe_exception_failures() == []


### PR DESCRIPTION
Currently pybind11 doesn't check when you define a new object (e.g. a
class, function, or exception) that overwrites an existing one.  If the
thing being overwritten is a class, this leads to a segfault (because
pybind still thinks the type is defined, even though Python no longer
has the type).  In other cases this is harmless (e.g. replacing a
function with an exception), but even in that case it's most likely a
bug.

This code doesn't prevent you from actively doing something harmful,
like deliberately overwriting a previous definition, but detects
overwriting with a run-time error if it occurs in the standard
class/function/exception/def registration interfaces.

All of the additions are in non-template code; the result is actually a
tiny decrease in .so size compared to master without the new test code
(977304 to 977272 bytes), and about 4K higher with the new tests.