### PR TITLE
pybind11: implicitly convert NumPy integer scalars

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -443,7 +443,14 @@ public:
             (std::is_integral<T>::value && sizeof(py_type) != sizeof(T) &&
                (py_value < (py_type) std::numeric_limits<T>::min() ||
                 py_value > (py_type) std::numeric_limits<T>::max()))) {
+#if PY_VERSION_HEX < 0x03000000
+            bool type_error = PyErr_ExceptionMatches(PyExc_SystemError);
+#else
+            bool type_error = PyErr_ExceptionMatches(PyExc_TypeError);
+#endif
             PyErr_Clear();
+            if (type_error && PyNumber_Check(src.ptr()))
+                return load(object(PyNumber_Long(src.ptr()), true), false);
             return false;
         }
 

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -124,4 +124,6 @@ test_initializer numpy_array([](py::module &m) {
             return py::array_t<int>({2}, {4}, a.data, obj);
         }
     );
+
+    sm.def("function_taking_uint64", [](uint64_t){ });
 });

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -238,3 +238,10 @@ def test_numpy_view(capture):
     assert capture == """
         ~ArrayClass()
     """
+
+
+@pytest.requires_numpy
+def test_cast_numpy_int64_to_uint64():
+    from pybind11_tests.array import function_taking_uint64
+    function_taking_uint64(123)
+    function_taking_uint64(np.uint64(123))


### PR DESCRIPTION
The current integer caster was unnecessarily strict and rejected
various kinds of NumPy integer types when calling C++ functions
expecting normal integers. This relaxes the current behavior.