### PR TITLE
Overriding field names when binding structured dtypes

### DIFF
--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -67,6 +67,11 @@ struct StringStruct {
     std::array<char, 3> b;
 };
 
+PYBIND11_PACKED(struct StructWithUglyNames {
+    int8_t __x__;
+    uint64_t __y__;
+});
+
 enum class E1 : int64_t { A = -1, B = 1 };
 enum E2 : uint8_t { X = 1, Y = 2 };
 
@@ -197,7 +202,8 @@ py::list print_dtypes() {
         py::dtype::of<PartialStruct>().str(),
         py::dtype::of<PartialNestedStruct>().str(),
         py::dtype::of<StringStruct>().str(),
-        py::dtype::of<EnumStruct>().str()
+        py::dtype::of<EnumStruct>().str(),
+        py::dtype::of<StructWithUglyNames>().str()
     };
     auto l = py::list();
     for (const auto &s : dtypes) {
@@ -311,6 +317,8 @@ test_initializer numpy_dtypes([](py::module &m) {
 
     // ... or after
     py::class_<PackedStruct>(m, "PackedStruct");
+
+    PYBIND11_NUMPY_DTYPE_EX(StructWithUglyNames, __x__, "x", __y__, "y");
 
     m.def("create_rec_simple", &create_recarray<SimpleStruct>);
     m.def("create_rec_packed", &create_recarray<PackedStruct>);

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -42,7 +42,8 @@ def test_dtype():
         "{'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8], 'itemsize':24}",
         "{'names':['a'], 'formats':[{'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8], 'itemsize':24}], 'offsets':[8], 'itemsize':40}",
         "[('a', 'S3'), ('b', 'S3')]",
-        "[('e1', '<i8'), ('e2', 'u1')]"
+        "[('e1', '<i8'), ('e2', 'u1')]",
+        "[('x', 'i1'), ('y', '<u8')]"
     ]
 
     d1 = np.dtype({'names': ['a', 'b'], 'formats': ['int32', 'float64'],


### PR DESCRIPTION
This is a very small but useful addition -- `PYBIND11_NUMPY_DTYPE_EX()` can be used to provide custom names to exported fields. Since it's quite common in C++ to have suffices/prefices (e.g. underscores) for private members, this allows to easily overcome this ugliness when exporting types to numpy. 

The example can be seen in the added test.