### PR TITLE
Only enable std::optional if compiling in >= C++14

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -22,7 +22,7 @@
 #pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
 #endif
 
-#ifdef __has_include
+#if defined(PYBIND11_CPP14) && defined(__has_include)
 // std::optional
 #  if __has_include(<optional>)
 #    include <optional>


### PR DESCRIPTION
Update the enabling macro to require both __has_include and C++14 support; otherwise gcc (at least) throws an error when trying to use it in C++11 mode.