### PR TITLE
Add debugging info about .so size to build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ MANIFEST
 /build
 /cmake/
 .cache/
+sosize-*.txt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,3 +89,8 @@ endif()
 # A single command to compile and run the tests
 add_custom_target(pytest COMMAND ${PYTHON_EXECUTABLE} -m pytest -rws ${PYBIND11_PYTEST_FILES}
                   DEPENDS pybind11_tests WORKING_DIRECTORY ${testdir})
+
+# And another to show the .so size and, if a previous size, compare it:
+add_custom_command(TARGET pybind11_tests POST_BUILD
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/libsize.py
+        $<TARGET_FILE:pybind11_tests> ${CMAKE_CURRENT_BINARY_DIR}/sosize-$<TARGET_FILE_NAME:pybind11_tests>.txt)

--- a/tools/libsize.py
+++ b/tools/libsize.py
@@ -13,8 +13,6 @@ if len(sys.argv) != 3:
 lib = sys.argv[1]
 save = sys.argv[2]
 
-libsize = -1
-
 if not os.path.exists(lib):
     sys.exit("Error: requested file ({}) does not exist".format(lib))
 
@@ -23,23 +21,18 @@ libsize = os.path.getsize(lib)
 print("------", os.path.basename(lib), "file size:", libsize, end='')
 
 if os.path.exists(save):
-    sf = open(save, 'r')
-    oldsize = int(sf.readline())
-    sf.close()
+    with open(save) as sf:
+        oldsize = int(sf.readline())
 
     if oldsize > 0:
         change = libsize - oldsize
-        pct = change / oldsize * 100
         if change == 0:
-            print(" (no change)", end='')
-        elif change > 0:
-            print(" (increase of {} bytes = {:.2f}%)".format(change, pct), end='')
+            print(" (no change)")
         else:
-            print(" (decrease of {} bytes = {:.2f}%)".format(-change, -pct), end='')
+            print(" (change of {:+} bytes = {:+.2%})".format(change, change / oldsize))
+else:
+    print()
 
-print()
-
-sf = open(save, 'w')
-sf.write(str(libsize))
-sf.close()
+with open(save, 'w') as sf:
+    sf.write(str(libsize))
 

--- a/tools/libsize.py
+++ b/tools/libsize.py
@@ -1,0 +1,45 @@
+from __future__ import print_function
+import os
+import sys
+
+# Internal build script for generating debugging test .so size.
+# Usage:
+#     python libsize.py file.so save.txt -- displays the size of file.so and, if save.txt exists, compares it to the
+#                                           size in it, then overwrites save.txt with the new size for future runs.
+
+if len(sys.argv) != 3:
+    sys.exit("Invalid arguments: usage: python libsize.py file.so save.txt")
+
+lib = sys.argv[1]
+save = sys.argv[2]
+
+libsize = -1
+
+if not os.path.exists(lib):
+    sys.exit("Error: requested file ({}) does not exist".format(lib))
+
+libsize = os.path.getsize(lib)
+
+print("------", os.path.basename(lib), "file size:", libsize, end='')
+
+if os.path.exists(save):
+    sf = open(save, 'r')
+    oldsize = int(sf.readline())
+    sf.close()
+
+    if oldsize > 0:
+        change = libsize - oldsize
+        pct = change / oldsize * 100
+        if change == 0:
+            print(" (no change)", end='')
+        elif change > 0:
+            print(" (increase of {} bytes = {:.2f}%)".format(change, pct), end='')
+        else:
+            print(" (decrease of {} bytes = {:.2f}%)".format(-change, -pct), end='')
+
+print()
+
+sf = open(save, 'w')
+sf.write(str(libsize))
+sf.close()
+


### PR DESCRIPTION
This adds a small python script to `tools/` that captures before-and-after .so sizes between builds and outputs this in the build output via a string such as:

`------ pybind11_tests.cpython-35m-x86_64-linux-gnu.so file size: 924696 (decrease of 73680 bytes = 7.38%)`

`------ pybind11_tests.cpython-35m-x86_64-linux-gnu.so file size: 998376 (increase of 73680 bytes = 7.97%)`

`------ pybind11_tests.cpython-35m-x86_64-linux-gnu.so file size: 998376 (no change)`

Or, if there was no .so during the build, just the .so size by itself:

`------ pybind11_tests.cpython-35m-x86_64-linux-gnu.so file size: 998376`

This allows you to, for example, build, checkout a different branch, rebuild, and easily see exactly the change in the pybind11_tests.so size.

It also allows looking at the travis and appveyor build logs to get an idea of .so sizes across different build systems (which you can see in the build checks for this PR).