### PR TITLE
Don't construct unique_ptr around unowned pointers

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -299,7 +299,7 @@ template <typename type> struct instance_essentials {
     type *value;
     PyObject *weakrefs;
     bool owned : 1;
-    bool constructed : 1;
+    bool holder_constructed : 1;
 };
 
 /// PyObject wrapper around generic types, includes a special holder type that is responsible for lifetime management

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1134,7 +1134,7 @@ private:
         } catch (const std::bad_weak_ptr &) {
             new (&inst->holder) holder_type(inst->value);
         }
-        inst->owned = true;
+        inst->constructed = true;
     }
 
     /// Initialize holder object, variant 2: try to construct from existing holder object, if possible
@@ -1145,31 +1145,32 @@ private:
             new (&inst->holder) holder_type(*holder_ptr);
         else
             new (&inst->holder) holder_type(inst->value);
-        inst->owned = true;
+        inst->constructed = true;
     }
 
     /// Initialize holder object, variant 3: holder is not copy constructible (e.g. unique_ptr), always initialize from raw pointer
     template <typename T = holder_type,
               detail::enable_if_t<!std::is_copy_constructible<T>::value, int> = 0>
     static void init_holder_helper(instance_type *inst, const holder_type * /* unused */, const void * /* dummy */) {
-        new (&inst->holder) holder_type(inst->value);
+        if (inst->owned) {
+            new (&inst->holder) holder_type(inst->value);
+            inst->constructed = true;
+        }
     }
 
     /// Initialize holder object of an instance, possibly given a pointer to an existing holder
     static void init_holder(PyObject *inst_, const void *holder_ptr) {
         auto inst = (instance_type *) inst_;
         init_holder_helper(inst, (const holder_type *) holder_ptr, inst->value);
-        inst->constructed = true;
     }
 
     static void dealloc(PyObject *inst_) {
         instance_type *inst = (instance_type *) inst_;
-        if (inst->owned) {
-            if (inst->constructed)
-                inst->holder.~holder_type();
-            else
-                ::operator delete(inst->value);
-        }
+        if (inst->constructed)
+            inst->holder.~holder_type();
+        else if (inst->owned)
+            ::operator delete(inst->value);
+
         generic_type::dealloc((detail::instance<void> *) inst);
     }
 

--- a/tests/constructor_stats.h
+++ b/tests/constructor_stats.h
@@ -56,7 +56,7 @@ from the ConstructorStats instance `.values()` method.
 In some cases, when you need to track instances of a C++ class not registered with pybind11, you
 need to add a function returning the ConstructorStats for the C++ class; this can be done with:
 
-    m.def("get_special_cstats", &ConstructorStats::get<SpecialClass>, py::return_value_policy::reference_internal)
+    m.def("get_special_cstats", &ConstructorStats::get<SpecialClass>, py::return_value_policy::reference)
 
 Finally, you can suppress the output messages, but keep the constructor tracking (for
 inspection/testing in python) by using the functions with `print_` replaced with `track_` (e.g.

--- a/tests/test_issues.cpp
+++ b/tests/test_issues.cpp
@@ -48,6 +48,24 @@ class Dupe2 {};
 class Dupe3 {};
 class DupeException : public std::runtime_error {};
 
+// #478
+template <typename T> class custom_unique_ptr {
+public:
+    custom_unique_ptr() { print_default_created(this); }
+    custom_unique_ptr(T *ptr) : _ptr{ptr} { print_created(this, ptr); }
+    custom_unique_ptr(custom_unique_ptr<T> &&move) : _ptr{move._ptr} { move._ptr = nullptr; print_move_created(this); }
+    custom_unique_ptr &operator=(custom_unique_ptr<T> &&move) { print_move_assigned(this); if (_ptr) destruct_ptr(); _ptr = move._ptr; move._ptr = nullptr; return *this; }
+    custom_unique_ptr(const custom_unique_ptr<T> &) = delete;
+    void operator=(const custom_unique_ptr<T> &copy) = delete;
+    ~custom_unique_ptr() { print_destroyed(this); if (_ptr) destruct_ptr(); }
+private:
+    T *_ptr = nullptr;
+    void destruct_ptr() { delete _ptr; }
+};
+PYBIND11_DECLARE_HOLDER_TYPE(T, custom_unique_ptr<T>);
+
+
+
 void init_issues(py::module &m) {
     py::module m2 = m.def_submodule("issues");
 
@@ -311,6 +329,24 @@ void init_issues(py::module &m) {
     py::class_<SharedParent, std::shared_ptr<SharedParent>>(m, "SharedParent")
         .def(py::init<>())
         .def("get_child", &SharedParent::get_child, py::return_value_policy::reference);
+
+    /// Issue/PR #478: unique ptrs constructed and freed without destruction
+    class SpecialHolderObj {
+    public:
+        int val = 0;
+        SpecialHolderObj *ch = nullptr;
+        SpecialHolderObj(int v, bool make_child = true) : val{v}, ch{make_child ? new SpecialHolderObj(val+1, false) : nullptr}
+        { print_created(this, val); }
+        ~SpecialHolderObj() { delete ch; print_destroyed(this); }
+        SpecialHolderObj *child() { return ch; }
+    };
+
+    py::class_<SpecialHolderObj, custom_unique_ptr<SpecialHolderObj>>(m, "SpecialHolderObj")
+        .def(py::init<int>())
+        .def("child", &SpecialHolderObj::child, pybind11::return_value_policy::reference_internal)
+        .def_readwrite("val", &SpecialHolderObj::val)
+        .def_static("holder_cstats", &ConstructorStats::get<custom_unique_ptr<SpecialHolderObj>>)
+        ;
 };
 
 

--- a/tests/test_issues.cpp
+++ b/tests/test_issues.cpp
@@ -345,7 +345,8 @@ void init_issues(py::module &m) {
         .def(py::init<int>())
         .def("child", &SpecialHolderObj::child, pybind11::return_value_policy::reference_internal)
         .def_readwrite("val", &SpecialHolderObj::val)
-        .def_static("holder_cstats", &ConstructorStats::get<custom_unique_ptr<SpecialHolderObj>>)
+        .def_static("holder_cstats", &ConstructorStats::get<custom_unique_ptr<SpecialHolderObj>>,
+                py::return_value_policy::reference)
         ;
 };
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -212,8 +212,9 @@ def test_non_destructed_holders():
     assert a.val == 123
     assert b.val == 124
 
-    assert SpecialHolderObj.holder_cstats().alive() == 1
+    cstats = SpecialHolderObj.holder_cstats()
+    assert cstats.alive() == 1
     del b
-    assert SpecialHolderObj.holder_cstats().alive() == 1
+    assert cstats.alive() == 1
     del a
-    assert SpecialHolderObj.holder_cstats().alive() == 0
+    assert cstats.alive() == 0

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -201,3 +201,19 @@ def test_enable_shared_from_this_with_reference_rvp():
     assert cstats.alive() == 1
     del child, parent
     assert cstats.alive() == 0
+
+def test_non_destructed_holders():
+    """ Issue #478: unique ptrs constructed and freed without destruction """
+    from pybind11_tests import SpecialHolderObj
+
+    a = SpecialHolderObj(123)
+    b = a.child()
+
+    assert a.val == 123
+    assert b.val == 124
+
+    assert SpecialHolderObj.holder_cstats().alive() == 1
+    del b
+    assert SpecialHolderObj.holder_cstats().alive() == 1
+    del a
+    assert SpecialHolderObj.holder_cstats().alive() == 0


### PR DESCRIPTION
This is a continuation of the discussion in #471 re: unique pointers.  I may be wrong about this, but the more I think about it, the more I think there is a problem here to be fixed w.r.t. non-copyable holders (i.e. `unique_ptr`s).  It isn't wrong in terms of when it destructs the pointed-at object, but it *is* wrong in that it is constructing holder types that are freed without having been destructed.

Right now, if we need to initialize a holder around an *unowned* instance, and the type's holder type is a `unique_ptr` (or similar, non-copyable holder), we currently construct the holder around the value pointer, but then never actually destruct that holder.  When `inst->owned = false`, we never invoke the part of `dealloc` that calls the holder destructor: that's called only for the instance that actually has `inst->owned = true` set, which it isn't in this case.

Moreover we don't *want* it to be destructed: as I found out by modifying `dealloc`, if we actually invoke its destructor we get multiple frees because we have multiple `unique_ptr`s around the *same* pointer: and of course we only *want* the destructor to happen for the owned one.

This seems like a bug, though probably not one that matters with `unique_ptr`: we're creating a holder type, but then never destroying it (instead we end up just freeing its memory (via `tp_free`) without calling the destructor when we dealloc the instance).  For unique_ptr this *probaby* doesn't matter in practice, but it's not hard to imagine some custom non-copyable holder type where freeing the type without invoking the destructor is a problem (and even if it happens to work for `std::unique_ptr` in practice, it still seems pretty wrong).

This commit changes the `init_holder_helper` logic to only construct a `unique_ptr`-type holder only when we actually want one--i.e. when we actually own the instance--and changes `dealloc` to destruct the constructed holder whenever we have one.  This still does the right thing w.r.t. pointed-at instances--the difference now is that only `owned` instances get a `unique_ptr` holder: for unowned instances (with unique holder types) we just keep a pointer and leave the holder type uninitialized.  Thus this should result in the same logic we have at present, but avoids the problem of allocating holder instances that we never properly destruct.