### PR TITLE
<optional> requires -std=c++17

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -16,6 +16,18 @@
 #  define NAMESPACE_END(name) }
 #endif
 
+// Neither MSVC nor Intel support enough of C++14 yet (in particular, as of MSVC 2015 and ICC 17
+// beta, neither support extended constexpr, which we rely on in descr.h), so don't enable pybind
+// CPP14 features for them.
+#if !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#  if __cplusplus >= 201402L
+#    define PYBIND11_CPP14
+#    if __cplusplus > 201402L /* Temporary: should be updated to >= the final C++17 value once known */
+#      define PYBIND11_CPP17
+#    endif
+#  endif
+#endif
+
 #if !defined(PYBIND11_EXPORT)
 #  if defined(WIN32) || defined(_WIN32)
 #    define PYBIND11_EXPORT __declspec(dllexport)
@@ -30,7 +42,7 @@
 #  define PYBIND11_NOINLINE __attribute__ ((noinline))
 #endif
 
-#if PYBIND11_CPP14
+#if defined(PYBIND11_CPP14)
 #  define PYBIND11_DEPRECATED(reason) [[deprecated(reason)]]
 #elif defined(__clang__)
 #  define PYBIND11_DEPRECATED(reason) __attribute__((deprecated(reason)))
@@ -143,18 +155,6 @@ extern "C" {
 #define PYBIND11_TOSTRING(x) PYBIND11_STRINGIFY(x)
 #define PYBIND11_INTERNALS_ID "__pybind11_" \
     PYBIND11_TOSTRING(PYBIND11_VERSION_MAJOR) "_" PYBIND11_TOSTRING(PYBIND11_VERSION_MINOR) "__"
-
-// Neither MSVC nor Intel support enough of C++14 yet (in particular, as of MSVC 2015 and ICC 17
-// beta, neither support extended constexpr, which we rely on in descr.h), so don't enable pybind
-// CPP14 features for them.
-#if !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-#  if __cplusplus >= 201402L
-#    define PYBIND11_CPP14
-#    if __cplusplus > 201402L /* Temporary: should be updated to >= the final C++17 value once known */
-#      define PYBIND11_CPP17
-#    endif
-#  endif
-#endif
 
 #define PYBIND11_PLUGIN(name)                                                  \
     static PyObject *pybind11_init();                                          \

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -30,7 +30,7 @@
 #  define PYBIND11_NOINLINE __attribute__ ((noinline))
 #endif
 
-#if __cplusplus > 201103L
+#if PYBIND11_CPP14
 #  define PYBIND11_DEPRECATED(reason) [[deprecated(reason)]]
 #elif defined(__clang__)
 #  define PYBIND11_DEPRECATED(reason) __attribute__((deprecated(reason)))
@@ -143,6 +143,18 @@ extern "C" {
 #define PYBIND11_TOSTRING(x) PYBIND11_STRINGIFY(x)
 #define PYBIND11_INTERNALS_ID "__pybind11_" \
     PYBIND11_TOSTRING(PYBIND11_VERSION_MAJOR) "_" PYBIND11_TOSTRING(PYBIND11_VERSION_MINOR) "__"
+
+// Neither MSVC nor Intel support enough of C++14 yet (in particular, as of MSVC 2015 and ICC 17
+// beta, neither support extended constexpr, which we rely on in descr.h), so don't enable pybind
+// CPP14 features for them.
+#if !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#  if __cplusplus >= 201402L
+#    define PYBIND11_CPP14
+#    if __cplusplus > 201402L /* Temporary: should be updated to >= the final C++17 value once known */
+#      define PYBIND11_CPP17
+#    endif
+#  endif
+#endif
 
 #define PYBIND11_PLUGIN(name)                                                  \
     static PyObject *pybind11_init();                                          \

--- a/include/pybind11/descr.h
+++ b/include/pybind11/descr.h
@@ -15,18 +15,6 @@
 NAMESPACE_BEGIN(pybind11)
 NAMESPACE_BEGIN(detail)
 
-#if defined(__INTEL_COMPILER)
-/* C++14 features not supported for now */
-#elif defined(__clang__)
-#  if __has_feature(cxx_return_type_deduction) && __has_feature(cxx_relaxed_constexpr)
-#    define PYBIND11_CPP14
-#  endif
-#elif defined(__GNUG__)
-#  if __cpp_constexpr >= 201304 && __cpp_decltype_auto >= 201304
-#    define PYBIND11_CPP14
-#  endif
-#endif
-
 #if defined(PYBIND11_CPP14) /* Concatenate type signatures at compile time using C++14 */
 
 template <size_t Size1, size_t Size2> class descr {

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -22,14 +22,14 @@
 #pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
 #endif
 
-#if defined(PYBIND11_CPP14) && defined(__has_include)
-// std::optional
-#  if __has_include(<optional>)
+#ifdef __has_include
+// std::optional (but including it in c++14 mode isn't allowed)
+#  if defined(PYBIND11_CPP17) && __has_include(<optional>)
 #    include <optional>
 #    define PYBIND11_HAS_OPTIONAL 1
 #  endif
-// std::experimental::optional
-#  if __has_include(<experimental/optional>)
+// std::experimental::optional (but not allowed in c++11 mode)
+#  if defined(PYBIND11_CPP14) && __has_include(<experimental/optional>)
 #    include <experimental/optional>
 #    if __cpp_lib_experimental_optional  // just in case
 #      define PYBIND11_HAS_EXP_OPTIONAL 1


### PR DESCRIPTION
This is a sort of continuation of #476: attempting to include <optional> in C++14 fails in just the same way (under g++-7, which actually adds it) as attempting to include <experimental/optional> under C++11.

This fixes it.

It also has a commit that generalizes the C++14/17 detection macros a bit (to look for C++14 mode instead of just the specific features descr.h needs), and moves them to `common.h` instead of `descr.h`.  (Neither MSVC or ICC get these turned on as current versions of both are still quite C++14-incomplete).