### PR TITLE
Add cmake option to override tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "MinSizeRel" "RelWithDebInfo")
 endif()
 
+# Full set of test files (you can override these; see below)
 set(PYBIND11_TEST_FILES
   test_alias_initialization.cpp
   test_buffers.cpp
@@ -36,6 +37,14 @@ set(PYBIND11_TEST_FILES
   test_stl_binders.cpp
   test_virtual_functions.cpp
 )
+
+# Invoking cmake with something like:
+#     cmake -DPYBIND11_TEST_OVERRIDE="test_issues.cpp;test_picking.cpp" ..
+# lets you override the tests that get compiled and run.  You can restore to all tests with:
+#     cmake -DPYBIND11_TEST_OVERRIDE= ..
+if (PYBIND11_TEST_OVERRIDE)
+  set(PYBIND11_TEST_FILES ${PYBIND11_TEST_OVERRIDE})
+endif()
 
 string(REPLACE ".cpp" ".py" PYBIND11_PYTEST_FILES "${PYBIND11_TEST_FILES}")
 
@@ -89,6 +98,11 @@ endif()
 # A single command to compile and run the tests
 add_custom_target(pytest COMMAND ${PYTHON_EXECUTABLE} -m pytest -rws ${PYBIND11_PYTEST_FILES}
                   DEPENDS pybind11_tests WORKING_DIRECTORY ${testdir})
+
+if(PYBIND11_TEST_OVERRIDE)
+  add_custom_command(TARGET pytest POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo "Note: not all tests run: -DPYBIND11_TEST_OVERRIDE is in effect")
+endif()
 
 # And another to show the .so size and, if a previous size, compare it:
 add_custom_command(TARGET pybind11_tests POST_BUILD


### PR DESCRIPTION
When working on some particular feature, it's nice to be able to disable all the tests except for the one I'm working on; this is currently possible by editing tests/CMakeLists.txt, and commenting out the tests you don't want.

This commit goes a step further by letting you give cmake a `;`-separated list of tests you want to build and test.  For example:
```
cmake -DPYBIND11_TEST_OVERRIDE="test_issues.cpp;test_pickling.cpp" ..
```
changes the build to build just those two tests (and causes the `pytest` target to invoke just the two associated tests).

This persists in the build directory until you disable it by running cmake with `-DPYBIND11_TEST_OVERRIDE=`.  It also adds a message after the pytest output to remind you that it is in effect:

```
Note: not all tests run: -DPYBIND11_TEST_OVERRIDE is in effect
```