### PR TITLE
Fix stl_bind to support movable, non-copyable value types

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -329,6 +329,18 @@ using cast_op_type = typename std::conditional<std::is_pointer<typename std::rem
     typename std::add_pointer<intrinsic_t<T>>::type,
     typename std::add_lvalue_reference<intrinsic_t<T>>::type>::type;
 
+// std::is_copy_constructible isn't quite enough: it lets std::vector<T> (and similar) through when
+// T is non-copyable, but code containing such a copy constructor fails to actually compile.
+template <typename T, typename SFINAE = void> struct is_copy_constructible : std::is_copy_constructible<T> {};
+
+// Specialization for types that appear to be copy constructible but also look like stl containers
+// (we specifically check for: has `value_type` and `reference` with `reference = value_type&`): if
+// so, copy constructability depends on whether the value_type is copy constructible.
+template <typename Container> struct is_copy_constructible<Container, enable_if_t<
+        std::is_copy_constructible<Container>::value &&
+        std::is_same<typename Container::value_type &, typename Container::reference>::value
+    >> : std::is_copy_constructible<typename Container::value_type> {};
+
 /// Generic type caster for objects stored on the heap
 template <typename type> class type_caster_base : public type_caster_generic {
     using itype = intrinsic_t<type>;
@@ -366,20 +378,21 @@ protected:
 #if !defined(_MSC_VER)
     /* Only enabled when the types are {copy,move}-constructible *and* when the type
        does not have a private operator new implementaton. */
-    template <typename T = type> static auto make_copy_constructor(const T *value) -> decltype(new T(*value), Constructor(nullptr)) {
+    template <typename T = type, typename = enable_if_t<is_copy_constructible<T>::value>> static auto make_copy_constructor(const T *value) -> decltype(new T(*value), Constructor(nullptr)) {
         return [](const void *arg) -> void * { return new T(*((const T *) arg)); }; }
     template <typename T = type> static auto make_move_constructor(const T *value) -> decltype(new T(std::move(*((T *) value))), Constructor(nullptr)) {
         return [](const void *arg) -> void * { return (void *) new T(std::move(*((T *) arg))); }; }
 #else
     /* Visual Studio 2015's SFINAE implementation doesn't yet handle the above robustly in all situations.
        Use a workaround that only tests for constructibility for now. */
-    template <typename T = type, typename = enable_if_t<std::is_copy_constructible<T>::value>>
+    template <typename T = type, typename = enable_if_t<is_copy_constructible<T>::value>>
     static Constructor make_copy_constructor(const T *value) {
         return [](const void *arg) -> void * { return new T(*((const T *)arg)); }; }
     template <typename T = type, typename = enable_if_t<std::is_move_constructible<T>::value>>
     static Constructor make_move_constructor(const T *value) {
         return [](const void *arg) -> void * { return (void *) new T(std::move(*((T *)arg))); }; }
 #endif
+
     static Constructor make_copy_constructor(...) { return nullptr; }
     static Constructor make_move_constructor(...) { return nullptr; }
 };

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -60,18 +60,19 @@ struct is_comparable<T, enable_if_t<container_traits<T>::is_pair>> {
 };
 
 /* Fallback functions */
-template <typename, typename, typename... Args> void vector_if_copy_constructible(const Args&...) { }
-template <typename, typename, typename... Args> void vector_if_equal_operator(const Args&...) { }
-template <typename, typename, typename... Args> void vector_if_insertion_operator(const Args&...) { }
+template <typename, typename, typename... Args> void vector_if_copy_constructible(const Args &...) { }
+template <typename, typename, typename... Args> void vector_if_equal_operator(const Args &...) { }
+template <typename, typename, typename... Args> void vector_if_insertion_operator(const Args &...) { }
 
-template<typename Vector, typename Class_, enable_if_t<std::is_copy_constructible<typename Vector::value_type>::value, int> = 0>
-void vector_if_copy_constructible(Class_ &cl) {
-    cl.def(pybind11::init<const Vector &>(),
-           "Copy constructor");
+template<typename Vector, typename Class_>
+void vector_if_copy_constructible(enable_if_t<
+    std::is_copy_constructible<typename Vector::value_type>::value, Class_> &cl) {
+
+    cl.def(pybind11::init<const Vector &>(), "Copy constructor");
 }
 
-template<typename Vector, typename Class_, enable_if_t<is_comparable<Vector>::value, int> = 0>
-void vector_if_equal_operator(Class_ &cl) {
+template<typename Vector, typename Class_>
+void vector_if_equal_operator(enable_if_t<is_comparable<Vector>::value, Class_> &cl) {
     using T = typename Vector::value_type;
 
     cl.def(self == self);
@@ -361,9 +362,10 @@ pybind11::class_<Vector, holder_type> bind_vector(pybind11::module &m, std::stri
 NAMESPACE_BEGIN(detail)
 
 /* Fallback functions */
-template <typename, typename, typename... Args> void map_if_insertion_operator(const Args&...) { }
+template <typename, typename, typename... Args> void map_if_insertion_operator(const Args &...) { }
 
-template <typename Map, typename Class_, typename... Args> void map_if_copy_assignable(Class_ &cl, const Args&...) {
+template <typename Map, typename Class_>
+void map_assignment(enable_if_t<std::is_copy_assignable<typename Map::mapped_type>::value, Class_> &cl) {
     using KeyType = typename Map::key_type;
     using MappedType = typename Map::mapped_type;
 
@@ -376,8 +378,10 @@ template <typename Map, typename Class_, typename... Args> void map_if_copy_assi
     );
 }
 
-template<typename Map, typename Class_, enable_if_t<!std::is_copy_assignable<typename Map::mapped_type>::value, int> = 0>
-void map_if_copy_assignable(Class_ &cl) {
+template<typename Map, typename Class_>
+void map_if_copy_assignable(enable_if_t<
+        !std::is_copy_assignable<typename Map::mapped_type>::value,
+        Class_> &cl) {
     using KeyType = typename Map::key_type;
     using MappedType = typename Map::mapped_type;
 

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -11,6 +11,7 @@
 
 #include <pybind11/stl_bind.h>
 #include <map>
+#include <deque>
 #include <unordered_map>
 
 class El {
@@ -26,6 +27,32 @@ std::ostream & operator<<(std::ostream &s, El const&v) {
     return s;
 }
 
+/// Issue #487: binding std::vector<E> with E non-copyable
+class E_nc {
+public:
+    explicit E_nc(int i) : value{i} {}
+    E_nc(const E_nc &) = delete;
+    E_nc &operator=(const E_nc &) = delete;
+    E_nc(E_nc &&) = default;
+    E_nc &operator=(E_nc &&) = default;
+
+    int value;
+};
+
+template <class Container> Container *one_to_n(int n) {
+    auto v = new Container();
+    for (int i = 1; i <= n; i++)
+        v->emplace_back(i);
+    return v;
+}
+
+template <class Map> Map *times_ten(int n) {
+    auto m = new Map();
+    for (int i = 1; i <= n; i++)
+        m->emplace(int(i), E_nc(10*i));
+    return m;
+}
+
 test_initializer stl_binder_vector([](py::module &m) {
     py::class_<El>(m, "El")
         .def(py::init<int>());
@@ -36,6 +63,7 @@ test_initializer stl_binder_vector([](py::module &m) {
     py::bind_vector<std::vector<El>>(m, "VectorEl");
 
     py::bind_vector<std::vector<std::vector<El>>>(m, "VectorVectorEl");
+
 });
 
 test_initializer stl_binder_map([](py::module &m) {
@@ -44,4 +72,24 @@ test_initializer stl_binder_map([](py::module &m) {
 
     py::bind_map<std::map<std::string, double const>>(m, "MapStringDoubleConst");
     py::bind_map<std::unordered_map<std::string, double const>>(m, "UnorderedMapStringDoubleConst");
+
 });
+
+test_initializer stl_binder_noncopyable([](py::module &m) {
+    py::class_<E_nc>(m, "ENC")
+        .def(py::init<int>())
+        .def_readwrite("value", &E_nc::value);
+
+    py::bind_vector<std::vector<E_nc>>(m, "VectorENC");
+    m.def("get_vnc", &one_to_n<std::vector<E_nc>>, py::return_value_policy::reference);
+
+    py::bind_vector<std::deque<E_nc>>(m, "DequeENC");
+    m.def("get_dnc", &one_to_n<std::deque<E_nc>>, py::return_value_policy::reference);
+
+    py::bind_map<std::map<int, E_nc>>(m, "MapENC");
+    m.def("get_mnc", &times_ten<std::map<int, E_nc>>, py::return_value_policy::reference);
+
+    py::bind_map<std::unordered_map<int, E_nc>>(m, "UmapENC");
+    m.def("get_umnc", &times_ten<std::unordered_map<int, E_nc>>, py::return_value_policy::reference);
+});
+

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -50,7 +50,6 @@ def test_vector_bool():
         assert vv_c[i] == (i % 2 == 0)
     assert str(vv_c) == "VectorBool[1, 0, 1, 0, 1, 0, 1, 0, 1, 0]"
 
-
 def test_map_string_double():
     from pybind11_tests import MapStringDouble, UnorderedMapStringDouble
 
@@ -97,3 +96,58 @@ def test_map_string_double_const():
     umc['b'] = 21.5
 
     str(umc)
+
+def test_noncopyable_vector():
+    from pybind11_tests import ENC, get_vnc
+
+    vnc = get_vnc(5)
+    for i in range(0, 5):
+        assert(vnc[i].value == i+1)
+
+    i = 1
+    for j in vnc:
+        assert(j.value == i)
+        i += 1
+
+def test_noncopyable_deque():
+    from pybind11_tests import ENC, get_dnc
+
+    dnc = get_dnc(5)
+    for i in range(0, 5):
+        assert(dnc[i].value == i+1)
+
+    i = 1
+    for j in dnc:
+        assert(j.value == i)
+        i += 1
+
+def test_noncopyable_map():
+    from pybind11_tests import ENC, get_mnc
+
+    mnc = get_mnc(5)
+    for i in range(1, 6):
+        assert(mnc[i].value == 10*i)
+
+    i = 1
+    vsum = 0
+    for k, v in mnc.items():
+        assert(v.value == 10*k)
+        vsum += v.value
+
+    assert(vsum == 150)
+
+def test_noncopyable_unordered_map():
+    from pybind11_tests import ENC, get_umnc
+
+    mnc = get_umnc(5)
+    for i in range(1, 6):
+        assert(mnc[i].value == 10*i)
+
+    i = 1
+    vsum = 0
+    for k, v in mnc.items():
+        assert(v.value == 10*k)
+        vsum += v.value
+
+    assert(vsum == 150)
+


### PR DESCRIPTION
Fixes #487 (but not ready for merging).

We require copyable types for pretty much all vector modifiers, so this basically moves them all into a method that is only enabled for copyable types.  (Technically we could allow `pop` and `__delitem__` without copying, but it seems a little weird to expose deletion but no other modifiers).

In practice, this means that if the type is non-copyable, it will be, for all intents and purposes, readonly from the Python side--but at least it's something (currently it fails to compile).

This is still incomplete: it needs similar support for bind_map, and needs a better solution for the current dirty hack in `cast.h`, on which I'd appreciate input on how to deal with it.  I definitely don't think it should remain as is: this was just a hack to get it working as a starting point.

The issue is that `make_copy_constructor` fails for `std::vector<vt>` where `vt` is non-copyable.  The `decltype(new std::vector<vt>(...))` succeeds (i.e. is a type), but an actual attempt to invoke the constructor results in a compilation failure.  (`std::is_copy_constructible` also fails in the same way, i.e. by returning true even when actually invoking the copy constructor results in a compilation failure).  For now I'm just hacking around it (and the hack is only on the non-MSVC path: the MSVC build of this will fail), but a better solution is needed.  @alzie (in #487) points to a workaround in http://stackoverflow.com/questions/18404108/issue-with-is-copy-constructible; any thoughts on something better?