### PR TITLE
Update travis and appveyor builds to eigen 3.3.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,9 +23,9 @@ install:
       conda install -y -q pytest numpy scipy
     }
 - ps: |
-    Start-FileDownload 'http://bitbucket.org/eigen/eigen/get/3.2.9.zip'
-    7z x 3.2.9.zip -y > $null
-    $env:CMAKE_INCLUDE_PATH = "eigen-eigen-dc6cfdf9bcec"
+    Start-FileDownload 'http://bitbucket.org/eigen/eigen/get/3.3.0.zip'
+    7z x 3.3.0.zip -y > $null
+    $env:CMAKE_INCLUDE_PATH = "eigen-eigen-26667be4f70b"
 build_script:
 - cmake -A "%CMAKE_ARCH%" -DPYBIND11_WERROR=ON
 - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,9 +97,9 @@ install:
   else
     pip install numpy scipy pytest
 
-    wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz
+    wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.3.0.tar.gz
     tar xzf eigen.tar.gz
-    export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=$PWD/eigen-eigen-dc6cfdf9bcec"
+    export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=$PWD/eigen-eigen-26667be4f70b"
   fi
 script:
 - $SCRIPT_RUN_PREFIX cmake ${CMAKE_EXTRA_ARGS}


### PR DESCRIPTION
Eigen 3.3.0 (final) was [released](http://eigen.tuxfamily.org/index.php?title=News:Eigen_3.3_released!) this morning.