### PR TITLE
Add type casters for nullopt_t, fix none refcount

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -499,14 +499,16 @@ public:
     PYBIND11_TYPE_CASTER(T, _<std::is_integral<T>::value>("int", "float"));
 };
 
-template <> class type_caster<void_type> {
+template<typename T> struct void_caster {
 public:
     bool load(handle, bool) { return false; }
-    static handle cast(void_type, return_value_policy /* policy */, handle /* parent */) {
+    static handle cast(T, return_value_policy /* policy */, handle /* parent */) {
         return none().inc_ref();
     }
-    PYBIND11_TYPE_CASTER(void_type, _("None"));
+    PYBIND11_TYPE_CASTER(T, _("None"));
 };
+
+template <> class type_caster<void_type> : public void_caster<void_type> {};
 
 template <> class type_caster<void> : public type_caster<void_type> {
 public:

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -232,11 +232,17 @@ private:
 #if PYBIND11_HAS_OPTIONAL
 template<typename T> struct type_caster<std::optional<T>>
     : public optional_caster<std::optional<T>> {};
+
+template<> struct type_caster<std::nullopt_t>
+    : public void_caster<std::nullopt_t> {};
 #endif
 
 #if PYBIND11_HAS_EXP_OPTIONAL
 template<typename T> struct type_caster<std::experimental::optional<T>>
     : public optional_caster<std::experimental::optional<T>> {};
+
+template<> struct type_caster<std::experimental::nullopt_t>
+    : public void_caster<std::experimental::nullopt_t> {};
 #endif
 
 NAMESPACE_END(detail)

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -205,7 +205,7 @@ template<typename T> struct optional_caster {
 
     static handle cast(const T& src, return_value_policy policy, handle parent) {
         if (!src)
-            return none();
+            return none().inc_ref();
         return caster_type::cast(*src, policy, parent);
     }
 

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -301,6 +301,9 @@ test_initializer python_types([](py::module &m) {
     m.def("half_or_none", [](int x) -> opt_int {
         return x ? opt_int(x / 2) : opt_int();
     });
+    m.def("test_nullopt", [](opt_int x) {
+        return x.value_or(42);
+    }, py::arg_v("x", std::experimental::nullopt, "None"));
 #endif
     m.attr("has_optional") = py::cast(has_optional);
 });

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -299,7 +299,7 @@ def test_accessors():
 
 @pytest.mark.skipif(not has_optional, reason='no <experimental/optional>')
 def test_optional():
-    from pybind11_tests import double_or_zero, half_or_none
+    from pybind11_tests import double_or_zero, half_or_none, test_nullopt
 
     assert double_or_zero(None) == 0
     assert double_or_zero(42) == 84
@@ -308,3 +308,8 @@ def test_optional():
     assert half_or_none(0) is None
     assert half_or_none(42) == 21
     pytest.raises(TypeError, half_or_none, 'foo')
+
+    assert test_nullopt() == 42
+    assert test_nullopt(None) == 42
+    assert test_nullopt(42) == 42
+    assert test_nullopt(43) == 43


### PR DESCRIPTION
- Add type casters for `std::nullopt_t` (or `std::experimental::nullopt_t`) as part of `stl.h`. This is needed, for example, if default value for an optional arg in `arg_v` is a `nullopt`, as seen in the test.
- Fix `none` refcount bug as spotted in https://github.com/pybind/pybind11/pull/464#issuecomment-258676623.