### PR TITLE
Only mark unaligned types in buffers

### DIFF
--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -30,13 +30,13 @@ def test_format_descriptors():
     assert re.match('^NumPy type info missing for .*UnboundStruct.*$', str(excinfo.value))
 
     assert print_format_descriptors() == [
-        "T{=?:x:3x=I:y:=f:z:}",
-        "T{=?:x:=I:y:=f:z:}",
-        "T{=T{=?:x:3x=I:y:=f:z:}:a:=T{=?:x:=I:y:=f:z:}:b:}",
-        "T{=?:x:3x=I:y:=f:z:12x}",
-        "T{8x=T{=?:x:3x=I:y:=f:z:12x}:a:8x}",
-        "T{=3s:a:=3s:b:}",
-        'T{=q:e1:=B:e2:}'
+        "T{?:x:3xI:y:f:z:}",
+        "T{?:x:=I:y:=f:z:}",
+        "T{T{?:x:3xI:y:f:z:}:a:T{?:x:=I:y:=f:z:}:b:}",
+        "T{?:x:3xI:y:f:z:12x}",
+        "T{8xT{?:x:3xI:y:f:z:12x}:a:8x}",
+        "T{3s:a:3s:b:}",
+        'T{q:e1:B:e2:}'
     ]
 
 


### PR DESCRIPTION
Previously all types are marked unaligned in buffer format strings, now we test for alignment before adding the '=' marker.

It's not a problem to mark all types as unaligned per-se, it's equivalent because of the explicit padding, but this goes partway to allowing comparison to format strings from other sources, e.g. numpy. It's much easier to test for alignment here rather than parsing the string and trying to work it out. In combination with my other PR #488 , it will be possible to construct a `vector<struct>` from a structured array without casting in some cases (namely where the member names are identical and there's no multibyte padding).