### PR TITLE
test_copy_move_policies slight fix

### DIFF
--- a/tests/test_copy_move_policies.cpp
+++ b/tests/test_copy_move_policies.cpp
@@ -21,7 +21,7 @@ struct lacking_copy_ctor : public empty<lacking_copy_ctor> {
     lacking_copy_ctor(const lacking_copy_ctor& other) = delete;
 };
 
-template <> lacking_copy_ctor empty<lacking_copy_ctor>::instance_ {};
+template <> lacking_copy_ctor empty<lacking_copy_ctor>::instance_ = {};
 
 struct lacking_move_ctor : public empty<lacking_move_ctor> {
     lacking_move_ctor() {}
@@ -29,7 +29,7 @@ struct lacking_move_ctor : public empty<lacking_move_ctor> {
     lacking_move_ctor(lacking_move_ctor&& other) = delete;
 };
 
-template <> lacking_move_ctor empty<lacking_move_ctor>::instance_ {};
+template <> lacking_move_ctor empty<lacking_move_ctor>::instance_ = {};
 
 test_initializer copy_move_policies([](py::module &m) {
     py::class_<lacking_copy_ctor>(m, "lacking_copy_ctor")


### PR DESCRIPTION
Allows test_copy_move_policies to compile (icpc (ICC) 16.0.3 20160415)(thanks to @ryanmrichard for the fix)

Error, for reference:
```
/path/to/pybind11/tests/test_copy_move_policies.cpp(24): error: expected a ";"
  template <> lacking_copy_ctor empty<lacking_copy_ctor>::instance_ {};
                                                                    ^

/path/to/pybind11/tests/test_copy_move_policies.cpp(32): error: expected a ";"
  template <> lacking_move_ctor empty<lacking_move_ctor>::instance_ {};
```                                                                    ^

