### PR TITLE
Add Type to bad args output

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -509,7 +509,7 @@ protected:
             msg += "\nInvoked with: ";
             auto args_ = reinterpret_borrow<tuple>(args);
             for (size_t ti = overloads->is_constructor ? 1 : 0; ti < args_.size(); ++ti) {
-                msg += static_cast<std::string>(pybind11::str(args_[ti]));
+                msg += pybind11::repr(args_[ti]);
                 if ((ti + 1) != args_.size() )
                     msg += ", ";
             }

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -96,7 +96,7 @@ def test_str_issue(msg):
             1. m.issues.StrIssue(arg0: int)
             2. m.issues.StrIssue()
 
-        Invoked with: no, such, constructor
+        Invoked with: 'no', 'such', 'constructor'
     """
 
 


### PR DESCRIPTION
The changes the error message for invalid arguments to display `Type (= strvalue)` instead of just `strvalue` for the given argument list.

Fixes #517.