### PR TITLE
Use correct itemsize when constructing a numpy dtype from a buffer_info

### DIFF
--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -282,9 +282,22 @@ py::list test_dtype_ctors() {
     dict["itemsize"] = py::int_(20);
     list.append(py::dtype::from_args(dict));
     list.append(py::dtype(names, formats, offsets, 20));
-    list.append(py::dtype(py::buffer_info((void *) 0, 1, "I", 1)));
-    list.append(py::dtype(py::buffer_info((void *) 0, 1, "T{i:a:f:b:}", 1)));
+    list.append(py::dtype(py::buffer_info((void *) 0, sizeof(unsigned int), "I", 1)));
+    list.append(py::dtype(py::buffer_info((void *) 0, 0, "T{i:a:f:b:}", 1)));
     return list;
+}
+
+struct TrailingPaddingStruct {
+    int32_t a;
+    char b;
+};
+
+py::dtype trailing_padding_dtype() {
+    return py::dtype::of<TrailingPaddingStruct>();
+}
+
+py::dtype buffer_to_dtype(py::buffer& buf) {
+    return py::dtype(buf.request());
 }
 
 py::list test_dtype_methods() {
@@ -314,6 +327,7 @@ test_initializer numpy_dtypes([](py::module &m) {
     PYBIND11_NUMPY_DTYPE(PartialNestedStruct, a);
     PYBIND11_NUMPY_DTYPE(StringStruct, a, b);
     PYBIND11_NUMPY_DTYPE(EnumStruct, e1, e2);
+    PYBIND11_NUMPY_DTYPE(TrailingPaddingStruct, a, b);
 
     // ... or after
     py::class_<PackedStruct>(m, "PackedStruct");
@@ -338,6 +352,8 @@ test_initializer numpy_dtypes([](py::module &m) {
     m.def("test_array_ctors", &test_array_ctors);
     m.def("test_dtype_ctors", &test_dtype_ctors);
     m.def("test_dtype_methods", &test_dtype_methods);
+    m.def("trailing_padding_dtype", &trailing_padding_dtype);
+    m.def("buffer_to_dtype", &buffer_to_dtype);
     m.def("f_simple", [](SimpleStruct s) { return s.y * 10; });
     m.def("f_packed", [](PackedStruct s) { return s.y * 10; });
     m.def("f_nested", [](NestedStruct s) { return s.a.y * 10; });

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -42,7 +42,7 @@ def test_format_descriptors():
 
 @pytest.requires_numpy
 def test_dtype(simple_dtype):
-    from pybind11_tests import print_dtypes, test_dtype_ctors, test_dtype_methods
+    from pybind11_tests import print_dtypes, test_dtype_ctors, test_dtype_methods, trailing_padding_dtype, buffer_to_dtype
 
     assert print_dtypes() == [
         "{'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8], 'itemsize':12}",
@@ -63,6 +63,8 @@ def test_dtype(simple_dtype):
 
     assert test_dtype_methods() == [np.dtype('int32'), simple_dtype, False, True,
                                     np.dtype('int32').itemsize, simple_dtype.itemsize]
+
+    assert trailing_padding_dtype() == buffer_to_dtype(np.zeros(1, trailing_padding_dtype()))
 
 
 @pytest.requires_numpy


### PR DESCRIPTION
As requested by @aldanor in #488