### PR TITLE
[RFC] Fix type_caster::{handle,load} under ubsan in gcc-4.9

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -835,6 +835,10 @@ protected:
             std::get<Indices>(value).load(PyTuple_GET_ITEM(src.ptr(), Indices), convert)...
         }};
         (void) convert; /* avoid a warning when the tuple is empty */
+        if (size == 0) {        
+            // UBSAN doesn't allow iteration over a zero-sized std::array.
+            return true;
+        }
         for (bool r : success)
             if (!r)
                 return false;
@@ -850,6 +854,10 @@ protected:
             if (!entry)
                 return handle();
         tuple result(size);
+        if (size == 0) {
+            // UBSAN doesn't allow iteration over a zero-sized std::array.
+            return result.release();
+        }
         int counter = 0;
         for (auto & entry: entries)
             PyTuple_SET_ITEM(result.ptr(), counter++, entry.release().ptr());


### PR DESCRIPTION
ubsan in gcc-4.9 doesn't allow iteration over a zero-sized std::array, so essentially all pybind11 bindings fail ubsan. https://gcc.gnu.org/ml/gcc-patches/2015-05/msg02617.html is a fix as well, but it might be nice to support gcc-4.9 sanitizers as well.