### PR TITLE
Allow references to objects held by smart pointers

### DIFF
--- a/docs/advanced/smart_ptrs.rst
+++ b/docs/advanced/smart_ptrs.rst
@@ -53,8 +53,6 @@ code?
 
 .. code-block:: cpp
 
-    PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
-
     class Child { };
 
     class Parent {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1138,21 +1138,26 @@ private:
     static void init_holder_helper(instance_type *inst, const holder_type * /* unused */, const std::enable_shared_from_this<T> * /* dummy */) {
         try {
             new (&inst->holder) holder_type(std::static_pointer_cast<typename holder_type::element_type>(inst->value->shared_from_this()));
+            inst->holder_constructed = true;
         } catch (const std::bad_weak_ptr &) {
-            new (&inst->holder) holder_type(inst->value);
+            if (inst->owned) {
+                new (&inst->holder) holder_type(inst->value);
+                inst->holder_constructed = true;
+            }
         }
-        inst->holder_constructed = true;
     }
 
     /// Initialize holder object, variant 2: try to construct from existing holder object, if possible
     template <typename T = holder_type,
               detail::enable_if_t<std::is_copy_constructible<T>::value, int> = 0>
     static void init_holder_helper(instance_type *inst, const holder_type *holder_ptr, const void * /* dummy */) {
-        if (holder_ptr)
+        if (holder_ptr) {
             new (&inst->holder) holder_type(*holder_ptr);
-        else
+            inst->holder_constructed = true;
+        } else if (inst->owned) {
             new (&inst->holder) holder_type(inst->value);
-        inst->holder_constructed = true;
+            inst->holder_constructed = true;
+        }
     }
 
     /// Initialize holder object, variant 3: holder is not copy constructible (e.g. unique_ptr), always initialize from raw pointer


### PR DESCRIPTION
The documentation rightfully [warns against](http://pybind11.readthedocs.io/en/latest/advanced/smart_ptrs.html#std-shared-ptr) mixing smart pointers and raw pointers in interfaces. However, it's easy to forget that `const&` has a similar issue and can result in a double free (I was bitten by this recently).

This PR makes it possible to return references to types which are wrapped with a `std::shared_ptr` or similar copyable smart pointer.  Here, 'references' mean `&` or `*` with RVP `reference` or `reference_internal`. Returning a `&` or `*` with RVP `take_ownership` is still bad as described in the docs.

In the added tests the values returned from `shared_ref` and `from_this_bad_wp` would usually result in a double free. This is resolved by not constructing the holder in cases where a non-owning reference is returned.

Because the holder isn't always constructed it's also not possible to cast that Python object back to the holder type. A check is added for this, which accounts for the expected `TypeError` when casting `ref -> holder` and `bad_wp -> holder`. Both `ref` and `bad_wp` are still perfectly valid references and can be used per usual. I think that having this case usable with just this limitation is preferable to a crash due to a double free.

The new test also covers every way of initializing a copyable holder type and casting it back to C++.