### PR TITLE
print traceback on failed import

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -511,7 +511,6 @@ PYBIND11_RUNTIME_EXCEPTION(stop_iteration, PyExc_StopIteration)
 PYBIND11_RUNTIME_EXCEPTION(index_error, PyExc_IndexError)
 PYBIND11_RUNTIME_EXCEPTION(key_error, PyExc_KeyError)
 PYBIND11_RUNTIME_EXCEPTION(value_error, PyExc_ValueError)
-PYBIND11_RUNTIME_EXCEPTION(import_error, PyExc_ImportError)
 PYBIND11_RUNTIME_EXCEPTION(type_error, PyExc_TypeError)
 PYBIND11_RUNTIME_EXCEPTION(cast_error, PyExc_RuntimeError) /// Thrown when pybind11::cast or handle::call fail due to a type casting error
 PYBIND11_RUNTIME_EXCEPTION(reference_cast_error, PyExc_RuntimeError) /// Used internally

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -580,7 +580,7 @@ public:
     static module import(const char *name) {
         PyObject *obj = PyImport_ImportModule(name);
         if (!obj)
-            throw import_error("Module \"" + std::string(name) + "\" not found!");
+            throw error_already_set();
         return reinterpret_steal<module>(obj);
     }
 
@@ -1495,7 +1495,7 @@ PYBIND11_NOINLINE inline void print(tuple args, dict kwargs) {
     } else {
         try {
             file = module::import("sys").attr("stdout");
-        } catch (const import_error &) {
+        } catch (const error_already_set &) {
             /* If print() is called from code that is executed as
                part of garbage collection during interpreter shutdown,
                importing 'sys' can fail. Give up rather than crashing the


### PR DESCRIPTION
This PR prints a traceback when a python import fails due to an error in the imported file. The existing implementation will print out a message about the module not being found. Here is an example demonstrating the issue:

```cpp
// example.cpp
#include <Python.h>
#include <pybind11/pybind11.h>

int main(int argc, char *argv[]) {
    Py_Initialize();
    pybind11::module::import(argv[1]);
    Py_Finalize();
    return 0;
}
```

```python
# example.py
raise Exception('exception raised on import')
```

Before this PR:
```bash
build: ./ex example                                                                     
terminate called after throwing an instance of 'pybind11::import_error'
  what():  Module "example" not found!
[1]    3744 abort (core dumped)  ./ex example
build: ./ex module_that_doesnt_exist                                                   
terminate called after throwing an instance of 'pybind11::import_error'
  what():  Module "module_that_doesnt_exist" not found!
[1]    3766 abort (core dumped)  ./ex module_that_doesnt_exist
```

After this PR:
```bash
build: ./ex example                                                                 
terminate called after throwing an instance of 'pybind11::error_already_set'
  what():  Exception: exception raised on import

At:
  /home/esquires3/Documents/pybind/example.py(1): <module>

[1]    3650 abort (core dumped)  ./ex example
build: ./ex module_that_doesnt_exist                                                      
terminate called after throwing an instance of 'pybind11::error_already_set'
  what():  ImportError: No module named module_that_doesnt_exist
[1]    3664 abort (core dumped)  ./ex module_that_doesnt_exist