### PR TITLE
Syntax sugar for resolving overloaded function pointers

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -104,6 +104,8 @@ With the above change, the same Python code now produces the following output:
     >>> print(p)
     <example.Pet named 'Molly'>
 
+.. [#f1] Stateless closures are those with an empty pair of brackets ``[]`` as the capture object.
+
 .. _properties:
 
 Instance and static fields
@@ -337,6 +339,35 @@ The overload signatures are also visible in the method's docstring:
      |
      |      Set the pet's name
 
+If you have a C++14 compatible compiler [#cpp14]_, you can use an alternative
+syntax to cast the overloaded function:
+
+.. code-block:: cpp
+
+    py::class_<Pet>(m, "Pet")
+        .def("set", py::overload_cast<int>(&Pet::set), "Set the pet's age")
+        .def("set", py::overload_cast<const std::string &>(&Pet::set), "Set the pet's name");
+
+Here, ``py::overload_cast`` only requires the parameter types to be specified.
+The return type and class are deduced. This avoids the additional noise of
+``void (Pet::*)()`` as seen in the raw cast. If a function is overloaded based
+on constness, the ``py::const_`` tag should be used:
+
+.. code-block:: cpp
+
+    struct Widget {
+        int foo(int x, float y);
+        int foo(int x, float y) const;
+    };
+
+    py::class_<Widget>(m, "Widget")
+       .def("foo_mutable", py::overload_cast<int, float>(&Widget::foo))
+       .def("foo_const",   py::overload_cast<int, float>(&Widget::foo, py::const_));
+
+
+.. [#cpp14] A compiler which supports the ``-std=c++14`` flag
+            or Visual Studio 2015 Update 2 and newer.
+
 .. note::
 
     To define multiple overloaded constructors, simply declare one after the
@@ -406,5 +437,3 @@ typed enums.
            ...
 
     By default, these are omitted to conserve space.
-
-.. [#f1] Stateless closures are those with an empty pair of brackets ``[]`` as the capture object.

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -23,6 +23,9 @@ std::string test_function3(int i) {
     return "test_function(" + std::to_string(i) + ")";
 }
 
+py::str test_function4(int, float) { return "test_function(int, float)"; }
+py::str test_function4(float, int) { return "test_function(float, int)"; }
+
 py::bytes return_bytes() {
     const char *data = "\x01\x00\x02\x00";
     return std::string(data, 4);
@@ -44,6 +47,14 @@ test_initializer constants_and_functions([](py::module &m) {
     m.def("test_function", &test_function1);
     m.def("test_function", &test_function2);
     m.def("test_function", &test_function3);
+
+#if defined(PYBIND11_OVERLOAD_CAST)
+    m.def("test_function", py::overload_cast<int, float>(&test_function4));
+    m.def("test_function", py::overload_cast<float, int>(&test_function4));
+#else
+    m.def("test_function", static_cast<py::str (*)(int, float)>(&test_function4));
+    m.def("test_function", static_cast<py::str (*)(float, int)>(&test_function4));
+#endif
 
     py::enum_<MyEnum>(m, "MyEnum")
         .value("EFirstEntry", EFirstEntry)

--- a/tests/test_constants_and_functions.py
+++ b/tests/test_constants_and_functions.py
@@ -14,6 +14,9 @@ def test_function_overloading():
     assert test_function(MyEnum.EFirstEntry) == "test_function(enum=1)"
     assert test_function(MyEnum.ESecondEntry) == "test_function(enum=2)"
 
+    assert test_function(1, 1.0) == "test_function(int, float)"
+    assert test_function(2.0, 2) == "test_function(float, int)"
+
 
 def test_bytes():
     from pybind11_tests import return_bytes, print_bytes

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -50,6 +50,11 @@ public:
     int *internal4() { return &value; }                           // return by pointer
     const int *internal5() { return &value; }                     // return by const pointer
 
+    py::str overloaded(int, float) { return "(int, float)"; }
+    py::str overloaded(float, int) { return "(float, int)"; }
+    py::str overloaded(int, float) const { return "(int, float) const"; }
+    py::str overloaded(float, int) const { return "(float, int) const"; }
+
     int value = 0;
 };
 
@@ -117,6 +122,17 @@ test_initializer methods_and_attributes([](py::module &m) {
         .def("internal3", &ExampleMandA::internal3)
         .def("internal4", &ExampleMandA::internal4)
         .def("internal5", &ExampleMandA::internal5)
+#if defined(PYBIND11_OVERLOAD_CAST)
+        .def("overloaded", py::overload_cast<int, float>(&ExampleMandA::overloaded))
+        .def("overloaded", py::overload_cast<float, int>(&ExampleMandA::overloaded))
+        .def("overloaded_const", py::overload_cast<int, float>(&ExampleMandA::overloaded, py::const_))
+        .def("overloaded_const", py::overload_cast<float, int>(&ExampleMandA::overloaded, py::const_))
+#else
+        .def("overloaded", static_cast<py::str (ExampleMandA::*)(int, float)>(&ExampleMandA::overloaded))
+        .def("overloaded", static_cast<py::str (ExampleMandA::*)(float, int)>(&ExampleMandA::overloaded))
+        .def("overloaded_const", static_cast<py::str (ExampleMandA::*)(int, float) const>(&ExampleMandA::overloaded))
+        .def("overloaded_const", static_cast<py::str (ExampleMandA::*)(float, int) const>(&ExampleMandA::overloaded))
+#endif
         .def("__str__", &ExampleMandA::toString)
         .def_readwrite("value", &ExampleMandA::value)
         ;

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -31,6 +31,11 @@ def test_methods_and_attributes():
     assert instance1.internal4() == 320
     assert instance1.internal5() == 320
 
+    assert instance1.overloaded(1, 1.0) == "(int, float)"
+    assert instance1.overloaded(2.0, 2) == "(float, int)"
+    assert instance1.overloaded_const(3, 3.0) == "(int, float) const"
+    assert instance1.overloaded_const(4.0, 4) == "(float, int) const"
+
     assert instance1.value == 320
     instance1.value = 100
     assert str(instance1) == "ExampleMandA[value=100]"


### PR DESCRIPTION
I'm actually hesitant about this PR because of the unusual syntax, so feel free to close this and label it "syntax gore" :) Anyway, here goes.

This tries to include something similar to [`overload_cast`](https://github.com/dean0x7d/overload_cast), but with a uniform C++11 and C++14 syntax. Overloaded functions need to be cast before passing to `def`:
```c++
.def("foo", static_cast<Return (Widget::*)(Arg0, Arg1, Arg2)>(&Widget::foo))
```
Here, the class name needs to be written twice, and the return type is completely unnecessary. The terser syntax introduced here is:
```c++
.def("foo", &Widget::foo | py::select<Arg0, Arg1, Arg2>())
```
`py::select` resolves the overload set just like the cast, but it only needs the arguments -- no extra `Return (Widget::*)()` noise. The `|` operator is an unfortunate evil here. Although, it can be interpreted as a shell-like pipe operator as is becoming popular in C++ (ranges TS). Ideally, `py::select` would just be an argument of `def` (so there would just be a normal comma there), but template type deduction can't resolve the function pointer in that case (at least with everything I've tried).

An alternative syntax is also possible with `overload_cast` as linked above, but this has its own syntax issues (split between C++11 and 14).

See the tests for examples. I can add proper docs if this feature is at all desired.