### PR TITLE
Set maximum line length for Python style checker

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,9 @@
 universal=1
 
 [flake8]
+max-line-length = 99
 show_source = True
 exclude = .git, __pycache__, build, dist, docs, tools, venv
 ignore =
-    # line too long
-    E501,
     # required for pretty matrix formating: multiple spaces after `,` and `[`
     E201, E241

--- a/tests/test_class_args.py
+++ b/tests/test_class_args.py
@@ -1,6 +1,8 @@
 
 
 def test_class_args():
-    # There's basically nothing to test here; just make sure the code compiled and declared its definition
+    """There's basically nothing to test here; just make sure the code compiled
+    and declared its definition
+    """
     from pybind11_tests import class_args_noop
     class_args_noop()

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -110,9 +110,15 @@ def test_special_matrix_objects():
 def test_dense_signature(doc):
     from pybind11_tests import double_col, double_row, double_mat_rm
 
-    assert doc(double_col) == "double_col(arg0: numpy.ndarray[float32[m, 1]]) -> numpy.ndarray[float32[m, 1]]"
-    assert doc(double_row) == "double_row(arg0: numpy.ndarray[float32[1, n]]) -> numpy.ndarray[float32[1, n]]"
-    assert doc(double_mat_rm) == "double_mat_rm(arg0: numpy.ndarray[float32[m, n]]) -> numpy.ndarray[float32[m, n]]"
+    assert doc(double_col) == """
+        double_col(arg0: numpy.ndarray[float32[m, 1]]) -> numpy.ndarray[float32[m, 1]]
+    """
+    assert doc(double_row) == """
+        double_row(arg0: numpy.ndarray[float32[1, n]]) -> numpy.ndarray[float32[1, n]]
+    """
+    assert doc(double_mat_rm) == """
+        double_mat_rm(arg0: numpy.ndarray[float32[m, n]]) -> numpy.ndarray[float32[m, n]]
+    """
 
 
 @pytest.requires_eigen_and_scipy
@@ -131,5 +137,9 @@ def test_sparse():
 def test_sparse_signature(doc):
     from pybind11_tests import sparse_passthrough_r, sparse_passthrough_c
 
-    assert doc(sparse_passthrough_r) == "sparse_passthrough_r(arg0: scipy.sparse.csr_matrix[float32]) -> scipy.sparse.csr_matrix[float32]"
-    assert doc(sparse_passthrough_c) == "sparse_passthrough_c(arg0: scipy.sparse.csc_matrix[float32]) -> scipy.sparse.csc_matrix[float32]"
+    assert doc(sparse_passthrough_r) == """
+        sparse_passthrough_r(arg0: scipy.sparse.csr_matrix[float32]) -> scipy.sparse.csr_matrix[float32]
+    """  # noqa: E501 line too long
+    assert doc(sparse_passthrough_c) == """
+        sparse_passthrough_c(arg0: scipy.sparse.csc_matrix[float32]) -> scipy.sparse.csc_matrix[float32]
+    """  # noqa: E501 line too long

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -42,14 +42,17 @@ def test_format_descriptors():
 
 @pytest.requires_numpy
 def test_dtype(simple_dtype):
-    from pybind11_tests import print_dtypes, test_dtype_ctors, test_dtype_methods, trailing_padding_dtype, buffer_to_dtype
+    from pybind11_tests import (print_dtypes, test_dtype_ctors, test_dtype_methods,
+                                trailing_padding_dtype, buffer_to_dtype)
 
     assert print_dtypes() == [
         "{'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8], 'itemsize':12}",
         "[('x', '?'), ('y', '<u4'), ('z', '<f4')]",
-        "[('a', {'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8], 'itemsize':12}), ('b', [('x', '?'), ('y', '<u4'), ('z', '<f4')])]",
+        "[('a', {'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8],"
+        " 'itemsize':12}), ('b', [('x', '?'), ('y', '<u4'), ('z', '<f4')])]",
         "{'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8], 'itemsize':24}",
-        "{'names':['a'], 'formats':[{'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8], 'itemsize':24}], 'offsets':[8], 'itemsize':40}",
+        "{'names':['a'], 'formats':[{'names':['x','y','z'], 'formats':['?','<u4','<f4'],"
+        " 'offsets':[0,4,8], 'itemsize':24}], 'offsets':[8], 'itemsize':40}",
         "[('a', 'S3'), ('b', 'S3')]",
         "[('e1', '<i8'), ('e2', 'u1')]",
         "[('x', 'i1'), ('y', '<u8')]"
@@ -117,7 +120,8 @@ def test_recarray(simple_dtype, packed_dtype):
     ]
 
     arr = create_rec_partial(3)
-    assert str(arr.dtype) == "{'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8], 'itemsize':24}"
+    assert str(arr.dtype) == \
+        "{'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8], 'itemsize':24}"
     partial_dtype = arr.dtype
     assert '' not in arr.dtype.fields
     assert partial_dtype.itemsize > simple_dtype.itemsize
@@ -125,7 +129,9 @@ def test_recarray(simple_dtype, packed_dtype):
     assert_equal(arr, elements, packed_dtype)
 
     arr = create_rec_partial_nested(3)
-    assert str(arr.dtype) == "{'names':['a'], 'formats':[{'names':['x','y','z'], 'formats':['?','<u4','<f4'], 'offsets':[0,4,8], 'itemsize':24}], 'offsets':[8], 'itemsize':40}"
+    assert str(arr.dtype) == \
+        "{'names':['a'], 'formats':[{'names':['x','y','z'], 'formats':['?','<u4','<f4']," \
+        " 'offsets':[0,4,8], 'itemsize':24}], 'offsets':[8], 'itemsize':40}"
     assert '' not in arr.dtype.fields
     assert '' not in arr.dtype.fields['a'][0].fields
     assert arr.dtype.itemsize > partial_dtype.itemsize

--- a/tests/test_numpy_vectorize.py
+++ b/tests/test_numpy_vectorize.py
@@ -71,4 +71,6 @@ def test_type_selection():
 def test_docs(doc):
     from pybind11_tests import vectorized_func
 
-    assert doc(vectorized_func) == "vectorized_func(arg0: numpy.ndarray[int], arg1: numpy.ndarray[float], arg2: numpy.ndarray[float]) -> object"
+    assert doc(vectorized_func) == """
+        vectorized_func(arg0: numpy.ndarray[int], arg1: numpy.ndarray[float], arg2: numpy.ndarray[float]) -> object
+    """  # noqa: E501 line too long

--- a/tests/test_opaque_types.py
+++ b/tests/test_opaque_types.py
@@ -39,7 +39,7 @@ def test_pointers(msg):
             1. (arg0: capsule) -> int
 
         Invoked with: [1, 2, 3]
-    """
+    """  # noqa: E501 line too long
 
     assert return_null_str() is None
     assert get_null_str_value(return_null_str()) is not None

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -223,7 +223,7 @@ def test_docs(doc):
         tuple_passthrough(self: m.ExamplePythonTypes, arg0: Tuple[bool, str, int]) -> Tuple[int, str, bool]
 
         Return a triple in reversed order
-    """
+    """  # noqa: E501 line too long
     assert doc(ExamplePythonTypes.throw_exception) == """
         throw_exception(self: m.ExamplePythonTypes) -> None
 

--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -36,7 +36,9 @@ def test_override(capture, msg):
     ex12 = ExampleVirt(10)
     with capture:
         assert runExampleVirt(ex12, 20) == 30
-    assert capture == "Original implementation of ExampleVirt::run(state=10, value=20, str1=default1, str2=default2)"
+    assert capture == """
+        Original implementation of ExampleVirt::run(state=10, value=20, str1=default1, str2=default2)
+    """  # noqa: E501 line too long
 
     with pytest.raises(RuntimeError) as excinfo:
         runExampleVirtVirtual(ex12)
@@ -48,7 +50,7 @@ def test_override(capture, msg):
     assert capture == """
         ExtendedExampleVirt::run(20), calling parent..
         Original implementation of ExampleVirt::run(state=11, value=21, str1=override1, str2=default2)
-    """
+    """  # noqa: E501 line too long
     with capture:
         assert runExampleVirtBool(ex12p) is False
     assert capture == "ExtendedExampleVirt::run_bool()"
@@ -62,7 +64,7 @@ def test_override(capture, msg):
     assert capture == """
         ExtendedExampleVirt::run(50), calling parent..
         Original implementation of ExampleVirt::run(state=17, value=51, str1=override1, str2=override2)
-    """
+    """  # noqa: E501 line too long
 
     cstats = ConstructorStats.get(ExampleVirt)
     assert cstats.alive() == 3


### PR DESCRIPTION
Based on comments from #527, this sets the flake8 `max-line-length` to 99 (previously unlimited).