### PR TITLE
Relax and optimize all_of_t/any_of_t

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1004,23 +1004,24 @@ class type_caster<T, enable_if_t<is_pyobject<T>::value>> : public pyobject_caste
 // - if the type is non-copy-constructible, the object must be the sole owner of the type (i.e. it
 //   must have ref_count() == 1)h
 // If any of the above are not satisfied, we fall back to copying.
-template <typename T, typename SFINAE = void> struct move_is_plain_type : std::false_type {};
-template <typename T> struct move_is_plain_type<T, enable_if_t<
-        !std::is_void<T>::value && !std::is_pointer<T>::value && !std::is_reference<T>::value && !std::is_const<T>::value
-    >> : std::true_type { };
+template <typename T> using move_is_plain_type = none_of<
+    std::is_void<T>, std::is_pointer<T>, std::is_reference<T>, std::is_const<T>
+>;
 template <typename T, typename SFINAE = void> struct move_always : std::false_type {};
-template <typename T> struct move_always<T, enable_if_t<
-        move_is_plain_type<T>::value &&
-        !std::is_copy_constructible<T>::value && std::is_move_constructible<T>::value &&
-        std::is_same<decltype(std::declval<type_caster<T>>().operator T&()), T&>::value
-    >> : std::true_type { };
+template <typename T> struct move_always<T, enable_if_t<all_of<
+    move_is_plain_type<T>,
+    negation<std::is_copy_constructible<T>>,
+    std::is_move_constructible<T>,
+    std::is_same<decltype(std::declval<type_caster<T>>().operator T&()), T&>
+>::value>> : std::true_type {};
 template <typename T, typename SFINAE = void> struct move_if_unreferenced : std::false_type {};
-template <typename T> struct move_if_unreferenced<T, enable_if_t<
-        move_is_plain_type<T>::value &&
-        !move_always<T>::value && std::is_move_constructible<T>::value &&
-        std::is_same<decltype(std::declval<type_caster<T>>().operator T&()), T&>::value
-    >> : std::true_type { };
-template <typename T> using move_never = std::integral_constant<bool, !move_always<T>::value && !move_if_unreferenced<T>::value>;
+template <typename T> struct move_if_unreferenced<T, enable_if_t<all_of<
+    move_is_plain_type<T>,
+    negation<move_always<T>>,
+    std::is_move_constructible<T>,
+    std::is_same<decltype(std::declval<type_caster<T>>().operator T&()), T&>
+>::value>> : std::true_type {};
+template <typename T> using move_never = none_of<move_always<T>, move_if_unreferenced<T>>;
 
 // Detect whether returning a `type` from a cast on type's type_caster is going to result in a
 // reference or pointer to a local variable of the type_caster.  Basically, only
@@ -1080,7 +1081,7 @@ template <typename T> T handle::cast() const { return pybind11::cast<T>(*this); 
 template <> inline void handle::cast() const { return; }
 
 template <typename T>
-detail::enable_if_t<detail::move_always<T>::value || detail::move_if_unreferenced<T>::value, T> move(object &&obj) {
+detail::enable_if_t<!detail::move_never<T>::value, T> move(object &&obj) {
     if (obj.ref_count() > 1)
 #if defined(NDEBUG)
         throw cast_error("Unable to cast Python instance to C++ rvalue: instance has multiple references"
@@ -1427,14 +1428,14 @@ private:
 
 /// Collect only positional arguments for a Python function call
 template <return_value_policy policy, typename... Args,
-          typename = enable_if_t<all_of_t<is_positional, Args...>::value>>
+          typename = enable_if_t<all_of<is_positional<Args>...>::value>>
 simple_collector<policy> collect_arguments(Args &&...args) {
     return simple_collector<policy>(std::forward<Args>(args)...);
 }
 
 /// Collect all arguments, including keywords and unpacking (only instantiated when needed)
 template <return_value_policy policy, typename... Args,
-          typename = enable_if_t<!all_of_t<is_positional, Args...>::value>>
+          typename = enable_if_t<!all_of<is_positional<Args>...>::value>>
 unpacking_collector<policy> collect_arguments(Args &&...args) {
     // Following argument order rules for generalized unpacking according to PEP 448
     static_assert(

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -374,7 +374,10 @@ template <class T> using negation = bool_constant<!T::value>;
 #endif
 
 /// Compile-time all/any/none of that check the ::value of all template types
-#if !defined(_MSC_VER)
+#ifdef PYBIND11_CPP17
+template <class... Ts> using all_of = bool_constant<(Ts::value && ...)>;
+template <class... Ts> using any_of = bool_constant<(Ts::value || ...)>;
+#elif !defined(_MSC_VER)
 template <bool...> struct bools {};
 template <class... Ts> using all_of = std::is_same<
     bools<Ts::value..., true>,

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -345,8 +345,17 @@ struct internals {
 /// Return a reference to the current 'internals' information
 inline internals &get_internals();
 
-/// Index sequence for convenient template metaprogramming involving tuples
+/// from __cpp_future__ import (convenient aliases from C++14/17)
 #ifdef PYBIND11_CPP14
+using std::enable_if_t;
+using std::conditional_t;
+#else
+template <bool B, typename T = void> using enable_if_t = typename std::enable_if<B, T>::type;
+template <bool B, typename T, typename F> using conditional_t = typename std::conditional<B, T, F>::type;
+#endif
+
+/// Index sequences
+#if defined(PYBIND11_CPP14) || defined(_MSC_VER)
 using std::index_sequence;
 using std::make_index_sequence;
 #else
@@ -355,6 +364,29 @@ template<size_t N, size_t ...S> struct make_index_sequence_impl : make_index_seq
 template<size_t ...S> struct make_index_sequence_impl <0, S...> { typedef index_sequence<S...> type; };
 template<size_t N> using make_index_sequence = typename make_index_sequence_impl<N>::type;
 #endif
+
+#if defined(PYBIND11_CPP17) || defined(_MSC_VER)
+using std::bool_constant;
+using std::negation;
+#else
+template <bool B> using bool_constant = std::integral_constant<bool, B>;
+template <class T> using negation = bool_constant<!T::value>;
+#endif
+
+/// Compile-time all/any/none of that check the ::value of all template types
+#if !defined(_MSC_VER)
+template <bool...> struct bools {};
+template <class... Ts> using all_of = std::is_same<
+    bools<Ts::value..., true>,
+    bools<true, Ts::value...>>;
+template <class... Ts> using any_of = negation<all_of<negation<Ts>...>>;
+#else
+// MSVC has trouble with the above, but supports std::conjunction, which we can use instead (albeit
+// at a slight loss of compilation efficiency).
+template <class... Ts> using all_of = std::conjunction<Ts...>;
+template <class... Ts> using any_of = std::disjunction<Ts...>;
+#endif
+template <class... Ts> using none_of = negation<any_of<Ts...>>;
 
 /// Strip the class from a method type
 template <typename T> struct remove_class { };
@@ -377,34 +409,10 @@ struct void_type { };
 /// Helper template which holds a list of types
 template <typename...> struct type_list { };
 
-/// from __cpp_future__ import (convenient aliases from C++14/17)
-template <bool B> using bool_constant = std::integral_constant<bool, B>;
-template <class T> using negation = bool_constant<!T::value>;
-template <bool B, typename T = void> using enable_if_t = typename std::enable_if<B, T>::type;
-template <bool B, typename T, typename F> using conditional_t = typename std::conditional<B, T, F>::type;
-
 /// Compile-time integer sum
 constexpr size_t constexpr_sum() { return 0; }
 template <typename T, typename... Ts>
 constexpr size_t constexpr_sum(T n, Ts... ns) { return size_t{n} + constexpr_sum(ns...); }
-
-// Counts the number of types in the template parameter pack matching the predicate
-#if !defined(_MSC_VER)
-template <template<typename> class Predicate, typename... Ts>
-using count_t = std::integral_constant<size_t, constexpr_sum(Predicate<Ts>::value...)>;
-#else
-// MSVC workaround (2015 Update 3 has issues with some member type aliases and constexpr)
-template <template<typename> class Predicate, typename... Ts> struct count_t;
-template <template<typename> class Predicate> struct count_t<Predicate> : std::integral_constant<size_t, 0> {};
-template <template<typename> class Predicate, class T, class... Ts>
-struct count_t<Predicate, T, Ts...> : std::integral_constant<size_t, Predicate<T>::value + count_t<Predicate, Ts...>::value> {};
-#endif
-
-/// Return true if all/any Ts satify Predicate<T>
-template <template<typename> class Predicate, typename... Ts>
-using all_of_t = bool_constant<(count_t<Predicate, Ts...>::value == sizeof...(Ts))>;
-template <template<typename> class Predicate, typename... Ts>
-using any_of_t = bool_constant<(count_t<Predicate, Ts...>::value > 0)>;
 
 // Extracts the first type from the template parameter pack matching the predicate, or Default if none match.
 template <template<class> class Predicate, class Default, class... Ts> struct first_of;

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -42,9 +42,10 @@ template <typename T> using is_eigen_ref = is_template_base_of<Eigen::RefBase, T
 // basically covers anything that can be assigned to a dense matrix but that don't have a typical
 // matrix data layout that can be copied from their .data().  For example, DiagonalMatrix and
 // SelfAdjointView fall into this category.
-template <typename T> using is_eigen_base = bool_constant<
-    is_template_base_of<Eigen::EigenBase, T>::value
-    && !is_eigen_dense<T>::value && !is_eigen_sparse<T>::value
+template <typename T> using is_eigen_base = all_of<
+    is_template_base_of<Eigen::EigenBase, T>,
+    negation<is_eigen_dense<T>>,
+    negation<is_eigen_sparse<T>>
 >;
 
 template<typename Type>

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -253,8 +253,8 @@ void vector_modifiers(enable_if_t<std::is_copy_constructible<typename Vector::va
 
 // If the type has an operator[] that doesn't return a reference (most notably std::vector<bool>),
 // we have to access by copying; otherwise we return by reference.
-template <typename Vector> using vector_needs_copy = bool_constant<
-    !std::is_same<decltype(std::declval<Vector>()[typename Vector::size_type()]), typename Vector::value_type &>::value>;
+template <typename Vector> using vector_needs_copy = negation<
+    std::is_same<decltype(std::declval<Vector>()[typename Vector::size_type()]), typename Vector::value_type &>>;
 
 // The usual case: access and iterate by reference
 template <typename Vector, typename Class_>

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -14,6 +14,11 @@
 #include <deque>
 #include <unordered_map>
 
+#ifdef _MSC_VER
+// We get some really long type names here which causes MSVC to emit warnings
+#  pragma warning(disable: 4503) // warning C4503: decorated name length exceeded, name was truncated
+#endif
+
 class El {
 public:
     El() = delete;


### PR DESCRIPTION
C++17 has `std::conjunction`/`disjunction` which are quite similar in purpose to our `all_of_t` and `any_of_t` in practice.  (They can differ if you pass in a Predicate with a non-bool ::value, but we don't do that).  Essentially `detail::all_of_t<P, T...>` is equivalent to `std::conjunction<P<T>...>`, and `any_of_t<P, T...>` corresponds to `std::disjunction<P<T>...>`.

Unlike `any`/`all_of_t`, `dis`/`conjunction` aren't tied to a single predicate, so it can be used as a compile-time `and` across multiple types with `::value`s, allowing some less verbose code in various circumstances.

This commit converts `all_of_t`/`any_of_t` into `conjunction`/`disjunction` calls, and uses conjunction/disjunction in a few other places for some code cleanups.

I also removed the `count_t` since `any_of_t` and `all_of_t` was the only thing using it.

This commit also uses aliases to the `std` implementations for C++14/17 features when under the appropriate compiler mode, as we were already doing for a few things (like index_sequence).  Most of these aren't saving much (the implementation for enable_if_t, for example, is trivial), but I think it makes the intention of the code instantly clear.

Since this introduces a slightly different implementation when compiling under C++17, I've also added a travis-ci build to compile in C++17 mode under gcc 6.  (I tried adding an experimental build with a recent gcc 7 snapshot, but pybind triggers an ICE in c++17 mode with a current g++ snapshot.)