### PR TITLE
Add temporary allow_failure for python 2.7/gcc 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ matrix:
     - flake8
   allow_failures:
     - env: PYTHON=3.5 CPP=17 GCC=7
+    - env: PYTHON=2.7 CPP=14 GCC=6 # Temporary until python >2.7.13-rc1 migrates to debian testing
 cache:
   directories:
   - $HOME/.cache/pip


### PR DESCRIPTION
Current debian testing has Python 2.7.13-RC1, which has a serious regression (upstream https://bugs.python.org/issue5322) which should be reverted for RC2 (or the final 2.7.13) that we hit on several tests.  Ignore build failures for that build temporarily (with the intention of reverting this commit in a couple of weeks once it stops failing, i.e. when debian testing picks up an updated python 2.7 release).