### PR TITLE
Avoid CMP0048 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@
 
 cmake_minimum_required(VERSION 2.8.12)
 
+if (POLICY CMP0048)
+  # cmake warns if loaded from a min-3.0-required parent dir, so silence the warning:
+  cmake_policy(SET CMP0048 NEW)
+endif()
+
 project(pybind11)
 
 # Check if pybind11 is being used directly or via add_subdirectory


### PR DESCRIPTION
Fixes #567.

If pybind's CMakeLists gets loaded via an include_directory from another CMakeLists with a higher minimum version (e.g. 3.0), the project() command without a version produces a CMP0048 warning.

This commit explicitly requests the old behaviour (if the policy exists in the active cmake).