### PR TITLE
Fix segfault when repr() with pybind11 type with metaclass

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -701,7 +701,7 @@ protected:
 
 #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
             /* Qualified names for Python >= 3.3 */
-            type->ht_qualname = ht_qualname.release().ptr();
+            type->ht_qualname = ht_qualname.inc_ref().ptr();
 #endif
             type->ht_type.tp_name = strdup(meta_name_.c_str());
             type->ht_type.tp_base = &PyType_Type;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -701,7 +701,7 @@ protected:
 
 #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
             /* Qualified names for Python >= 3.3 */
-            type->ht_qualname = ht_qualname.inc_ref().ptr();
+            type->ht_qualname = ht_qualname_meta.release().ptr();
 #endif
             type->ht_type.tp_name = strdup(meta_name_.c_str());
             type->ht_type.tp_base = &PyType_Type;

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -3,6 +3,11 @@ import pytest
 from pybind11_tests import ExamplePythonTypes, ConstructorStats, has_optional, has_exp_optional
 
 
+def test_repr():
+    assert "<class 'pybind11_tests.ExamplePythonTypes__Meta'>" == repr(type(ExamplePythonTypes))
+    assert "<class 'pybind11_tests.ExamplePythonTypes'>" == repr(ExamplePythonTypes)
+
+
 def test_static():
     ExamplePythonTypes.value = 15
     assert ExamplePythonTypes.value == 15

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -3,9 +3,9 @@ import pytest
 from pybind11_tests import ExamplePythonTypes, ConstructorStats, has_optional, has_exp_optional
 
 
-def test_repr():
-    assert "ExamplePythonTypes__Meta" in repr(type(ExamplePythonTypes))
-    assert "ExamplePythonTypes" in repr(ExamplePythonTypes)
+def test_qualname():
+    assert "ExamplePythonTypes__Meta" == type(ExamplePythonTypes).__qualname__
+    assert "ExamplePythonTypes" == ExamplePythonTypes.__qualname__
 
 
 def test_static():

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -4,8 +4,8 @@ from pybind11_tests import ExamplePythonTypes, ConstructorStats, has_optional, h
 
 
 def test_repr():
-    assert "<class 'pybind11_tests.ExamplePythonTypes__Meta'>" == repr(type(ExamplePythonTypes))
-    assert "<class 'pybind11_tests.ExamplePythonTypes'>" == repr(ExamplePythonTypes)
+    assert "ExamplePythonTypes__Meta" in repr(type(ExamplePythonTypes))
+    assert "ExamplePythonTypes" in repr(ExamplePythonTypes)
 
 
 def test_static():

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -3,9 +3,10 @@ import pytest
 from pybind11_tests import ExamplePythonTypes, ConstructorStats, has_optional, has_exp_optional
 
 
-def test_qualname():
-    assert "ExamplePythonTypes__Meta" == type(ExamplePythonTypes).__qualname__
-    assert "ExamplePythonTypes" == ExamplePythonTypes.__qualname__
+def test_repr():
+    # In Python 3.3+, repr() accesses __qualname__
+    assert "ExamplePythonTypes__Meta" in repr(type(ExamplePythonTypes))
+    assert "ExamplePythonTypes" in repr(ExamplePythonTypes)
 
 
 def test_static():


### PR DESCRIPTION
Correct the ``ht_qualname`` field for ``PyHeapTypeObject`` with metaclass.

When filling the ``ht_qualname`` field of the metaclass ``PyHeapTypeObject``, the object shouldn't be released.  Otherwise later the major type object receives a NULL ``ht_qualname``, and then ``__repr__()`` results into segfault (``typeobject.c``:``type_qualname()`` increments the ref count unconditionally by ``Py_INCREF(et->ht_qualname)``).

Note that pickler relies on repr, and crashes as well.  If needed I can provide a test case.