### PR TITLE
Temporarily allows osx homebrew Python 3.6 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
   allow_failures:
     - env: PYTHON=3.5 CPP=17 GCC=7
     - env: PYTHON=2.7 CPP=14 GCC=6 # Temporary until python >2.7.13-rc1 migrates to debian testing
+    - env: PYTHON=3.5 CPP=14 CLANG # Temporary until binary wheels of numpy and scipy become available on brew Python 3.6
 cache:
   directories:
   - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     env: PYTHON=2.7 CPP=14 CLANG
   - os: osx
     osx_image: xcode7.3
-    env: PYTHON=3.5 CPP=14 CLANG
+    env: PYTHON=3.6 CPP=14 CLANG
   # Test a PyPy 2.7 nightly build
   - os: linux
     env: PYPY=1 PYTHON=2.7 CPP=11 GCC=4.8
@@ -59,7 +59,7 @@ matrix:
   allow_failures:
     - env: PYTHON=3.5 CPP=17 GCC=7
     - env: PYTHON=2.7 CPP=14 GCC=6 # Temporary until python >2.7.13-rc1 migrates to debian testing
-    - env: PYTHON=3.5 CPP=14 CLANG # Temporary until binary wheels of numpy and scipy become available on brew Python 3.6
+    - env: PYTHON=3.6 CPP=14 CLANG # Temporary until binary wheels of numpy and scipy become available on brew Python 3.6
 cache:
   directories:
   - $HOME/.cache/pip


### PR DESCRIPTION
Based on @dean0x7d's [comment](https://github.com/pybind/pybind11/pull/570#issuecomment-269120613):

> Homebrew just got Python 3.6 (brew install python3), but numpy and scipy don't have binary wheels for 3.6 yet so it's trying to compile from source and failing.

I added a line in `.travis.yml` to allow the build to fail.  It's my first time trying this feature and I am not sure it's the right way to do it.  If it's not please feel free to scrap it.

(@jagerman @wjakob)