### PR TITLE
Make non-ancient version of GCC explicit in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ In addition to the core functionality, pybind11 provides some extra goodies:
 ## Supported compilers
 
 1. Clang/LLVM (any non-ancient version with C++11 support)
-2. GCC (any non-ancient version with C++11 support)
+2. GCC 4.8 or newer
 3. Microsoft Visual Studio 2015 or newer
 4. Intel C++ compiler 16 or newer (15 with a [workaround](https://github.com/pybind/pybind11/issues/276))
 5. Cygwin/GCC (tested on 2.5.1)

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -90,6 +90,6 @@ Supported compilers
 *******************
 
 1. Clang/LLVM (any non-ancient version with C++11 support)
-2. GCC (any non-ancient version with C++11 support)
+2. GCC 4.8 or newer
 3. Microsoft Visual Studio 2015 or newer
 4. Intel C++ compiler v15 or newer


### PR DESCRIPTION
Testing pybind11 on my Debian 7 machine that comes with gcc 4.7.2, I noticed the simple source file

    #include <pybind11/pybind11.h>
    
    void dummy() {}

does not compile with the following error message:

    In file included from /my_source_dir/pybind11/include/pybind11/pytypes.h:12:0,
                     from /my_source_dir/pybind11/include/pybind11/cast.h:13,
                     from /my_source_dir/pybind11/include/pybind11/attr.h:13,
                     from /my_source_dir/pybind11/include/pybind11/pybind11.h:36,
                     from /my_source_dir/my_source_file.cpp:1:
    /my_source_dir/pybind11/include/pybind11/common.h:384:61: sorry, unimplemented: use of ‘type_pack_expansion’ in template
    /my_source_dir/pybind11/include/pybind11/common.h:403:61: error: template argument 1 is invalid
    /vagrant/turbodbc/pybind11/include/pybind11/common.h:516:12: error: looser throw specifier for ‘virtual pybind11::error_already_set::~error_already_set()’
    [... snip ...]

Checking the travis build indicates that compiling with gcc 4.8 works fine. I have updated the two locations that mentioned "non-ancient versions" of GCC, and have replaced it with GCC 4.8 or newer.

Since one of the goals of this project is to get rid of Boost's compiler workarounds, I figured a patch for GCC 4.7 would not come any time soon ;-).