### PR TITLE
Remove temporary allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,6 @@ matrix:
     - flake8
   allow_failures:
     - env: PYTHON=3.5 CPP=17 GCC=7
-    - env: PYTHON=2.7 CPP=14 GCC=6 # Temporary until python >2.7.13-rc1 migrates to debian testing
-    - env: PYTHON=3.6 CPP=14 CLANG # Temporary until binary wheels of numpy and scipy become available on brew Python 3.6
 cache:
   directories:
   - $HOME/.cache/pip


### PR DESCRIPTION
Both are no longer needed: debian testing has Python 2.7.13 final now, and wheels of numpy and scipy are available.