### PR TITLE
Fix pointer to reference error in type_caster on MSVC

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1015,14 +1015,14 @@ template <typename T> struct move_always<T, enable_if_t<all_of<
     move_is_plain_type<T>,
     negation<std::is_copy_constructible<T>>,
     std::is_move_constructible<T>,
-    std::is_same<decltype(std::declval<type_caster<T>>().operator T&()), T&>
+    std::is_same<decltype(std::declval<make_caster<T>>().operator T&()), T&>
 >::value>> : std::true_type {};
 template <typename T, typename SFINAE = void> struct move_if_unreferenced : std::false_type {};
 template <typename T> struct move_if_unreferenced<T, enable_if_t<all_of<
     move_is_plain_type<T>,
     negation<move_always<T>>,
     std::is_move_constructible<T>,
-    std::is_same<decltype(std::declval<type_caster<T>>().operator T&()), T&>
+    std::is_same<decltype(std::declval<make_caster<T>>().operator T&()), T&>
 >::value>> : std::true_type {};
 template <typename T> using move_never = none_of<move_always<T>, move_if_unreferenced<T>>;
 

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -137,7 +137,7 @@ struct type_caster<Eigen::Ref<CVDerived, Options, StrideType>> {
 protected:
     using Type = Eigen::Ref<CVDerived, Options, StrideType>;
     using Derived = typename std::remove_const<CVDerived>::type;
-    using DerivedCaster = type_caster<Derived>;
+    using DerivedCaster = make_caster<Derived>;
     DerivedCaster derived_caster;
     std::unique_ptr<Type> value;
 public:
@@ -158,7 +158,7 @@ template <typename Type>
 struct type_caster<Type, enable_if_t<is_eigen_base<Type>::value && !is_eigen_ref<Type>::value>> {
 protected:
     using Matrix = Eigen::Matrix<typename Type::Scalar, Eigen::Dynamic, Eigen::Dynamic>;
-    using MatrixCaster = type_caster<Matrix>;
+    using MatrixCaster = make_caster<Matrix>;
 public:
     [[noreturn]] bool load(handle, bool) { pybind11_fail("Unable to load() into specialized EigenBase object"); }
     static handle cast(const Type &src, return_value_policy policy, handle parent) { return MatrixCaster::cast(Matrix(src), policy, parent); }

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -73,7 +73,7 @@ public:
 
     PYBIND11_TYPE_CASTER(type, _("Callable[[") +
             argument_loader<Args...>::arg_names() + _("], ") +
-            type_caster<retval_type>::name() +
+            make_caster<retval_type>::name() +
             _("]"));
 };
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1140,7 +1140,7 @@ struct vectorize_helper {
 };
 
 template <typename T, int Flags> struct handle_type_name<array_t<T, Flags>> {
-    static PYBIND11_DESCR name() { return _("numpy.ndarray[") + type_caster<T>::name() + _("]"); }
+    static PYBIND11_DESCR name() { return _("numpy.ndarray[") + make_caster<T>::name() + _("]"); }
 };
 
 NAMESPACE_END(detail)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1076,7 +1076,7 @@ public:
         struct capture { Func func; };
         capture *ptr = new capture { std::forward<Func>(func) };
         install_buffer_funcs([](PyObject *obj, void *ptr) -> buffer_info* {
-            detail::type_caster<type> caster;
+            detail::make_caster<type> caster;
             if (!caster.load(obj, false))
                 return nullptr;
             return new buffer_info(((capture *) ptr)->func(caster));
@@ -1480,7 +1480,7 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
 
 template <typename InputType, typename OutputType> void implicitly_convertible() {
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {
-        if (!detail::type_caster<InputType>().load(obj, false))
+        if (!detail::make_caster<InputType>().load(obj, false))
             return nullptr;
         tuple args(1);
         args[0] = obj;


### PR DESCRIPTION
MSVC fails to compile casts of the form `obj.cast<T&>()` in certain situations. The problem is due to an instantiation of a pointer to a reference (invalid). This PR does not include a test because it seemed too contrived, but let me know if it's needed. The fix just replaces `type_caster` with `make_caster` everywhere in order to strip references (which should be preferable anyway).