### PR TITLE
Make Python version selection in CMake more convenient

### DIFF
--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -8,7 +8,9 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 # Add a CMake parameter for choosing a desired Python version
-set(PYBIND11_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling modules")
+if(NOT PYBIND11_PYTHON_VERSION)
+  set(PYBIND11_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling modules")
+endif()
 
 set(Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5 3.4)
 find_package(PythonLibsNew ${PYBIND11_PYTHON_VERSION} REQUIRED)


### PR DESCRIPTION
See #587. This makes it possible to use a non-`CACHE` variable. For example:
```
set(PYBIND11_PYTHON_VERSION <value>)
add_subdirectory(pybind11)
```

This also improves consistency with `find_package(pybind11)` since it already accepts a regular variable.