### PR TITLE
Add the ability to mark an object's pointer as invalid

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -212,13 +212,19 @@ public:
         if (typeinfo->simple_type) { /* Case 1: no multiple inheritance etc. involved */
             /* Check if we can safely perform a reinterpret-style cast */
             if (PyType_IsSubtype(tobj, typeinfo->type)) {
-                value = reinterpret_cast<instance<void> *>(src.ptr())->value;
+                auto info = reinterpret_cast<instance<void> *>(src.ptr());
+                if (!info->valid)
+                    throw std::runtime_error("Pointer for object is no longer valid");
+                value = info->value;
                 return true;
             }
         } else { /* Case 2: multiple inheritance */
             /* Check if we can safely perform a reinterpret-style cast */
             if (tobj == typeinfo->type) {
-                value = reinterpret_cast<instance<void> *>(src.ptr())->value;
+                auto info = reinterpret_cast<instance<void> *>(src.ptr());
+                if (!info->valid)
+                    throw std::runtime_error("Pointer for object is no longer valid");
+                value = info->value;
                 return true;
             }
 
@@ -300,6 +306,7 @@ public:
 
         wrapper->value = nullptr;
         wrapper->owned = false;
+        wrapper->valid = true;
 
         switch (policy) {
             case return_value_policy::automatic:

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -323,6 +323,7 @@ template <typename type> struct instance_essentials {
     PyObject *weakrefs;
     bool owned : 1;
     bool holder_constructed : 1;
+    bool valid : 1;
 };
 
 /// PyObject wrapper around generic types, includes a special holder type that is responsible for lifetime management

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -176,6 +176,14 @@ test_initializer methods_and_attributes([](py::module &m) {
         .def_property_readonly("rvalue", &TestPropRVP::get_rvalue)
         .def_property_readonly_static("static_rvalue", [](py::object) { return SimpleValue(); });
 
+    m.def("is_valid", &py::is_valid);
+    m.def("set_invalid", [](py::object obj) {
+        ExampleMandA *cpp_obj = obj.cast<ExampleMandA *>();
+        py::set_invalid(obj);
+        delete cpp_obj;
+    });
+    m.def("ptr_test_func", [](ExampleMandA *) {});
+
 #if !defined(PYPY_VERSION)
     py::class_<DynamicClass>(m, "DynamicClass", py::dynamic_attr())
         .def(py::init());

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -203,3 +203,29 @@ def test_cyclic_gc():
     assert cstats.alive() == 2
     del i1, i2
     assert cstats.alive() == 0
+
+
+def test_invalid_ptr():
+    from pybind11_tests import ExampleMandA, is_valid, set_invalid, ptr_test_func
+
+    instance = ExampleMandA()
+    ptr_error_msg = "Pointer for object is no longer valid"
+
+    assert is_valid(instance)
+    set_invalid(instance)
+    assert not is_valid(instance)
+
+    # Function call
+    with pytest.raises(RuntimeError) as excinfo:
+        instance.internal1()
+    assert str(excinfo.value) == ptr_error_msg
+
+    # Property access
+    with pytest.raises(RuntimeError) as excinfo:
+        instance.value
+    assert str(excinfo.value) == ptr_error_msg
+
+    # As function argument
+    with pytest.raises(RuntimeError) as excinfo:
+        ptr_test_func(instance)
+    assert str(excinfo.value) == ptr_error_msg


### PR DESCRIPTION
This pull request adds the ability for the user to mark the pointer of a PB11 object as invalid - this can be handy if you're wrapping an object that can be deleted outside of Python, and you have the ability to make the object call a callback in its destructor that could call `py::set_invalid` on its wrapper.

If you try to call a method of, access a property of, or cast an "invalid" object, a runtime error will be thrown rather than risking a segfault.

The following functions are added:
* `bool py::is_valid(py::object)`
  If an object is a valid PB11 object, it will return whether or not it is marked as valid. Throws an exception if not.
* `void py::set_invalid(py::object obj)`
  Mark the pointer of this object as invalid. Does not call the object's destructor.
