### PR TITLE
Correct function signature for Python 2.x module init function

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -139,7 +139,11 @@
 #define PYBIND11_STR_TYPE ::pybind11::bytes
 #define PYBIND11_OB_TYPE(ht_type) (ht_type).ob_type
 #define PYBIND11_PLUGIN_IMPL(name) \
-    extern "C" PYBIND11_EXPORT PyObject *init##name()
+    static PyObject *pybind11_init_wrapper();               \
+    extern "C" PYBIND11_EXPORT void init##name() {          \
+        (void)pybind11_init_wrapper();                      \
+    }                                                       \
+    PyObject *pybind11_init_wrapper()
 #endif
 
 #if PY_VERSION_HEX >= 0x03050000 && PY_VERSION_HEX < 0x03050200


### PR DESCRIPTION
The PYBIND11_PLUGIN_IMPL macro defines an ``initXXX()`` function with a wrong signature. Under Python 2.x it should have return type ``void`` instead of ``PyObject*``, see

https://docs.python.org/2/extending/extending.html#the-module-s-method-table-and-initialization-function
and
https://docs.python.org/2.7/c-api/import.html#c.PyImport_AppendInittab

This pull request corrects this by wrapping the existing init function with ``PyObject*`` return type in a function with ``void`` return type.