### PR TITLE
slight cmake target name fix

### DIFF
--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -71,7 +71,7 @@ if(NOT (CMAKE_VERSION VERSION_LESS 3.0))
 # Don't include targets if this file is being picked up by another
 # project which has already built this as a subproject
 #-----------------------------------------------------------------------------
-if(NOT TARGET ${PN}::pybind11)
+if(NOT TARGET ${PN}::module)
     include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
 
     find_package(PythonLibsNew ${PYBIND11_PYTHON_VERSION} MODULE REQUIRED)


### PR DESCRIPTION
One `pybind11::pybind11` --> `pybind11::module` got missed, so this corrects it. This is trivial so feel free to commit directly and close this PR.