### PR TITLE
Update common.h

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -61,7 +61,7 @@
 #  define HAVE_ROUND
 #  pragma warning(push)
 #  pragma warning(disable: 4510 4610 4512 4005)
-#  if _DEBUG
+#  if defined(_DEBUG)
 #    define PYBIND11_DEBUG_MARKER
 #    undef _DEBUG
 #  endif


### PR DESCRIPTION
fixed VS build, when _DEBUG is just defined without any value assigned (e.g. VS15)