### PR TITLE
Improve custom holder support

### DIFF
--- a/docs/advanced/smart_ptrs.rst
+++ b/docs/advanced/smart_ptrs.rst
@@ -149,6 +149,27 @@ situation where ``true`` should be passed is when the ``T`` instances use
 
 Please take a look at the :ref:`macro_notes` before using this feature.
 
+By default, pybind11 assumes that your custom smart pointer has a standard
+interface, i.e. provides a ``.get()`` member function to access the underlying
+raw pointer. If this is not the case, pybind11's ``holder_helper`` must be
+specialized:
+
+.. code-block:: cpp
+
+    // Always needed for custom holder types
+    PYBIND11_DECLARE_HOLDER_TYPE(T, SmartPtr<T>);
+
+    // Only needed if the type's `.get()` goes by another name
+    namespace pybind11 { namespace detail {
+        template <typename T>
+        struct holder_helper<SmartPtr<T>> { // <-- specialization
+            static const T *get(const SmartPtr<T> &p) { return p.getPointer(); }
+        };
+    }}
+
+The above specialization informs pybind11 that the custom ``SmartPtr`` class
+provides ``.get()`` functionality via ``.getPointer()``.
+
 .. seealso::
 
     The file :file:`tests/test_smart_ptr.cpp` contains a complete example

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1193,24 +1193,22 @@ private:
         }
     }
 
-    /// Initialize holder object, variant 2: try to construct from existing holder object, if possible
-    template <typename T = holder_type,
-              detail::enable_if_t<std::is_copy_constructible<T>::value, int> = 0>
-    static void init_holder_helper(instance_type *inst, const holder_type *holder_ptr, const void * /* dummy */) {
-        if (holder_ptr) {
-            new (&inst->holder) holder_type(*holder_ptr);
-            inst->holder_constructed = true;
-        } else if (inst->owned || detail::always_construct_holder<holder_type>::value) {
-            new (&inst->holder) holder_type(inst->value);
-            inst->holder_constructed = true;
-        }
+    static void init_holder_from_existing(instance_type *inst, const holder_type *holder_ptr,
+                                          std::true_type /*is_copy_constructible*/) {
+        new (&inst->holder) holder_type(*holder_ptr);
     }
 
-    /// Initialize holder object, variant 3: holder is not copy constructible (e.g. unique_ptr), always initialize from raw pointer
-    template <typename T = holder_type,
-              detail::enable_if_t<!std::is_copy_constructible<T>::value, int> = 0>
-    static void init_holder_helper(instance_type *inst, const holder_type * /* unused */, const void * /* dummy */) {
-        if (inst->owned || detail::always_construct_holder<holder_type>::value) {
+    static void init_holder_from_existing(instance_type *inst, const holder_type *holder_ptr,
+                                          std::false_type /*is_copy_constructible*/) {
+        new (&inst->holder) holder_type(std::move(*const_cast<holder_type *>(holder_ptr)));
+    }
+
+    /// Initialize holder object, variant 2: try to construct from existing holder object, if possible
+    static void init_holder_helper(instance_type *inst, const holder_type *holder_ptr, const void * /* dummy */) {
+        if (holder_ptr) {
+            init_holder_from_existing(inst, holder_ptr, std::is_copy_constructible<holder_type>());
+            inst->holder_constructed = true;
+        } else if (inst->owned || detail::always_construct_holder<holder_type>::value) {
             new (&inst->holder) holder_type(inst->value);
             inst->holder_constructed = true;
         }

--- a/tests/object.h
+++ b/tests/object.h
@@ -164,10 +164,10 @@ public:
     operator T* () { return m_ptr; }
 
     /// Return a const pointer to the referenced object
-    T* get() { return m_ptr; }
+    T* get_ptr() { return m_ptr; }
 
     /// Return a pointer to the referenced object
-    const T* get() const { return m_ptr; }
+    const T* get_ptr() const { return m_ptr; }
 private:
     T *m_ptr;
 };

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -90,6 +90,14 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, ref<T>, true);
 PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>); // Not required any more for std::shared_ptr,
                                                      // but it should compile without error
 
+// Make pybind11 aware of the non-standard getter member function
+namespace pybind11 { namespace detail {
+    template <typename T>
+    struct holder_helper<ref<T>> {
+        static const T *get(const ref<T> &p) { return p.get_ptr(); }
+    };
+}}
+
 Object *make_object_1() { return new MyObject1(1); }
 ref<Object> make_object_2() { return new MyObject1(2); }
 

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -201,3 +201,13 @@ def test_shared_ptr_from_this_and_references():
 
     del ref, bad_wp, copy, holder_ref, holder_copy, s
     assert stats.alive() == 0
+
+
+def test_move_only_holder():
+    from pybind11_tests.smart_ptr import TypeWithMoveOnlyHolder
+
+    a = TypeWithMoveOnlyHolder.make()
+    stats = ConstructorStats.get(TypeWithMoveOnlyHolder)
+    assert stats.alive() == 1
+    del a
+    assert stats.alive() == 0


### PR DESCRIPTION
This PR resolves issues #585 and #605.

1. Adds a helper struct to abstract away the holder's `.get()` function as suggested by @aldanor in #585. This is only required for type's with a renamed `.get()`.

    An alternative solution would be to use just a function instead of the struct, but in that case, the user-provided overload would need to be placed either in the global namespace or in the same namespace as the custom holder (ADL rules) which could possibly conflict with existing functions.

2. Support for custom move-only holders. It seems that so far only `std::unique_ptr` worked properly. For move-only types `init_holder_helper` would create a new holder from a raw pointer. This works for `std::unique_ptr` because its `type_caster` specialization would call `.release()`. However, custom move-only holders were handled using `type_caster_holder` which does not call `.release()` leading to the issue reported in #605.

   This PR renames `type_caster_holder` to `copyable_holder_caster` and adds a `move_only_holder_caster`. The `type_caster<std::unique_ptr<type, deleter>>` is removed in favor of `move_only_holder_caster` which does the same job but accepts any move-only holder. Instead of calling `.release()` on the moved-out pointer, this is now handled by the move constructor in `init_holder_helper`. This is a more portable solution since the custom holder type might not have a `.release()` function.

   An alternative solution would be to handle all holders using one `type_caster_holder`, but this would require some ugly SFINAE to disable `.load()` for move-only holders and for `cast()` to accept copyable holders only by `const holder_type &` and move-only by `holder_type &&`.