### PR TITLE
Eigen/numpy referencing

### DIFF
--- a/docs/advanced/cast/eigen.rst
+++ b/docs/advanced/cast/eigen.rst
@@ -1,48 +1,308 @@
 Eigen
-=====
+#####
 
 `Eigen <http://eigen.tuxfamily.org>`_ is C++ header-based library for dense and
 sparse linear algebra. Due to its popularity and widespread adoption, pybind11
-provides transparent conversion support between Eigen and Scientific Python linear
-algebra data types.
+provides transparent conversion and limited mapping support between Eigen and
+Scientific Python linear algebra data types.
 
-Specifically, when including the optional header file :file:`pybind11/eigen.h`,
-pybind11 will automatically and transparently convert
+To enable the built-in Eigen support you must include the optional header file
+:file:`pybind11/eigen.h`.
 
-1. Static and dynamic Eigen dense vectors and matrices to instances of
-   ``numpy.ndarray`` (and vice versa).
+Pass-by-value
+=============
 
-2. Returned matrix expressions such as blocks (including columns or rows) and
-   diagonals will be converted to ``numpy.ndarray`` of the expression
-   values.
+When binding a function with ordinary Eigen dense object arguments (for
+example, ``Eigen::MatrixXd``), pybind11 will accept any input value that is
+already (or convertible to) a ``numpy.ndarray`` with dimensions compatible with
+the Eigen type, copy its values into a temporary Eigen variable of the
+appropriate type, then call the function with this temporary variable.
 
-3. Returned matrix-like objects such as Eigen::DiagonalMatrix or
-   Eigen::SelfAdjointView will be converted to ``numpy.ndarray`` containing the
-   expressed value.
+Sparse matrices are similarly copied to or from
+``scipy.sparse.csr_matrix``/``scipy.sparse.csc_matrix`` objects.
 
-4. Eigen sparse vectors and matrices to instances of
-   ``scipy.sparse.csr_matrix``/``scipy.sparse.csc_matrix`` (and vice versa).
+Pass-by-reference
+=================
 
-This makes it possible to bind most kinds of functions that rely on these types.
-One major caveat are functions that take Eigen matrices *by reference* and modify
-them somehow, in which case the information won't be propagated to the caller.
+One major limitation of the above is that every data conversion implicitly
+involves a copy, which can be both expensive (for large matrices) and disallows
+binding functions that change their (Matrix) arguments.  Pybind11 allows you to
+work around this by using Eigen's ``Eigen::Ref<MatrixType>`` class much as you
+would when writing a function taking a generic type in Eigen itself (subject to
+some limitations discussed below).
+
+When calling a bound function accepting a ``Eigen::Ref<const MatrixType>``
+type, pybind11 will attempt to avoid copying by using an ``Eigen::Map`` object
+that maps into the source ``numpy.ndarray`` data: this requires both that the
+data types are the same (e.g. ``dtype='float64'`` and ``MatrixType::Scalar`` is
+``double``); and that the storage is layout compatible.  The latter limitation
+is discussed in detail in the section below, and requires careful
+consideration: by default, numpy matrices and eigen matrices are *not* storage
+compatible.
+
+If the numpy matrix cannot be used as is (either because its types differ, e.g.
+passing an array of integers to an Eigen paramater requiring doubles, or
+because the storage is incompatible), pybind11 makes a temporary copy and
+passes the copy instead.
+
+When a bound function parameter is instead ``Eigen::Ref<MatrixType>`` (note the
+lack of ``const``), pybind11 will only allow the function to be called if it
+can be mapped *and* if the numpy array is writeable (that is
+``a.flags.writeable`` is true).  Any access (including modification) made to
+the passed variable will be transparently carried out directly on the
+``numpy.ndarray``.
+
+This means you can can write code such as the following and have it work as
+expected:
 
 .. code-block:: cpp
 
-    /* The Python bindings of these functions won't replicate
-       the intended effect of modifying the function arguments */
-    void scale_by_2(Eigen::Vector3f &v) {
-        v *= 2;
-    }
-    void scale_by_2(Eigen::Ref<Eigen::MatrixXd> &v) {
+    void scale_by_2(Eigen::Ref<Eigen::VectorXd> m) {
         v *= 2;
     }
 
-To see why this is, refer to the section on :ref:`opaque` (although that
-section specifically covers STL data types, the underlying issue is the same).
-The :ref:`numpy` sections discuss an efficient alternative for exposing the
-underlying native Eigen types as opaque objects in a way that still integrates
-with NumPy and SciPy.
+Note, however, that you will likely run into limitations due to numpy and
+Eigen's difference default storage order for data; see the below section on
+:ref:`storage_orders` for details on how to bind code that won't run into such
+limitations.
+
+.. note::
+
+    Passing by reference is not supported for sparse types.
+
+Returning values to Python
+==========================
+
+When returning an ordinary dense Eigen matrix type to numpy (e.g.
+``Eigen::MatrixXd`` or ``Eigen::RowVectorXf``) pybind11 keeps the matrix and
+returns a numpy array that directly references the Eigen matrix: no copy of the
+data is performed.  The numpy array will have ``array.flags.owndata`` set to
+``False`` to indicate that it does not own the data, and the lifetime of the
+stored Eigen matrix will be tied to the returned ``array``.
+
+If you bind a function with a non-reference, ``const`` return type (e.g.
+``const Eigen::MatrixXd``), the same thing happens except that pybind11 also
+sets the numpy array's ``writeable`` flag to false.
+
+If you return an lvalue reference or pointer, the usual pybind11 rules apply,
+as dictated by the binding function's return value policy (see the
+documentation on :ref:`return_value_policies` for full details).  That means,
+without an explicit return value policy, lvalue references will be copied and
+pointers will be managed by pybind11.  In order to avoid copying, you should
+explictly specify an appropriate return value policy, as in the following
+example:
+
+.. code-block:: cpp
+
+    class MyClass {
+        Eigen::MatrixXd big_mat = Eigen::MatrixXd::Zero(10000, 10000);
+    public:
+        Eigen::MatrixXd &getMatrix() { return big_mat; }
+        const Eigen::MatrixXd &viewMatrix() { return big_mat; }
+    };
+
+    // Later, in binding code:
+    py::class_<MyClass>(m, "MyClass")
+        .def(py::init<>())
+        .def("copy_matrix", &MyClass::getMatrix) // Makes a copy!
+        .def("get_matrix", &MyClass::getMatrix, py::return_value_policy::reference_internal)
+        .def("view_matrix", &MyClass::viewMatrix, py::return_value_policy::reference_internal)
+        ;
+
+.. code-block:: python
+
+    a = MyClass()
+    m = a.get_matrix()   # flags.writeable = True,  flags.owndata = False
+    v = a.view_matrix()  # flags.writeable = False, flags.owndata = False
+    c = a.copy_matrix()  # flags.writeable = True,  flags.owndata = True
+    # m[5,6] and v[5,6] refer to the same element, c[5,6] does not.
+
+Note in this example that ``py::return_value_policy::reference_internal`` is
+used to tie the life of the MyClass object to the life of the returned arrays.
+
+You may also return an ``Eigen::Ref``, ``Eigen::Map`` or other map-like Eigen
+object (for example, the return value of ``matrix.block()`` and related
+methods) that map into a dense Eigen type.  When doing so, the default
+behaviour of pybind11 is to simply reference the returned data: you must take
+care to ensure that this data remains valid!  You may ask pybind11 to
+explicitly *copy* such a return value by using the
+``py::return_value_policy::copy`` policy when binding the function.  You may
+also use ``py::return_value_policy::reference_internal`` or a
+``py::keep_alive`` to ensure the data stays valid as long as the returned numpy
+array does.
+
+When returning such a reference of map, pybind11 additionally respects the
+readonly-status of the returned value, marking the numpy array as non-writeable
+if the reference or map was itself read-only.
+
+.. note::
+
+    Sparse types are always copied when returned.
+
+.. _storage_orders:
+
+Storage orders
+==============
+
+Passing arguments via ``Eigen::Ref`` has some limitations that you must be
+aware of in order to effectively pass matrices by reference.  First and
+foremost is that the default ``Eigen::Ref<MatrixType>`` class requires
+contiguous storage along columns (for column-major types, the default in Eigen)
+or rows if ``MatrixType`` is specifically an ``Eigen::RowMajor`` storage type.
+The former, Eigen's default, is incompatible with ``numpy``'s default row-major
+storage, and so you will not be able to pass numpy arrays to Eigen by reference
+without making one of two changes.
+
+(Note that this does not apply to vectors (or column or row matrices): for such
+types the "row-major" and "column-major" distinction is meaningless).
+
+The first approach is to change the use of ``Eigen::Ref<MatrixType>`` to the
+more general ``Eigen::Ref<MatrixType, 0, Eigen::Stride<Eigen::Dynamic,
+Eigen::Dynamic>>`` (or similar type with a fully dynamic stride type in the
+third template argument).  Since this is a rather cumbersome type, pybind11
+provides a ``py::EigenDRef<MatrixType>`` type alias for your convenience (along
+with EigenDMap for the equivalent Map, and EigenDStride for just the stride
+type).
+
+This type allows Eigen to map into any arbitrary storage order.  This is not
+the default in Eigen for performance reasons: contiguous storage allows
+vectorization that cannot be done when storage is not known to be contiguous at
+compile time.  The default ``Eigen::Ref`` stride type allows non-contiguous
+storage along the outer dimension (that is, the rows of a column-major matrix
+or columns of a row-major matrix), but not along the inner dimension.
+
+This type, however, has the added benefit of also being able to map numpy array
+slices.  For example, the following (contrived) example uses Eigen with a numpy
+slice to multiply by 2 all coefficients that are both on even rows (0, 2, 4,
+...) and in columns 2, 5, or 8:
+
+.. code-block:: cpp
+
+    m.def("scale", [](py::EigenDRef<Eigen::MatrixXd> m, double c) { m *= c; });
+
+.. code-block:: python
+
+    # a = np.array(...)
+    scale_by_2(myarray[0::2, 2:9:3])
+
+The second approach to avoid copying is more intrusive: rearranging the
+underlying data types to not run into the non-contiguous storage problem in the
+first place.  In particular, that means using matrices with ``Eigen::RowMajor``
+storage, where appropriate, such as:
+
+.. code-block:: cpp
+
+    using RowMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    // Use RowMatrixXd instead of MatrixXd
+
+Now bound functions accepting ``Eigen::Ref<RowMatrixXd>`` arguments will be
+callable with numpy's (default) arrays without involving a copying.
+
+You can, alternatively, change the storage order that numpy arrays use by
+adding the ``order='F'`` option when creating an array:
+
+.. code-block:: python
+
+    myarray = np.array(source, order='F')
+
+Such an object will be passable to a bound function accepting an
+``Eigen::Ref<MatrixXd>`` (or similar column-major Eigen type).
+
+One major caveat with this approach, however, is that it is not entirely as
+easy as simply flipping all Eigen or numpy usage from one to the other: some
+operations may alter the storage order of a numpy array.  For example, ``a2 =
+array.transpose()`` results in ``a2`` being a view of ``array`` that references
+the same data, but in the opposite storage order!
+
+While this approach allows fully optimized vectorized calculations in Eigen, it
+cannot be used with array slices, unlike the first approach.
+
+When *returning* a matrix to Python (either a regular matrix, a reference via
+``Eigen::Ref<>``, or a map/block into a matrix), no special storage
+consideration is required: the created numpy array will have the required
+stride that allows numpy to properly interpret the array, whatever its storage
+order.
+
+Failing rather than copying
+===========================
+
+The default behaviour when binding ``Eigen::Ref<const MatrixType>`` eigen
+references is to copy matrix values when passed a numpy array that does not
+conform to the element type of ``MatrixType`` or does not have a compatible
+stride layout.  If you want to explicitly avoid copying in such a case, you
+should bind arguments using the ``py::arg().noconvert()`` annotation (as
+described in the :ref:`nonconverting_arguments` documentation).
+
+The following example shows an example of arguments that don't allow data
+copying to take place:
+
+.. code-block:: cpp
+
+    // The method and function to be bound:
+    class MyClass {
+        // ...
+        double some_method(const Eigen::Ref<const MatrixXd> &matrix) { /* ... */ }
+    };
+    float some_function(const Eigen::Ref<const MatrixXf> &big,
+                        const Eigen::Ref<const MatrixXf> &small) {
+        // ...
+    }
+
+    // The associated binding code:
+    using namespace pybind11::literals; // for "arg"_a
+    py::class_<MyClass>(m, "MyClass")
+        // ... other class definitions
+        .def("some_method", &MyClass::some_method, py::arg().nocopy());
+
+    m.def("some_function", &some_function,
+        "big"_a.nocopy(), // <- Don't allow copying for this arg
+        "small"_a         // <- This one can be copied if needed
+    );
+
+With the above binding code, attempting to call the the ``some_method(m)``
+method on a ``MyClass`` object, or attempting to call ``some_function(m, m2)``
+will raise a ``RuntimeError`` rather than making a temporary copy of the array.
+It will, however, allow the ``m2`` argument to be copied into a temporary if
+necessary.
+
+Note that explicitly specifying ``.noconvert()`` is not required for *mutable*
+Eigen references (e.g. ``Eigen::Ref<MatrixXd>`` without ``const`` on the
+``MatrixXd``): mutable references will never be called with a temporary copy.
+
+Vectors versus column/row matrices
+==================================
+
+Eigen and numpy have fundamentally different notions of a vector.  In Eigen, a
+vector is simply a matrix with the number of columns or rows set to 1 at
+compile time (for a column vector or row vector, respectively).  Numpy, in
+contast, has comparable 2-dimensional 1xN and Nx1 arrays, but *also* has
+1-dimensional arrays of size N.
+
+When passing a 2-dimensional 1xN or Nx1 array to Eigen, the Eigen type must
+have matching dimensions: That is, you cannot pass a 2-dimensional Nx1 numpy
+array to an Eigen value expecting a row vector, or a 1xN numpy array as a
+column vector argument.
+
+On the other hand, pybind11 allows you to pass 1-dimensional arrays of length N
+as Eigen parameters.  If the Eigen type can hold a column vector of length N it
+will be passed as such a column vector.  If not, but the Eigen type constraints
+will accept a row vector, it will be passed as a row vector.  (The column
+vector takes precendence when both are supported, for example, when passing a
+1D numpy array to a MatrixXd argument).  Note that the type need not be
+expicitly a vector: it is permitted to pass a 1D numpy array of size 5 to an
+Eigen ``Matrix<double, Dynamic, 5>``: you would end up with a 1x5 Eigen matrix.
+Passing the same to an ``Eigen::MatrixXd`` would result in a 5x1 Eigen matrix.
+
+When returning an eigen vector to numpy, the conversion is ambiguous: a row
+vector of length 4 could be returned as either a 1D array of length 4, or as a
+2D array of size 1x4.  When encoutering such a situation, pybind11 compromises
+by considering the returned Eigen type: if it is a compile-time vector--that
+is, the type has either the number of rows or columns set to 1 at compile
+time--pybind11 converts to a 1D numpy array when returning the value.  For
+instances that are a vector only at run-time (e.g. ``MatrixXd``,
+``Matrix<float, Dynamic, 4>``), pybind11 returns the vector as a 2D array to
+numpy.  If this isn't want you want, you can use ``array.reshape(...)`` to get
+a view of the same data in the desired dimensions.
 
 .. seealso::
 

--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -6,6 +6,8 @@ with the basics of binding functions and classes, as explained in :doc:`/basics`
 and :doc:`/classes`. The following guide is applicable to both free and member
 functions, i.e. *methods* in Python.
 
+.. _return_value_policies:
+
 Return value policies
 =====================
 
@@ -318,6 +320,8 @@ like so:
 
     py::class_<MyClass>("MyClass")
         .def("myFunction", py::arg("arg") = (SomeType *) nullptr);
+
+.. _nonconverting_arguments:
 
 Non-converting arguments
 ========================

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1090,6 +1090,17 @@ template <typename type> using cast_is_temporary_value_reference = bool_constant
     !std::is_base_of<type_caster_generic, make_caster<type>>::value
 >;
 
+// When a value returned from a C++ function is being cast back to Python, we almost always want to
+// force `policy = move`, regardless of the return value policy the function/method was declared
+// with.  Some classes (most notably Eigen::Ref and related) need to avoid this, and so can do so by
+// specializing this struct.
+template <typename Return, typename SFINAE = void> struct return_value_policy_override {
+    static return_value_policy policy(return_value_policy p) {
+        return !std::is_lvalue_reference<Return>::value && !std::is_pointer<Return>::value
+            ? return_value_policy::move : p;
+    }
+};
+
 // Basic python -> C++ casting; throws if casting fails
 template <typename T, typename SFINAE> type_caster<T, SFINAE> &load_type(type_caster<T, SFINAE> &conv, const handle &handle) {
     if (!conv.load(handle, true)) {

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -383,9 +383,11 @@ inline internals &get_internals();
 #ifdef PYBIND11_CPP14
 using std::enable_if_t;
 using std::conditional_t;
+using std::remove_cv_t;
 #else
 template <bool B, typename T = void> using enable_if_t = typename std::enable_if<B, T>::type;
 template <bool B, typename T, typename F> using conditional_t = typename std::conditional<B, T, F>::type;
+template <typename T> using remove_cv_t = typename std::remove_cv<T>::type;
 #endif
 
 /// Index sequences
@@ -504,9 +506,9 @@ struct is_template_base_of_impl {
 /// `is_template_base_of<Base, T>` is true if `struct T : Base<U> {}` where U can be anything
 template <template<typename...> class Base, typename T>
 #if !defined(_MSC_VER)
-using is_template_base_of = decltype(is_template_base_of_impl<Base>::check((T*)nullptr));
+using is_template_base_of = decltype(is_template_base_of_impl<Base>::check((remove_cv_t<T>*)nullptr));
 #else // MSVC2015 has trouble with decltype in template aliases
-struct is_template_base_of : decltype(is_template_base_of_impl<Base>::check((T*)nullptr)) { };
+struct is_template_base_of : decltype(is_template_base_of_impl<Base>::check((remove_cv_t<T>*)nullptr)) { };
 #endif
 
 /// Check if T is std::shared_ptr<U> where U can be anything

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -536,7 +536,7 @@ protected:
 
     void check_writeable() const {
         if (!writeable())
-            throw std::runtime_error("array is not writeable");
+            throw std::domain_error("array is not writeable");
     }
 
     static std::vector<size_t> default_strides(const std::vector<size_t>& shape, size_t itemsize) {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -107,11 +107,11 @@ inline numpy_internals& get_numpy_internals() {
 
 struct npy_api {
     enum constants {
-        NPY_C_CONTIGUOUS_ = 0x0001,
-        NPY_F_CONTIGUOUS_ = 0x0002,
+        NPY_ARRAY_C_CONTIGUOUS_ = 0x0001,
+        NPY_ARRAY_F_CONTIGUOUS_ = 0x0002,
         NPY_ARRAY_OWNDATA_ = 0x0004,
         NPY_ARRAY_FORCECAST_ = 0x0010,
-        NPY_ENSURE_ARRAY_ = 0x0040,
+        NPY_ARRAY_ENSUREARRAY_ = 0x0040,
         NPY_ARRAY_ALIGNED_ = 0x0100,
         NPY_ARRAY_WRITEABLE_ = 0x0400,
         NPY_BOOL_ = 0,
@@ -330,8 +330,8 @@ public:
     PYBIND11_OBJECT_CVT(array, buffer, detail::npy_api::get().PyArray_Check_, raw_array)
 
     enum {
-        c_style = detail::npy_api::NPY_C_CONTIGUOUS_,
-        f_style = detail::npy_api::NPY_F_CONTIGUOUS_,
+        c_style = detail::npy_api::NPY_ARRAY_C_CONTIGUOUS_,
+        f_style = detail::npy_api::NPY_ARRAY_F_CONTIGUOUS_,
         forcecast = detail::npy_api::NPY_ARRAY_FORCECAST_
     };
 
@@ -568,7 +568,7 @@ protected:
         if (ptr == nullptr)
             return nullptr;
         return detail::npy_api::get().PyArray_FromAny_(
-            ptr, nullptr, 0, 0, detail::npy_api::NPY_ENSURE_ARRAY_ | ExtraFlags, nullptr);
+            ptr, nullptr, 0, 0, detail::npy_api::NPY_ARRAY_ENSUREARRAY_ | ExtraFlags, nullptr);
     }
 };
 
@@ -654,7 +654,7 @@ protected:
             return nullptr;
         return detail::npy_api::get().PyArray_FromAny_(
             ptr, dtype::of<T>().release().ptr(), 0, 0,
-            detail::npy_api::NPY_ENSURE_ARRAY_ | ExtraFlags, nullptr);
+            detail::npy_api::NPY_ARRAY_ENSUREARRAY_ | ExtraFlags, nullptr);
     }
 };
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -133,10 +133,8 @@ protected:
                          ? &call.func.data : call.func.data[0]);
             capture *cap = const_cast<capture *>(reinterpret_cast<const capture *>(data));
 
-            /* Override policy for rvalues -- always move */
-            constexpr auto is_rvalue = !std::is_pointer<Return>::value
-                                       && !std::is_lvalue_reference<Return>::value;
-            const auto policy = is_rvalue ? return_value_policy::move : call.func.policy;
+            /* Override policy for rvalues -- usually to enforce rvp::move on an rvalue */
+            const auto policy = detail::return_value_policy_override<Return>::policy(call.func.policy);
 
             /* Perform the function call */
             handle result = cast_out::cast(args_converter.template call<Return>(cap->f),

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -37,6 +37,10 @@ test_initializer eigen([](py::module &m) {
     typedef Eigen::Matrix<float, 5, 6> FixedMatrixC;
     typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> DenseMatrixR;
     typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> DenseMatrixC;
+    typedef Eigen::Matrix<float, 4, Eigen::Dynamic> FourRowMatrixC;
+    typedef Eigen::Matrix<float, Eigen::Dynamic, 4> FourColMatrixC;
+    typedef Eigen::Matrix<float, 4, Eigen::Dynamic> FourRowMatrixR;
+    typedef Eigen::Matrix<float, Eigen::Dynamic, 4> FourColMatrixR;
     typedef Eigen::SparseMatrix<float, Eigen::RowMajor> SparseMatrixR;
     typedef Eigen::SparseMatrix<float> SparseMatrixC;
 
@@ -129,6 +133,19 @@ test_initializer eigen([](py::module &m) {
     });
 
     m.def("sparse_passthrough_c", [](const SparseMatrixC &m) -> SparseMatrixC {
+        return m;
+    });
+
+    m.def("partial_passthrough_four_rm_r", [](const FourRowMatrixR &m) -> FourRowMatrixR {
+        return m;
+    });
+    m.def("partial_passthrough_four_rm_c", [](const FourColMatrixR &m) -> FourColMatrixR {
+        return m;
+    });
+    m.def("partial_passthrough_four_cm_r", [](const FourRowMatrixC &m) -> FourRowMatrixC {
+        return m;
+    });
+    m.def("partial_passthrough_four_cm_c", [](const FourColMatrixC &m) -> FourColMatrixC {
         return m;
     });
 });

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -8,29 +8,47 @@
 */
 
 #include "pybind11_tests.h"
+#include "constructor_stats.h"
 #include <pybind11/eigen.h>
 #include <Eigen/Cholesky>
 
-Eigen::VectorXf double_col(const Eigen::VectorXf& x)
-{ return 2.0f * x; }
+using MatrixXdR = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
-Eigen::RowVectorXf double_row(const Eigen::RowVectorXf& x)
-{ return 2.0f * x; }
 
-Eigen::MatrixXf double_mat_cm(const Eigen::MatrixXf& x)
-{ return 2.0f * x; }
 
-// Different ways of passing via Eigen::Ref; the first and second are the Eigen-recommended
-Eigen::MatrixXd cholesky1(Eigen::Ref<Eigen::MatrixXd> &x) { return x.llt().matrixL(); }
-Eigen::MatrixXd cholesky2(const Eigen::Ref<const Eigen::MatrixXd> &x) { return x.llt().matrixL(); }
-Eigen::MatrixXd cholesky3(const Eigen::Ref<Eigen::MatrixXd> &x) { return x.llt().matrixL(); }
-Eigen::MatrixXd cholesky4(Eigen::Ref<const Eigen::MatrixXd> &x) { return x.llt().matrixL(); }
-Eigen::MatrixXd cholesky5(Eigen::Ref<Eigen::MatrixXd> x) { return x.llt().matrixL(); }
-Eigen::MatrixXd cholesky6(Eigen::Ref<const Eigen::MatrixXd> x) { return x.llt().matrixL(); }
+// Sets/resets a testing reference matrix to have values of 10*r + c, where r and c are the
+// (1-based) row/column number.
+template <typename M> void reset_ref(M &x) {
+    for (int i = 0; i < x.rows(); i++) for (int j = 0; j < x.cols(); j++)
+        x(i, j) = 11 + 10*i + j;
+}
 
-typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> MatrixXfRowMajor;
-MatrixXfRowMajor double_mat_rm(const MatrixXfRowMajor& x)
-{ return 2.0f * x; }
+// Returns a static, column-major matrix
+Eigen::MatrixXd &get_cm() {
+    static Eigen::MatrixXd *x;
+    if (!x) {
+        x = new Eigen::MatrixXd(3, 3);
+        reset_ref(*x);
+    }
+    return *x;
+}
+// Likewise, but row-major
+MatrixXdR &get_rm() {
+    static MatrixXdR *x;
+    if (!x) {
+        x = new MatrixXdR(3, 3);
+        reset_ref(*x);
+    }
+    return *x;
+}
+// Resets the values of the static matrices returned by get_cm()/get_rm()
+void reset_refs() {
+    reset_ref(get_cm());
+    reset_ref(get_rm());
+}
+
+// Returns element 2,1 from a matrix (used to test copy/nocopy)
+double get_elem(Eigen::Ref<const Eigen::MatrixXd> m) { return m(2, 1); };
 
 test_initializer eigen([](py::module &m) {
     typedef Eigen::Matrix<float, 5, 6, Eigen::RowMajor> FixedMatrixR;
@@ -46,21 +64,84 @@ test_initializer eigen([](py::module &m) {
 
     m.attr("have_eigen") = true;
 
-    // Non-symmetric matrix with zero elements
-    Eigen::MatrixXf mat(5, 6);
-    mat << 0, 3, 0, 0, 0, 11, 22, 0, 0, 0, 17, 11, 7, 5, 0, 1, 0, 11, 0,
-        0, 0, 0, 0, 11, 0, 0, 14, 0, 8, 11;
+    m.def("double_col", [](const Eigen::VectorXf &x) -> Eigen::VectorXf { return 2.0f * x; });
+    m.def("double_row", [](const Eigen::RowVectorXf &x) -> Eigen::RowVectorXf { return 2.0f * x; });
+    m.def("double_threec", [](py::EigenDRef<Eigen::Vector3f> x) { x *= 2; });
+    m.def("double_threer", [](py::EigenDRef<Eigen::RowVector3f> x) { x *= 2; });
+    m.def("double_mat_cm", [](Eigen::MatrixXf x) -> Eigen::MatrixXf { return 2.0f * x; });
+    m.def("double_mat_rm", [](DenseMatrixR x) -> DenseMatrixR { return 2.0f * x; });
 
-    m.def("double_col", &double_col);
-    m.def("double_row", &double_row);
-    m.def("double_mat_cm", &double_mat_cm);
-    m.def("double_mat_rm", &double_mat_rm);
-    m.def("cholesky1", &cholesky1);
-    m.def("cholesky2", &cholesky2);
-    m.def("cholesky3", &cholesky3);
-    m.def("cholesky4", &cholesky4);
-    m.def("cholesky5", &cholesky5);
-    m.def("cholesky6", &cholesky6);
+    // Different ways of passing via Eigen::Ref; the first and second are the Eigen-recommended
+    m.def("cholesky1", [](Eigen::Ref<MatrixXdR> x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
+    m.def("cholesky2", [](const Eigen::Ref<const MatrixXdR> &x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
+    m.def("cholesky3", [](const Eigen::Ref<MatrixXdR> &x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
+    m.def("cholesky4", [](Eigen::Ref<const MatrixXdR> x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
+
+    // Mutators: these add some value to the given element using Eigen, but Eigen should be mapping into
+    // the numpy array data and so the result should show up there.  There are three versions: one that
+    // works on a contiguous-row matrix (numpy's default), one for a contiguous-column matrix, and one
+    // for any matrix.
+    auto add_rm = [](Eigen::Ref<MatrixXdR> x, int r, int c, double v) { x(r,c) += v; };
+    auto add_cm = [](Eigen::Ref<Eigen::MatrixXd> x, int r, int c, double v) { x(r,c) += v; };
+
+    // Mutators (Eigen maps into numpy variables):
+    m.def("add_rm", add_rm); // Only takes row-contiguous
+    m.def("add_cm", add_cm); // Only takes column-contiguous
+    // Overloaded versions that will accept either row or column contiguous:
+    m.def("add1", add_rm);
+    m.def("add1", add_cm);
+    m.def("add2", add_cm);
+    m.def("add2", add_rm);
+    // This one accepts a matrix of any stride:
+    m.def("add_any", [](py::EigenDRef<Eigen::MatrixXd> x, int r, int c, double v) { x(r,c) += v; });
+
+    // Return mutable references (numpy maps into eigen varibles)
+    m.def("get_cm_ref", []() { return Eigen::Ref<Eigen::MatrixXd>(get_cm()); });
+    m.def("get_rm_ref", []() { return Eigen::Ref<MatrixXdR>(get_rm()); });
+    // The same references, but non-mutable (numpy maps into eigen variables, but is !writeable)
+    m.def("get_cm_const_ref", []() { return Eigen::Ref<const Eigen::MatrixXd>(get_cm()); });
+    m.def("get_rm_const_ref", []() { return Eigen::Ref<const MatrixXdR>(get_rm()); });
+    // Just the corners (via a Map instead of a Ref):
+    m.def("get_cm_corners", []() {
+        auto &x = get_cm();
+        return py::EigenDMap<Eigen::Matrix2d>(
+                x.data(),
+                py::EigenDStride(x.outerStride() * (x.rows() - 1), x.innerStride() * (x.cols() - 1)));
+    });
+    m.def("get_cm_corners_const", []() {
+        const auto &x = get_cm();
+        return py::EigenDMap<const Eigen::Matrix2d>(
+                x.data(),
+                py::EigenDStride(x.outerStride() * (x.rows() - 1), x.innerStride() * (x.cols() - 1)));
+    });
+
+    m.def("reset_refs", reset_refs); // Restores get_{cm,rm}_ref to original values
+
+    // Increments and returns ref to (same) matrix
+    m.def("incr_matrix", [](Eigen::Ref<Eigen::MatrixXd> m, double v) {
+        m += Eigen::MatrixXd::Constant(m.rows(), m.cols(), v);
+        return m;
+    }, py::return_value_policy::reference);
+
+    // Same, but accepts a matrix of any strides
+    m.def("incr_matrix_any", [](py::EigenDRef<Eigen::MatrixXd> m, double v) {
+        m += Eigen::MatrixXd::Constant(m.rows(), m.cols(), v);
+        return m;
+    }, py::return_value_policy::reference);
+
+    // Returns an eigen slice of even rows
+    m.def("even_rows", [](py::EigenDRef<Eigen::MatrixXd> m) {
+        return py::EigenDMap<Eigen::MatrixXd>(
+                m.data(), (m.rows() + 1) / 2, m.cols(),
+                py::EigenDStride(m.outerStride(), 2 * m.innerStride()));
+    }, py::return_value_policy::reference);
+
+    // Returns an eigen slice of even columns
+    m.def("even_cols", [](py::EigenDRef<Eigen::MatrixXd> m) {
+        return py::EigenDMap<Eigen::MatrixXd>(
+                m.data(), m.rows(), (m.cols() + 1) / 2,
+                py::EigenDStride(2 * m.outerStride(), m.innerStride()));
+    }, py::return_value_policy::reference);
 
     // Returns diagonals: a vector-like object with an inner stride != 1
     m.def("diagonal", [](const Eigen::Ref<const Eigen::MatrixXd> &x) { return x.diagonal(); });
@@ -71,6 +152,52 @@ test_initializer eigen([](py::module &m) {
     m.def("block", [](const Eigen::Ref<const Eigen::MatrixXd> &x, int start_row, int start_col, int block_rows, int block_cols) {
         return x.block(start_row, start_col, block_rows, block_cols);
     });
+
+    // return value referencing/copying tests:
+    class ReturnTester {
+        Eigen::MatrixXd mat = create();
+    public:
+        ReturnTester() { print_created(this); }
+        ~ReturnTester() { print_destroyed(this); }
+        static Eigen::MatrixXd create() { return Eigen::MatrixXd::Ones(10, 10); }
+        static const Eigen::MatrixXd createConst() { return Eigen::MatrixXd::Ones(10, 10); }
+        Eigen::MatrixXd &get() { return mat; }
+        Eigen::MatrixXd *getPtr() { return &mat; }
+        const Eigen::MatrixXd &view() { return mat; }
+        const Eigen::MatrixXd *viewPtr() { return &mat; }
+        Eigen::Ref<Eigen::MatrixXd> ref() { return mat; }
+        Eigen::Ref<const Eigen::MatrixXd> refConst() { return mat; }
+        Eigen::Block<Eigen::MatrixXd> block(int r, int c, int nrow, int ncol) { return mat.block(r, c, nrow, ncol); }
+        Eigen::Block<const Eigen::MatrixXd> blockConst(int r, int c, int nrow, int ncol) const { return mat.block(r, c, nrow, ncol); }
+        py::EigenDMap<Eigen::Matrix2d> corners() { return py::EigenDMap<Eigen::Matrix2d>(mat.data(),
+                    py::EigenDStride(mat.outerStride() * (mat.outerSize()-1), mat.innerStride() * (mat.innerSize()-1))); }
+        py::EigenDMap<const Eigen::Matrix2d> cornersConst() const { return py::EigenDMap<const Eigen::Matrix2d>(mat.data(),
+                    py::EigenDStride(mat.outerStride() * (mat.outerSize()-1), mat.innerStride() * (mat.innerSize()-1))); }
+    };
+    using rvp = py::return_value_policy;
+    py::class_<ReturnTester>(m, "ReturnTester")
+        .def(py::init<>())
+        .def_static("create", &ReturnTester::create)
+        .def_static("create_const", &ReturnTester::createConst)
+        .def("get", &ReturnTester::get, rvp::reference_internal)
+        .def("get_ptr", &ReturnTester::getPtr, rvp::reference_internal)
+        .def("view", &ReturnTester::view, rvp::reference_internal)
+        .def("view_ptr", &ReturnTester::view, rvp::reference_internal)
+        .def("copy_get", &ReturnTester::get)   // Default rvp: copy
+        .def("copy_view", &ReturnTester::view) //         "
+        .def("ref", &ReturnTester::ref) // Default for Ref is to reference
+        .def("ref_const", &ReturnTester::refConst) // Likewise, but const
+        .def("ref_safe", &ReturnTester::ref, rvp::reference_internal)
+        .def("ref_const_safe", &ReturnTester::refConst, rvp::reference_internal)
+        .def("copy_ref", &ReturnTester::ref, rvp::copy)
+        .def("copy_ref_const", &ReturnTester::refConst, rvp::copy)
+        .def("block", &ReturnTester::block)
+        .def("block_safe", &ReturnTester::block, rvp::reference_internal)
+        .def("block_const", &ReturnTester::blockConst, rvp::reference_internal)
+        .def("copy_block", &ReturnTester::block, rvp::copy)
+        .def("corners", &ReturnTester::corners, rvp::reference_internal)
+        .def("corners_const", &ReturnTester::cornersConst, rvp::reference_internal)
+        ;
 
     // Returns a DiagonalMatrix with diagonal (1,2,3,...)
     m.def("incr_diag", [](int k) {
@@ -88,64 +215,49 @@ test_initializer eigen([](py::module &m) {
             return m.selfadjointView<Eigen::Upper>();
     });
 
-    m.def("fixed_r", [mat]() -> FixedMatrixR {
-        return FixedMatrixR(mat);
-    });
+    // Test matrix for various functions below.
+    Eigen::MatrixXf mat(5, 6);
+    mat << 0,  3,  0,  0,  0, 11,
+           22, 0,  0,  0, 17, 11,
+           7,  5,  0,  1,  0, 11,
+           0,  0,  0,  0,  0, 11,
+           0,  0, 14,  0,  8, 11;
 
-    m.def("fixed_c", [mat]() -> FixedMatrixC {
-        return FixedMatrixC(mat);
-    });
+    m.def("fixed_r", [mat]() -> FixedMatrixR { return FixedMatrixR(mat); });
+    m.def("fixed_r_const", [mat]() -> const FixedMatrixR { return FixedMatrixR(mat); });
+    m.def("fixed_c", [mat]() -> FixedMatrixC { return FixedMatrixC(mat); });
+    m.def("fixed_copy_r", [](const FixedMatrixR &m) -> FixedMatrixR { return m; });
+    m.def("fixed_copy_c", [](const FixedMatrixC &m) -> FixedMatrixC { return m; });
+    m.def("fixed_mutator_r", [](Eigen::Ref<FixedMatrixR>) {});
+    m.def("fixed_mutator_c", [](Eigen::Ref<FixedMatrixC>) {});
+    m.def("fixed_mutator_a", [](py::EigenDRef<FixedMatrixC>) {});
+    m.def("dense_r", [mat]() -> DenseMatrixR { return DenseMatrixR(mat); });
+    m.def("dense_c", [mat]() -> DenseMatrixC { return DenseMatrixC(mat); });
+    m.def("dense_copy_r", [](const DenseMatrixR &m) -> DenseMatrixR { return m; });
+    m.def("dense_copy_c", [](const DenseMatrixC &m) -> DenseMatrixC { return m; });
+    m.def("sparse_r", [mat]() -> SparseMatrixR { return Eigen::SparseView<Eigen::MatrixXf>(mat); });
+    m.def("sparse_c", [mat]() -> SparseMatrixC { return Eigen::SparseView<Eigen::MatrixXf>(mat); });
+    m.def("sparse_copy_r", [](const SparseMatrixR &m) -> SparseMatrixR { return m; });
+    m.def("sparse_copy_c", [](const SparseMatrixC &m) -> SparseMatrixC { return m; });
+    m.def("partial_copy_four_rm_r", [](const FourRowMatrixR &m) -> FourRowMatrixR { return m; });
+    m.def("partial_copy_four_rm_c", [](const FourColMatrixR &m) -> FourColMatrixR { return m; });
+    m.def("partial_copy_four_cm_r", [](const FourRowMatrixC &m) -> FourRowMatrixC { return m; });
+    m.def("partial_copy_four_cm_c", [](const FourColMatrixC &m) -> FourColMatrixC { return m; });
 
-    m.def("fixed_passthrough_r", [](const FixedMatrixR &m) -> FixedMatrixR {
-        return m;
-    });
+    // Test that we can cast a numpy object to a Eigen::MatrixXd explicitly
+    m.def("cpp_copy", [](py::handle m) { return m.cast<Eigen::MatrixXd>()(1, 0); });
+    m.def("cpp_ref_c", [](py::handle m) { return m.cast<Eigen::Ref<Eigen::MatrixXd>>()(1, 0); });
+    m.def("cpp_ref_r", [](py::handle m) { return m.cast<Eigen::Ref<MatrixXdR>>()(1, 0); });
+    m.def("cpp_ref_any", [](py::handle m) { return m.cast<py::EigenDRef<Eigen::MatrixXd>>()(1, 0); });
 
-    m.def("fixed_passthrough_c", [](const FixedMatrixC &m) -> FixedMatrixC {
-        return m;
-    });
 
-    m.def("dense_r", [mat]() -> DenseMatrixR {
-        return DenseMatrixR(mat);
-    });
-
-    m.def("dense_c", [mat]() -> DenseMatrixC {
-        return DenseMatrixC(mat);
-    });
-
-    m.def("dense_passthrough_r", [](const DenseMatrixR &m) -> DenseMatrixR {
-        return m;
-    });
-
-    m.def("dense_passthrough_c", [](const DenseMatrixC &m) -> DenseMatrixC {
-        return m;
-    });
-
-    m.def("sparse_r", [mat]() -> SparseMatrixR {
-        return Eigen::SparseView<Eigen::MatrixXf>(mat);
-    });
-
-    m.def("sparse_c", [mat]() -> SparseMatrixC {
-        return Eigen::SparseView<Eigen::MatrixXf>(mat);
-    });
-
-    m.def("sparse_passthrough_r", [](const SparseMatrixR &m) -> SparseMatrixR {
-        return m;
-    });
-
-    m.def("sparse_passthrough_c", [](const SparseMatrixC &m) -> SparseMatrixC {
-        return m;
-    });
-
-    m.def("partial_passthrough_four_rm_r", [](const FourRowMatrixR &m) -> FourRowMatrixR {
-        return m;
-    });
-    m.def("partial_passthrough_four_rm_c", [](const FourColMatrixR &m) -> FourColMatrixR {
-        return m;
-    });
-    m.def("partial_passthrough_four_cm_r", [](const FourRowMatrixC &m) -> FourRowMatrixC {
-        return m;
-    });
-    m.def("partial_passthrough_four_cm_c", [](const FourColMatrixC &m) -> FourColMatrixC {
-        return m;
-    });
+    // Test that we can prevent copying into an argument that would normally copy: First a version
+    // that would allow copying (if types or strides don't match) for comparison:
+    m.def("get_elem", &get_elem);
+    // Now this alternative that calls the tells pybind to fail rather than copy:
+    m.def("get_elem_nocopy", [](Eigen::Ref<const Eigen::MatrixXd> m) -> double { return get_elem(m); },
+            py::arg().noconvert());
+    // Also test a row-major-only no-copy const ref:
+    m.def("get_elem_rm_nocopy", [](Eigen::Ref<const Eigen::Matrix<long, -1, -1, Eigen::RowMajor>> &m) -> long { return m(2, 1); },
+            py::arg().noconvert());
 });

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -3,7 +3,7 @@ import pytest
 with pytest.suppress(ImportError):
     import numpy as np
 
-    ref = np.array([[ 0,  3,  0,  0,  0, 11],
+    ref = np.array([[ 0.,  3,  0,  0,  0, 11],
                     [22,  0,  0,  0, 17, 11],
                     [ 7,  5,  0,  1,  0, 11],
                     [ 0,  0,  0,  0,  0, 11],
@@ -20,63 +20,141 @@ def assert_sparse_equal_ref(sparse_mat):
 
 @pytest.requires_eigen_and_numpy
 def test_fixed():
-    from pybind11_tests import fixed_r, fixed_c, fixed_passthrough_r, fixed_passthrough_c
+    from pybind11_tests import fixed_r, fixed_c, fixed_copy_r, fixed_copy_c
 
     assert_equal_ref(fixed_c())
     assert_equal_ref(fixed_r())
-    assert_equal_ref(fixed_passthrough_r(fixed_r()))
-    assert_equal_ref(fixed_passthrough_c(fixed_c()))
-    assert_equal_ref(fixed_passthrough_r(fixed_c()))
-    assert_equal_ref(fixed_passthrough_c(fixed_r()))
+    assert_equal_ref(fixed_copy_r(fixed_r()))
+    assert_equal_ref(fixed_copy_c(fixed_c()))
+    assert_equal_ref(fixed_copy_r(fixed_c()))
+    assert_equal_ref(fixed_copy_c(fixed_r()))
 
 
 @pytest.requires_eigen_and_numpy
 def test_dense():
-    from pybind11_tests import dense_r, dense_c, dense_passthrough_r, dense_passthrough_c
+    from pybind11_tests import dense_r, dense_c, dense_copy_r, dense_copy_c
 
     assert_equal_ref(dense_r())
     assert_equal_ref(dense_c())
-    assert_equal_ref(dense_passthrough_r(dense_r()))
-    assert_equal_ref(dense_passthrough_c(dense_c()))
-    assert_equal_ref(dense_passthrough_r(dense_c()))
-    assert_equal_ref(dense_passthrough_c(dense_r()))
+    assert_equal_ref(dense_copy_r(dense_r()))
+    assert_equal_ref(dense_copy_c(dense_c()))
+    assert_equal_ref(dense_copy_r(dense_c()))
+    assert_equal_ref(dense_copy_c(dense_r()))
+
 
 @pytest.requires_eigen_and_numpy
 def test_partially_fixed():
-    from pybind11_tests import partial_passthrough_four_rm_r, partial_passthrough_four_rm_c, partial_passthrough_four_cm_r, partial_passthrough_four_cm_c
+    from pybind11_tests import (partial_copy_four_rm_r, partial_copy_four_rm_c,
+                                partial_copy_four_cm_r, partial_copy_four_cm_c)
 
-    ref2 = np.array([[0,1,2,3], [4,5,6,7], [8,9,10,11], [12,13,14,15]])
-    np.testing.assert_array_equal(partial_passthrough_four_rm_r(ref2), ref2)
-    np.testing.assert_array_equal(partial_passthrough_four_rm_c(ref2), ref2)
-    np.testing.assert_array_equal(partial_passthrough_four_rm_r(ref2[:, 1]), ref2[:, [1]])
-    np.testing.assert_array_equal(partial_passthrough_four_rm_c(ref2[0, :]), ref2[[0], :])
-    np.testing.assert_array_equal(partial_passthrough_four_rm_r(ref2[:, (0, 2)]), ref2[:, (0,2)])
-    np.testing.assert_array_equal(partial_passthrough_four_rm_c(ref2[(3,1,2), :]), ref2[(3,1,2), :])
+    ref2 = np.array([[0., 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]])
+    np.testing.assert_array_equal(partial_copy_four_rm_r(ref2), ref2)
+    np.testing.assert_array_equal(partial_copy_four_rm_c(ref2), ref2)
+    np.testing.assert_array_equal(partial_copy_four_rm_r(ref2[:, 1]), ref2[:, [1]])
+    np.testing.assert_array_equal(partial_copy_four_rm_c(ref2[0, :]), ref2[[0], :])
+    np.testing.assert_array_equal(partial_copy_four_rm_r(ref2[:, (0, 2)]), ref2[:, (0, 2)])
+    np.testing.assert_array_equal(
+        partial_copy_four_rm_c(ref2[(3, 1, 2), :]), ref2[(3, 1, 2), :])
 
-    np.testing.assert_array_equal(partial_passthrough_four_cm_r(ref2), ref2)
-    np.testing.assert_array_equal(partial_passthrough_four_cm_c(ref2), ref2)
-    np.testing.assert_array_equal(partial_passthrough_four_cm_r(ref2[:, 1]), ref2[:, [1]])
-    np.testing.assert_array_equal(partial_passthrough_four_cm_c(ref2[0, :]), ref2[[0], :])
-    np.testing.assert_array_equal(partial_passthrough_four_cm_r(ref2[:, (0, 2)]), ref2[:, (0,2)])
-    np.testing.assert_array_equal(partial_passthrough_four_cm_c(ref2[(3,1,2), :]), ref2[(3,1,2), :])
+    np.testing.assert_array_equal(partial_copy_four_cm_r(ref2), ref2)
+    np.testing.assert_array_equal(partial_copy_four_cm_c(ref2), ref2)
+    np.testing.assert_array_equal(partial_copy_four_cm_r(ref2[:, 1]), ref2[:, [1]])
+    np.testing.assert_array_equal(partial_copy_four_cm_c(ref2[0, :]), ref2[[0], :])
+    np.testing.assert_array_equal(partial_copy_four_cm_r(ref2[:, (0, 2)]), ref2[:, (0, 2)])
+    np.testing.assert_array_equal(
+        partial_copy_four_cm_c(ref2[(3, 1, 2), :]), ref2[(3, 1, 2), :])
+
+
+@pytest.requires_eigen_and_numpy
+def test_mutator_descriptors():
+    from pybind11_tests import fixed_mutator_r, fixed_mutator_c, fixed_mutator_a
+    zr = np.arange(30, dtype='float32').reshape(5, 6)  # row-major
+    zc = zr.reshape(6, 5).transpose()  # column-major
+
+    fixed_mutator_r(zr)
+    fixed_mutator_c(zc)
+    fixed_mutator_a(zr)
+    fixed_mutator_a(zc)
+    with pytest.raises(TypeError) as excinfo:
+        fixed_mutator_r(zc)
+    assert ('(numpy.ndarray[float32[5, 6], flags.writeable, flags.c_contiguous]) -> arg0: None'
+            in str(excinfo.value))
+    with pytest.raises(TypeError) as excinfo:
+        fixed_mutator_c(zr)
+    assert ('(numpy.ndarray[float32[5, 6], flags.writeable, flags.f_contiguous]) -> arg0: None'
+            in str(excinfo.value))
+    with pytest.raises(TypeError) as excinfo:
+        fixed_mutator_a(np.array([[1, 2], [3, 4]], dtype='float32'))
+    assert ('(numpy.ndarray[float32[5, 6], flags.writeable]) -> arg0: None'
+            in str(excinfo.value))
+    zr.flags.writeable = False
+    with pytest.raises(TypeError):
+        fixed_mutator_r(zr)
+    with pytest.raises(TypeError):
+        fixed_mutator_a(zr)
+
+
+@pytest.requires_eigen_and_numpy
+def test_cpp_casting():
+    from pybind11_tests import (cpp_copy, cpp_ref_c, cpp_ref_r, cpp_ref_any,
+                                fixed_r, fixed_c, get_cm_ref, get_rm_ref, ReturnTester)
+    assert cpp_copy(fixed_r()) == 22.
+    assert cpp_copy(fixed_c()) == 22.
+    z = np.array([[5., 6], [7, 8]])
+    assert cpp_copy(z) == 7.
+    assert cpp_copy(get_cm_ref()) == 21.
+    assert cpp_copy(get_rm_ref()) == 21.
+    assert cpp_ref_c(get_cm_ref()) == 21.
+    assert cpp_ref_r(get_rm_ref()) == 21.
+    with pytest.raises(RuntimeError) as excinfo:
+        # Can't reference fixed_c: it contains floats, cpp_ref_any wants doubles
+        cpp_ref_any(fixed_c())
+    assert 'Unable to cast Python instance' in str(excinfo.value)
+    with pytest.raises(RuntimeError) as excinfo:
+        # Can't reference fixed_r: it contains floats, cpp_ref_any wants doubles
+        cpp_ref_any(fixed_r())
+    assert 'Unable to cast Python instance' in str(excinfo.value)
+    assert cpp_ref_any(ReturnTester.create()) == 1.
+
+    assert cpp_ref_any(get_cm_ref()) == 21.
+    assert cpp_ref_any(get_cm_ref()) == 21.
+
+
+@pytest.requires_eigen_and_numpy
+def test_pass_readonly_array():
+    from pybind11_tests import fixed_copy_r, fixed_r, fixed_r_const
+    z = np.full((5, 6), 42.0)
+    z.flags.writeable = False
+    np.testing.assert_array_equal(z, fixed_copy_r(z))
+    np.testing.assert_array_equal(fixed_r_const(), fixed_r())
+    assert not fixed_r_const().flags.writeable
+    np.testing.assert_array_equal(fixed_copy_r(fixed_r_const()), fixed_r_const())
+
 
 @pytest.requires_eigen_and_numpy
 def test_nonunit_stride_from_python():
-    from pybind11_tests import double_row, double_col, double_mat_cm, double_mat_rm
+    from pybind11_tests import (
+        double_row, double_col, double_mat_cm, double_mat_rm,
+        double_threec, double_threer)
 
     counting_mat = np.arange(9.0, dtype=np.float32).reshape((3, 3))
-    first_row = counting_mat[0, :]
-    first_col = counting_mat[:, 0]
-    np.testing.assert_array_equal(double_row(first_row), 2.0 * first_row)
-    np.testing.assert_array_equal(double_col(first_row), 2.0 * first_row)
-    np.testing.assert_array_equal(double_row(first_col), 2.0 * first_col)
-    np.testing.assert_array_equal(double_col(first_col), 2.0 * first_col)
+    second_row = counting_mat[1, :]
+    second_col = counting_mat[:, 1]
+    np.testing.assert_array_equal(double_row(second_row), 2.0 * second_row)
+    np.testing.assert_array_equal(double_col(second_row), 2.0 * second_row)
+    np.testing.assert_array_equal(double_row(second_col), 2.0 * second_col)
+    np.testing.assert_array_equal(double_col(second_col), 2.0 * second_col)
 
     counting_3d = np.arange(27.0, dtype=np.float32).reshape((3, 3, 3))
     slices = [counting_3d[0, :, :], counting_3d[:, 0, :], counting_3d[:, :, 0]]
     for slice_idx, ref_mat in enumerate(slices):
         np.testing.assert_array_equal(double_mat_cm(ref_mat), 2.0 * ref_mat)
         np.testing.assert_array_equal(double_mat_rm(ref_mat), 2.0 * ref_mat)
+
+    # Mutator:
+    double_threer(second_row)
+    double_threec(second_col)
+    np.testing.assert_array_equal(counting_mat, [[0., 2, 2], [6, 16, 10], [6, 14, 8]])
 
 
 @pytest.requires_eigen_and_numpy
@@ -95,21 +173,396 @@ def test_nonunit_stride_to_python():
 
 @pytest.requires_eigen_and_numpy
 def test_eigen_ref_to_python():
-    from pybind11_tests import cholesky1, cholesky2, cholesky3, cholesky4, cholesky5, cholesky6
+    from pybind11_tests import cholesky1, cholesky2, cholesky3, cholesky4
 
-    chols = [cholesky1, cholesky2, cholesky3, cholesky4, cholesky5, cholesky6]
+    chols = [cholesky1, cholesky2, cholesky3, cholesky4]
     for i, chol in enumerate(chols, start=1):
-        mymat = chol(np.array([[1, 2, 4], [2, 13, 23], [4, 23, 77]]))
+        mymat = chol(np.array([[1., 2, 4], [2, 13, 23], [4, 23, 77]]))
         assert np.all(mymat == np.array([[1, 0, 0], [2, 3, 0], [4, 5, 6]])), "cholesky{}".format(i)
+
+
+def assign_both(a1, a2, r, c, v):
+    a1[r, c] = v
+    a2[r, c] = v
+
+
+def array_copy_but_one(a, r, c, v):
+    z = np.array(a, copy=True)
+    z[r, c] = v
+    return z
+
+
+@pytest.requires_eigen_and_numpy
+def test_eigen_return_references():
+    """Tests various ways of returning references and non-referencing copies"""
+    from pybind11_tests import ReturnTester
+    master = np.ones((10, 10))
+    a = ReturnTester()
+    a_get1 = a.get()
+    assert not a_get1.flags.owndata and a_get1.flags.writeable
+    assign_both(a_get1, master, 3, 3, 5)
+    a_get2 = a.get_ptr()
+    assert not a_get2.flags.owndata and a_get2.flags.writeable
+    assign_both(a_get1, master, 2, 3, 6)
+
+    a_view1 = a.view()
+    assert not a_view1.flags.owndata and not a_view1.flags.writeable
+    with pytest.raises(ValueError):
+        a_view1[2, 3] = 4
+    a_view2 = a.view_ptr()
+    assert not a_view2.flags.owndata and not a_view2.flags.writeable
+    with pytest.raises(ValueError):
+        a_view2[2, 3] = 4
+
+    a_copy1 = a.copy_get()
+    assert a_copy1.flags.owndata and a_copy1.flags.writeable
+    np.testing.assert_array_equal(a_copy1, master)
+    a_copy1[7, 7] = -44  # Shouldn't affect anything else
+    c1want = array_copy_but_one(master, 7, 7, -44)
+    a_copy2 = a.copy_view()
+    assert a_copy2.flags.owndata and a_copy2.flags.writeable
+    np.testing.assert_array_equal(a_copy2, master)
+    a_copy2[4, 4] = -22  # Shouldn't affect anything else
+    c2want = array_copy_but_one(master, 4, 4, -22)
+
+    a_ref1 = a.ref()
+    assert not a_ref1.flags.owndata and a_ref1.flags.writeable
+    assign_both(a_ref1, master, 1, 1, 15)
+    a_ref2 = a.ref_const()
+    assert not a_ref2.flags.owndata and not a_ref2.flags.writeable
+    with pytest.raises(ValueError):
+        a_ref2[5, 5] = 33
+    a_ref3 = a.ref_safe()
+    assert not a_ref3.flags.owndata and a_ref3.flags.writeable
+    assign_both(a_ref3, master, 0, 7, 99)
+    a_ref4 = a.ref_const_safe()
+    assert not a_ref4.flags.owndata and not a_ref4.flags.writeable
+    with pytest.raises(ValueError):
+        a_ref4[7, 0] = 987654321
+
+    a_copy3 = a.copy_ref()
+    assert a_copy3.flags.owndata and a_copy3.flags.writeable
+    np.testing.assert_array_equal(a_copy3, master)
+    a_copy3[8, 1] = 11
+    c3want = array_copy_but_one(master, 8, 1, 11)
+    a_copy4 = a.copy_ref_const()
+    assert a_copy4.flags.owndata and a_copy4.flags.writeable
+    np.testing.assert_array_equal(a_copy4, master)
+    a_copy4[8, 4] = 88
+    c4want = array_copy_but_one(master, 8, 4, 88)
+
+    a_block1 = a.block(3, 3, 2, 2)
+    assert not a_block1.flags.owndata and a_block1.flags.writeable
+    a_block1[0, 0] = 55
+    master[3, 3] = 55
+    a_block2 = a.block_safe(2, 2, 3, 2)
+    assert not a_block2.flags.owndata and a_block2.flags.writeable
+    a_block2[2, 1] = -123
+    master[4, 3] = -123
+    a_block3 = a.block_const(6, 7, 4, 3)
+    assert not a_block3.flags.owndata and not a_block3.flags.writeable
+    with pytest.raises(ValueError):
+        a_block3[2, 2] = -44444
+
+    a_copy5 = a.copy_block(2, 2, 2, 3)
+    assert a_copy5.flags.owndata and a_copy5.flags.writeable
+    np.testing.assert_array_equal(a_copy5, master[2:4, 2:5])
+    a_copy5[1, 1] = 777
+    c5want = array_copy_but_one(master[2:4, 2:5], 1, 1, 777)
+
+    a_corn1 = a.corners()
+    assert not a_corn1.flags.owndata and a_corn1.flags.writeable
+    a_corn1 *= 50
+    a_corn1[1, 1] = 999
+    master[0, 0] = 50
+    master[0, 9] = 50
+    master[9, 0] = 50
+    master[9, 9] = 999
+    a_corn2 = a.corners_const()
+    assert not a_corn2.flags.owndata and not a_corn2.flags.writeable
+    with pytest.raises(ValueError):
+        a_corn2[1, 0] = 51
+
+    # All of the changes made all the way along should be visible everywhere
+    # now (except for the copies, of course)
+    np.testing.assert_array_equal(a_get1, master)
+    np.testing.assert_array_equal(a_get2, master)
+    np.testing.assert_array_equal(a_view1, master)
+    np.testing.assert_array_equal(a_view2, master)
+    np.testing.assert_array_equal(a_ref1, master)
+    np.testing.assert_array_equal(a_ref2, master)
+    np.testing.assert_array_equal(a_ref3, master)
+    np.testing.assert_array_equal(a_ref4, master)
+    np.testing.assert_array_equal(a_block1, master[3:5, 3:5])
+    np.testing.assert_array_equal(a_block2, master[2:5, 2:4])
+    np.testing.assert_array_equal(a_block3, master[6:10, 7:10])
+    np.testing.assert_array_equal(a_corn1, master[0::master.shape[0] - 1, 0::master.shape[1] - 1])
+    np.testing.assert_array_equal(a_corn2, master[0::master.shape[0] - 1, 0::master.shape[1] - 1])
+
+    np.testing.assert_array_equal(a_copy1, c1want)
+    np.testing.assert_array_equal(a_copy2, c2want)
+    np.testing.assert_array_equal(a_copy3, c3want)
+    np.testing.assert_array_equal(a_copy4, c4want)
+    np.testing.assert_array_equal(a_copy5, c5want)
+
+
+def assert_keeps_alive(cl, method, *args):
+    from pybind11_tests import ConstructorStats
+    cstats = ConstructorStats.get(cl)
+    start_with = cstats.alive()
+    a = cl()
+    assert cstats.alive() == start_with + 1
+    z = method(a, *args)
+    assert cstats.alive() == start_with + 1
+    del a
+    # Here's the keep alive in action:
+    assert cstats.alive() == start_with + 1
+    del z
+    # Keep alive should have expired:
+    assert cstats.alive() == start_with
+
+
+@pytest.requires_eigen_and_numpy
+def test_eigen_keepalive():
+    from pybind11_tests import ReturnTester, ConstructorStats
+    a = ReturnTester()
+
+    cstats = ConstructorStats.get(ReturnTester)
+    assert cstats.alive() == 1
+    unsafe = [a.ref(), a.ref_const(), a.block(1, 2, 3, 4)]
+    copies = [a.copy_get(), a.copy_view(), a.copy_ref(), a.copy_ref_const(),
+              a.copy_block(4, 3, 2, 1)]
+    del a
+    assert cstats.alive() == 0
+    del unsafe
+    del copies
+
+    for meth in [ReturnTester.get, ReturnTester.get_ptr, ReturnTester.view,
+                 ReturnTester.view_ptr, ReturnTester.ref_safe, ReturnTester.ref_const_safe,
+                 ReturnTester.corners, ReturnTester.corners_const]:
+        assert_keeps_alive(ReturnTester, meth)
+
+    for meth in [ReturnTester.block_safe, ReturnTester.block_const]:
+        assert_keeps_alive(ReturnTester, meth, 4, 3, 2, 1)
+
+
+@pytest.requires_eigen_and_numpy
+def test_eigen_ref_mutators():
+    """Tests whether Eigen can mutate numpy values"""
+    from pybind11_tests import add_rm, add_cm, add_any, add1, add2
+    orig = np.array([[1., 2, 3], [4, 5, 6], [7, 8, 9]])
+    zr = np.array(orig)
+    zc = np.array(orig, order='F')
+    add_rm(zr, 1, 0, 100)
+    assert np.all(zr == np.array([[1., 2, 3], [104, 5, 6], [7, 8, 9]]))
+    add_cm(zc, 1, 0, 200)
+    assert np.all(zc == np.array([[1., 2, 3], [204, 5, 6], [7, 8, 9]]))
+
+    add_any(zr, 1, 0, 20)
+    assert np.all(zr == np.array([[1., 2, 3], [124, 5, 6], [7, 8, 9]]))
+    add_any(zc, 1, 0, 10)
+    assert np.all(zc == np.array([[1., 2, 3], [214, 5, 6], [7, 8, 9]]))
+
+    # Can't reference a col-major array with a row-major Ref, and vice versa:
+    with pytest.raises(TypeError):
+        add_rm(zc, 1, 0, 1)
+    with pytest.raises(TypeError):
+        add_cm(zr, 1, 0, 1)
+
+    # Overloads:
+    add1(zr, 1, 0, -100)
+    add2(zr, 1, 0, -20)
+    assert np.all(zr == orig)
+    add1(zc, 1, 0, -200)
+    add2(zc, 1, 0, -10)
+    assert np.all(zc == orig)
+
+    # a non-contiguous slice (this won't work on either the row- or
+    # column-contiguous refs, but should work for the any)
+    cornersr = zr[0::2, 0::2]
+    cornersc = zc[0::2, 0::2]
+
+    assert np.all(cornersr == np.array([[1., 3], [7, 9]]))
+    assert np.all(cornersc == np.array([[1., 3], [7, 9]]))
+
+    with pytest.raises(TypeError):
+        add_rm(cornersr, 0, 1, 25)
+    with pytest.raises(TypeError):
+        add_cm(cornersr, 0, 1, 25)
+    with pytest.raises(TypeError):
+        add_rm(cornersc, 0, 1, 25)
+    with pytest.raises(TypeError):
+        add_cm(cornersc, 0, 1, 25)
+    add_any(cornersr, 0, 1, 25)
+    add_any(cornersc, 0, 1, 44)
+    assert np.all(zr == np.array([[1., 2, 28], [4, 5, 6], [7, 8, 9]]))
+    assert np.all(zc == np.array([[1., 2, 47], [4, 5, 6], [7, 8, 9]]))
+
+    # You shouldn't be allowed to pass a non-writeable array to a mutating Eigen method:
+    zro = zr[0:4, 0:4]
+    zro.flags.writeable = False
+    with pytest.raises(TypeError):
+        add_rm(zro, 0, 0, 0)
+    with pytest.raises(TypeError):
+        add_any(zro, 0, 0, 0)
+    with pytest.raises(TypeError):
+        add1(zro, 0, 0, 0)
+    with pytest.raises(TypeError):
+        add2(zro, 0, 0, 0)
+
+    # integer array shouldn't be passable to a double-matrix-accepting mutating func:
+    zi = np.array([[1, 2], [3, 4]])
+    with pytest.raises(TypeError):
+        add_rm(zi)
+
+
+@pytest.requires_eigen_and_numpy
+def test_numpy_ref_mutators():
+    """Tests numpy mutating Eigen matrices (for returned Eigen::Ref<...>s)"""
+    from pybind11_tests import (
+        get_cm_ref, get_cm_const_ref, get_rm_ref, get_rm_const_ref, reset_refs)
+    reset_refs()  # In case another test already changed it
+
+    zc = get_cm_ref()
+    zcro = get_cm_const_ref()
+    zr = get_rm_ref()
+    zrro = get_rm_const_ref()
+
+    assert [zc[1, 2], zcro[1, 2], zr[1, 2], zrro[1, 2]] == [23] * 4
+
+    assert not zc.flags.owndata and zc.flags.writeable
+    assert not zr.flags.owndata and zr.flags.writeable
+    assert not zcro.flags.owndata and not zcro.flags.writeable
+    assert not zrro.flags.owndata and not zrro.flags.writeable
+
+    zc[1, 2] = 99
+    expect = np.array([[11., 12, 13], [21, 22, 99], [31, 32, 33]])
+    # We should have just changed zc, of course, but also zcro and the original eigen matrix
+    assert np.all(zc == expect)
+    assert np.all(zcro == expect)
+    assert np.all(get_cm_ref() == expect)
+
+    zr[1, 2] = 99
+    assert np.all(zr == expect)
+    assert np.all(zrro == expect)
+    assert np.all(get_rm_ref() == expect)
+
+    # Make sure the readonly ones are numpy-readonly:
+    with pytest.raises(ValueError):
+        zcro[1, 2] = 6
+    with pytest.raises(ValueError):
+        zrro[1, 2] = 6
+
+    # We should be able to explicitly copy like this (and since we're copying,
+    # the const should drop away)
+    y1 = np.array(get_cm_const_ref())
+
+    assert y1.flags.owndata and y1.flags.writeable
+    # We should get copies of the eigen data, which was modified above:
+    assert y1[1, 2] == 99
+    y1[1, 2] += 12
+    assert y1[1, 2] == 111
+    assert zc[1, 2] == 99  # Make sure we aren't referencing the original
+
+
+@pytest.requires_eigen_and_numpy
+def test_both_ref_mutators():
+    """Tests a complex chain of nested eigen/numpy references"""
+    from pybind11_tests import (
+        incr_matrix, get_cm_ref, incr_matrix_any, even_cols, even_rows, reset_refs)
+    reset_refs()  # In case another test already changed it
+
+    z = get_cm_ref()  # numpy -> eigen
+    z[0, 2] -= 3
+    z2 = incr_matrix(z, 1)  # numpy -> eigen -> numpy -> eigen
+    z2[1, 1] += 6
+    z3 = incr_matrix(z, 2)  # (numpy -> eigen)^3
+    z3[2, 2] += -5
+    z4 = incr_matrix(z, 3)  # (numpy -> eigen)^4
+    z4[1, 1] -= 1
+    z5 = incr_matrix(z, 4)  # (numpy -> eigen)^5
+    z5[0, 0] = 0
+    assert np.all(z == z2)
+    assert np.all(z == z3)
+    assert np.all(z == z4)
+    assert np.all(z == z5)
+    expect = np.array([[0., 22, 20], [31, 37, 33], [41, 42, 38]])
+    assert np.all(z == expect)
+
+    y = np.array(range(100), dtype='float64').reshape(10, 10)
+    y2 = incr_matrix_any(y, 10)  # np -> eigen -> np
+    y3 = incr_matrix_any(y2[0::2, 0::2], -33)  # np -> eigen -> np slice -> np -> eigen -> np
+    y4 = even_rows(y3)  # numpy -> eigen slice -> (... y3)
+    y5 = even_cols(y4)  # numpy -> eigen slice -> (... y4)
+    y6 = incr_matrix_any(y5, 1000)  # numpy -> eigen -> (... y5)
+
+    # Apply same mutations using just numpy:
+    yexpect = np.array(range(100), dtype='float64').reshape(10, 10)
+    yexpect += 10
+    yexpect[0::2, 0::2] -= 33
+    yexpect[0::4, 0::4] += 1000
+    assert np.all(y6 == yexpect[0::4, 0::4])
+    assert np.all(y5 == yexpect[0::4, 0::4])
+    assert np.all(y4 == yexpect[0::4, 0::2])
+    assert np.all(y3 == yexpect[0::2, 0::2])
+    assert np.all(y2 == yexpect)
+    assert np.all(y == yexpect)
+
+
+@pytest.requires_eigen_and_numpy
+def test_nocopy_wrapper():
+    from pybind11_tests import get_elem, get_elem_nocopy, get_elem_rm_nocopy
+    # get_elem requires a column-contiguous matrix reference, but should be
+    # callable with other types of matrix (via copying):
+    int_matrix_colmajor = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], order='F')
+    dbl_matrix_colmajor = np.array(int_matrix_colmajor, dtype='double', order='F', copy=True)
+    int_matrix_rowmajor = np.array(int_matrix_colmajor, order='C', copy=True)
+    dbl_matrix_rowmajor = np.array(int_matrix_rowmajor, dtype='double', order='C', copy=True)
+
+    # All should be callable via get_elem:
+    assert get_elem(int_matrix_colmajor) == 8
+    assert get_elem(dbl_matrix_colmajor) == 8
+    assert get_elem(int_matrix_rowmajor) == 8
+    assert get_elem(dbl_matrix_rowmajor) == 8
+
+    # All but the second should fail with get_elem_nocopy:
+    with pytest.raises(TypeError) as excinfo:
+        get_elem_nocopy(int_matrix_colmajor)
+    assert ('get_elem_nocopy(): incompatible function arguments.' in str(excinfo.value) and
+            ', flags.f_contiguous' in str(excinfo.value))
+    assert get_elem_nocopy(dbl_matrix_colmajor) == 8
+    with pytest.raises(TypeError) as excinfo:
+        get_elem_nocopy(int_matrix_rowmajor)
+    assert ('get_elem_nocopy(): incompatible function arguments.' in str(excinfo.value) and
+            ', flags.f_contiguous' in str(excinfo.value))
+    with pytest.raises(TypeError) as excinfo:
+        get_elem_nocopy(dbl_matrix_rowmajor)
+    assert ('get_elem_nocopy(): incompatible function arguments.' in str(excinfo.value) and
+            ', flags.f_contiguous' in str(excinfo.value))
+
+    # For the row-major test, we take a long matrix in row-major, so only the third is allowed:
+    with pytest.raises(TypeError) as excinfo:
+        get_elem_rm_nocopy(int_matrix_colmajor)
+    assert ('get_elem_rm_nocopy(): incompatible function arguments.' in str(excinfo.value) and
+            ', flags.c_contiguous' in str(excinfo.value))
+    with pytest.raises(TypeError) as excinfo:
+        get_elem_rm_nocopy(dbl_matrix_colmajor)
+    assert ('get_elem_rm_nocopy(): incompatible function arguments.' in str(excinfo.value) and
+            ', flags.c_contiguous' in str(excinfo.value))
+    assert get_elem_rm_nocopy(int_matrix_rowmajor) == 8
+    with pytest.raises(TypeError) as excinfo:
+        get_elem_rm_nocopy(dbl_matrix_rowmajor)
+    assert ('get_elem_rm_nocopy(): incompatible function arguments.' in str(excinfo.value) and
+            ', flags.c_contiguous' in str(excinfo.value))
 
 
 @pytest.requires_eigen_and_numpy
 def test_special_matrix_objects():
     from pybind11_tests import incr_diag, symmetric_upper, symmetric_lower
 
-    assert np.all(incr_diag(7) == np.diag([1, 2, 3, 4, 5, 6, 7]))
+    assert np.all(incr_diag(7) == np.diag([1., 2, 3, 4, 5, 6, 7]))
 
-    asymm = np.array([[ 1,  2,  3,  4],
+    asymm = np.array([[ 1.,  2,  3,  4],
                       [ 5,  6,  7,  8],
                       [ 9, 10, 11, 12],
                       [13, 14, 15, 16]])
@@ -141,23 +594,23 @@ def test_dense_signature(doc):
 
 @pytest.requires_eigen_and_scipy
 def test_sparse():
-    from pybind11_tests import sparse_r, sparse_c, sparse_passthrough_r, sparse_passthrough_c
+    from pybind11_tests import sparse_r, sparse_c, sparse_copy_r, sparse_copy_c
 
     assert_sparse_equal_ref(sparse_r())
     assert_sparse_equal_ref(sparse_c())
-    assert_sparse_equal_ref(sparse_passthrough_r(sparse_r()))
-    assert_sparse_equal_ref(sparse_passthrough_c(sparse_c()))
-    assert_sparse_equal_ref(sparse_passthrough_r(sparse_c()))
-    assert_sparse_equal_ref(sparse_passthrough_c(sparse_r()))
+    assert_sparse_equal_ref(sparse_copy_r(sparse_r()))
+    assert_sparse_equal_ref(sparse_copy_c(sparse_c()))
+    assert_sparse_equal_ref(sparse_copy_r(sparse_c()))
+    assert_sparse_equal_ref(sparse_copy_c(sparse_r()))
 
 
 @pytest.requires_eigen_and_scipy
 def test_sparse_signature(doc):
-    from pybind11_tests import sparse_passthrough_r, sparse_passthrough_c
+    from pybind11_tests import sparse_copy_r, sparse_copy_c
 
-    assert doc(sparse_passthrough_r) == """
-        sparse_passthrough_r(arg0: scipy.sparse.csr_matrix[float32]) -> scipy.sparse.csr_matrix[float32]
+    assert doc(sparse_copy_r) == """
+        sparse_copy_r(arg0: scipy.sparse.csr_matrix[float32]) -> scipy.sparse.csr_matrix[float32]
     """  # noqa: E501 line too long
-    assert doc(sparse_passthrough_c) == """
-        sparse_passthrough_c(arg0: scipy.sparse.csc_matrix[float32]) -> scipy.sparse.csc_matrix[float32]
+    assert doc(sparse_copy_c) == """
+        sparse_copy_c(arg0: scipy.sparse.csc_matrix[float32]) -> scipy.sparse.csc_matrix[float32]
     """  # noqa: E501 line too long

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytestmark = pytest.requires_eigen_and_numpy
+
 with pytest.suppress(ImportError):
     import numpy as np
 
@@ -18,7 +20,6 @@ def assert_sparse_equal_ref(sparse_mat):
     assert_equal_ref(sparse_mat.todense())
 
 
-@pytest.requires_eigen_and_numpy
 def test_fixed():
     from pybind11_tests import fixed_r, fixed_c, fixed_copy_r, fixed_copy_c
 
@@ -30,7 +31,6 @@ def test_fixed():
     assert_equal_ref(fixed_copy_c(fixed_r()))
 
 
-@pytest.requires_eigen_and_numpy
 def test_dense():
     from pybind11_tests import dense_r, dense_c, dense_copy_r, dense_copy_c
 
@@ -42,7 +42,6 @@ def test_dense():
     assert_equal_ref(dense_copy_c(dense_r()))
 
 
-@pytest.requires_eigen_and_numpy
 def test_partially_fixed():
     from pybind11_tests import (partial_copy_four_rm_r, partial_copy_four_rm_c,
                                 partial_copy_four_cm_r, partial_copy_four_cm_c)
@@ -65,7 +64,6 @@ def test_partially_fixed():
         partial_copy_four_cm_c(ref2[(3, 1, 2), :]), ref2[(3, 1, 2), :])
 
 
-@pytest.requires_eigen_and_numpy
 def test_mutator_descriptors():
     from pybind11_tests import fixed_mutator_r, fixed_mutator_c, fixed_mutator_a
     zr = np.arange(30, dtype='float32').reshape(5, 6)  # row-major
@@ -94,7 +92,6 @@ def test_mutator_descriptors():
         fixed_mutator_a(zr)
 
 
-@pytest.requires_eigen_and_numpy
 def test_cpp_casting():
     from pybind11_tests import (cpp_copy, cpp_ref_c, cpp_ref_r, cpp_ref_any,
                                 fixed_r, fixed_c, get_cm_ref, get_rm_ref, ReturnTester)
@@ -120,7 +117,6 @@ def test_cpp_casting():
     assert cpp_ref_any(get_cm_ref()) == 21.
 
 
-@pytest.requires_eigen_and_numpy
 def test_pass_readonly_array():
     from pybind11_tests import fixed_copy_r, fixed_r, fixed_r_const
     z = np.full((5, 6), 42.0)
@@ -131,7 +127,6 @@ def test_pass_readonly_array():
     np.testing.assert_array_equal(fixed_copy_r(fixed_r_const()), fixed_r_const())
 
 
-@pytest.requires_eigen_and_numpy
 def test_nonunit_stride_from_python():
     from pybind11_tests import (
         double_row, double_col, double_mat_cm, double_mat_rm,
@@ -157,7 +152,6 @@ def test_nonunit_stride_from_python():
     np.testing.assert_array_equal(counting_mat, [[0., 2, 2], [6, 16, 10], [6, 14, 8]])
 
 
-@pytest.requires_eigen_and_numpy
 def test_nonunit_stride_to_python():
     from pybind11_tests import diagonal, diagonal_1, diagonal_n, block
 
@@ -171,7 +165,6 @@ def test_nonunit_stride_to_python():
     assert np.all(block(ref, 1, 4, 3, 2) == ref[1:4, 4:])
 
 
-@pytest.requires_eigen_and_numpy
 def test_eigen_ref_to_python():
     from pybind11_tests import cholesky1, cholesky2, cholesky3, cholesky4
 
@@ -192,7 +185,6 @@ def array_copy_but_one(a, r, c, v):
     return z
 
 
-@pytest.requires_eigen_and_numpy
 def test_eigen_return_references():
     """Tests various ways of returning references and non-referencing copies"""
     from pybind11_tests import ReturnTester
@@ -322,7 +314,6 @@ def assert_keeps_alive(cl, method, *args):
     assert cstats.alive() == start_with
 
 
-@pytest.requires_eigen_and_numpy
 def test_eigen_keepalive():
     from pybind11_tests import ReturnTester, ConstructorStats
     a = ReturnTester()
@@ -346,7 +337,6 @@ def test_eigen_keepalive():
         assert_keeps_alive(ReturnTester, meth, 4, 3, 2, 1)
 
 
-@pytest.requires_eigen_and_numpy
 def test_eigen_ref_mutators():
     """Tests whether Eigen can mutate numpy values"""
     from pybind11_tests import add_rm, add_cm, add_any, add1, add2
@@ -416,7 +406,6 @@ def test_eigen_ref_mutators():
         add_rm(zi)
 
 
-@pytest.requires_eigen_and_numpy
 def test_numpy_ref_mutators():
     """Tests numpy mutating Eigen matrices (for returned Eigen::Ref<...>s)"""
     from pybind11_tests import (
@@ -465,7 +454,6 @@ def test_numpy_ref_mutators():
     assert zc[1, 2] == 99  # Make sure we aren't referencing the original
 
 
-@pytest.requires_eigen_and_numpy
 def test_both_ref_mutators():
     """Tests a complex chain of nested eigen/numpy references"""
     from pybind11_tests import (
@@ -509,7 +497,6 @@ def test_both_ref_mutators():
     assert np.all(y == yexpect)
 
 
-@pytest.requires_eigen_and_numpy
 def test_nocopy_wrapper():
     from pybind11_tests import get_elem, get_elem_nocopy, get_elem_rm_nocopy
     # get_elem requires a column-contiguous matrix reference, but should be
@@ -556,7 +543,6 @@ def test_nocopy_wrapper():
             ', flags.c_contiguous' in str(excinfo.value))
 
 
-@pytest.requires_eigen_and_numpy
 def test_special_matrix_objects():
     from pybind11_tests import incr_diag, symmetric_upper, symmetric_lower
 
@@ -577,7 +563,6 @@ def test_special_matrix_objects():
     assert np.all(symmetric_upper(asymm) == symm_upper)
 
 
-@pytest.requires_eigen_and_numpy
 def test_dense_signature(doc):
     from pybind11_tests import double_col, double_row, double_mat_rm
 

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -41,6 +41,24 @@ def test_dense():
     assert_equal_ref(dense_passthrough_r(dense_c()))
     assert_equal_ref(dense_passthrough_c(dense_r()))
 
+@pytest.requires_eigen_and_numpy
+def test_partially_fixed():
+    from pybind11_tests import partial_passthrough_four_rm_r, partial_passthrough_four_rm_c, partial_passthrough_four_cm_r, partial_passthrough_four_cm_c
+
+    ref2 = np.array([[0,1,2,3], [4,5,6,7], [8,9,10,11], [12,13,14,15]])
+    np.testing.assert_array_equal(partial_passthrough_four_rm_r(ref2), ref2)
+    np.testing.assert_array_equal(partial_passthrough_four_rm_c(ref2), ref2)
+    np.testing.assert_array_equal(partial_passthrough_four_rm_r(ref2[:, 1]), ref2[:, [1]])
+    np.testing.assert_array_equal(partial_passthrough_four_rm_c(ref2[0, :]), ref2[[0], :])
+    np.testing.assert_array_equal(partial_passthrough_four_rm_r(ref2[:, (0, 2)]), ref2[:, (0,2)])
+    np.testing.assert_array_equal(partial_passthrough_four_rm_c(ref2[(3,1,2), :]), ref2[(3,1,2), :])
+
+    np.testing.assert_array_equal(partial_passthrough_four_cm_r(ref2), ref2)
+    np.testing.assert_array_equal(partial_passthrough_four_cm_c(ref2), ref2)
+    np.testing.assert_array_equal(partial_passthrough_four_cm_r(ref2[:, 1]), ref2[:, [1]])
+    np.testing.assert_array_equal(partial_passthrough_four_cm_c(ref2[0, :]), ref2[[0], :])
+    np.testing.assert_array_equal(partial_passthrough_four_cm_r(ref2[:, (0, 2)]), ref2[:, (0,2)])
+    np.testing.assert_array_equal(partial_passthrough_four_cm_c(ref2[(3,1,2), :]), ref2[(3,1,2), :])
 
 @pytest.requires_eigen_and_numpy
 def test_nonunit_stride_from_python():
@@ -49,16 +67,16 @@ def test_nonunit_stride_from_python():
     counting_mat = np.arange(9.0, dtype=np.float32).reshape((3, 3))
     first_row = counting_mat[0, :]
     first_col = counting_mat[:, 0]
-    assert np.array_equal(double_row(first_row), 2.0 * first_row)
-    assert np.array_equal(double_col(first_row), 2.0 * first_row)
-    assert np.array_equal(double_row(first_col), 2.0 * first_col)
-    assert np.array_equal(double_col(first_col), 2.0 * first_col)
+    np.testing.assert_array_equal(double_row(first_row), 2.0 * first_row)
+    np.testing.assert_array_equal(double_col(first_row), 2.0 * first_row)
+    np.testing.assert_array_equal(double_row(first_col), 2.0 * first_col)
+    np.testing.assert_array_equal(double_col(first_col), 2.0 * first_col)
 
     counting_3d = np.arange(27.0, dtype=np.float32).reshape((3, 3, 3))
     slices = [counting_3d[0, :, :], counting_3d[:, 0, :], counting_3d[:, :, 0]]
     for slice_idx, ref_mat in enumerate(slices):
-        assert np.array_equal(double_mat_cm(ref_mat), 2.0 * ref_mat)
-        assert np.array_equal(double_mat_rm(ref_mat), 2.0 * ref_mat)
+        np.testing.assert_array_equal(double_mat_cm(ref_mat), 2.0 * ref_mat)
+        np.testing.assert_array_equal(double_mat_rm(ref_mat), 2.0 * ref_mat)
 
 
 @pytest.requires_eigen_and_numpy

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -92,7 +92,7 @@ def test_mutate_readonly(arr):
     from pybind11_tests.array import mutate_data, mutate_data_t, mutate_at_t
     arr.flags.writeable = False
     for func, args in (mutate_data, ()), (mutate_data_t, ()), (mutate_at_t, (0, 0)):
-        with pytest.raises(RuntimeError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             func(arr, *args)
         assert str(excinfo.value) == 'array is not writeable'
 

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytestmark = pytest.requires_numpy
+
 with pytest.suppress(ImportError):
     import numpy as np
 
@@ -9,7 +11,6 @@ def arr():
     return np.array([[1, 2, 3], [4, 5, 6]], '<u2')
 
 
-@pytest.requires_numpy
 def test_array_attributes():
     from pybind11_tests.array import (
         ndim, shape, strides, writeable, size, itemsize, nbytes, owndata
@@ -53,7 +54,6 @@ def test_array_attributes():
     assert not owndata(a)
 
 
-@pytest.requires_numpy
 @pytest.mark.parametrize('args, ret', [([], 0), ([0], 0), ([1], 3), ([0, 1], 1), ([1, 2], 5)])
 def test_index_offset(arr, args, ret):
     from pybind11_tests.array import index_at, index_at_t, offset_at, offset_at_t
@@ -63,7 +63,6 @@ def test_index_offset(arr, args, ret):
     assert offset_at_t(arr, *args) == ret * arr.dtype.itemsize
 
 
-@pytest.requires_numpy
 def test_dim_check_fail(arr):
     from pybind11_tests.array import (index_at, index_at_t, offset_at, offset_at_t, data, data_t,
                                       mutate_data, mutate_data_t)
@@ -74,7 +73,6 @@ def test_dim_check_fail(arr):
         assert str(excinfo.value) == 'too many indices for an array: 3 (ndim = 2)'
 
 
-@pytest.requires_numpy
 @pytest.mark.parametrize('args, ret',
                          [([], [1, 2, 3, 4, 5, 6]),
                           ([1], [4, 5, 6]),
@@ -87,7 +85,6 @@ def test_data(arr, args, ret):
     assert all(data(arr, *args)[1::2] == 0)
 
 
-@pytest.requires_numpy
 def test_mutate_readonly(arr):
     from pybind11_tests.array import mutate_data, mutate_data_t, mutate_at_t
     arr.flags.writeable = False
@@ -97,7 +94,6 @@ def test_mutate_readonly(arr):
         assert str(excinfo.value) == 'array is not writeable'
 
 
-@pytest.requires_numpy
 @pytest.mark.parametrize('dim', [0, 1, 3])
 def test_at_fail(arr, dim):
     from pybind11_tests.array import at_t, mutate_at_t
@@ -107,7 +103,6 @@ def test_at_fail(arr, dim):
         assert str(excinfo.value) == 'index dimension mismatch: {} (ndim = 2)'.format(dim)
 
 
-@pytest.requires_numpy
 def test_at(arr):
     from pybind11_tests.array import at_t, mutate_at_t
 
@@ -118,7 +113,6 @@ def test_at(arr):
     assert all(mutate_at_t(arr, 1, 0).ravel() == [1, 2, 4, 5, 5, 6])
 
 
-@pytest.requires_numpy
 def test_mutate_data(arr):
     from pybind11_tests.array import mutate_data, mutate_data_t
 
@@ -135,7 +129,6 @@ def test_mutate_data(arr):
     assert all(mutate_data_t(arr, 1, 2).ravel() == [6, 19, 27, 68, 84, 197])
 
 
-@pytest.requires_numpy
 def test_bounds_check(arr):
     from pybind11_tests.array import (index_at, index_at_t, data, data_t,
                                       mutate_data, mutate_data_t, at_t, mutate_at_t)
@@ -150,7 +143,6 @@ def test_bounds_check(arr):
         assert str(excinfo.value) == 'index 4 is out of bounds for axis 1 with size 3'
 
 
-@pytest.requires_numpy
 def test_make_c_f_array():
     from pybind11_tests.array import (
         make_c_array, make_f_array
@@ -161,7 +153,6 @@ def test_make_c_f_array():
     assert not make_f_array().flags.c_contiguous
 
 
-@pytest.requires_numpy
 def test_wrap():
     from pybind11_tests.array import wrap
 
@@ -212,7 +203,6 @@ def test_wrap():
     assert_references(a1d, a2, a1)
 
 
-@pytest.requires_numpy
 def test_numpy_view(capture):
     from pybind11_tests.array import ArrayClass
     with capture:
@@ -242,14 +232,12 @@ def test_numpy_view(capture):
 
 
 @pytest.unsupported_on_pypy
-@pytest.requires_numpy
 def test_cast_numpy_int64_to_uint64():
     from pybind11_tests.array import function_taking_uint64
     function_taking_uint64(123)
     function_taking_uint64(np.uint64(123))
 
 
-@pytest.requires_numpy
 def test_isinstance():
     from pybind11_tests.array import isinstance_untyped, isinstance_typed
 
@@ -257,7 +245,6 @@ def test_isinstance():
     assert isinstance_typed(np.array([1.0, 2.0, 3.0]))
 
 
-@pytest.requires_numpy
 def test_constructors():
     from pybind11_tests.array import default_constructors, converting_constructors
 

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -165,7 +165,9 @@ def test_make_c_f_array():
 def test_wrap():
     from pybind11_tests.array import wrap
 
-    def assert_references(a, b):
+    def assert_references(a, b, base=None):
+        if base is None:
+            base = a
         assert a is not b
         assert a.__array_interface__['data'][0] == b.__array_interface__['data'][0]
         assert a.shape == b.shape
@@ -177,7 +179,7 @@ def test_wrap():
         assert a.flags.updateifcopy == b.flags.updateifcopy
         assert np.all(a == b)
         assert not b.flags.owndata
-        assert b.base is a
+        assert b.base is base
         if a.flags.writeable and a.ndim == 2:
             a[0, 0] = 1234
             assert b[0, 0] == 1234
@@ -201,13 +203,13 @@ def test_wrap():
     a2 = wrap(a1)
     assert_references(a1, a2)
 
-    a1 = a1.transpose()
-    a2 = wrap(a1)
-    assert_references(a1, a2)
+    a1t = a1.transpose()
+    a2 = wrap(a1t)
+    assert_references(a1t, a2, a1)
 
-    a1 = a1.diagonal()
-    a2 = wrap(a1)
-    assert_references(a1, a2)
+    a1d = a1.diagonal()
+    a2 = wrap(a1d)
+    assert_references(a1d, a2, a1)
 
 
 @pytest.requires_numpy

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -1,6 +1,8 @@
 import re
 import pytest
 
+pytestmark = pytest.requires_numpy
+
 with pytest.suppress(ImportError):
     import numpy as np
 
@@ -58,7 +60,6 @@ def assert_equal(actual, expected_data, expected_dtype):
     np.testing.assert_equal(actual, np.array(expected_data, dtype=expected_dtype))
 
 
-@pytest.requires_numpy
 def test_format_descriptors():
     from pybind11_tests import get_format_unbound, print_format_descriptors
 
@@ -85,7 +86,6 @@ def test_format_descriptors():
     ]
 
 
-@pytest.requires_numpy
 def test_dtype(simple_dtype):
     from pybind11_tests import (print_dtypes, test_dtype_ctors, test_dtype_methods,
                                 trailing_padding_dtype, buffer_to_dtype)
@@ -113,7 +113,6 @@ def test_dtype(simple_dtype):
     assert trailing_padding_dtype() == buffer_to_dtype(np.zeros(1, trailing_padding_dtype()))
 
 
-@pytest.requires_numpy
 def test_recarray(simple_dtype, packed_dtype):
     from pybind11_tests import (create_rec_simple, create_rec_packed, create_rec_nested,
                                 print_rec_simple, print_rec_packed, print_rec_nested,
@@ -178,7 +177,6 @@ def test_recarray(simple_dtype, packed_dtype):
     np.testing.assert_equal(arr['a'], create_rec_partial(3))
 
 
-@pytest.requires_numpy
 def test_array_constructors():
     from pybind11_tests import test_array_ctors
 
@@ -191,7 +189,6 @@ def test_array_constructors():
         np.testing.assert_array_equal(test_array_ctors(40 + i), data)
 
 
-@pytest.requires_numpy
 def test_string_array():
     from pybind11_tests import create_string_array, print_string_array
 
@@ -210,7 +207,6 @@ def test_string_array():
     assert dtype == arr.dtype
 
 
-@pytest.requires_numpy
 def test_enum_array():
     from pybind11_tests import create_enum_array, print_enum_array
 
@@ -227,14 +223,12 @@ def test_enum_array():
     assert create_enum_array(0).dtype == dtype
 
 
-@pytest.requires_numpy
 def test_signature(doc):
     from pybind11_tests import create_rec_nested
 
     assert doc(create_rec_nested) == "create_rec_nested(arg0: int) -> numpy.ndarray[NestedStruct]"
 
 
-@pytest.requires_numpy
 def test_scalar_conversion():
     from pybind11_tests import (create_rec_simple, f_simple,
                                 create_rec_packed, f_packed,
@@ -256,7 +250,6 @@ def test_scalar_conversion():
                 assert 'incompatible function arguments' in str(excinfo.value)
 
 
-@pytest.requires_numpy
 def test_register_dtype():
     from pybind11_tests import register_dtype
 

--- a/tests/test_numpy_vectorize.py
+++ b/tests/test_numpy_vectorize.py
@@ -1,10 +1,11 @@
 import pytest
 
+pytestmark = pytest.requires_numpy
+
 with pytest.suppress(ImportError):
     import numpy as np
 
 
-@pytest.requires_numpy
 def test_vectorize(capture):
     from pybind11_tests import vectorized_func, vectorized_func2, vectorized_func3
 
@@ -58,7 +59,6 @@ def test_vectorize(capture):
         """
 
 
-@pytest.requires_numpy
 def test_type_selection():
     from pybind11_tests import selective_func
 
@@ -67,7 +67,6 @@ def test_type_selection():
     assert selective_func(np.array([1.0j], dtype=np.complex64)) == "Complex float branch taken."
 
 
-@pytest.requires_numpy
 def test_docs(doc):
     from pybind11_tests import vectorized_func
 


### PR DESCRIPTION
pybind's current Eigen support relies on copying whenever transferring data back and forth between Eigen C++ types and numpy arrays.  In many cases we can avoid such copies by either having Eigen reference a numpy array data, or having numpy reference eigen's data.  This PR does that.

(I'd like to leave it here for a while for people to comment/criticize/etc. before merging!)

Full details are in the documentation commit, but the basic highlights are:

- when returning an rvalue Eigen concrete type (e.g. `MatrixXd`), we now return a numpy `array` *without copying* which references the `MatrixXd` data.  The MatrixXd itself gets stashed into a `capsule` which is tied to the lifetime of the returned `array`.
- when returning a reference (e.g. `const MatrixXd &`) we copy by default, but you can get a numpy reference instead via `return_value_policy::reference` or a reference tied to the parent via `::reference_internal`.
- when passing a numpy array to a function taking an `Eigen::Ref<MatrixXd>` or `Eigen::Ref<const MatrixXd>`, we avoid copying *if possible*.  Unfortunately it is often *not* possible: `Eigen::Ref` by default assumes a contiguous inner stride, which means contiguous columns for a MatrixXd.  Two possible solutions:
    - Thus you either need to pay attention to the order of passed numpy arrays (i.e. creating with `order='F'`), or change Eigen types from `MatrixXd` to `Matrix<double, Dynamic, Dynamic, RowMajor>`.  But even this isn't always enough: numpy's `a.transpose()`, for example, returns a view into the original numpy array, but just flips the column/row majors.
    - A nicer solution is to take arguments as `Eigen::Ref<Eigen::MatrixXd, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>`.  In addition to numpy arrays of either row/column contiguity, it also allows non-contiguous inputs such as array slices.  Since this is really cumbersome to write, I added `py::EigenDRef<MatrixType>`/`py::EigenDMap<MatrixType>`/`py::EigenDStride` as useful shortcuts.
- mutable Eigen arguments (e.g. `Eigen::Ref<MatrixXd>`) are supported.  Unlike non-mutable references (e.g. `Eigen::Ref<const MatrixXd>`) you won't be allowed to call such a function if a conversion of copy is required.
- you can return `Eigen::Block`s, `Eigen::Map`s, and `Eigen::Ref`s when return a numpy array that references the block/map/matrix data without copying it.  You'll very often want to use a `py::return_value_policy::reference_internal` here (if a method returning internal data) or some other keep-alive mechanism, for obvious reasons.  You can explicitly ask for data to be copied into a new numpy array by using `return_value_policy::copy`.
- we honour `flags.writeable`: you can't pass a `flags.writeable = False` numpy array as an `Eigen::Map<Matrix>` argument.  We also honour the other way: if you return a const Matrix value, reference, or Eigen::Ref, you end up with an array with `flags.writeable = False`.
- you can even do some crazy nested numpy-eigen-numpy-eigen-... referencing, if you feel so inclined (one of the added tests does this just to see that it works).

This PR also contains a few other mostly-related odds and ends that I ran into when writing all of this up.