### PR TITLE
Move eigen dl version to single file, update to 3.3.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,9 +23,10 @@ install:
       conda install -y -q pytest numpy scipy
     }
 - ps: |
-    Start-FileDownload 'http://bitbucket.org/eigen/eigen/get/3.3.0.zip'
-    7z x 3.3.0.zip -y > $null
-    $env:CMAKE_INCLUDE_PATH = "eigen-eigen-26667be4f70b"
+    $eigen = Get-Content -head 2 .eigen-build-version
+    Start-FileDownload "http://bitbucket.org/eigen/eigen/get/$($eigen[0]).zip"
+    7z x "$($eigen[0]).zip" -y > $null
+    $env:CMAKE_INCLUDE_PATH = $eigen[1]
 build_script:
 - cmake -A "%CMAKE_ARCH%" -DPYBIND11_WERROR=ON
 - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/.eigen-build-version
+++ b/.eigen-build-version
@@ -1,0 +1,5 @@
+3.3.2
+eigen-eigen-da9b4e14c255
+# This is the version and extracted directory used for appveyor and travis-ci
+# builds.  The first line is the eigen version to download, the second is the
+# extracted directory name.  These comments must stay after the first two lines.

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,9 +124,9 @@ install:
   else
     pip install numpy scipy pytest
 
-    wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.3.0.tar.gz
-    tar xzf eigen.tar.gz
-    export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=$PWD/eigen-eigen-26667be4f70b"
+    eigen=($(head -n 2 .eigen-build-version))
+    curl https://bitbucket.org/eigen/eigen/get/${eigen[0]}.tar.bz2 | tar xj
+    export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=$PWD/${eigen[1]}"
   fi
 script:
 - $SCRIPT_RUN_PREFIX cmake ${CMAKE_EXTRA_ARGS}


### PR DESCRIPTION
This moves the eigen download version and extraction path to a single file (.eigen-build-version), loaded by both the appveyor and travis-ci scripts.

It also updates the eigen version from 3.3.0 to the latest 3.3.2.

Finally it saves (a tiny amount of) storage use on the travis-ci builds by extracting the .tar.bz2 on the fly rather than downloading first then decompressing the saved file.  (It also saves slightly on download bandwidth by downloading the source tar.bz2 instead of the tar.gz).