### PR TITLE
Numpy: better compilation errors, long double support

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -176,9 +176,10 @@ function overload.
 Structured types
 ================
 
-In order for ``py::array_t`` to work with structured (record) types, we first need
-to register the memory layout of the type. This can be done via ``PYBIND11_NUMPY_DTYPE``
-macro which expects the type followed by field names:
+In order for ``py::array_t`` to work with structured (record) types, we first
+need to register the memory layout of the type. This can be done via
+``PYBIND11_NUMPY_DTYPE`` macro, called in the plugin definition code, which
+expects the type followed by field names:
 
 .. code-block:: cpp
 
@@ -192,10 +193,14 @@ macro which expects the type followed by field names:
         A a;
     };
 
-    PYBIND11_NUMPY_DTYPE(A, x, y);
-    PYBIND11_NUMPY_DTYPE(B, z, a);
+    // ...
+    PYBIND11_PLUGIN(test) {
+        // ...
 
-    /* now both A and B can be used as template arguments to py::array_t */
+        PYBIND11_NUMPY_DTYPE(A, x, y);
+        PYBIND11_NUMPY_DTYPE(B, z, a);
+        /* now both A and B can be used as template arguments to py::array_t */
+    }
 
 Vectorizing functions
 =====================

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1007,8 +1007,8 @@ class type_caster<T, enable_if_t<is_pyobject<T>::value>> : public pyobject_caste
 // - if the type is non-copy-constructible, the object must be the sole owner of the type (i.e. it
 //   must have ref_count() == 1)h
 // If any of the above are not satisfied, we fall back to copying.
-template <typename T> using move_is_plain_type = none_of<
-    std::is_void<T>, std::is_pointer<T>, std::is_reference<T>, std::is_const<T>
+template <typename T> using move_is_plain_type = satisfies_none_of<T,
+    std::is_void, std::is_pointer, std::is_reference, std::is_const
 >;
 template <typename T, typename SFINAE = void> struct move_always : std::false_type {};
 template <typename T> struct move_always<T, enable_if_t<all_of<

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -406,6 +406,10 @@ template <class... Ts> using any_of = std::disjunction<Ts...>;
 #endif
 template <class... Ts> using none_of = negation<any_of<Ts...>>;
 
+template <class T, template<class> class... Predicates> using satisfies_all_of = all_of<Predicates<T>...>;
+template <class T, template<class> class... Predicates> using satisfies_any_of = any_of<Predicates<T>...>;
+template <class T, template<class> class... Predicates> using satisfies_none_of = none_of<Predicates<T>...>;
+
 /// Strip the class from a method type
 template <typename T> struct remove_class { };
 template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...)> { typedef R type(A...); };

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -18,11 +18,14 @@
 #endif
 
 NAMESPACE_BEGIN(pybind11)
-
-PYBIND11_DECL_FMT(std::complex<float>, "Zf");
-PYBIND11_DECL_FMT(std::complex<double>, "Zd");
-
 NAMESPACE_BEGIN(detail)
+
+// The format codes are already in the string in common.h, we just need to provide a specialization
+template <typename T> struct is_fmt_numeric<std::complex<T>> {
+    static constexpr bool value = true;
+    static constexpr int index = is_fmt_numeric<T>::index + 3;
+};
+
 template <typename T> class type_caster<std::complex<T>> {
 public:
     bool load(handle src, bool) {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -180,21 +180,21 @@ private:
         void **api_ptr = (void **) PyCObject_AsVoidPtr(c.ptr());
 #endif
         npy_api api;
-#define DECL_NPY_API(Func) api.Func##_ = (decltype(api.Func##_)) api_ptr[API_##Func];
-        DECL_NPY_API(PyArray_Type);
-        DECL_NPY_API(PyVoidArrType_Type);
-        DECL_NPY_API(PyArrayDescr_Type);
-        DECL_NPY_API(PyArray_DescrFromType);
-        DECL_NPY_API(PyArray_DescrFromScalar);
-        DECL_NPY_API(PyArray_FromAny);
-        DECL_NPY_API(PyArray_NewCopy);
-        DECL_NPY_API(PyArray_NewFromDescr);
-        DECL_NPY_API(PyArray_DescrNewFromType);
-        DECL_NPY_API(PyArray_DescrConverter);
-        DECL_NPY_API(PyArray_EquivTypes);
-        DECL_NPY_API(PyArray_GetArrayParamsFromObject);
-        DECL_NPY_API(PyArray_Squeeze);
-#undef DECL_NPY_API
+#define PYBIND11_DECL_NPY_API(Func) api.Func##_ = (decltype(api.Func##_)) api_ptr[API_##Func];
+        PYBIND11_DECL_NPY_API(PyArray_Type);
+        PYBIND11_DECL_NPY_API(PyVoidArrType_Type);
+        PYBIND11_DECL_NPY_API(PyArrayDescr_Type);
+        PYBIND11_DECL_NPY_API(PyArray_DescrFromType);
+        PYBIND11_DECL_NPY_API(PyArray_DescrFromScalar);
+        PYBIND11_DECL_NPY_API(PyArray_FromAny);
+        PYBIND11_DECL_NPY_API(PyArray_NewCopy);
+        PYBIND11_DECL_NPY_API(PyArray_NewFromDescr);
+        PYBIND11_DECL_NPY_API(PyArray_DescrNewFromType);
+        PYBIND11_DECL_NPY_API(PyArray_DescrConverter);
+        PYBIND11_DECL_NPY_API(PyArray_EquivTypes);
+        PYBIND11_DECL_NPY_API(PyArray_GetArrayParamsFromObject);
+        PYBIND11_DECL_NPY_API(PyArray_Squeeze);
+#undef PYBIND11_DECL_NPY_API
         return api;
     }
 };
@@ -714,7 +714,7 @@ public:
 template <typename T> constexpr const int npy_format_descriptor<
     T, enable_if_t<std::is_integral<T>::value>>::values[8];
 
-#define DECL_FMT(Type, NumPyName, Name) template<> struct npy_format_descriptor<Type> { \
+#define PYBIND11_DECL_NPY_FMT(Type, NumPyName, Name) template<> struct npy_format_descriptor<Type> { \
     enum { value = npy_api::NumPyName }; \
     static pybind11::dtype dtype() { \
         if (auto ptr = npy_api::get().PyArray_DescrFromType_(value)) \
@@ -722,19 +722,19 @@ template <typename T> constexpr const int npy_format_descriptor<
         pybind11_fail("Unsupported buffer format!"); \
     } \
     static PYBIND11_DESCR name() { return _(Name); } }
-DECL_FMT(float, NPY_FLOAT_, "float32");
-DECL_FMT(double, NPY_DOUBLE_, "float64");
-DECL_FMT(bool, NPY_BOOL_, "bool");
-DECL_FMT(std::complex<float>, NPY_CFLOAT_, "complex64");
-DECL_FMT(std::complex<double>, NPY_CDOUBLE_, "complex128");
-#undef DECL_FMT
+PYBIND11_DECL_NPY_FMT(float, NPY_FLOAT_, "float32");
+PYBIND11_DECL_NPY_FMT(double, NPY_DOUBLE_, "float64");
+PYBIND11_DECL_NPY_FMT(bool, NPY_BOOL_, "bool");
+PYBIND11_DECL_NPY_FMT(std::complex<float>, NPY_CFLOAT_, "complex64");
+PYBIND11_DECL_NPY_FMT(std::complex<double>, NPY_CDOUBLE_, "complex128");
+#undef PYBIND11_DECL_NPY_FMT
 
-#define DECL_CHAR_FMT \
+#define PYBIND11_DECL_CHAR_FMT \
     static PYBIND11_DESCR name() { return _("S") + _<N>(); } \
     static pybind11::dtype dtype() { return pybind11::dtype(std::string("S") + std::to_string(N)); }
-template <size_t N> struct npy_format_descriptor<char[N]> { DECL_CHAR_FMT };
-template <size_t N> struct npy_format_descriptor<std::array<char, N>> { DECL_CHAR_FMT };
-#undef DECL_CHAR_FMT
+template <size_t N> struct npy_format_descriptor<char[N]> { PYBIND11_DECL_CHAR_FMT };
+template <size_t N> struct npy_format_descriptor<std::array<char, N>> { PYBIND11_DECL_CHAR_FMT };
+#undef PYBIND11_DECL_CHAR_FMT
 
 template<typename T> struct npy_format_descriptor<T, enable_if_t<std::is_enum<T>::value>> {
 private:

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -417,10 +417,10 @@ public:
 template <typename T> using is_keyword = std::is_base_of<arg, T>;
 template <typename T> using is_s_unpacking = std::is_same<args_proxy, T>; // * unpacking
 template <typename T> using is_ds_unpacking = std::is_same<kwargs_proxy, T>; // ** unpacking
-template <typename T> using is_positional = none_of<
-    is_keyword<T>, is_s_unpacking<T>, is_ds_unpacking<T>
+template <typename T> using is_positional = satisfies_none_of<T,
+    is_keyword, is_s_unpacking, is_ds_unpacking
 >;
-template <typename T> using is_keyword_or_ds = any_of<is_keyword<T>, is_ds_unpacking<T>>;
+template <typename T> using is_keyword_or_ds = satisfies_any_of<T, is_keyword, is_ds_unpacking>;
 
 // Call argument collector forward declarations
 template <return_value_policy policy = return_value_policy::automatic_reference>

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -334,6 +334,11 @@ test_initializer numpy_dtypes([](py::module &m) {
 
     PYBIND11_NUMPY_DTYPE_EX(StructWithUglyNames, __x__, "x", __y__, "y");
 
+    // If uncommented, this should produce a static_assert failure telling the user that the struct
+    // is not a POD type
+//    struct NotPOD { std::string v; NotPOD() : v("hi") {}; };
+//    PYBIND11_NUMPY_DTYPE(NotPOD, v);
+
     m.def("create_rec_simple", &create_recarray<SimpleStruct>);
     m.def("create_rec_packed", &create_recarray<PackedStruct>);
     m.def("create_rec_nested", &create_nested);

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -19,23 +19,25 @@
 namespace py = pybind11;
 
 struct SimpleStruct {
-    bool x;
-    uint32_t y;
-    float z;
+    bool bool_;
+    uint32_t uint_;
+    float float_;
+    long double ldbl_;
 };
 
 std::ostream& operator<<(std::ostream& os, const SimpleStruct& v) {
-    return os << "s:" << v.x << "," << v.y << "," << v.z;
+    return os << "s:" << v.bool_ << "," << v.uint_ << "," << v.float_ << "," << v.ldbl_;
 }
 
 PYBIND11_PACKED(struct PackedStruct {
-    bool x;
-    uint32_t y;
-    float z;
+    bool bool_;
+    uint32_t uint_;
+    float float_;
+    long double ldbl_;
 });
 
 std::ostream& operator<<(std::ostream& os, const PackedStruct& v) {
-    return os << "p:" << v.x << "," << v.y << "," << v.z;
+    return os << "p:" << v.bool_ << "," << v.uint_ << "," << v.float_ << "," << v.ldbl_;
 }
 
 PYBIND11_PACKED(struct NestedStruct {
@@ -48,10 +50,11 @@ std::ostream& operator<<(std::ostream& os, const NestedStruct& v) {
 }
 
 struct PartialStruct {
-    bool x;
-    uint32_t y;
-    float z;
+    bool bool_;
+    uint32_t uint_;
+    float float_;
     uint64_t dummy2;
+    long double ldbl_;
 };
 
 struct PartialNestedStruct {
@@ -99,13 +102,19 @@ py::array mkarray_via_buffer(size_t n) {
                                      1, { n }, { sizeof(T) }));
 }
 
+#define SET_TEST_VALS(s, i) do { \
+    s.bool_ = (i) % 2 != 0; \
+    s.uint_ = (uint32_t) (i); \
+    s.float_ = (float) (i) * 1.5f; \
+    s.ldbl_ = (long double) (i) * -2.5L; } while (0)
+
 template <typename S>
 py::array_t<S, 0> create_recarray(size_t n) {
     auto arr = mkarray_via_buffer<S>(n);
     auto req = arr.request();
     auto ptr = static_cast<S*>(req.ptr);
     for (size_t i = 0; i < n; i++) {
-        ptr[i].x = i % 2 != 0; ptr[i].y = (uint32_t) i; ptr[i].z = (float) i * 1.5f;
+        SET_TEST_VALS(ptr[i], i);
     }
     return arr;
 }
@@ -119,8 +128,8 @@ py::array_t<NestedStruct, 0> create_nested(size_t n) {
     auto req = arr.request();
     auto ptr = static_cast<NestedStruct*>(req.ptr);
     for (size_t i = 0; i < n; i++) {
-        ptr[i].a.x = i % 2 != 0; ptr[i].a.y = (uint32_t) i; ptr[i].a.z = (float) i * 1.5f;
-        ptr[i].b.x = (i + 1) % 2 != 0; ptr[i].b.y = (uint32_t) (i + 1); ptr[i].b.z = (float) (i + 1) * 1.5f;
+        SET_TEST_VALS(ptr[i].a, i);
+        SET_TEST_VALS(ptr[i].b, i + 1);
     }
     return arr;
 }
@@ -130,7 +139,7 @@ py::array_t<PartialNestedStruct, 0> create_partial_nested(size_t n) {
     auto req = arr.request();
     auto ptr = static_cast<PartialNestedStruct*>(req.ptr);
     for (size_t i = 0; i < n; i++) {
-        ptr[i].a.x = i % 2 != 0; ptr[i].a.y = (uint32_t) i; ptr[i].a.z = (float) i * 1.5f;
+        SET_TEST_VALS(ptr[i].a, i);
     }
     return arr;
 }
@@ -320,10 +329,10 @@ test_initializer numpy_dtypes([](py::module &m) {
     // typeinfo may be registered before the dtype descriptor for scalar casts to work...
     py::class_<SimpleStruct>(m, "SimpleStruct");
 
-    PYBIND11_NUMPY_DTYPE(SimpleStruct, x, y, z);
-    PYBIND11_NUMPY_DTYPE(PackedStruct, x, y, z);
+    PYBIND11_NUMPY_DTYPE(SimpleStruct, bool_, uint_, float_, ldbl_);
+    PYBIND11_NUMPY_DTYPE(PackedStruct, bool_, uint_, float_, ldbl_);
     PYBIND11_NUMPY_DTYPE(NestedStruct, a, b);
-    PYBIND11_NUMPY_DTYPE(PartialStruct, x, y, z);
+    PYBIND11_NUMPY_DTYPE(PartialStruct, bool_, uint_, float_, ldbl_);
     PYBIND11_NUMPY_DTYPE(PartialNestedStruct, a);
     PYBIND11_NUMPY_DTYPE(StringStruct, a, b);
     PYBIND11_NUMPY_DTYPE(EnumStruct, e1, e2);
@@ -359,10 +368,10 @@ test_initializer numpy_dtypes([](py::module &m) {
     m.def("test_dtype_methods", &test_dtype_methods);
     m.def("trailing_padding_dtype", &trailing_padding_dtype);
     m.def("buffer_to_dtype", &buffer_to_dtype);
-    m.def("f_simple", [](SimpleStruct s) { return s.y * 10; });
-    m.def("f_packed", [](PackedStruct s) { return s.y * 10; });
-    m.def("f_nested", [](NestedStruct s) { return s.a.y * 10; });
-    m.def("register_dtype", []() { PYBIND11_NUMPY_DTYPE(SimpleStruct, x, y, z); });
+    m.def("f_simple", [](SimpleStruct s) { return s.uint_ * 10; });
+    m.def("f_packed", [](PackedStruct s) { return s.uint_ * 10; });
+    m.def("f_nested", [](NestedStruct s) { return s.a.uint_ * 10; });
+    m.def("register_dtype", []() { PYBIND11_NUMPY_DTYPE(SimpleStruct, bool_, uint_, float_, ldbl_); });
 });
 
 #undef PYBIND11_PACKED


### PR DESCRIPTION
A few small-ish changes related to numpy:

- the dtype declaration macro documentation was unclear
- non-POD types resulted in non-obvious compilation errors (changed to a static_assert)
- added `long double` (and `std::complex<long double>`) support: there's not a huge reason to *not* support them--supporting all floating point types makes the code a little cleaner--and this allows binding of Eigen code that has long doubles.

The changes to the numpy dtype test script also resolve the linux/i386 test failure from #612.