### PR TITLE
Prefer non-converting argument overloads

### DIFF
--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -388,6 +388,8 @@ crucial that instances are deallocated on the C++ side to avoid memory leaks.
     py::class_<MyClass, std::unique_ptr<MyClass, py::nodelete>>(m, "MyClass")
         .def(py::init<>())
 
+.. _implicit_conversions:
+
 Implicit conversions
 ====================
 

--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -372,3 +372,33 @@ name, i.e. by specifying ``py::arg().noconvert()``.
     enable no-convert behaviour for just one of several arguments, you will
     need to specify a ``py::arg()`` annotation for each argument with the
     no-convert argument modified to ``py::arg().noconvert()``.
+
+Overload resolution order
+=========================
+
+When a function or method with multiple overloads is called from Python,
+pybind11 determines which overload to call in two passes.  The first pass
+attempts to call each overload without allowing argument conversion (as if
+every argument had been specified as ``py::arg().noconvert()`` as decribed
+above).
+
+If no overload succeeds in the no-conversion first pass, a second pass is
+attempted in which argument conversion is allowed (except where prohibited via
+an explicit ``py::arg().noconvert()`` attribute in the function definition).
+
+If the second pass also fails a ``TypeError`` is raised.
+
+Within each pass, overloads are tried in the order they were registered with
+pybind11.
+
+What this means in practice is that pybind11 will prefer any overload that does
+not require conversion of arguments to an overload that does, but otherwise prefers
+earlier-defined overloads to later-defined ones.
+
+.. note::
+
+    pybind11 does *not* further prioritize based on the number/pattern of
+    overloaded arguments.  That is, pybind11 does not prioritize a function
+    requiring one conversion over one requiring three, but only prioritizes
+    overloads requiring no conversion at all to overloads that require
+    conversion of at least one argument.

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -28,8 +28,10 @@ template <typename T> struct is_fmt_numeric<std::complex<T>> {
 
 template <typename T> class type_caster<std::complex<T>> {
 public:
-    bool load(handle src, bool) {
+    bool load(handle src, bool convert) {
         if (!src)
+            return false;
+        if (!convert && !PyComplex_Check(src.ptr()))
             return false;
         Py_complex result = PyComplex_AsCComplex(src.ptr());
         if (result.real == -1.0 && PyErr_Occurred()) {

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -97,6 +97,42 @@ public:
 
 class CppDerivedDynamicClass : public DynamicClass { };
 
+// py::arg/py::arg_v testing: these arguments just record their argument when invoked
+class ArgInspector1 { public: std::string arg = "(default arg inspector 1)"; };
+class ArgInspector2 { public: std::string arg = "(default arg inspector 2)"; };
+namespace pybind11 { namespace detail {
+template <> struct type_caster<ArgInspector1> {
+public:
+    PYBIND11_TYPE_CASTER(ArgInspector1, _("ArgInspector1"));
+
+    bool load(handle src, bool convert) {
+        value.arg = "loading ArgInspector1 argument " +
+            std::string(convert ? "WITH" : "WITHOUT") + " conversion allowed.  "
+            "Argument value = " + (std::string) str(src);
+        return true;
+    }
+
+    static handle cast(const ArgInspector1 &src, return_value_policy, handle) {
+        return str(src.arg).release();
+    }
+};
+template <> struct type_caster<ArgInspector2> {
+public:
+    PYBIND11_TYPE_CASTER(ArgInspector2, _("ArgInspector2"));
+
+    bool load(handle src, bool convert) {
+        value.arg = "loading ArgInspector2 argument " +
+            std::string(convert ? "WITH" : "WITHOUT") + " conversion allowed.  "
+            "Argument value = " + (std::string) str(src);
+        return true;
+    }
+
+    static handle cast(const ArgInspector2 &src, return_value_policy, handle) {
+        return str(src.arg).release();
+    }
+};
+}}
+
 test_initializer methods_and_attributes([](py::module &m) {
     py::class_<ExampleMandA>(m, "ExampleMandA")
         .def(py::init<>())
@@ -183,4 +219,25 @@ test_initializer methods_and_attributes([](py::module &m) {
     py::class_<CppDerivedDynamicClass, DynamicClass>(m, "CppDerivedDynamicClass")
         .def(py::init());
 #endif
+
+    class ArgInspector {
+    public:
+        ArgInspector1 f(ArgInspector1 a) { return a; }
+        std::string g(ArgInspector1 a, const ArgInspector1 &b, int c, ArgInspector2 *d) {
+            return a.arg + "\n" + b.arg + "\n" + std::to_string(c) + "\n" + d->arg;
+        }
+        static ArgInspector2 h(ArgInspector2 a) { return a; }
+    };
+    py::class_<ArgInspector>(m, "ArgInspector")
+        .def(py::init<>())
+        .def("f", &ArgInspector::f)
+        .def("g", &ArgInspector::g, "a"_a.noconvert(), "b"_a, "c"_a.noconvert()=13, "d"_a=ArgInspector2())
+        .def_static("h", &ArgInspector::h, py::arg().noconvert())
+        ;
+    m.def("arg_inspect_func", [](ArgInspector2 a, ArgInspector1 b) { return a.arg + "\n" + b.arg; },
+            py::arg().noconvert(false), py::arg_v(nullptr, ArgInspector1()).noconvert(true));
+
+    m.def("floats_preferred", [](double f) { return 0.5 * f; }, py::arg("f"));
+    m.def("floats_only", [](double f) { return 0.5 * f; }, py::arg("f").noconvert());
+
 });

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -203,3 +203,47 @@ def test_cyclic_gc():
     assert cstats.alive() == 2
     del i1, i2
     assert cstats.alive() == 0
+
+
+def test_noconvert_args(msg):
+    from pybind11_tests import ArgInspector, arg_inspect_func, floats_only, floats_preferred
+
+    a = ArgInspector()
+    assert msg(a.f("hi")) == """
+        loading ArgInspector1 argument WITH conversion allowed.  Argument value = hi
+    """
+    assert msg(a.g("this is a", "this is b")) == """
+        loading ArgInspector1 argument WITHOUT conversion allowed.  Argument value = this is a
+        loading ArgInspector1 argument WITH conversion allowed.  Argument value = this is b
+        13
+        loading ArgInspector2 argument WITH conversion allowed.  Argument value = (default arg inspector 2)
+    """  # noqa: E501 line too long
+    assert msg(a.g("this is a", "this is b", 42)) == """
+        loading ArgInspector1 argument WITHOUT conversion allowed.  Argument value = this is a
+        loading ArgInspector1 argument WITH conversion allowed.  Argument value = this is b
+        42
+        loading ArgInspector2 argument WITH conversion allowed.  Argument value = (default arg inspector 2)
+    """  # noqa: E501 line too long
+    assert msg(a.g("this is a", "this is b", 42, "this is d")) == """
+        loading ArgInspector1 argument WITHOUT conversion allowed.  Argument value = this is a
+        loading ArgInspector1 argument WITH conversion allowed.  Argument value = this is b
+        42
+        loading ArgInspector2 argument WITH conversion allowed.  Argument value = this is d
+    """
+    assert (a.h("arg 1") ==
+            "loading ArgInspector2 argument WITHOUT conversion allowed.  Argument value = arg 1")
+    assert msg(arg_inspect_func("A1", "A2")) == """
+        loading ArgInspector2 argument WITH conversion allowed.  Argument value = A1
+        loading ArgInspector1 argument WITHOUT conversion allowed.  Argument value = A2
+    """
+
+    assert floats_preferred(4) == 2.0
+    assert floats_only(4.0) == 2.0
+    with pytest.raises(TypeError) as excinfo:
+        floats_only(4)
+    assert msg(excinfo.value) == """
+        floats_only(): incompatible function arguments. The following argument types are supported:
+            1. (f: float) -> float
+
+        Invoked with: 4
+    """

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -33,8 +33,16 @@ def test_methods_and_attributes():
 
     assert instance1.overloaded(1, 1.0) == "(int, float)"
     assert instance1.overloaded(2.0, 2) == "(float, int)"
-    assert instance1.overloaded_const(3, 3.0) == "(int, float) const"
-    assert instance1.overloaded_const(4.0, 4) == "(float, int) const"
+    assert instance1.overloaded(3,   3) == "(int, int)"
+    assert instance1.overloaded(4., 4.) == "(float, float)"
+    assert instance1.overloaded_const(5, 5.0) == "(int, float) const"
+    assert instance1.overloaded_const(6.0, 6) == "(float, int) const"
+    assert instance1.overloaded_const(7,   7) == "(int, int) const"
+    assert instance1.overloaded_const(8., 8.) == "(float, float) const"
+    assert instance1.overloaded_float(1, 1) == "(float, float)"
+    assert instance1.overloaded_float(1, 1.) == "(float, float)"
+    assert instance1.overloaded_float(1., 1) == "(float, float)"
+    assert instance1.overloaded_float(1., 1.) == "(float, float)"
 
     assert instance1.value == 320
     instance1.value = 100

--- a/tests/test_opaque_types.py
+++ b/tests/test_opaque_types.py
@@ -28,9 +28,10 @@ def test_pointers(msg):
                                 print_opaque_list, return_null_str, get_null_str_value,
                                 return_unique_ptr, ConstructorStats)
 
+    living_before = ConstructorStats.get(ExampleMandA).alive()
     assert get_void_ptr_value(return_void_ptr()) == 0x1234
     assert get_void_ptr_value(ExampleMandA())  # Should also work for other C++ types
-    assert ConstructorStats.get(ExampleMandA).alive() == 0
+    assert ConstructorStats.get(ExampleMandA).alive() == living_before
 
     with pytest.raises(TypeError) as excinfo:
         get_void_ptr_value([1, 2, 3])  # This should not work


### PR DESCRIPTION
This changes function dispatching to work in two passes for overloaded functions: the first tries calling a function with all arguments loaded with `convert=false`.  If this fails for all overloads, a second pass is tried which allows conversion (except for those arguments where it is explicitly disabled with `py::arg().noconvert()`).

The main point here is to prefer calls to overloads that don't require conversion over calls that do require conversion, regardless of the order in which the functions were registered.  This should allow issues like #631 to be solved relatively easily by not loading when `convert=false` except when the type already matches.

For non-overloaded functions, this code doesn't bother with two passes at all (there's no point in first trying a non-converting call because if it fails we'd just immediately make the converting call anyway).

For overloads where there are no converting argument anyway (either no arguments, or all arguments are `py::arg().noconvert()`) we don't bother with the second pass attempt (since it would have `convert_args` flags exactly identical to the first pass).

---
Without the included tests, this increases the test .so size by 4KB under both GCC and macOS Sierra Clang, but that's a constant increase (i.e. the same increase for binding just one function or the entire test suite).

Note that the first two commits here are just PR #634, which this depends on, but I'm submitting this as a separate PR because it's really a completely different feature and deserves separate consideration/discussion.  (Also note that the no-variable-.so increase I mentioned above is relative to #634, i.e. there's a small variable increase relative to master, but that's coming from #634).