### PR TITLE
Add a GitHub issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+Make sure you've completed the following steps before submitting your issue -- thank you!
+You can remove this template text afterward.
+
+1. Check if your question has already been answered in the [FAQ](http://pybind11.readthedocs.io/en/latest/faq.html) section.
+2. Make sure you've read the [documentation](http://pybind11.readthedocs.io/en/latest/). Your issue may be addressed there.
+3. If those resources didn't help and you only have a short question (not a bug report), consider asking in the [Gitter chat room](https://gitter.im/pybind/Lobby).
+4. If you have a genuine bug report or a more complex question which is not answered in the previous items (or not suitable for chat), please fill in the details below.
+5. Include a self-contained and minimal piece of code that reproduces the problem. If that's not possible, try to make the description as clear as possible.
+
+
+#### Issue description
+
+(Provide a short description, state the expected behavior and what actually happens.)
+
+#### Reproducible example code
+
+(The code should be minimal, have no external dependencies, isolate the function(s) that cause breakage. Submit matched and complete C++ and Python snippets that can be easily compiled and run to diagnose the issue.)


### PR DESCRIPTION
This is a suggestion to start using GitHub's [issue template feature](https://github.com/blog/2111-issue-and-pull-request-templates). Most of what's written here is already covered by `CONTRIBUTING.md` (and some of the text is just copy-pasted from there), but the "guidelines for contributing" link above new issues is easy to miss. The text from `ISSUE_TEMPLATE.md` will show up as the default text inside the editor after hitting the "New issue" button. I figure this might make issue guidelines more visible (or make them feel more relevant) and also offload some of the shorter question to the Gitter room.

 Side note: http://pybind11.readthedocs.io/ has both `latest` and `master` builds which are identical (there's also `stable` but that's different - always points to the last tagged release). `CONTRIBUTING.md` links to `latest`, while `README.md` links to `master`. I guess it would be good to delete one and use the other everywhere. But which one?

**Edit:** The commit message contains `[skip ci]` to avoid using unnecessary CI server cycles.