### PR TITLE
Fix path to libsize.py

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,7 +107,7 @@ endif()
 
 # And another to show the .so size and, if a previous size, compare it:
 add_custom_command(TARGET pybind11_tests POST_BUILD
-  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/libsize.py
+  COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/libsize.py
   $<TARGET_FILE:pybind11_tests> ${CMAKE_CURRENT_BINARY_DIR}/sosize-$<TARGET_FILE_NAME:pybind11_tests>.txt)
 
 # Test CMake build using functions and targets from subdirectory or installed location


### PR DESCRIPTION
Use `PROJECT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR` as the base of the path to `libsize.py`. This fixes an error if pybind11 is being built directly within another project.