### PR TITLE
Avoid C-style const casts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ function(pybind11_enable_warnings target_name)
   if(MSVC)
     target_compile_options(${target_name} PRIVATE /W4)
   else()
-    target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wconversion)
+    target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wconversion -Wcast-qual)
   endif()
 
   if(PYBIND11_WERROR)

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -422,7 +422,7 @@ protected:
     template <typename T = type, typename = enable_if_t<is_copy_constructible<T>::value>> static auto make_copy_constructor(const T *value) -> decltype(new T(*value), Constructor(nullptr)) {
         return [](const void *arg) -> void * { return new T(*((const T *) arg)); }; }
     template <typename T = type> static auto make_move_constructor(const T *value) -> decltype(new T(std::move(*((T *) value))), Constructor(nullptr)) {
-        return [](const void *arg) -> void * { return (void *) new T(std::move(*((T *) arg))); }; }
+        return [](const void *arg) -> void * { return (void *) new T(std::move(*const_cast<T *>(reinterpret_cast<const T *>(arg)))); }; }
 #else
     /* Visual Studio 2015's SFINAE implementation doesn't yet handle the above robustly in all situations.
        Use a workaround that only tests for constructibility for now. */
@@ -706,7 +706,7 @@ public:
         return PyUnicode_DecodeLatin1(str, 1, nullptr);
     }
 
-    operator char*() { return success ? (char *) value.c_str() : nullptr; }
+    operator char*() { return success ? const_cast<char *>(value.c_str()) : nullptr; }
     operator char&() { return value[0]; }
 
     static PYBIND11_DESCR name() { return type_descr(_(PYBIND11_STRING_NAME)); }
@@ -729,7 +729,7 @@ public:
         return PyUnicode_FromWideChar(wstr, 1);
     }
 
-    operator wchar_t*() { return success ? (wchar_t *) value.c_str() : nullptr; }
+    operator wchar_t*() { return success ? const_cast<wchar_t *>(value.c_str()) : nullptr; }
     operator wchar_t&() { return value[0]; }
 
     static PYBIND11_DESCR name() { return type_descr(_(PYBIND11_STRING_NAME)); }

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -357,8 +357,10 @@ public:
         }
 
         auto tmp = reinterpret_steal<object>(api.PyArray_NewFromDescr_(
-            api.PyArray_Type_, descr.release().ptr(), (int) ndim, (Py_intptr_t *) shape.data(),
-            (Py_intptr_t *) strides.data(), const_cast<void *>(ptr), flags, nullptr));
+            api.PyArray_Type_, descr.release().ptr(), (int) ndim,
+            reinterpret_cast<Py_intptr_t *>(const_cast<size_t*>(shape.data())),
+            reinterpret_cast<Py_intptr_t *>(const_cast<size_t*>(strides.data())),
+            const_cast<void *>(ptr), flags, nullptr));
         if (!tmp)
             pybind11_fail("NumPy: unable to create array!");
         if (ptr) {
@@ -382,7 +384,7 @@ public:
     template<typename T> array(const std::vector<size_t>& shape,
                                const std::vector<size_t>& strides,
                                const T* ptr, handle base = handle())
-    : array(pybind11::dtype::of<T>(), shape, strides, (void *) ptr, base) { }
+    : array(pybind11::dtype::of<T>(), shape, strides, (const void *) ptr, base) { }
 
     template <typename T>
     array(const std::vector<size_t> &shape, const T *ptr,


### PR DESCRIPTION
Replace C-style casts that discard `const` with `const_cast` (and, where necessary, `reinterpret_cast` as well).

Avoiding C-style casts entirely would probably be good, but this at least avoids tripping `-Wcast-qual`.