### PR TITLE
Fix sequence_item reference leak

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -254,7 +254,7 @@ public:
 
     .. code-block:: cpp
 
-        PyObject *result = PySequence_GetItem(obj, index);
+        PyObject *p = PyList_GetItem(obj, index);
         py::object o = reinterpret_borrow<py::object>(p);
         // or
         py::tuple t = reinterpret_borrow<py::tuple>(p); // <-- `p` must be already be a `tuple`
@@ -453,7 +453,7 @@ struct sequence_item {
     static object get(handle obj, size_t index) {
         PyObject *result = PySequence_GetItem(obj.ptr(), static_cast<ssize_t>(index));
         if (!result) { throw error_already_set(); }
-        return reinterpret_borrow<object>(result);
+        return reinterpret_steal<object>(result);
     }
 
     static void set(handle obj, size_t index, handle val) {


### PR DESCRIPTION
[`PySequence_GetItem`](https://docs.python.org/3/c-api/sequence.html#c.PySequence_GetItem) returns a new reference so `sequence_item` must steal it. This PR also fixes a code sample which was written based on `sequence_item`.