### PR TITLE
Complete the iterator interface: error handling and STL algorithms

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1457,29 +1457,10 @@ public:
 
     /// Export enumeration entries into the parent scope
     enum_ &export_values() {
-#if !defined(PYPY_VERSION)
-        PyObject *dict = ((PyTypeObject *) this->m_ptr)->tp_dict;
-        PyObject *key, *value;
-        ssize_t pos = 0;
-
-        while (PyDict_Next(dict, &pos, &key, &value)) {
-            if (PyObject_IsInstance(value, this->m_ptr))
-                m_parent.attr(key) = value;
+        for (auto item : reinterpret_borrow<dict>(((PyTypeObject *) this->m_ptr)->tp_dict)) {
+            if (isinstance(item.second, this->m_ptr))
+                m_parent.attr(item.first) = item.second;
         }
-#else
-        /* PyPy's cpyext still has difficulties with the above
-           CPython API calls; emulate using Python code. */
-        dict d; d["t"] = *this; d["p"] = m_parent;
-        PyObject *result = PyRun_String(
-            "for k, v in t.__dict__.items():\n"
-            "    if isinstance(v, t):\n"
-            "        setattr(p, k, v)\n",
-            Py_file_input, d.ptr(), d.ptr());
-        if (result == nullptr)
-            throw error_already_set();
-        Py_DECREF(result);
-#endif
-
         return *this;
     }
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -613,8 +613,14 @@ private:
 };
 NAMESPACE_END(iterator_policies)
 
+#if !defined(PYPY_VERSION)
 using tuple_iterator = generic_iterator<iterator_policies::sequence_fast_readonly>;
 using list_iterator = generic_iterator<iterator_policies::sequence_fast_readonly>;
+#else
+using tuple_iterator = generic_iterator<iterator_policies::sequence_slow_readwrite>;
+using list_iterator = generic_iterator<iterator_policies::sequence_slow_readwrite>;
+#endif
+
 using sequence_iterator = generic_iterator<iterator_policies::sequence_slow_readwrite>;
 using dict_iterator = generic_iterator<iterator_policies::dict_readonly>;
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -602,6 +602,12 @@ NAMESPACE_END(detail)
 \endrst */
 class iterator : public object {
 public:
+    using iterator_category = std::input_iterator_tag;
+    using difference_type = ssize_t;
+    using value_type = handle;
+    using reference = const handle;
+    using pointer = const handle *;
+
     PYBIND11_OBJECT_DEFAULT(iterator, object, PyIter_Check)
 
     iterator& operator++() {
@@ -615,7 +621,7 @@ public:
         return rv;
     }
 
-    handle operator*() const {
+    reference operator*() const {
         if (m_ptr && !value.ptr()) {
             auto& self = const_cast<iterator &>(*this);
             self.advance();
@@ -623,7 +629,7 @@ public:
         return value;
     }
 
-    const handle *operator->() const { operator*(); return &value; }
+    pointer operator->() const { operator*(); return &value; }
 
     /** \rst
          The value which marks the end of the iteration. ``it == iterator::sentinel()``

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -290,4 +290,14 @@ test_initializer sequences_and_iterators([](py::module &pm) {
         }
         return l;
     });
+
+    // Make sure that py::iterator works with std algorithms
+    m.def("count_none", [](py::object o) {
+        return std::count_if(o.begin(), o.end(), [](py::handle h) { return h.is_none(); });
+    });
+
+    m.def("find_none", [](py::object o) {
+        auto it = std::find_if(o.begin(), o.end(), [](py::handle h) { return h.is_none(); });
+        return it->is_none();
+    });
 });

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -169,7 +169,8 @@ bool operator==(const NonZeroIterator<std::pair<A, B>>& it, const NonZeroSentine
     return !(*it).first || !(*it).second;
 }
 
-test_initializer sequences_and_iterators([](py::module &m) {
+test_initializer sequences_and_iterators([](py::module &pm) {
+    auto m = pm.def_submodule("sequences_and_iterators");
 
     py::class_<Sequence> seq(m, "Sequence");
 
@@ -272,4 +273,21 @@ test_initializer sequences_and_iterators([](py::module &m) {
     On the actual Sequence object, the iterator would be constructed as follows:
     .def("__iter__", [](py::object s) { return PySequenceIterator(s.cast<const Sequence &>(), s); })
 #endif
+
+    m.def("object_to_list", [](py::object o) {
+        auto l = py::list();
+        for (auto item : o) {
+            l.append(item);
+        }
+        return l;
+    });
+
+    m.def("iterator_to_list", [](py::iterator it) {
+        auto l = py::list();
+        while (it != py::iterator::sentinel()) {
+            l.append(*it);
+            ++it;
+        }
+        return l;
+    });
 });

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -113,3 +113,7 @@ def test_python_iterator_in_cpp():
     with pytest.raises(RuntimeError) as excinfo:
         m.iterator_to_list(iter(bad_next_call, None))
     assert str(excinfo.value) == "py::iterator::advance() should propagate errors"
+
+    l = [1, None, 0, None]
+    assert m.count_none(l) == 2
+    assert m.find_none(l) is True

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -117,3 +117,9 @@ def test_python_iterator_in_cpp():
     l = [1, None, 0, None]
     assert m.count_none(l) == 2
     assert m.find_none(l) is True
+    assert m.count_nonzeros({"a": 0, "b": 1, "c": 2}) == 2
+
+    r = range(5)
+    assert all(m.tuple_iterator(tuple(r)))
+    assert all(m.list_iterator(list(r)))
+    assert all(m.sequence_iterator(r))


### PR DESCRIPTION
This PR fills in some of the missing bits in `py::iterator`:

* `PyObject_GetIter` and `PyIter_Next` errors are now being handled properly.
* Add the required type aliases to `py::iterator` so that it can use used with `<algorithm>`. It models an `InputIterator` (`std::input_iterator_tag`) which is perfectly in line with the restrictions of `py::iterator`: copying doesn't clone the internal state, i.e. no multipass guarantee.

`py::iterator` works for any `py::object`, but the sequence types can get specialized implementations which are simultaneously slimmer and more capable:

* `py::tuple`, `py::list` get a `PySequence_Fast` iterator.
* `py::sequence` gets a slower but more generic sequence iterator.
* These model `RandomAccessIterator` and are STL-compatible.
* The slimmer iterators reduce binary size of the test module by ~0.3% (measured without the new tests).

`py::dict` already had a specialized iterator. This PR just folds it in with the others. It models a `ForwardIterator` (input + multipass).