### PR TITLE
Independent tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,6 @@ matrix:
     env: PYTHON=3.5 CPP=14 CLANG=3.9 INSTALL=1
     script:
       - |
-        # Temporary workaround pending PR #604:
-        export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DHAS_LTO_FLAG=0"
         $SCRIPT_RUN_PREFIX sh -c "set -e
         cmake ${CMAKE_EXTRA_ARGS} -DPYBIND11_INSTALL=1 -DPYBIND11_TEST=0
         make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,21 @@ matrix:
   - sudo: true
     services: docker
     env: ARCH=i386 PYTHON=3.5 CPP=14 GCC=6
+  # This next one does a make install *before* testing, then builds the tests against the installed version:
+  - sudo: true
+    services: docker
+    env: PYTHON=3.5 CPP=14 CLANG=3.9 INSTALL=1
+    script:
+      - |
+        # Temporary workaround pending PR #604:
+        export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DHAS_LTO_FLAG=0"
+        $SCRIPT_RUN_PREFIX sh -c "set -e
+        cmake ${CMAKE_EXTRA_ARGS} -DPYBIND11_INSTALL=1 -DPYBIND11_TEST=0
+        make install
+        cp -a tests /pybind11-tests
+        mkdir /build-tests && cd /build-tests
+        cmake ../pybind11-tests ${CMAKE_EXTRA_ARGS} -DPYBIND11_WERROR=ON
+        make pytest -j 2"
   # A barebones build makes sure everything still works without optional deps (numpy/scipy/eigen)
   # and also tests the automatic discovery functions in CMake (Python version, C++ standard).
   - os: linux
@@ -72,9 +87,15 @@ before_install:
 - |
   # Configure build variables
   if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    if [ -z "$GCC" ]; then export GCC=4.8; fi
-    export CXX=g++-$GCC CC=gcc-$GCC;
-    if [ "$GCC" = "6" ]; then export DOCKER=${ARCH:+$ARCH/}debian:testing
+    if [ -n "$CLANG" ]; then
+      export CXX=clang++-$CLANG CC=clang-$CLANG COMPILER_PACKAGES="clang-$CLANG llvm-$CLANG-dev"
+    else
+      if [ -z "$GCC" ]; then export GCC=4.8
+      else export COMPILER_PACKAGES=g++-$GCC
+      fi
+      export CXX=g++-$GCC CC=gcc-$GCC
+    fi
+    if [ "$GCC" = "6" ] || [ -n "$CLANG" ]; then export DOCKER=${ARCH:+$ARCH/}debian:testing
     elif [ "$GCC" = "7" ]; then export DOCKER=debian:experimental APT_GET_EXTRA="-t experimental"
     fi
   elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
@@ -131,7 +152,7 @@ install:
     docker exec --tty "$containerid" sh -c "for s in 0 15; do sleep \$s; \
       apt-get -qy --no-install-recommends $APT_GET_EXTRA install \
         python$PY-dev python$PY-pytest python$PY-scipy \
-        libeigen3-dev cmake make g++-$GCC && break; done"
+        libeigen3-dev cmake make ${COMPILER_PACKAGES} && break; done"
   else
     pip install numpy scipy pytest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ endif()
 
 option(PYBIND11_INSTALL "Install pybind11 header files?" ${PYBIND11_MASTER_PROJECT})
 option(PYBIND11_TEST    "Build pybind11 test suite?"     ${PYBIND11_MASTER_PROJECT})
-option(PYBIND11_WERROR  "Report all warnings as errors"  OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/tools")
 
@@ -34,23 +33,6 @@ set(PYTHON_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS} CACHE INTERNAL "")
 set(PYTHON_LIBRARIES ${PYTHON_LIBRARIES} CACHE INTERNAL "")
 set(PYTHON_MODULE_PREFIX ${PYTHON_MODULE_PREFIX} CACHE INTERNAL "")
 set(PYTHON_MODULE_EXTENSION ${PYTHON_MODULE_EXTENSION} CACHE INTERNAL "")
-
-# Compile with compiler warnings turned on
-function(pybind11_enable_warnings target_name)
-  if(MSVC)
-    target_compile_options(${target_name} PRIVATE /W4)
-  else()
-    target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wconversion -Wcast-qual)
-  endif()
-
-  if(PYBIND11_WERROR)
-    if(MSVC)
-      target_compile_options(${target_name} PRIVATE /WX)
-    else()
-      target_compile_options(${target_name} PRIVATE -Werror)
-    endif()
-  endif()
-endfunction()
 
 set(PYBIND11_HEADERS
   include/pybind11/attr.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,9 +73,26 @@ string(REPLACE ".cpp" ".py" PYBIND11_PYTEST_FILES "${PYBIND11_TEST_FILES}")
 # skip message).
 list(FIND PYBIND11_TEST_FILES test_eigen.cpp PYBIND11_TEST_FILES_EIGEN_I)
 if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
-  find_package(Eigen3 QUIET)
+  # Try loading via newer Eigen's Eigen3Config first (bypassing tools/FindEigen3.cmake):
+  find_package(Eigen3 QUIET CONFIG)
+  if (EIGEN3_FOUND)
+    # Eigen 3.3.1+ exports a cmake 3.0+ target for handling dependency requirements
+    if (EIGEN3_VERSION_STRING AND NOT EIGEN3_VERSION_STRING VERSION_LESS 3.3.1 AND NOT CMAKE_VERSION VERSION_LESS 3.0)
+      set(PYBIND11_EIGEN_VIA_TARGET 1)
+    endif()
+  else()
+    # Couldn't load via target, so fall back to allowing module mode finding, which will pick up
+    # tools/FindEigen3.cmake
+    find_package(Eigen3 QUIET)
+  endif()
 
   if(EIGEN3_FOUND)
+    # Eigen 3.3.1+ cmake sets EIGEN3_VERSION_STRING (and hard codes the version when installed
+    # rather than looking it up in the cmake script); older versions, and the
+    # tools/FindEigen3.cmake, set EIGEN3_VERSION instead.
+    if(NOT EIGEN3_VERSION AND EIGEN3_VERSION_STRING)
+      set(EIGEN3_VERSION ${EIGEN3_VERSION_STRING})
+    endif()
     message(STATUS "Building tests with Eigen v${EIGEN3_VERSION}")
   else()
     list(REMOVE_AT PYBIND11_TEST_FILES ${PYBIND11_TEST_FILES_EIGEN_I})
@@ -108,7 +125,11 @@ pybind11_add_module(pybind11_tests THIN_LTO pybind11_tests.cpp
 pybind11_enable_warnings(pybind11_tests)
 
 if(EIGEN3_FOUND)
-  target_include_directories(pybind11_tests PRIVATE ${EIGEN3_INCLUDE_DIR})
+  if (PYBIND11_EIGEN_VIA_TARGET)
+    target_link_libraries(pybind11_tests PRIVATE Eigen3::Eigen)
+  else()
+    target_include_directories(pybind11_tests PRIVATE ${EIGEN3_INCLUDE_DIR})
+  endif()
   target_compile_definitions(pybind11_tests PRIVATE -DPYBIND11_TEST_EIGEN)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,22 @@
+# CMakeLists.txt -- Build system for the pybind11 test suite
+#
+# Copyright (c) 2015 Wenzel Jakob <wenzel@inf.ethz.ch>
+#
+# All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+cmake_minimum_required(VERSION 2.8.12)
+
+option(PYBIND11_WERROR  "Report all warnings as errors"  OFF)
+
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # We're being loaded directly, i.e. not via add_subdirectory, so make this
+    # work as its own project and load the pybind11Config to get the tools we need
+    project(pybind11_tests)
+
+    find_package(pybind11 REQUIRED CONFIG)
+endif()
+
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting tests build type to MinSizeRel as none was specified")
   set(CMAKE_BUILD_TYPE MinSizeRel CACHE STRING "Choose the type of build." FORCE)
@@ -64,6 +83,24 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
   endif()
 endif()
 
+# Compile with compiler warnings turned on
+function(pybind11_enable_warnings target_name)
+  if(MSVC)
+    target_compile_options(${target_name} PRIVATE /W4)
+  else()
+      target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wconversion -Wcast-qual)
+  endif()
+
+  if(PYBIND11_WERROR)
+    if(MSVC)
+      target_compile_options(${target_name} PRIVATE /WX)
+    else()
+      target_compile_options(${target_name} PRIVATE -Werror)
+    endif()
+  endif()
+endfunction()
+
+
 # Create the binding library
 pybind11_add_module(pybind11_tests THIN_LTO pybind11_tests.cpp
   ${PYBIND11_TEST_FILES} ${PYBIND11_HEADERS})
@@ -75,7 +112,7 @@ if(EIGEN3_FOUND)
   target_compile_definitions(pybind11_tests PRIVATE -DPYBIND11_TEST_EIGEN)
 endif()
 
-set(testdir ${PROJECT_SOURCE_DIR}/tests)
+set(testdir ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Always write the output file directly into the 'tests' directory (even on MSVC)
 if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
@@ -105,7 +142,16 @@ if(PYBIND11_TEST_OVERRIDE)
     COMMAND ${CMAKE_COMMAND} -E echo "Note: not all tests run: -DPYBIND11_TEST_OVERRIDE is in effect")
 endif()
 
-# And another to show the .so size and, if a previous size, compare it:
+# Add a check target to run all the tests, starting with pytest (we add dependencies to this below)
+add_custom_target(check DEPENDS pytest)
+
+# The remaining tests only apply when being built as part of the pybind11 project, but not if the
+# tests are being built independently.
+if (NOT PROJECT_NAME STREQUAL "pybind11")
+  return()
+endif()
+
+# Add a post-build comment to show the .so size and, if a previous size, compare it:
 add_custom_command(TARGET pybind11_tests POST_BUILD
   COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/libsize.py
   $<TARGET_FILE:pybind11_tests> ${CMAKE_CURRENT_BINARY_DIR}/sosize-$<TARGET_FILE_NAME:pybind11_tests>.txt)
@@ -160,5 +206,4 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.1)
   endif()
 endif()
 
-# Run all the tests
-add_custom_target(check DEPENDS pytest test_cmake_build)
+add_dependencies(check test_cmake_build)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,14 +73,18 @@ string(REPLACE ".cpp" ".py" PYBIND11_PYTEST_FILES "${PYBIND11_TEST_FILES}")
 # skip message).
 list(FIND PYBIND11_TEST_FILES test_eigen.cpp PYBIND11_TEST_FILES_EIGEN_I)
 if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
-  # Try loading via newer Eigen's Eigen3Config first (bypassing tools/FindEigen3.cmake):
-  find_package(Eigen3 QUIET CONFIG)
-  if (EIGEN3_FOUND)
-    # Eigen 3.3.1+ exports a cmake 3.0+ target for handling dependency requirements
-    if (EIGEN3_VERSION_STRING AND NOT EIGEN3_VERSION_STRING VERSION_LESS 3.3.1 AND NOT CMAKE_VERSION VERSION_LESS 3.0)
-      set(PYBIND11_EIGEN_VIA_TARGET 1)
+  # Try loading via newer Eigen's Eigen3Config first (bypassing tools/FindEigen3.cmake).
+  # Eigen 3.3.1+ exports a cmake 3.0+ target for handling dependency requirements, but also
+  # produces a fatal error if loaded from a pre-3.0 cmake.
+  if (NOT CMAKE_VERSION VERSION_LESS 3.0)
+    find_package(Eigen3 QUIET CONFIG)
+    if (EIGEN3_FOUND)
+      if (EIGEN3_VERSION_STRING AND NOT EIGEN3_VERSION_STRING VERSION_LESS 3.3.1)
+        set(PYBIND11_EIGEN_VIA_TARGET 1)
+      endif()
     endif()
-  else()
+  endif()
+  if (NOT EIGEN3_FOUND)
     # Couldn't load via target, so fall back to allowing module mode finding, which will pick up
     # tools/FindEigen3.cmake
     find_package(Eigen3 QUIET)


### PR DESCRIPTION
This modifies tests/CMakeLists.txt so that it can optionally be loaded as an independent cmake project, which then allows building the test suite against an installed pybind11 package, as suggested in #663.  It also updates the Eigen finding code to properly handle newer Eigen's Eigen3Config.cmake (which will be loaded by a system build), and finally adds a new travis-ci build to do an system-install-then-test build.

The new test also uses clang 3.9 (on linux) to build, so that it also provides some additional testing variety.

Expect test failures from the Debian GCC builds: Debian stretch just got an updated GCC 6 with the pybind11-breaking LTO support.