### PR TITLE
Fix readthedocs build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,7 @@ channels:
 - dean0x7d
 - defaults
 dependencies:
+- python==3.5
 - doxygen
 - pip
 - pip:

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -337,9 +337,8 @@ public:
 
     array() : array(0, static_cast<const double *>(nullptr)) {}
 
-    template <typename Shape, typename Strides>
-    array(const pybind11::dtype &dt, const Shape &shape,
-          const Strides &strides, const void *ptr = nullptr,
+    array(const pybind11::dtype &dt, const std::vector<size_t> &shape,
+          const std::vector<size_t> &strides, const void *ptr = nullptr,
           handle base = handle()) {
         auto& api = detail::npy_api::get();
         auto ndim = shape.size();
@@ -537,7 +536,7 @@ protected:
             throw std::runtime_error("array is not writeable");
     }
 
-    template <typename Shape> static std::vector<size_t> default_strides(const Shape& shape, size_t itemsize) {
+    static std::vector<size_t> default_strides(const std::vector<size_t>& shape, size_t itemsize) {
         auto ndim = shape.size();
         std::vector<size_t> strides(ndim);
         if (ndim) {


### PR DESCRIPTION
Fixes #667

The sphinx version is pinned by readthedocs, but sphinx 1.3.5 is not available with conda python 3.6. The workaround is to pin the python version to 3.5 (it doesn't really matter for the docs build).

**Note:** This PR also reverts #582 because it produces compiler errors on all platforms and the CI tests don't pass otherwise. If there is some other plan for that, let me know and I'll remove it from this PR.