### PR TITLE
Don't strip debug symbols in debug mode

### DIFF
--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -173,8 +173,8 @@ function(pybind11_add_module target_name)
 
   _pybind11_add_lto_flags(${target_name} ${ARG_THIN_LTO})
 
-  # Set the default symbol visibility to hidden (very important to obtain small binaries)
-  if (NOT MSVC)
+  if (NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
+    # Set the default symbol visibility to hidden (very important to obtain small binaries)
     target_compile_options(${target_name} PRIVATE "-fvisibility=hidden")
 
     # Strip unnecessary sections of the binary on Linux/Mac OS


### PR DESCRIPTION
Just a quick fix to restore the `not Debug` condition around `strip` which was accidentally removed in #604 amid the bigger changes.