### PR TITLE
Revert noexcept deduction in favour of SFINAE lambda function matching

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -202,17 +202,6 @@ extern "C" {
     }                                                                          \
     PyObject *pybind11_init()
 
-// Function return value and argument type deduction support.  When compiling under C++17 these
-// differ as C++17 makes the noexcept specifier part of the function type, while it is not part of
-// the type under earlier standards.
-#ifdef __cpp_noexcept_function_type
-#  define PYBIND11_NOEXCEPT_TPL_ARG , bool NoExceptions
-#  define PYBIND11_NOEXCEPT_SPECIFIER noexcept(NoExceptions)
-#else
-#  define PYBIND11_NOEXCEPT_TPL_ARG
-#  define PYBIND11_NOEXCEPT_SPECIFIER
-#endif
-
 NAMESPACE_BEGIN(pybind11)
 
 using ssize_t = Py_ssize_t;
@@ -643,16 +632,16 @@ struct nodelete { template <typename T> void operator()(T*) { } };
 NAMESPACE_BEGIN(detail)
 template <typename... Args>
 struct overload_cast_impl {
-    template <typename Return /*,*/ PYBIND11_NOEXCEPT_TPL_ARG>
-    constexpr auto operator()(Return (*pf)(Args...) PYBIND11_NOEXCEPT_SPECIFIER) const noexcept
+    template <typename Return>
+    constexpr auto operator()(Return (*pf)(Args...)) const noexcept
                               -> decltype(pf) { return pf; }
 
-    template <typename Return, typename Class /*,*/ PYBIND11_NOEXCEPT_TPL_ARG>
-    constexpr auto operator()(Return (Class::*pmf)(Args...) PYBIND11_NOEXCEPT_SPECIFIER, std::false_type = {}) const noexcept
+    template <typename Return, typename Class>
+    constexpr auto operator()(Return (Class::*pmf)(Args...), std::false_type = {}) const noexcept
                               -> decltype(pmf) { return pmf; }
 
-    template <typename Return, typename Class /*,*/ PYBIND11_NOEXCEPT_TPL_ARG>
-    constexpr auto operator()(Return (Class::*pmf)(Args...) const PYBIND11_NOEXCEPT_SPECIFIER, std::true_type) const noexcept
+    template <typename Return, typename Class>
+    constexpr auto operator()(Return (Class::*pmf)(Args...) const, std::true_type) const noexcept
                               -> decltype(pmf) { return pmf; }
 };
 NAMESPACE_END(detail)

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -15,11 +15,11 @@
 NAMESPACE_BEGIN(pybind11)
 NAMESPACE_BEGIN(detail)
 
-template <typename Return, typename... Args /*,*/ PYBIND11_NOEXCEPT_TPL_ARG>
-struct type_caster<std::function<Return(Args...) PYBIND11_NOEXCEPT_SPECIFIER>> {
-    using type = std::function<Return(Args...) PYBIND11_NOEXCEPT_SPECIFIER>;
+template <typename Return, typename... Args>
+struct type_caster<std::function<Return(Args...)>> {
+    using type = std::function<Return(Args...)>;
     using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
-    using function_type = Return (*) (Args...) PYBIND11_NOEXCEPT_SPECIFIER;
+    using function_type = Return (*) (Args...);
 
 public:
     bool load(handle src_, bool) {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1140,23 +1140,22 @@ template <typename T, int Flags> struct handle_type_name<array_t<T, Flags>> {
 
 NAMESPACE_END(detail)
 
-template <typename Func, typename Return, typename... Args /*,*/ PYBIND11_NOEXCEPT_TPL_ARG>
+template <typename Func, typename Return, typename... Args>
 detail::vectorize_helper<Func, Return, Args...>
-vectorize(const Func &f, Return (*) (Args ...) PYBIND11_NOEXCEPT_SPECIFIER) {
+vectorize(const Func &f, Return (*) (Args ...)) {
     return detail::vectorize_helper<Func, Return, Args...>(f);
 }
 
-template <typename Return, typename... Args /*,*/ PYBIND11_NOEXCEPT_TPL_ARG>
-detail::vectorize_helper<Return (*) (Args ...) PYBIND11_NOEXCEPT_SPECIFIER, Return, Args...>
-vectorize(Return (*f) (Args ...) PYBIND11_NOEXCEPT_SPECIFIER) {
+template <typename Return, typename... Args>
+detail::vectorize_helper<Return (*) (Args ...), Return, Args...>
+vectorize(Return (*f) (Args ...)) {
     return vectorize<Return (*) (Args ...), Return, Args...>(f, f);
 }
 
-template <typename Func>
+template <typename Func, typename FuncType = typename detail::remove_class<decltype(&std::remove_reference<Func>::type::operator())>::type>
 auto vectorize(Func &&f) -> decltype(
-        vectorize(std::forward<Func>(f), (typename detail::remove_class<decltype(&std::remove_reference<Func>::type::operator())>::type *) nullptr)) {
-    return vectorize(std::forward<Func>(f), (typename detail::remove_class<decltype(
-                   &std::remove_reference<Func>::type::operator())>::type *) nullptr);
+        vectorize(std::forward<Func>(f), (FuncType *) nullptr)) {
+    return vectorize(std::forward<Func>(f), (FuncType *) nullptr);
 }
 
 NAMESPACE_END(pybind11)


### PR DESCRIPTION
`noexcept` deduction, added in PR #555, doesn't work with clang's `-std=c++1z`; and while it works with g++, it isn't entirely clear to me that it is required to work in C++17.

What should work, however, is C++17's umplicit conversion of a `noexcept(true)` function pointer to a `noexcept(false)` one (i.e.  default, `noexcept`-specifier-omitted).  That was breaking in C++17 mode in pybind11 before #555 because the `cpp_function` template used for lambdas provided a better match (i.e. without requiring an implicit conversion), but it then failed when trying to treat the matched function pointer as a lambda object.

This commit takes a different approach of using SFINAE on the lambda function to prevent it from matching a non-lambda object, which then gets implicit conversion from a `noexcept` function pointer to a `noexcept(false)` function pointer.  This much nicer solution also gets rid of the C++17 NOEXCEPT macros, and works in both clang and g++.

With this, pybind11 builds and tests successfully with clang 4.0 and libc++ 4.0 on linux under `-std=c++1z`.