### PR TITLE
Fix multiple inheritance with static properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(PYBIND11_HEADERS
   include/pybind11/attr.h
   include/pybind11/cast.h
   include/pybind11/chrono.h
+  include/pybind11/class_support.h
   include/pybind11/common.h
   include/pybind11/complex.h
   include/pybind11/descr.h

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -437,24 +437,15 @@ The section on :ref:`properties` discussed the creation of instance properties
 that are implemented in terms of C++ getters and setters.
 
 Static properties can also be created in a similar way to expose getters and
-setters of static class attributes. Two things are important to note:
-
-1. Static properties are implemented by instrumenting the *metaclass* of the
-   class in question -- however, this requires the class to have a modifiable
-   metaclass in the first place. pybind11 provides a ``py::metaclass()``
-   annotation that must be specified in the ``class_`` constructor, or any
-   later method calls to ``def_{property_,∅}_{readwrite,readonly}_static`` will
-   fail (see the example below).
-
-2. For static properties defined in terms of setter and getter functions, note
-   that the implicit ``self`` argument also exists in this case and is used to
-   pass the Python ``type`` subclass instance. This parameter will often not be
-   needed by the C++ side, and the following example illustrates how to
-   instantiate a lambda getter function that ignores it:
+setters of static class attributes. Note that the implicit ``self`` argument
+also exists in this case and is used to pass the Python ``type`` subclass
+instance. This parameter will often not be needed by the C++ side, and the
+following example illustrates how to instantiate a lambda getter function
+that ignores it:
 
 .. code-block:: cpp
 
-    py::class_<Foo>(m, "Foo", py::metaclass())
+    py::class_<Foo>(m, "Foo")
         .def_property_readonly_static("foo", [](py::object /* self */) { return Foo(); });
 
 Operator overloading

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -18,6 +18,8 @@
 
 NAMESPACE_BEGIN(pybind11)
 NAMESPACE_BEGIN(detail)
+inline PyTypeObject *make_static_property_type();
+inline PyTypeObject *make_default_metaclass();
 
 /// Additional type information which does not fit into the PyTypeObject
 struct type_info {
@@ -73,6 +75,8 @@ PYBIND11_NOINLINE inline internals &get_internals() {
                 }
             }
         );
+        internals_ptr->static_property_type = make_static_property_type();
+        internals_ptr->default_metaclass = make_default_metaclass();
     }
     return *internals_ptr;
 }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -26,6 +26,7 @@ struct type_info {
     PyTypeObject *type;
     size_t type_size;
     void (*init_holder)(PyObject *, const void *);
+    void (*dealloc)(PyObject *);
     std::vector<PyObject *(*)(PyObject *, PyTypeObject *)> implicit_conversions;
     std::vector<std::pair<const std::type_info *, void *(*)(void *)>> implicit_casts;
     std::vector<bool (*)(PyObject *, void *&)> *direct_conversions;

--- a/include/pybind11/class_support.h
+++ b/include/pybind11/class_support.h
@@ -1,0 +1,147 @@
+/*
+    pybind11/class_support.h: Python C API implementation details for py::class_
+
+    Copyright (c) 2017 Wenzel Jakob <wenzel.jakob@epfl.ch>
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include "attr.h"
+
+NAMESPACE_BEGIN(pybind11)
+NAMESPACE_BEGIN(detail)
+
+#if !defined(PYPY_VERSION)
+
+/// `pybind11_static_property.__get__()`: Always pass the class instead of the instance.
+extern "C" inline PyObject *pybind11_static_get(PyObject *self, PyObject * /*ob*/, PyObject *cls) {
+    return PyProperty_Type.tp_descr_get(self, cls, cls);
+}
+
+/// `pybind11_static_property.__set__()`: Just like the above `__get__()`.
+extern "C" inline int pybind11_static_set(PyObject *self, PyObject *obj, PyObject *value) {
+    PyObject *cls = PyType_Check(obj) ? obj : (PyObject *) Py_TYPE(obj);
+    return PyProperty_Type.tp_descr_set(self, cls, value);
+}
+
+/** A `static_property` is the same as a `property` but the `__get__()` and `__set__()`
+    methods are modified to always use the object type instead of a concrete instance.
+    Return value: New reference. */
+inline PyTypeObject *make_static_property_type() {
+    constexpr auto *name = "pybind11_static_property";
+    auto name_obj = reinterpret_steal<object>(PYBIND11_FROM_STRING(name));
+
+    /* Danger zone: from now (and until PyType_Ready), make sure to
+       issue no Python C API calls which could potentially invoke the
+       garbage collector (the GC will call type_traverse(), which will in
+       turn find the newly constructed type in an invalid state) */
+    auto heap_type = (PyHeapTypeObject *) PyType_Type.tp_alloc(&PyType_Type, 0);
+    if (!heap_type)
+        pybind11_fail("make_static_property_type(): error allocating type!");
+
+    heap_type->ht_name = name_obj.inc_ref().ptr();
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
+    heap_type->ht_qualname = name_obj.inc_ref().ptr();
+#endif
+
+    auto type = &heap_type->ht_type;
+    type->tp_name = name;
+    type->tp_base = &PyProperty_Type;
+    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
+    type->tp_descr_get = pybind11_static_get;
+    type->tp_descr_set = pybind11_static_set;
+
+    if (PyType_Ready(type) < 0)
+        pybind11_fail("make_static_property_type(): failure in PyType_Ready()!");
+
+    return type;
+}
+
+#else // PYPY
+
+/** PyPy has some issues with the above C API, so we evaluate Python code instead.
+    This function will only be called once so performance isn't really a concern.
+    Return value: New reference. */
+inline PyTypeObject *make_static_property_type() {
+    auto d = dict();
+    PyObject *result = PyRun_String(R"(\
+        class pybind11_static_property(property):
+            def __get__(self, obj, cls):
+                return property.__get__(self, cls, cls)
+
+            def __set__(self, obj, value):
+                cls = obj if isinstance(obj, type) else type(obj)
+                property.__set__(self, cls, value)
+        )", Py_file_input, d.ptr(), d.ptr()
+    );
+    if (result == nullptr)
+        throw error_already_set();
+    Py_DECREF(result);
+    return (PyTypeObject *) d["pybind11_static_property"].cast<object>().release().ptr();
+}
+
+#endif // PYPY
+
+/** Types with static properties need to handle `Type.static_prop = x` in a specific way.
+    By default, Python replaces the `static_property` itself, but for wrapped C++ types
+    we need to call `static_property.__set__()` in order to propagate the new value to
+    the underlying C++ data structure. */
+extern "C" inline int pybind11_meta_setattro(PyObject* obj, PyObject* name, PyObject* value) {
+    // Use `_PyType_Lookup()` instead of `PyObject_GetAttr()` in order to get the raw
+    // descriptor (`property`) instead of calling `tp_descr_get` (`property.__get__()`).
+    PyObject *descr = _PyType_Lookup((PyTypeObject *) obj, name);
+
+    // Call `static_property.__set__()` instead of replacing the `static_property`.
+    if (descr && PyObject_IsInstance(descr, (PyObject *) get_internals().static_property_type)) {
+#if !defined(PYPY_VERSION)
+        return Py_TYPE(descr)->tp_descr_set(descr, obj, value);
+#else
+        if (PyObject *result = PyObject_CallMethod(descr, "__set__", "OO", obj, value)) {
+            Py_DECREF(result);
+            return 0;
+        } else {
+            return -1;
+        }
+#endif
+    } else {
+        return PyType_Type.tp_setattro(obj, name, value);
+    }
+}
+
+/** This metaclass is assigned by default to all pybind11 types and is required in order
+    for static properties to function correctly. Users may override this using `py::metaclass`.
+    Return value: New reference. */
+inline PyTypeObject* make_default_metaclass() {
+    constexpr auto *name = "pybind11_type";
+    auto name_obj = reinterpret_steal<object>(PYBIND11_FROM_STRING(name));
+
+    /* Danger zone: from now (and until PyType_Ready), make sure to
+       issue no Python C API calls which could potentially invoke the
+       garbage collector (the GC will call type_traverse(), which will in
+       turn find the newly constructed type in an invalid state) */
+    auto heap_type = (PyHeapTypeObject *) PyType_Type.tp_alloc(&PyType_Type, 0);
+    if (!heap_type)
+        pybind11_fail("make_default_metaclass(): error allocating metaclass!");
+
+    heap_type->ht_name = name_obj.inc_ref().ptr();
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
+    heap_type->ht_qualname = name_obj.inc_ref().ptr();
+#endif
+
+    auto type = &heap_type->ht_type;
+    type->tp_name = name;
+    type->tp_base = &PyType_Type;
+    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
+    type->tp_setattro = pybind11_meta_setattro;
+
+    if (PyType_Ready(type) < 0)
+        pybind11_fail("make_default_metaclass(): failure in PyType_Ready()!");
+
+    return type;
+}
+
+NAMESPACE_END(detail)
+NAMESPACE_END(pybind11)

--- a/include/pybind11/class_support.h
+++ b/include/pybind11/class_support.h
@@ -85,6 +85,34 @@ inline PyTypeObject *make_static_property_type() {
 
 #endif // PYPY
 
+/** Inheriting from multiple C++ types in Python is not supported -- set an error instead.
+    A Python definition (`class C(A, B): pass`) will call `tp_new` so we check for multiple
+    C++ bases here. On the other hand, C++ type definitions (`py::class_<C, A, B>(m, "C")`)
+    don't not use `tp_new` and will not trigger this error. */
+extern "C" inline PyObject *pybind11_meta_new(PyTypeObject *metaclass, PyObject *args,
+                                              PyObject *kwargs) {
+    PyObject *bases = PyTuple_GetItem(args, 1); // arguments: (name, bases, dict)
+    if (!bases)
+        return nullptr;
+
+    auto &internals = get_internals();
+    auto num_cpp_bases = 0;
+    for (auto base : reinterpret_borrow<tuple>(bases)) {
+        auto base_type = (PyTypeObject *) base.ptr();
+        auto instance_size = static_cast<size_t>(base_type->tp_basicsize);
+        if (PyObject_IsSubclass(base.ptr(), internals.get_base(instance_size)))
+            ++num_cpp_bases;
+    }
+
+    if (num_cpp_bases > 1) {
+        PyErr_SetString(PyExc_TypeError, "Can't inherit from multiple C++ classes in Python."
+                                         "Use py::class_ to define the class in C++ instead.");
+        return nullptr;
+    } else {
+        return PyType_Type.tp_new(metaclass, args, kwargs);
+    }
+}
+
 /** Types with static properties need to handle `Type.static_prop = x` in a specific way.
     By default, Python replaces the `static_property` itself, but for wrapped C++ types
     we need to call `static_property.__set__()` in order to propagate the new value to
@@ -135,12 +163,337 @@ inline PyTypeObject* make_default_metaclass() {
     type->tp_name = name;
     type->tp_base = &PyType_Type;
     type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
+
+    type->tp_new = pybind11_meta_new;
     type->tp_setattro = pybind11_meta_setattro;
 
     if (PyType_Ready(type) < 0)
         pybind11_fail("make_default_metaclass(): failure in PyType_Ready()!");
 
     return type;
+}
+
+/// Instance creation function for all pybind11 types. It only allocates space for the
+/// C++ object, but doesn't call the constructor -- an `__init__` function must do that.
+extern "C" inline PyObject *pybind11_object_new(PyTypeObject *type, PyObject *, PyObject *) {
+    PyObject *self = type->tp_alloc(type, 0);
+    auto instance = (instance_essentials<void> *) self;
+    auto tinfo = get_type_info(type);
+    instance->value = ::operator new(tinfo->type_size);
+    instance->owned = true;
+    instance->holder_constructed = false;
+    get_internals().registered_instances.emplace(instance->value, self);
+    return self;
+}
+
+/// An `__init__` function constructs the C++ object. Users should provide at least one
+/// of these using `py::init` or directly with `.def(__init__, ...)`. Otherwise, the
+/// following default function will be used which simply throws an exception.
+extern "C" inline int pybind11_object_init(PyObject *self, PyObject *, PyObject *) {
+    PyTypeObject *type = Py_TYPE(self);
+    std::string msg;
+#if defined(PYPY_VERSION)
+    msg += handle((PyObject *) type).attr("__module__").cast<std::string>() + ".";
+#endif
+    msg += type->tp_name;
+    msg += ": No constructor defined!";
+    PyErr_SetString(PyExc_TypeError, msg.c_str());
+    return -1;
+}
+
+/// Instance destructor function for all pybind11 types. It calls `type_info.dealloc`
+/// to destroy the C++ object itself, while the rest is Python bookkeeping.
+extern "C" inline void pybind11_object_dealloc(PyObject *self) {
+    auto instance = (instance_essentials<void> *) self;
+    if (instance->value) {
+        auto type = Py_TYPE(self);
+        get_type_info(type)->dealloc(self);
+
+        auto &registered_instances = get_internals().registered_instances;
+        auto range = registered_instances.equal_range(instance->value);
+        bool found = false;
+        for (auto it = range.first; it != range.second; ++it) {
+            if (type == Py_TYPE(it->second)) {
+                registered_instances.erase(it);
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            pybind11_fail("pybind11_object_dealloc(): Tried to deallocate unregistered instance!");
+
+        if (instance->weakrefs)
+            PyObject_ClearWeakRefs(self);
+
+        PyObject **dict_ptr = _PyObject_GetDictPtr(self);
+        if (dict_ptr)
+            Py_CLEAR(*dict_ptr);
+    }
+    Py_TYPE(self)->tp_free(self);
+}
+
+/** Create a type which can be used as a common base for all classes with the same
+    instance size, i.e. all classes with the same `sizeof(holder_type)`. This is
+    needed in order to satisfy Python's requirements for multiple inheritance.
+    Return value: New reference. */
+inline PyObject *make_object_base_type(size_t instance_size) {
+    auto name = "pybind11_object_" + std::to_string(instance_size);
+    auto name_obj = reinterpret_steal<object>(PYBIND11_FROM_STRING(name.c_str()));
+
+    /* Danger zone: from now (and until PyType_Ready), make sure to
+       issue no Python C API calls which could potentially invoke the
+       garbage collector (the GC will call type_traverse(), which will in
+       turn find the newly constructed type in an invalid state) */
+    auto heap_type = (PyHeapTypeObject *) PyType_Type.tp_alloc(&PyType_Type, 0);
+    if (!heap_type)
+        pybind11_fail("make_object_base_type(): error allocating type!");
+
+    heap_type->ht_name = name_obj.inc_ref().ptr();
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
+    heap_type->ht_qualname = name_obj.inc_ref().ptr();
+#endif
+
+    auto type = &heap_type->ht_type;
+    type->tp_name = strdup(name.c_str());
+    type->tp_base = &PyBaseObject_Type;
+    type->tp_basicsize = static_cast<ssize_t>(instance_size);
+    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
+
+    type->tp_new = pybind11_object_new;
+    type->tp_init = pybind11_object_init;
+    type->tp_dealloc = pybind11_object_dealloc;
+
+    /* Support weak references (needed for the keep_alive feature) */
+    type->tp_weaklistoffset = offsetof(instance_essentials<void>, weakrefs);
+
+    if (PyType_Ready(type) < 0)
+        pybind11_fail("PyType_Ready failed in make_object_base_type():" + error_string());
+
+    assert(!PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC));
+    return (PyObject *) heap_type;
+}
+
+/** Return the appropriate base type for the given instance size. The results are cached
+    in `internals.bases` so that only a single base is ever created for any size value.
+    Return value: Borrowed reference. */
+inline PyObject *internals::get_base(size_t instance_size) {
+    auto it = bases.find(instance_size);
+    if (it != bases.end()) {
+        return it->second;
+    } else {
+        auto base = make_object_base_type(instance_size);
+        bases[instance_size] = base;
+        return base;
+    }
+}
+
+/// dynamic_attr: Support for `d = instance.__dict__`.
+extern "C" inline PyObject *pybind11_get_dict(PyObject *self, void *) {
+    PyObject *&dict = *_PyObject_GetDictPtr(self);
+    if (!dict)
+        dict = PyDict_New();
+    Py_XINCREF(dict);
+    return dict;
+}
+
+/// dynamic_attr: Support for `instance.__dict__ = dict()`.
+extern "C" inline int pybind11_set_dict(PyObject *self, PyObject *new_dict, void *) {
+    if (!PyDict_Check(new_dict)) {
+        PyErr_Format(PyExc_TypeError, "__dict__ must be set to a dictionary, not a '%.200s'",
+                     Py_TYPE(new_dict)->tp_name);
+        return -1;
+    }
+    PyObject *&dict = *_PyObject_GetDictPtr(self);
+    Py_INCREF(new_dict);
+    Py_CLEAR(dict);
+    dict = new_dict;
+    return 0;
+}
+
+/// dynamic_attr: Allow the garbage collector to traverse the internal instance `__dict__`.
+extern "C" inline int pybind11_traverse(PyObject *self, visitproc visit, void *arg) {
+    PyObject *&dict = *_PyObject_GetDictPtr(self);
+    Py_VISIT(dict);
+    return 0;
+}
+
+/// dynamic_attr: Allow the GC to clear the dictionary.
+extern "C" inline int pybind11_clear(PyObject *self) {
+    PyObject *&dict = *_PyObject_GetDictPtr(self);
+    Py_CLEAR(dict);
+    return 0;
+}
+
+/// Give instances of this type a `__dict__` and opt into garbage collection.
+inline void enable_dynamic_attributes(PyHeapTypeObject *heap_type) {
+    auto type = &heap_type->ht_type;
+#if defined(PYPY_VERSION)
+    pybind11_fail(std::string(type->tp_name) + ": dynamic attributes are "
+                                               "currently not supported in "
+                                               "conjunction with PyPy!");
+#endif
+    type->tp_flags |= Py_TPFLAGS_HAVE_GC;
+    type->tp_dictoffset = type->tp_basicsize; // place dict at the end
+    type->tp_basicsize += sizeof(PyObject *); // and allocate enough space for it
+    type->tp_traverse = pybind11_traverse;
+    type->tp_clear = pybind11_clear;
+
+    static PyGetSetDef getset[] = {
+        {const_cast<char*>("__dict__"), pybind11_get_dict, pybind11_set_dict, nullptr, nullptr},
+        {nullptr, nullptr, nullptr, nullptr, nullptr}
+    };
+    type->tp_getset = getset;
+}
+
+/// buffer_protocol: Fill in the view as specified by flags.
+extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int flags) {
+    auto tinfo = get_type_info(Py_TYPE(obj));
+    if (view == nullptr || obj == nullptr || !tinfo || !tinfo->get_buffer) {
+        if (view)
+            view->obj = nullptr;
+        PyErr_SetString(PyExc_BufferError, "generic_type::getbuffer(): Internal error");
+        return -1;
+    }
+    memset(view, 0, sizeof(Py_buffer));
+    buffer_info *info = tinfo->get_buffer(obj, tinfo->get_buffer_data);
+    view->obj = obj;
+    view->ndim = 1;
+    view->internal = info;
+    view->buf = info->ptr;
+    view->itemsize = (ssize_t) info->itemsize;
+    view->len = view->itemsize;
+    for (auto s : info->shape)
+        view->len *= s;
+    if ((flags & PyBUF_FORMAT) == PyBUF_FORMAT)
+        view->format = const_cast<char *>(info->format.c_str());
+    if ((flags & PyBUF_STRIDES) == PyBUF_STRIDES) {
+        view->ndim = (int) info->ndim;
+        view->strides = (ssize_t *) &info->strides[0];
+        view->shape = (ssize_t *) &info->shape[0];
+    }
+    Py_INCREF(view->obj);
+    return 0;
+}
+
+/// buffer_protocol: Release the resources of the buffer.
+extern "C" inline void pybind11_releasebuffer(PyObject *, Py_buffer *view) {
+    delete (buffer_info *) view->internal;
+}
+
+/// Give this type a buffer interface.
+inline void enable_buffer_protocol(PyHeapTypeObject *heap_type) {
+    heap_type->ht_type.tp_as_buffer = &heap_type->as_buffer;
+#if PY_MAJOR_VERSION < 3
+    heap_type->ht_type.tp_flags |= Py_TPFLAGS_HAVE_NEWBUFFER;
+#endif
+
+    heap_type->as_buffer.bf_getbuffer = pybind11_getbuffer;
+    heap_type->as_buffer.bf_releasebuffer = pybind11_releasebuffer;
+}
+
+/** Create a brand new Python type according to the `type_record` specification.
+    Return value: New reference. */
+inline PyObject* make_new_python_type(const type_record &rec) {
+    auto name = reinterpret_steal<object>(PYBIND11_FROM_STRING(rec.name));
+
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
+    auto ht_qualname = name;
+    if (rec.scope && hasattr(rec.scope, "__qualname__")) {
+        ht_qualname = reinterpret_steal<object>(
+            PyUnicode_FromFormat("%U.%U", rec.scope.attr("__qualname__").ptr(), name.ptr()));
+    }
+#endif
+
+    object module;
+    if (rec.scope) {
+        if (hasattr(rec.scope, "__module__"))
+            module = rec.scope.attr("__module__");
+        else if (hasattr(rec.scope, "__name__"))
+            module = rec.scope.attr("__name__");
+    }
+
+#if !defined(PYPY_VERSION)
+    const auto full_name = module ? str(module).cast<std::string>() + "." + rec.name
+                                  : std::string(rec.name);
+#else
+    const auto full_name = std::string(rec.name);
+#endif
+
+    char *tp_doc = nullptr;
+    if (rec.doc && options::show_user_defined_docstrings()) {
+        /* Allocate memory for docstring (using PyObject_MALLOC, since
+           Python will free this later on) */
+        size_t size = strlen(rec.doc) + 1;
+        tp_doc = (char *) PyObject_MALLOC(size);
+        memcpy((void *) tp_doc, rec.doc, size);
+    }
+
+    auto &internals = get_internals();
+    auto bases = tuple(rec.bases);
+    auto base = (bases.size() == 0) ? internals.get_base(rec.instance_size)
+                                    : bases[0].ptr();
+
+    /* Danger zone: from now (and until PyType_Ready), make sure to
+       issue no Python C API calls which could potentially invoke the
+       garbage collector (the GC will call type_traverse(), which will in
+       turn find the newly constructed type in an invalid state) */
+    auto heap_type = (PyHeapTypeObject *) PyType_Type.tp_alloc(&PyType_Type, 0);
+    if (!heap_type)
+        pybind11_fail(std::string(rec.name) + ": Unable to create type object!");
+
+    heap_type->ht_name = name.release().ptr();
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
+    heap_type->ht_qualname = ht_qualname.release().ptr();
+#endif
+
+    auto type = &heap_type->ht_type;
+    type->tp_name = strdup(full_name.c_str());
+    type->tp_doc = tp_doc;
+    type->tp_base = (PyTypeObject *) handle(base).inc_ref().ptr();
+    type->tp_basicsize = static_cast<ssize_t>(rec.instance_size);
+    if (bases.size() > 0)
+        type->tp_bases = bases.release().ptr();
+
+    /* Don't inherit base __init__ */
+    type->tp_init = pybind11_object_init;
+
+    /* Custom metaclass if requested (used for static properties) */
+    if (rec.metaclass) {
+        Py_INCREF(internals.default_metaclass);
+        Py_TYPE(type) = (PyTypeObject *) internals.default_metaclass;
+    }
+
+    /* Supported protocols */
+    type->tp_as_number = &heap_type->as_number;
+    type->tp_as_sequence = &heap_type->as_sequence;
+    type->tp_as_mapping = &heap_type->as_mapping;
+
+    /* Flags */
+    type->tp_flags |= Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
+#if PY_MAJOR_VERSION < 3
+    type->tp_flags |= Py_TPFLAGS_CHECKTYPES;
+#endif
+
+    if (rec.dynamic_attr)
+        enable_dynamic_attributes(heap_type);
+
+    if (rec.buffer_protocol)
+        enable_buffer_protocol(heap_type);
+
+    if (PyType_Ready(type) < 0)
+        pybind11_fail(std::string(rec.name) + ": PyType_Ready failed (" + error_string() + ")!");
+
+    assert(rec.dynamic_attr ? PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC)
+                            : !PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC));
+
+    /* Register type with the parent scope */
+    if (rec.scope)
+        setattr(rec.scope, rec.name, (PyObject *) type);
+
+    if (module) // Needed by pydoc
+        setattr((PyObject *) type, "__module__", module);
+
+    return (PyObject *) type;
 }
 
 NAMESPACE_END(detail)

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -352,7 +352,7 @@ struct overload_hash {
     }
 };
 
-/// Internal data struture used to track registered instances and types
+/// Internal data structure used to track registered instances and types
 struct internals {
     std::unordered_map<std::type_index, void*> registered_types_cpp;   // std::type_index -> type_info
     std::unordered_map<const void *, void*> registered_types_py;       // PyTypeObject* -> type_info
@@ -361,6 +361,8 @@ struct internals {
     std::unordered_map<std::type_index, std::vector<bool (*)(PyObject *, void *&)>> direct_conversions;
     std::forward_list<void (*) (std::exception_ptr)> registered_exception_translators;
     std::unordered_map<std::string, void *> shared_data; // Custom data to be shared across extensions
+    PyTypeObject *static_property_type;
+    PyTypeObject *default_metaclass;
 #if defined(WITH_THREAD)
     decltype(PyThread_create_key()) tstate = 0; // Usually an int but a long on Cygwin64 with Python 3.x
     PyInterpreterState *istate = nullptr;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -829,18 +829,6 @@ protected:
         const auto is_static = !(rec_fget->is_method && rec_fget->scope);
         const auto has_doc = rec_fget->doc && pybind11::options::show_user_defined_docstrings();
 
-        if (is_static) {
-            auto mclass = handle((PyObject *) Py_TYPE(m_ptr));
-
-            if ((PyTypeObject *) mclass.ptr() == &PyType_Type)
-                pybind11_fail(
-                    "Adding static properties to the type '" +
-                    std::string(((PyTypeObject *) m_ptr)->tp_name) +
-                    "' requires the type to have a custom metaclass. Please "
-                    "ensure that one is created by supplying the pybind11::metaclass() "
-                    "annotation to the associated class_<>(..) invocation.");
-        }
-
         auto property = handle((PyObject *) (is_static ? get_internals().static_property_type
                                                        : &PyProperty_Type));
         attr(name) = property(fget.ptr() ? fget : none(),

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ else:
         'include/pybind11/attr.h',
         'include/pybind11/cast.h',
         'include/pybind11/chrono.h',
+        'include/pybind11/class_support.h',
         'include/pybind11/common.h',
         'include/pybind11/complex.h',
         'include/pybind11/descr.h',

--- a/tests/test_inheritance.cpp
+++ b/tests/test_inheritance.cpp
@@ -36,6 +36,10 @@ public:
     Hamster(const std::string &name) : Pet(name, "rodent") {}
 };
 
+class Chimera : public Pet {
+    Chimera() : Pet("Kimmy", "chimera") {}
+};
+
 std::string pet_name_species(const Pet &pet) {
     return pet.name() + " is a " + pet.species();
 }
@@ -73,6 +77,8 @@ test_initializer inheritance([](py::module &m) {
     /* And another: list parent in class template arguments */
     py::class_<Hamster, Pet>(m, "Hamster")
         .def(py::init<std::string>());
+
+    py::class_<Chimera, Pet>(m, "Chimera");
 
     m.def("pet_name_species", pet_name_species);
     m.def("dog_bark", dog_bark);

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -2,7 +2,7 @@ import pytest
 
 
 def test_inheritance(msg):
-    from pybind11_tests import Pet, Dog, Rabbit, Hamster, dog_bark, pet_name_species
+    from pybind11_tests import Pet, Dog, Rabbit, Hamster, Chimera, dog_bark, pet_name_species
 
     roger = Rabbit('Rabbit')
     assert roger.name() + " is a " + roger.species() == "Rabbit is a parrot"
@@ -29,6 +29,10 @@ def test_inheritance(msg):
 
         Invoked with: <m.Pet object at 0>
     """
+
+    with pytest.raises(TypeError) as excinfo:
+        Chimera("lion", "goat")
+    assert "No constructor defined!" in str(excinfo.value)
 
 
 def test_automatic_upcasting():

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -214,7 +214,10 @@ test_initializer methods_and_attributes([](py::module &m) {
                                       [](py::object) { return TestProperties::static_get(); })
         .def_property_static("def_property_static",
                              [](py::object) { return TestProperties::static_get(); },
-                             [](py::object, int v) { return TestProperties::static_set(v); });
+                             [](py::object, int v) { TestProperties::static_set(v); })
+        .def_property_static("static_cls",
+                             [](py::object cls) { return cls; },
+                             [](py::object cls, py::function f) { f(cls); });
 
     py::class_<SimpleValue>(m, "SimpleValue")
         .def_readwrite("value", &SimpleValue::value);

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -202,7 +202,7 @@ test_initializer methods_and_attributes([](py::module &m) {
         .def("__str__", &ExampleMandA::toString)
         .def_readwrite("value", &ExampleMandA::value);
 
-    py::class_<TestProperties>(m, "TestProperties", py::metaclass())
+    py::class_<TestProperties>(m, "TestProperties")
         .def(py::init<>())
         .def_readonly("def_readonly", &TestProperties::value)
         .def_readwrite("def_readwrite", &TestProperties::value)
@@ -228,7 +228,7 @@ test_initializer methods_and_attributes([](py::module &m) {
     auto static_set2 = [](py::object, int v) { TestPropRVP::sv2.value = v; };
     auto rvp_copy = py::return_value_policy::copy;
 
-    py::class_<TestPropRVP>(m, "TestPropRVP", py::metaclass())
+    py::class_<TestPropRVP>(m, "TestPropRVP")
         .def(py::init<>())
         .def_property_readonly("ro_ref", &TestPropRVP::get1)
         .def_property_readonly("ro_copy", &TestPropRVP::get2, rvp_copy)
@@ -244,6 +244,10 @@ test_initializer methods_and_attributes([](py::module &m) {
         .def_property_static("static_rw_func", py::cpp_function(static_get2, rvp_copy), static_set2)
         .def_property_readonly("rvalue", &TestPropRVP::get_rvalue)
         .def_property_readonly_static("static_rvalue", [](py::object) { return SimpleValue(); });
+
+    struct MetaclassOverride { };
+    py::class_<MetaclassOverride>(m, "MetaclassOverride", py::metaclass((PyObject *) &PyType_Type))
+        .def_property_readonly_static("readonly", [](py::object) { return 1; });
 
 #if !defined(PYPY_VERSION)
     py::class_<DynamicClass>(m, "DynamicClass", py::dynamic_attr())

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -126,6 +126,22 @@ def test_static_cls():
     instance.static_cls = check_self
 
 
+def test_metaclass_override():
+    """Overriding pybind11's default metaclass changes the behavior of `static_property`"""
+    from pybind11_tests import MetaclassOverride
+
+    assert type(ExampleMandA).__name__ == "pybind11_type"
+    assert type(MetaclassOverride).__name__ == "type"
+
+    assert MetaclassOverride.readonly == 1
+    assert type(MetaclassOverride.__dict__["readonly"]).__name__ == "pybind11_static_property"
+
+    # Regular `type` replaces the property instead of calling `__set__()`
+    MetaclassOverride.readonly = 2
+    assert MetaclassOverride.readonly == 2
+    assert isinstance(MetaclassOverride.__dict__["readonly"], int)
+
+
 @pytest.mark.parametrize("access", ["ro", "rw", "static_ro", "static_rw"])
 def test_property_return_value_policies(access):
     from pybind11_tests import TestPropRVP

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -84,18 +84,46 @@ def test_static_properties():
     from pybind11_tests import TestProperties as Type
 
     assert Type.def_readonly_static == 1
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError) as excinfo:
         Type.def_readonly_static = 2
+    assert "can't set attribute" in str(excinfo)
 
     Type.def_readwrite_static = 2
     assert Type.def_readwrite_static == 2
 
     assert Type.def_property_readonly_static == 2
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError) as excinfo:
         Type.def_property_readonly_static = 3
+    assert "can't set attribute" in str(excinfo)
 
     Type.def_property_static = 3
     assert Type.def_property_static == 3
+
+    # Static property read and write via instance
+    instance = Type()
+
+    Type.def_readwrite_static = 0
+    assert Type.def_readwrite_static == 0
+    assert instance.def_readwrite_static == 0
+
+    instance.def_readwrite_static = 2
+    assert Type.def_readwrite_static == 2
+    assert instance.def_readwrite_static == 2
+
+
+def test_static_cls():
+    """Static property getter and setters expect the type object as the their only argument"""
+    from pybind11_tests import TestProperties as Type
+
+    instance = Type()
+    assert Type.static_cls is Type
+    assert instance.static_cls is Type
+
+    def check_self(self):
+        assert self is Type
+
+    Type.static_cls = check_self
+    instance.static_cls = check_self
 
 
 @pytest.mark.parametrize("access", ["ro", "rw", "static_ro", "static_rw"])

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -81,3 +81,73 @@ test_initializer multiple_inheritance_nonexplicit([](py::module &m) {
     m.def("bar_base2a", [](Base2a *b) { return b->bar(); });
     m.def("bar_base2a_sharedptr", [](std::shared_ptr<Base2a> b) { return b->bar(); });
 });
+
+struct Vanilla {
+    std::string vanilla() { return "Vanilla"; };
+};
+
+struct WithStatic1 {
+    static std::string static_func1() { return "WithStatic1"; };
+    static int static_value1;
+};
+
+struct WithStatic2 {
+    static std::string static_func2() { return "WithStatic2"; };
+    static int static_value2;
+};
+
+struct WithDict { };
+
+struct VanillaStaticMix1 : Vanilla, WithStatic1, WithStatic2 {
+    static std::string static_func() { return "VanillaStaticMix1"; }
+    static int static_value;
+};
+
+struct VanillaStaticMix2 : WithStatic1, Vanilla, WithStatic2 {
+    static std::string static_func() { return "VanillaStaticMix2"; }
+    static int static_value;
+};
+
+struct VanillaDictMix1 : Vanilla, WithDict { };
+struct VanillaDictMix2 : WithDict, Vanilla { };
+
+int WithStatic1::static_value1 = 1;
+int WithStatic2::static_value2 = 2;
+int VanillaStaticMix1::static_value = 12;
+int VanillaStaticMix2::static_value = 12;
+
+test_initializer mi_static_properties([](py::module &pm) {
+    auto m = pm.def_submodule("mi");
+
+    py::class_<Vanilla>(m, "Vanilla")
+        .def(py::init<>())
+        .def("vanilla", &Vanilla::vanilla);
+
+    py::class_<WithStatic1>(m, "WithStatic1", py::metaclass())
+        .def(py::init<>())
+        .def_static("static_func1", &WithStatic1::static_func1)
+        .def_readwrite_static("static_value1", &WithStatic1::static_value1);
+
+    py::class_<WithStatic2>(m, "WithStatic2", py::metaclass())
+        .def(py::init<>())
+        .def_static("static_func2", &WithStatic2::static_func2)
+        .def_readwrite_static("static_value2", &WithStatic2::static_value2);
+
+    py::class_<VanillaStaticMix1, Vanilla, WithStatic1, WithStatic2>(
+        m, "VanillaStaticMix1", py::metaclass())
+        .def(py::init<>())
+        .def_static("static_func", &VanillaStaticMix1::static_func)
+        .def_readwrite_static("static_value", &VanillaStaticMix1::static_value);
+
+    py::class_<VanillaStaticMix2, WithStatic1, Vanilla, WithStatic2>(
+        m, "VanillaStaticMix2", py::metaclass())
+        .def(py::init<>())
+        .def_static("static_func", &VanillaStaticMix2::static_func)
+        .def_readwrite_static("static_value", &VanillaStaticMix2::static_value);
+
+#if !defined(PYPY_VERSION)
+    py::class_<WithDict>(m, "WithDict", py::dynamic_attr()).def(py::init<>());
+    py::class_<VanillaDictMix1, Vanilla, WithDict>(m, "VanillaDictMix1").def(py::init<>());
+    py::class_<VanillaDictMix2, WithDict, Vanilla>(m, "VanillaDictMix2").def(py::init<>());
+#endif
+});

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -123,24 +123,24 @@ test_initializer mi_static_properties([](py::module &pm) {
         .def(py::init<>())
         .def("vanilla", &Vanilla::vanilla);
 
-    py::class_<WithStatic1>(m, "WithStatic1", py::metaclass())
+    py::class_<WithStatic1>(m, "WithStatic1")
         .def(py::init<>())
         .def_static("static_func1", &WithStatic1::static_func1)
         .def_readwrite_static("static_value1", &WithStatic1::static_value1);
 
-    py::class_<WithStatic2>(m, "WithStatic2", py::metaclass())
+    py::class_<WithStatic2>(m, "WithStatic2")
         .def(py::init<>())
         .def_static("static_func2", &WithStatic2::static_func2)
         .def_readwrite_static("static_value2", &WithStatic2::static_value2);
 
     py::class_<VanillaStaticMix1, Vanilla, WithStatic1, WithStatic2>(
-        m, "VanillaStaticMix1", py::metaclass())
+        m, "VanillaStaticMix1")
         .def(py::init<>())
         .def_static("static_func", &VanillaStaticMix1::static_func)
         .def_readwrite_static("static_value", &VanillaStaticMix1::static_value);
 
     py::class_<VanillaStaticMix2, WithStatic1, Vanilla, WithStatic2>(
-        m, "VanillaStaticMix2", py::metaclass())
+        m, "VanillaStaticMix2")
         .def(py::init<>())
         .def_static("static_func", &VanillaStaticMix2::static_func)
         .def_readwrite_static("static_value", &VanillaStaticMix2::static_value);

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_multiple_inheritance_cpp():
     from pybind11_tests import MIType
 
@@ -49,6 +52,17 @@ def test_multiple_inheritance_mix2():
     assert mt.bar() == 4
 
 
+def test_multiple_inheritance_error():
+    """Inheriting from multiple C++ bases in Python is not supported"""
+    from pybind11_tests import Base1, Base2
+
+    with pytest.raises(TypeError) as excinfo:
+        # noinspection PyUnusedLocal
+        class MI(Base1, Base2):
+            pass
+    assert "Can't inherit from multiple C++ classes in Python" in str(excinfo.value)
+
+
 def test_multiple_inheritance_virtbase():
     from pybind11_tests import Base12a, bar_base2a, bar_base2a_sharedptr
 
@@ -60,3 +74,38 @@ def test_multiple_inheritance_virtbase():
     assert mt.bar() == 4
     assert bar_base2a(mt) == 4
     assert bar_base2a_sharedptr(mt) == 4
+
+
+def test_mi_static_properties():
+    """Mixing bases with and without static properties should be possible
+     and the result should be independent of base definition order"""
+    from pybind11_tests import mi
+
+    for d in (mi.VanillaStaticMix1(), mi.VanillaStaticMix2()):
+        assert d.vanilla() == "Vanilla"
+        assert d.static_func1() == "WithStatic1"
+        assert d.static_func2() == "WithStatic2"
+        assert d.static_func() == d.__class__.__name__
+
+        mi.WithStatic1.static_value1 = 1
+        mi.WithStatic2.static_value2 = 2
+        assert d.static_value1 == 1
+        assert d.static_value2 == 2
+        assert d.static_value == 12
+
+        d.static_value1 = 0
+        assert d.static_value1 == 0
+        d.static_value2 = 0
+        assert d.static_value2 == 0
+        d.static_value = 0
+        assert d.static_value == 0
+
+
+@pytest.unsupported_on_pypy
+def test_mi_dynamic_attributes():
+    """Mixing bases with and without dynamic attribute support"""
+    from pybind11_tests import mi
+
+    for d in (mi.VanillaDictMix1(), mi.VanillaDictMix2()):
+        d.dynamic = 1
+        assert d.dynamic == 1

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -190,7 +190,7 @@ struct MoveOutContainer {
 test_initializer python_types([](py::module &m) {
     /* No constructor is explicitly defined below. An exception is raised when
        trying to construct it directly from Python */
-    py::class_<ExamplePythonTypes>(m, "ExamplePythonTypes", "Example 2 documentation", py::metaclass())
+    py::class_<ExamplePythonTypes>(m, "ExamplePythonTypes", "Example 2 documentation")
         .def("get_dict", &ExamplePythonTypes::get_dict, "Return a Python dictionary")
         .def("get_dict_2", &ExamplePythonTypes::get_dict_2, "Return a C++ dictionary")
         .def("get_list", &ExamplePythonTypes::get_list, "Return a Python list")

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -6,7 +6,7 @@ from pybind11_tests import ExamplePythonTypes, ConstructorStats, has_optional, h
 
 def test_repr():
     # In Python 3.3+, repr() accesses __qualname__
-    assert "ExamplePythonTypes__Meta" in repr(type(ExamplePythonTypes))
+    assert "pybind11_type" in repr(type(ExamplePythonTypes))
     assert "ExamplePythonTypes" in repr(ExamplePythonTypes)
 
 


### PR DESCRIPTION
This fixes #597 and also (unintentionally) resolves #594.

@pschella: This fixes the original test code that you posted in #597 and I think the fix is quite thorough. But it might be good if you could test these changes in case there are any missing corner cases.

### Changes

The main issue for multiple inheritance is that Python not only requires that all base types are layout compatible, but also that they have a common metaclass. This resulted in problems when mixing classes with different `py::metaclass` and `py::dynamic_attr` specifications. This PR attempts to bring harmony to the different type hierarchies. This is a bit involved but most of the changes are organizational, not fundamental (the types are just stacked a bit differently).

#### Benefits

* Multiple inheritance now works with combinations of `py::metaclass`, `py::dynamic_attr` and 'vanilla' classes, independent of base list order. This works for multiple inheritance in C++: `py::class_<T, CppType1, CppType2>(m, "T")`.

  ~~The new uniform layout also makes it possible to inherit from multiple C++ types in Python: defining `class PyType(CppType1, CppType2)` works just like `py::class_<T, CppType1, CppType2>`.~~ (Not so much this part. See comments below.)

* The new metaclass implementation is cheap (essentially free) making it possible to enable `py::metaclass` for all classes by default. `py::metaclass` is thus deprecated.

* The new metaclass/static property implementation also brings a minor semantics improvement: it's now possible to access static properties via instances (`x = instance.static_prop`) where this was previously type-only (`x = Type.static_prop`).

#### Cost

* There's some extra global data (see `internals`) and a an extra pointer in the per-type data (`type_info`). But the per-type unique metaclass is now replaced with a single shared metaclass which reduces overall memory requirements.

* Not counting the new tests, the binary size of the test module stays about the same (+140 bytes = +0.01% on clang/macOS).


### Implementation

I hope the following quick ASCII diagrams will help illustrate the implementation change. A general relationship between instance, type and metatype looks something like this:
```
               TypeBase     MetatypeBase
                  |              |
instance  -->    Type   -->   Metatype
                  |
               Derived
```
Here `Type` is some user-define class and `instance = Type()`. `Metatype` is the type's type and the inheritance is shown top-down, separately for the type and the metatype.

Typically, this is pretty simple in Python:
```
                object     
                  |
instance  -->    Type  -->  type
                  |
               Derived
```
Here `object` and `type` are Python builtins and the above just illustrates the following in Python3:
```python
class Type:
    pass

class Derived(Type):
    pass

instance = Type()
```

Now, the existing pybind11 implementation for classes with static properties (`py::metaclass`) looks a bit like this:
```
                object             type
                  |                 |
instance  -->    Type   -->   UniqueMetatype
                    \                      \
                     \-> property           \-> property (static)
```
Regular properties (`instance.prop`) are stored in `Type` while static properties (`Type.prop`) are stored in a metaclass which is unique for each `Type`. This doubles the amount of data allocated per type which makes it expensive and thus guarded by `py::metaclass`.

This PR changes things around to look like this:
```
                object             type
                  |                 |
instance  -->    Type   -->   SharedMetatype
                    \
                     \-> property
                     |-> static_property
```
This approach is inspired by `boost.python` but with a slimmer implementation (most notably it doesn't replicate any CPython internal structures). The basic idea is that we extend Python's builtin `property` type and adapt it for static data. The following Python code is the exact implementation, but we just create it using the C API:
```python
class pybind11_static_property(property):
    """Exactly like property, but we always pass the type (`cls`)
    instead of the instance (`obj`)"""

    def __get__(self, obj, cls):
        return property.__get__(self, cls, cls)

    def __set__(self, obj, value):
        cls = obj if isinstance(obj, type) else type(obj)
        property.__set__(self, cls, value)
```

The `static_property` still needs a bit of support from a metaclass (see the code for details), but this is only a uniform behavior change and the metaclass doesn't need to store any data. Therefore, the metaclass doesn't need to be unique per type. We create a single one and share it among all the types which need it. And since that's all there is, we can also just let all types point to it and have "free" static properties.

This resolves one part of the multiple inheritance MRO issues: having a common metaclass for all types makes them compatible while the unique metatypes were blockers. However, there is an additional hurdle. In order to fully satisfy Python's type layout requirements, all types should have a common 'solid' base. A solid base is one which has the same instance size as the derived type (not counting the space required for the optional `dict_ptr` and `weakrefs_ptr`). Thus, `object` does not qualify as a solid base for pybind11 types and this can lead to issues with multiple inheritance.
```
             object
            /      \
Pybind11Type1      Pybind11Type2
            \      /
             MIType
```
In the example above, `instance_size(Pybind11Type1) > instance_size(object)` and `instance_size(Pybind11Type1) == instance_size(Pybind11Type2)` so `object` is not considered a solid base of `MIType`. This can result in `PyType_Ready()` complaining about layout and refusing to finalize the type for some base combinations.

The solution is to create a new base type:
```
         pybind11_object
            /      \
Pybind11Type1      Pybind11Type2
            \      /
             MIType
```
Here `instance_size(pybind11_object) == instance_size(Pybind11Type1, Pybind11Type2)` and thus `PyType_Ready()` is perfectly happy to support it.

### Notes

Since this changes a good bit of the `py::class_` implementation, I've also used this opportunity to move most of the details into a separate file (`detail/class_.h`) since the main `pybind11.h` is loaded enough as it is.