### PR TITLE
fix msvc warning when Python.h was included before pybind11.h

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -58,7 +58,9 @@
 
 /// Include Python header, disable linking to pythonX_d.lib on Windows in debug mode
 #if defined(_MSC_VER)
-#  define HAVE_ROUND
+#  if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4) 
+#    define HAVE_ROUND 1
+#  endif
 #  pragma warning(push)
 #  pragma warning(disable: 4510 4610 4512 4005)
 #  if defined(_DEBUG)

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -58,7 +58,7 @@
 
 /// Include Python header, disable linking to pythonX_d.lib on Windows in debug mode
 #if defined(_MSC_VER)
-#  if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4) 
+#  if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4)
 #    define HAVE_ROUND 1
 #  endif
 #  pragma warning(push)


### PR DESCRIPTION
MSVC gives a warning about macro redefinition of "HAVE_ROUND".
According to the Python ticket: https://bugs.python.org/issue21958 it was fixed in Python 2.7/3.4.
Since 2.7 is the minimum requirement for pybind11, I just added checks for python lower than 3.4.

I also changed the definition of HAVE_ROUND to a number (1 in this case) to be consistent with the python implementation. MSVC version check like in python is not required, since msvc2015 is the first support version.