### PR TITLE
Minor docs build maintenance

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,7 +4,9 @@ channels:
 - defaults
 dependencies:
 - python==3.5
+- sphinx==1.5.1
+- sphinx_rtd_theme==0.1.9
 - doxygen
 - pip
 - pip:
-  - https://github.com/michaeljones/breathe/archive/master.zip
+  - breathe


### PR DESCRIPTION
* Switch breathe to stable releases. It was previously pulling directly from master because a required bugfix was not in a stable release yet.

* Force update sphinx and RTD theme. When using conda, readthedocs pins `sphinx==1.3.5` and `sphinx_rtd_theme==0.1.7`, which is a bit older than the ones used in the RTD regular (non-`conda`) build. The newer theme has nicer sidebar navigation (4-level depth vs. only 2-level on the older version*). Note that the `python==3.5` requirement must stay because RTD still installs the older sphinx at one point which isn't available with Python 3.6. This just updated the theme at a later stage.

  (*) Compare the sidebar navigation depth on [stable (pre-doxygen, non-conda build)](http://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html#buffer-protocol) vs. [master (doxygen, conda build)](http://pybind11.readthedocs.io/en/master/advanced/pycpp/numpy.html#buffer-protocol). The latter is currently missing third level navigation (regression after moving to the conda build for doxygen). This PR restores the nicer RTD sidebar.

**Note**: Skipped CI tests since this is a pure RTD config change, i.e. completely transparent to CI.