### PR TITLE
Python multiple inheritance

### DIFF
--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -619,27 +619,19 @@ interspersed with alias types and holder types (discussed earlier in this
 document)---pybind11 will automatically find out which is which. The only
 requirement is that the first template argument is the type to be declared.
 
-There are two caveats regarding the implementation of this feature:
+It is also permitted to inherit multiply from exported C++ classes in Python,
+as well as inheriting from multiple Python and/or pybind-exported classes.
 
-1. When only one base type is specified for a C++ type that actually has
-   multiple bases, pybind11 will assume that it does not participate in
-   multiple inheritance, which can lead to undefined behavior. In such cases,
-   add the tag ``multiple_inheritance``:
+There is one caveat regarding the implementation of this feature:
 
-    .. code-block:: cpp
+When only one base type is specified for a C++ type that actually has multiple
+bases, pybind11 will assume that it does not participate in multiple
+inheritance, which can lead to undefined behavior. In such cases, add the tag
+``multiple_inheritance`` to the class constructor:
 
-        py::class_<MyType, BaseType2>(m, "MyType", py::multiple_inheritance());
+.. code-block:: cpp
 
-   The tag is redundant and does not need to be specified when multiple base
-   types are listed.
+    py::class_<MyType, BaseType2>(m, "MyType", py::multiple_inheritance());
 
-2. As was previously discussed in the section on :ref:`overriding_virtuals`, it
-   is easy to create Python types that derive from C++ classes. It is even
-   possible to make use of multiple inheritance to declare a Python class which
-   has e.g. a C++ and a Python class as bases. However, any attempt to create a
-   type that has *two or more* C++ classes in its hierarchy of base types will
-   fail with a fatal error message: ``TypeError: multiple bases have instance
-   lay-out conflict``. Core Python types that are implemented in C (e.g.
-   ``dict``, ``list``, ``Exception``, etc.) also fall under this combination
-   and cannot be combined with C++ types bound using pybind11 via multiple
-   inheritance.
+The tag is redundant and does not need to be specified when multiple base types
+are listed.

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -210,17 +210,17 @@ struct type_record {
     /// How large is the underlying C++ type?
     size_t type_size = 0;
 
-    /// How large is pybind11::instance<type>?
-    size_t instance_size = 0;
+    /// How large is the type's holder?
+    size_t holder_size = 0;
 
     /// The global operator new can be overridden with a class-specific variant
     void *(*operator_new)(size_t) = ::operator new;
 
     /// Function pointer to class_<..>::init_holder
-    void (*init_holder)(PyObject *, const void *) = nullptr;
+    void (*init_holder)(instance *, const void *) = nullptr;
 
     /// Function pointer to class_<..>::dealloc
-    void (*dealloc)(PyObject *) = nullptr;
+    void (*dealloc)(const detail::value_and_holder &) = nullptr;
 
     /// List of base classes of the newly created type
     list bases;

--- a/include/pybind11/class_support.h
+++ b/include/pybind11/class_support.h
@@ -87,34 +87,6 @@ inline PyTypeObject *make_static_property_type() {
 
 #endif // PYPY
 
-/** Inheriting from multiple C++ types in Python is not supported -- set an error instead.
-    A Python definition (`class C(A, B): pass`) will call `tp_new` so we check for multiple
-    C++ bases here. On the other hand, C++ type definitions (`py::class_<C, A, B>(m, "C")`)
-    don't not use `tp_new` and will not trigger this error. */
-extern "C" inline PyObject *pybind11_meta_new(PyTypeObject *metaclass, PyObject *args,
-                                              PyObject *kwargs) {
-    PyObject *bases = PyTuple_GetItem(args, 1); // arguments: (name, bases, dict)
-    if (!bases)
-        return nullptr;
-
-    auto &internals = get_internals();
-    auto num_cpp_bases = 0;
-    for (auto base : reinterpret_borrow<tuple>(bases)) {
-        auto base_type = (PyTypeObject *) base.ptr();
-        auto instance_size = static_cast<size_t>(base_type->tp_basicsize);
-        if (PyObject_IsSubclass(base.ptr(), internals.get_base(instance_size)))
-            ++num_cpp_bases;
-    }
-
-    if (num_cpp_bases > 1) {
-        PyErr_SetString(PyExc_TypeError, "Can't inherit from multiple C++ classes in Python."
-                                         "Use py::class_ to define the class in C++ instead.");
-        return nullptr;
-    } else {
-        return PyType_Type.tp_new(metaclass, args, kwargs);
-    }
-}
-
 /** Types with static properties need to handle `Type.static_prop = x` in a specific way.
     By default, Python replaces the `static_property` itself, but for wrapped C++ types
     we need to call `static_property.__set__()` in order to propagate the new value to
@@ -193,7 +165,6 @@ inline PyTypeObject* make_default_metaclass() {
     type->tp_base = &PyType_Type;
     type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
 
-    type->tp_new = pybind11_meta_new;
     type->tp_setattro = pybind11_meta_setattro;
 #if PY_MAJOR_VERSION >= 3
     type->tp_getattro = pybind11_meta_getattro;
@@ -210,8 +181,8 @@ inline PyTypeObject* make_default_metaclass() {
 /// For multiple inheritance types we need to recursively register/deregister base pointers for any
 /// base classes with pointers that are difference from the instance value pointer so that we can
 /// correctly recognize an offset base class pointer. This calls a function with any offset base ptrs.
-inline void traverse_offset_bases(void *valueptr, const detail::type_info *tinfo, void *self,
-        bool (*f)(void * /*parentptr*/, void * /*self*/)) {
+inline void traverse_offset_bases(void *valueptr, const detail::type_info *tinfo, instance *self,
+        bool (*f)(void * /*parentptr*/, instance * /*self*/)) {
     for (handle h : reinterpret_borrow<tuple>(tinfo->type->tp_bases)) {
         if (auto parent_tinfo = get_type_info((PyTypeObject *) h.ptr())) {
             for (auto &c : parent_tinfo->implicit_casts) {
@@ -227,11 +198,11 @@ inline void traverse_offset_bases(void *valueptr, const detail::type_info *tinfo
     }
 }
 
-inline bool register_instance_impl(void *ptr, void *self) {
+inline bool register_instance_impl(void *ptr, instance *self) {
     get_internals().registered_instances.emplace(ptr, self);
     return true; // unused, but gives the same signature as the deregister func
 }
-inline bool deregister_instance_impl(void *ptr, void *self) {
+inline bool deregister_instance_impl(void *ptr, instance *self) {
     auto &registered_instances = get_internals().registered_instances;
     auto range = registered_instances.equal_range(ptr);
     for (auto it = range.first; it != range.second; ++it) {
@@ -243,36 +214,48 @@ inline bool deregister_instance_impl(void *ptr, void *self) {
     return false;
 }
 
-inline void register_instance(void *self, const type_info *tinfo) {
-    auto *inst = (instance_essentials<void> *) self;
-    register_instance_impl(inst->value, self);
+inline void register_instance(instance *self, void *valptr, const type_info *tinfo) {
+    register_instance_impl(valptr, self);
     if (!tinfo->simple_ancestors)
-        traverse_offset_bases(inst->value, tinfo, self, register_instance_impl);
+        traverse_offset_bases(valptr, tinfo, self, register_instance_impl);
 }
 
-inline bool deregister_instance(void *self, const detail::type_info *tinfo) {
-    auto *inst = (instance_essentials<void> *) self;
-    bool ret = deregister_instance_impl(inst->value, self);
+inline bool deregister_instance(instance *self, void *valptr, const type_info *tinfo) {
+    bool ret = deregister_instance_impl(valptr, self);
     if (!tinfo->simple_ancestors)
-        traverse_offset_bases(inst->value, tinfo, self, deregister_instance_impl);
+        traverse_offset_bases(valptr, tinfo, self, deregister_instance_impl);
     return ret;
 }
 
-/// Creates a new instance which, by default, includes allocation (but not construction of) the
-/// wrapped C++ instance.  If allocating value, the instance is registered; otherwise
-/// register_instance will need to be called once the value has been assigned.
+/// Instance creation function for all pybind11 types. It only allocates space for the C++ object
+/// (or multiple objects, for Python-side inheritance from multiple pybind11 types), but doesn't
+/// call the constructor -- an `__init__` function must do that.  If allocating value, the instance
+/// is registered; otherwise register_instance will need to be called once the value has been
+/// assigned.
 inline PyObject *make_new_instance(PyTypeObject *type, bool allocate_value /*= true (in cast.h)*/) {
-    PyObject *self = type->tp_alloc(type, 0);
-    auto instance = (instance_essentials<void> *) self;
-    auto tinfo = get_type_info(type);
-    instance->owned = true;
-    instance->holder_constructed = false;
-    if (allocate_value) {
-        instance->value = tinfo->operator_new(tinfo->type_size);
-        register_instance(self, tinfo);
-    } else {
-        instance->value = nullptr;
+#if defined(PYPY_VERSION)
+    // PyPy gets tp_basicsize wrong (issue 2482) under multiple inheritance when the first inherited
+    // object is a a plain Python type (i.e. not derived from an extension type).  Fix it.
+    ssize_t instance_size = static_cast<ssize_t>(sizeof(instance));
+    if (type->tp_basicsize < instance_size) {
+        type->tp_basicsize = instance_size;
     }
+#endif
+    PyObject *self = type->tp_alloc(type, 0);
+    auto inst = reinterpret_cast<instance *>(self);
+    // Allocate the value/holder internals:
+    inst->allocate_layout();
+
+    inst->owned = true;
+    // Allocate (if requested) the value pointers; otherwise leave them as nullptr
+    if (allocate_value) {
+        for (auto &v_h : values_and_holders(inst)) {
+            void *&vptr = v_h.value_ptr();
+            vptr = v_h.type->operator_new(v_h.type->type_size);
+            register_instance(inst, vptr, v_h.type);
+        }
+    }
+
     return self;
 }
 
@@ -300,26 +283,27 @@ extern "C" inline int pybind11_object_init(PyObject *self, PyObject *, PyObject 
 /// Clears all internal data from the instance and removes it from registered instances in
 /// preparation for deallocation.
 inline void clear_instance(PyObject *self) {
-    auto instance = (instance_essentials<void> *) self;
-    bool has_value = instance->value;
-    type_info *tinfo = nullptr;
-    if (has_value || instance->holder_constructed) {
-        auto type = Py_TYPE(self);
-        tinfo = get_type_info(type);
-        tinfo->dealloc(self);
-    }
-    if (has_value) {
-        if (!tinfo) tinfo = get_type_info(Py_TYPE(self));
-        if (!deregister_instance(self, tinfo))
-            pybind11_fail("pybind11_object_dealloc(): Tried to deallocate unregistered instance!");
+    auto instance = reinterpret_cast<detail::instance *>(self);
 
-        if (instance->weakrefs)
-            PyObject_ClearWeakRefs(self);
+    // Deallocate any values/holders, if present:
+    for (auto &v_h : values_and_holders(instance)) {
+        if (v_h) {
+            if (instance->owned || v_h.holder_constructed())
+                v_h.type->dealloc(v_h);
 
-        PyObject **dict_ptr = _PyObject_GetDictPtr(self);
-        if (dict_ptr)
-            Py_CLEAR(*dict_ptr);
+            if (!deregister_instance(instance, v_h.value_ptr(), v_h.type))
+                pybind11_fail("pybind11_object_dealloc(): Tried to deallocate unregistered instance!");
+        }
     }
+    // Deallocate the value/holder layout internals:
+    instance->deallocate_layout();
+
+    if (instance->weakrefs)
+        PyObject_ClearWeakRefs(self);
+
+    PyObject **dict_ptr = _PyObject_GetDictPtr(self);
+    if (dict_ptr)
+        Py_CLEAR(*dict_ptr);
 }
 
 /// Instance destructor function for all pybind11 types. It calls `type_info.dealloc`
@@ -329,19 +313,17 @@ extern "C" inline void pybind11_object_dealloc(PyObject *self) {
     Py_TYPE(self)->tp_free(self);
 }
 
-/** Create a type which can be used as a common base for all classes with the same
-    instance size, i.e. all classes with the same `sizeof(holder_type)`. This is
+/** Create the type which can be used as a common base for all classes.  This is
     needed in order to satisfy Python's requirements for multiple inheritance.
     Return value: New reference. */
-inline PyObject *make_object_base_type(size_t instance_size) {
-    auto name = "pybind11_object_" + std::to_string(instance_size);
-    auto name_obj = reinterpret_steal<object>(PYBIND11_FROM_STRING(name.c_str()));
+inline PyObject *make_object_base_type(PyTypeObject *metaclass) {
+    constexpr auto *name = "pybind11_object";
+    auto name_obj = reinterpret_steal<object>(PYBIND11_FROM_STRING(name));
 
     /* Danger zone: from now (and until PyType_Ready), make sure to
        issue no Python C API calls which could potentially invoke the
        garbage collector (the GC will call type_traverse(), which will in
        turn find the newly constructed type in an invalid state) */
-    auto metaclass = get_internals().default_metaclass;
     auto heap_type = (PyHeapTypeObject *) metaclass->tp_alloc(metaclass, 0);
     if (!heap_type)
         pybind11_fail("make_object_base_type(): error allocating type!");
@@ -352,9 +334,9 @@ inline PyObject *make_object_base_type(size_t instance_size) {
 #endif
 
     auto type = &heap_type->ht_type;
-    type->tp_name = strdup(name.c_str());
+    type->tp_name = name;
     type->tp_base = &PyBaseObject_Type;
-    type->tp_basicsize = static_cast<ssize_t>(instance_size);
+    type->tp_basicsize = static_cast<ssize_t>(sizeof(instance));
     type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
 
     type->tp_new = pybind11_object_new;
@@ -362,7 +344,7 @@ inline PyObject *make_object_base_type(size_t instance_size) {
     type->tp_dealloc = pybind11_object_dealloc;
 
     /* Support weak references (needed for the keep_alive feature) */
-    type->tp_weaklistoffset = offsetof(instance_essentials<void>, weakrefs);
+    type->tp_weaklistoffset = offsetof(instance, weakrefs);
 
     if (PyType_Ready(type) < 0)
         pybind11_fail("PyType_Ready failed in make_object_base_type():" + error_string());
@@ -371,20 +353,6 @@ inline PyObject *make_object_base_type(size_t instance_size) {
 
     assert(!PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC));
     return (PyObject *) heap_type;
-}
-
-/** Return the appropriate base type for the given instance size. The results are cached
-    in `internals.bases` so that only a single base is ever created for any size value.
-    Return value: Borrowed reference. */
-inline PyObject *internals::get_base(size_t instance_size) {
-    auto it = bases.find(instance_size);
-    if (it != bases.end()) {
-        return it->second;
-    } else {
-        auto base = make_object_base_type(instance_size);
-        bases[instance_size] = base;
-        return base;
-    }
 }
 
 /// dynamic_attr: Support for `d = instance.__dict__`.
@@ -460,7 +428,7 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
         PyErr_SetString(PyExc_BufferError, "pybind11_getbuffer(): Internal error");
         return -1;
     }
-    memset(view, 0, sizeof(Py_buffer));
+    std::memset(view, 0, sizeof(Py_buffer));
     buffer_info *info = tinfo->get_buffer(obj, tinfo->get_buffer_data);
     view->obj = obj;
     view->ndim = 1;
@@ -536,7 +504,7 @@ inline PyObject* make_new_python_type(const type_record &rec) {
 
     auto &internals = get_internals();
     auto bases = tuple(rec.bases);
-    auto base = (bases.size() == 0) ? internals.get_base(rec.instance_size)
+    auto base = (bases.size() == 0) ? internals.instance_base
                                     : bases[0].ptr();
 
     /* Danger zone: from now (and until PyType_Ready), make sure to
@@ -559,7 +527,7 @@ inline PyObject* make_new_python_type(const type_record &rec) {
     type->tp_name = strdup(full_name.c_str());
     type->tp_doc = tp_doc;
     type->tp_base = (PyTypeObject *) handle(base).inc_ref().ptr();
-    type->tp_basicsize = static_cast<ssize_t>(rec.instance_size);
+    type->tp_basicsize = static_cast<ssize_t>(sizeof(instance));
     if (bases.size() > 0)
         type->tp_bases = bases.release().ptr();
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -293,7 +293,7 @@ protected:
         if (!chain) {
             /* No existing overload was found, create a new function object */
             rec->def = new PyMethodDef();
-            memset(rec->def, 0, sizeof(PyMethodDef));
+            std::memset(rec->def, 0, sizeof(PyMethodDef));
             rec->def->ml_name = rec->name;
             rec->def->ml_meth = reinterpret_cast<PyCFunction>(*dispatcher);
             rec->def->ml_flags = METH_VARARGS | METH_KEYWORDS;
@@ -707,10 +707,8 @@ protected:
             return nullptr;
         } else {
             if (overloads->is_constructor) {
-                /* When a constructor ran successfully, the corresponding
-                   holder type (e.g. std::unique_ptr) must still be initialized. */
-                auto tinfo = get_type_info(Py_TYPE(parent.ptr()));
-                tinfo->init_holder(parent.ptr(), nullptr);
+                auto tinfo = get_type_info((PyTypeObject *) overloads->scope.ptr());
+                tinfo->init_holder(reinterpret_cast<instance *>(parent.ptr()), nullptr);
             }
             return result.ptr();
         }
@@ -727,7 +725,7 @@ public:
         if (!options::show_user_defined_docstrings()) doc = nullptr;
 #if PY_MAJOR_VERSION >= 3
         PyModuleDef *def = new PyModuleDef();
-        memset(def, 0, sizeof(PyModuleDef));
+        std::memset(def, 0, sizeof(PyModuleDef));
         def->m_name = name;
         def->m_doc = doc;
         def->m_size = -1;
@@ -830,6 +828,7 @@ protected:
         tinfo->cpptype = rec.type;
         tinfo->type_size = rec.type_size;
         tinfo->operator_new = rec.operator_new;
+        tinfo->holder_size_in_ptrs = size_in_ptrs(rec.holder_size);
         tinfo->init_holder = rec.init_holder;
         tinfo->dealloc = rec.dealloc;
         tinfo->simple_type = true;
@@ -840,7 +839,7 @@ protected:
         tinfo->direct_conversions = &internals.direct_conversions[tindex];
         tinfo->default_holder = rec.default_holder;
         internals.registered_types_cpp[tindex] = tinfo;
-        internals.registered_types_py[m_ptr] = tinfo;
+        internals.registered_types_py[(PyTypeObject *) m_ptr] = { tinfo };
 
         if (rec.bases.size() > 1 || rec.multiple_inheritance) {
             mark_parents_nonsimple(tinfo->type);
@@ -923,7 +922,6 @@ public:
     using type_alias = detail::exactly_one_t<is_subtype, void, options...>;
     constexpr static bool has_alias = !std::is_void<type_alias>::value;
     using holder_type = detail::exactly_one_t<is_holder, std::unique_ptr<type>, options...>;
-    using instance_type = detail::instance<type, holder_type>;
 
     static_assert(detail::all_of<is_valid_class_option<options>...>::value,
             "Unknown/invalid class_ template parameters provided");
@@ -947,7 +945,7 @@ public:
         record.name = name;
         record.type = &typeid(type);
         record.type_size = sizeof(conditional_t<has_alias, type_alias, type>);
-        record.instance_size = sizeof(instance_type);
+        record.holder_size = sizeof(holder_type);
         record.init_holder = init_holder;
         record.dealloc = dealloc;
         record.default_holder = std::is_same<holder_type, std::unique_ptr<type>>::value;
@@ -1139,53 +1137,57 @@ public:
 private:
     /// Initialize holder object, variant 1: object derives from enable_shared_from_this
     template <typename T>
-    static void init_holder_helper(instance_type *inst, const holder_type * /* unused */, const std::enable_shared_from_this<T> * /* dummy */) {
+    static void init_holder_helper(detail::instance *inst, detail::value_and_holder &v_h,
+            const holder_type * /* unused */, const std::enable_shared_from_this<T> * /* dummy */) {
         try {
-            auto sh = std::dynamic_pointer_cast<typename holder_type::element_type>(inst->value->shared_from_this());
+            auto sh = std::dynamic_pointer_cast<typename holder_type::element_type>(
+                    v_h.value_ptr<type>()->shared_from_this());
             if (sh) {
-                new (&inst->holder) holder_type(std::move(sh));
-                inst->holder_constructed = true;
+                new (&v_h.holder<holder_type>()) holder_type(std::move(sh));
+                v_h.set_holder_constructed();
             }
         } catch (const std::bad_weak_ptr &) {}
-        if (!inst->holder_constructed && inst->owned) {
-            new (&inst->holder) holder_type(inst->value);
-            inst->holder_constructed = true;
+
+        if (!v_h.holder_constructed() && inst->owned) {
+            new (&v_h.holder<holder_type>()) holder_type(v_h.value_ptr<type>());
+            v_h.set_holder_constructed();
         }
     }
 
-    static void init_holder_from_existing(instance_type *inst, const holder_type *holder_ptr,
-                                          std::true_type /*is_copy_constructible*/) {
-        new (&inst->holder) holder_type(*holder_ptr);
+    static void init_holder_from_existing(const detail::value_and_holder &v_h,
+            const holder_type *holder_ptr, std::true_type /*is_copy_constructible*/) {
+        new (&v_h.holder<holder_type>()) holder_type(*reinterpret_cast<const holder_type *>(holder_ptr));
     }
 
-    static void init_holder_from_existing(instance_type *inst, const holder_type *holder_ptr,
-                                          std::false_type /*is_copy_constructible*/) {
-        new (&inst->holder) holder_type(std::move(*const_cast<holder_type *>(holder_ptr)));
+    static void init_holder_from_existing(const detail::value_and_holder &v_h,
+            const holder_type *holder_ptr, std::false_type /*is_copy_constructible*/) {
+        new (&v_h.holder<holder_type>()) holder_type(std::move(*const_cast<holder_type *>(holder_ptr)));
     }
 
     /// Initialize holder object, variant 2: try to construct from existing holder object, if possible
-    static void init_holder_helper(instance_type *inst, const holder_type *holder_ptr, const void * /* dummy */) {
+    static void init_holder_helper(detail::instance *inst, detail::value_and_holder &v_h,
+            const holder_type *holder_ptr, const void * /* dummy -- not enable_shared_from_this<T>) */) {
         if (holder_ptr) {
-            init_holder_from_existing(inst, holder_ptr, std::is_copy_constructible<holder_type>());
-            inst->holder_constructed = true;
+            init_holder_from_existing(v_h, holder_ptr, std::is_copy_constructible<holder_type>());
+            v_h.set_holder_constructed();
         } else if (inst->owned || detail::always_construct_holder<holder_type>::value) {
-            new (&inst->holder) holder_type(inst->value);
-            inst->holder_constructed = true;
+            new (&v_h.holder<holder_type>()) holder_type(v_h.value_ptr<type>());
+            v_h.set_holder_constructed();
         }
     }
 
     /// Initialize holder object of an instance, possibly given a pointer to an existing holder
-    static void init_holder(PyObject *inst_, const void *holder_ptr) {
-        auto inst = (instance_type *) inst_;
-        init_holder_helper(inst, (const holder_type *) holder_ptr, inst->value);
+    static void init_holder(detail::instance *inst, const void *holder_ptr) {
+        auto v_h = inst->get_value_and_holder(detail::get_type_info(typeid(type)));
+        init_holder_helper(inst, v_h, (const holder_type *) holder_ptr, v_h.value_ptr<type>());
     }
 
-    static void dealloc(PyObject *inst_) {
-        instance_type *inst = (instance_type *) inst_;
-        if (inst->holder_constructed)
-            inst->holder.~holder_type();
-        else if (inst->owned)
-            detail::call_operator_delete(inst->value);
+    /// Deallocates an instance; via holder, if constructed; otherwise via operator delete.
+    static void dealloc(const detail::value_and_holder &v_h) {
+        if (v_h.holder_constructed())
+            v_h.holder<holder_type>().~holder_type();
+        else
+            detail::call_operator_delete(v_h.value_ptr<type>());
     }
 
     static detail::function_record *get_function_record(handle h) {
@@ -1347,6 +1349,25 @@ PYBIND11_NOINLINE inline void keep_alive_impl(size_t Nurse, size_t Patient, func
         Nurse   == 0 ? ret : Nurse   <= call.args.size() ? call.args[Nurse   - 1] : handle(),
         Patient == 0 ? ret : Patient <= call.args.size() ? call.args[Patient - 1] : handle()
     );
+}
+
+inline std::pair<decltype(internals::registered_types_py)::iterator, bool> all_type_info_get_cache(PyTypeObject *type) {
+    auto res = get_internals().registered_types_py
+#ifdef z__cpp_lib_unordered_map_try_emplace
+        .try_emplace(type);
+#else
+        .emplace(type, std::vector<detail::type_info *>());
+#endif
+    if (res.second) {
+        // New cache entry created; set up a weak reference to automatically remove it if the type
+        // gets destroyed:
+        weakref((PyObject *) type, cpp_function([type](handle wr) {
+            get_internals().registered_types_py.erase(type);
+            wr.dec_ref();
+        })).release();
+    }
+
+    return res;
 }
 
 template <typename Iterator, typename Sentinel, bool KeyIterator, return_value_policy Policy>

--- a/tests/constructor_stats.h
+++ b/tests/constructor_stats.h
@@ -169,7 +169,7 @@ public:
         auto &internals = py::detail::get_internals();
         const std::type_index *t1 = nullptr, *t2 = nullptr;
         try {
-            auto *type_info = internals.registered_types_py.at(class_.ptr());
+            auto *type_info = internals.registered_types_py.at((PyTypeObject *) class_.ptr()).at(0);
             for (auto &p : internals.registered_types_cpp) {
                 if (p.second == type_info) {
                     if (t1) {

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -23,6 +23,11 @@ struct Base2 {
     int i;
 };
 
+template <int N> struct BaseN {
+    BaseN(int i) : i(i) { }
+    int i;
+};
+
 struct Base12 : Base1, Base2 {
     Base12(int i, int j) : Base1(i), Base2(j) { }
 };
@@ -44,6 +49,15 @@ test_initializer multiple_inheritance([](py::module &m) {
 
     py::class_<MIType, Base12>(m, "MIType")
         .def(py::init<int, int>());
+
+    // Many bases for testing that multiple inheritance from many classes (i.e. requiring extra
+    // space for holder constructed flags) works.
+    #define PYBIND11_BASEN(N) py::class_<BaseN<N>>(m, "BaseN" #N).def(py::init<int>()).def("f" #N, [](BaseN<N> &b) { return b.i + N; })
+    PYBIND11_BASEN( 1); PYBIND11_BASEN( 2); PYBIND11_BASEN( 3); PYBIND11_BASEN( 4);
+    PYBIND11_BASEN( 5); PYBIND11_BASEN( 6); PYBIND11_BASEN( 7); PYBIND11_BASEN( 8);
+    PYBIND11_BASEN( 9); PYBIND11_BASEN(10); PYBIND11_BASEN(11); PYBIND11_BASEN(12);
+    PYBIND11_BASEN(13); PYBIND11_BASEN(14); PYBIND11_BASEN(15); PYBIND11_BASEN(16);
+    PYBIND11_BASEN(17);
 
     // Uncommenting this should result in a compile time failure (MI can only be specified via
     // template parameters because pybind has to know the types involved; see discussion in #742 for

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -132,6 +132,16 @@ def test_unique_nodelete():
     assert cstats.alive() == 1  # Leak, but that's intentional
 
 
+def test_large_holder():
+    from pybind11_tests import MyObject5
+    o = MyObject5(5)
+    assert o.value == 5
+    cstats = ConstructorStats.get(MyObject5)
+    assert cstats.alive() == 1
+    del o
+    assert cstats.alive() == 0
+
+
 def test_shared_ptr_and_references():
     from pybind11_tests.smart_ptr import SharedPtrRef, A
 


### PR DESCRIPTION
This builds on @dean0x7d's #679 to support multiple inheritance of C++ classes from Python.  This required no dispatch changing at all, but does require some changes to be able to store multiple C++ base objects in a single instance.

This is done by changing the `instance` layout to contain a single `void**` which is allocated to the correct size and contains value/holder pointer pairs.  The value pointers are themselves each set to newly-allocated memory of the size required for each value, and the holders are initialized to nullptr.

Thus the instance changes from this:

- ... python stuff ...
- pointer to VALUE data
- weakrefs *
- bools
- HOLDER

to:

- ... python stuff ...
- pointer to value/holder data: [[VALUE1 *][HOLDER1 *][VALUE2 *][HOLDER2 *]...]
- weakrefs *
- bools

where each VALUEn pointer is to newly allocated memory of the size required by the value type, and each HOLDERn starts out set to nulptr.

This has three effects: First, all instances have the same size (more on this below).  Second, `instance` can store multiple base values and holders for those base values.  Third, we don't need the `instance_essentials`/`instance<HolderType>` distinction anymore: there is now just one `instance` which can contain any number of values and holders of whatever size.

Structure aside, a new `get_all_type_info()` function is added which takes a type and returns a vector of all the pybind types that make up the input type.  For types that are already a pybind type, or that inheriting just one pybind-registered type, this is just that the `typeinfo` for that type.  For multiple inheritance, this will be a list.

A companion function, `get_value_and_holder()`, contains the logic of using the `get_all_type_info()` to extract the correct references to the value and holder pointers for a given type from the `instance`.

As for method dispatching: we don't have to do anything.  Python takes care of the MRO.  (Cross-class overloads won't work, but that's true in Python in general).  The generic type caster now knows how to extract the correct value from a multi-valued instance, and an invoked constructor can get the correct holder type/pointer by simply using the parent of the constructor itself (rather than the instance itself, which may have multiple holders).

.so size increases slightly (~1.2%, or about 20KB, on the full test suite compared to #679 under g++6).  I think it's worthwhile (and I expect a good chunk of that increase is constant).

Currently this fails under PyPy: I haven't investigated in detail, but will do so.

Some other comments:

- since we don't store the holder_type directly in the instance anymore (instead it's in the pointer of pointers), we don't need #679's one-base-per-instance-size (because there is now just one instance size): I've replaced it with just one base for all pybind11 types, instead of one per instance size.  It's also now constructed in the `get_internals()` initialization rather than on demand.

- the `holder_constructed` flag isn't needed anymore: a `nullptr` holder pointer now indicates a non-constructed holder.  `instance_size` is similarly dropped.

- the recursive loading in the generic type caster (and mirrored in the copyable holder caster) isn't needed anymore (the `get_all_type_info`/`get_value_and_holder` logic handles python base class traversal now).
