### PR TITLE
Make string conversion stricter

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -657,6 +657,8 @@ struct type_caster<std::basic_string<CharT, Traits, Allocator>, enable_if_t<is_s
             return false;
             // The below is a guaranteed failure in Python 3 when PyUnicode_Check returns false
 #else
+            if (!PYBIND11_BYTES_CHECK(load_src.ptr()))
+                return false;
             temp = reinterpret_steal<object>(PyUnicode_FromObject(load_src.ptr()));
             if (!temp) { PyErr_Clear(); return false; }
             load_src = temp;

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -150,4 +150,9 @@ test_initializer numpy_array([](py::module &m) {
             "array_t<double>"_a=py::array_t<double>(o)
         );
     });
+
+    // Issue 685: ndarray shouldn't go to std::string overload
+    sm.def("issue685", [](std::string) { return "string"; });
+    sm.def("issue685", [](py::array) { return "array"; });
+    sm.def("issue685", [](py::object) { return "other"; });
 });

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -274,6 +274,7 @@ def test_constructors():
     assert results["array_t<double>"].dtype == np.float64
 
 
+@pytest.requires_numpy
 def test_greedy_string_overload():  # issue 685
     from pybind11_tests.array import issue685
 

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -272,3 +272,11 @@ def test_constructors():
     assert results["array"].dtype == np.int_
     assert results["array_t<int32>"].dtype == np.int32
     assert results["array_t<double>"].dtype == np.float64
+
+
+def test_greedy_string_overload():  # issue 685
+    from pybind11_tests.array import issue685
+
+    assert issue685("abc") == "string"
+    assert issue685(np.array([97, 98, 99], dtype='b')) == "array"
+    assert issue685(123) == "other"


### PR DESCRIPTION
The string conversion logic added in PR #624 for all std::basic_strings
was derived from the old std::wstring logic, but that was underused and
turns out to have had a bug in accepting almost anything convertible to
unicode, while the previous std::string logic was much stricter.  This
restores the previous std::string logic by only allowing actual unicode
or string types.

Fixes #685.