### PR TITLE
Fix negative refcount in PyCapsule destructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,9 +147,13 @@ install:
 - |
   # Install dependencies
   if [ -n "$DOCKER" ]; then
+    if [ -n "$DEBUG" ]; then
+      PY_DEBUG="python$PY-dbg python$PY-scipy-dbg"
+      export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DPYTHON_EXECUTABLE=/usr/bin/python${PYTHON}dm"
+    fi
     docker exec --tty "$containerid" sh -c "for s in 0 15; do sleep \$s; \
       apt-get -qy --no-install-recommends $APT_GET_EXTRA install \
-        python$PY-dev python$PY-pytest python$PY-scipy \
+        $PY_DEBUG python$PY-dev python$PY-pytest python$PY-scipy \
         libeigen3-dev cmake make ${COMPILER_PACKAGES} && break; done"
   else
     pip install numpy scipy pytest

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -229,7 +229,7 @@ handle eigen_ref_array(Type &src, handle parent = none()) {
 // not the Type of the pointer given is const.
 template <typename props, typename Type, typename = enable_if_t<is_eigen_dense_plain<Type>::value>>
 handle eigen_encapsulate(Type *src) {
-    capsule base(src, [](PyObject *o) { delete reinterpret_steal<capsule>(o).operator Type*(); });
+    capsule base(src, [](PyObject *o) { delete static_cast<Type *>(PyCapsule_GetPointer(o, nullptr)); });
     return eigen_ref_array<props>(*src, base);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -159,7 +159,7 @@ if(NOT PYBIND11_PYTEST_FOUND)
 endif()
 
 # A single command to compile and run the tests
-add_custom_target(pytest COMMAND ${PYTHON_EXECUTABLE} -m pytest -rws ${PYBIND11_PYTEST_FILES}
+add_custom_target(pytest COMMAND ${PYTHON_EXECUTABLE} -m pytest -rws --capture=sys ${PYBIND11_PYTEST_FILES}
                   DEPENDS pybind11_tests WORKING_DIRECTORY ${testdir})
 
 if(PYBIND11_TEST_OVERRIDE)

--- a/tests/test_cmake_build/installed_target/CMakeLists.txt
+++ b/tests/test_cmake_build/installed_target/CMakeLists.txt
@@ -14,5 +14,9 @@ target_link_libraries(test_cmake_build PRIVATE pybind11::module)
 set_target_properties(test_cmake_build PROPERTIES PREFIX "${PYTHON_MODULE_PREFIX}"
                                                   SUFFIX "${PYTHON_MODULE_EXTENSION}")
 
+# Do not treat includes from IMPORTED target as SYSTEM (Python headers in pybind11::module).
+# This may be needed to resolve header conflicts, e.g. between Python release and debug headers.
+set_target_properties(test_cmake_build PROPERTIES NO_SYSTEM_FROM_IMPORTED ON)
+
 add_custom_target(check ${CMAKE_COMMAND} -E env PYTHONPATH=$<TARGET_FILE_DIR:test_cmake_build>
                   ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/../test.py ${PROJECT_NAME})


### PR DESCRIPTION
When running the tests with a debug build of Python, the following error occurs:
```
Fatal Python error: /pybind11/include/pybind11/pytypes.h:159 object at 0x7f4672c01100 has negative ref count -1
```

This is due to a `reinterpret_steal` in a PyCapsule destructor. Note that `reinterpret_borrow` also isn't appropriate because the destructor is called just before the capsule is to be deallocated. All reference counting should be avoided at that point. The fix in this PR just uses the raw C API.

Since this was only picked up by a debug build of Python itself, I figure it would be nice to have one of the CI configs cover it. The existing `DEBUG=1` config is modified to also use `python3-dbg` in addition to the debug build of `pybind11_tests`. This Travis config now reports the refcount error above. [See the log](https://travis-ci.org/dean0x7d/pybind11/jobs/205982087#L1031).