### PR TITLE
Fix compilation of Eigen casters with complex scalars

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -731,7 +731,7 @@ public:
     template <typename T2 = T, enable_if_t<is_complex<T2>::value, int> = 0>
     static PYBIND11_DESCR name() {
         return _<std::is_same<typename T2::value_type, float>::value || std::is_same<typename T2::value_type, double>::value>(
-                _("complex") + _<sizeof(T2::value_type)*16>(), _("longcomplex"));
+                _("complex") + _<sizeof(typename T2::value_type)*16>(), _("longcomplex"));
     }
 };
 

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -66,6 +66,7 @@ test_initializer eigen([](py::module &m) {
 
     m.def("double_col", [](const Eigen::VectorXf &x) -> Eigen::VectorXf { return 2.0f * x; });
     m.def("double_row", [](const Eigen::RowVectorXf &x) -> Eigen::RowVectorXf { return 2.0f * x; });
+    m.def("double_complex", [](const Eigen::VectorXcf &x) -> Eigen::VectorXcf { return 2.0f * x; });
     m.def("double_threec", [](py::EigenDRef<Eigen::Vector3f> x) { x *= 2; });
     m.def("double_threer", [](py::EigenDRef<Eigen::RowVector3f> x) { x *= 2; });
     m.def("double_mat_cm", [](Eigen::MatrixXf x) -> Eigen::MatrixXf { return 2.0f * x; });

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -129,7 +129,7 @@ def test_pass_readonly_array():
 
 def test_nonunit_stride_from_python():
     from pybind11_tests import (
-        double_row, double_col, double_mat_cm, double_mat_rm,
+        double_row, double_col, double_complex, double_mat_cm, double_mat_rm,
         double_threec, double_threer)
 
     counting_mat = np.arange(9.0, dtype=np.float32).reshape((3, 3))
@@ -137,8 +137,10 @@ def test_nonunit_stride_from_python():
     second_col = counting_mat[:, 1]
     np.testing.assert_array_equal(double_row(second_row), 2.0 * second_row)
     np.testing.assert_array_equal(double_col(second_row), 2.0 * second_row)
+    np.testing.assert_array_equal(double_complex(second_row), 2.0 * second_row)
     np.testing.assert_array_equal(double_row(second_col), 2.0 * second_col)
     np.testing.assert_array_equal(double_col(second_col), 2.0 * second_col)
+    np.testing.assert_array_equal(double_complex(second_col), 2.0 * second_col)
 
     counting_3d = np.arange(27.0, dtype=np.float32).reshape((3, 3, 3))
     slices = [counting_3d[0, :, :], counting_3d[:, 0, :], counting_3d[:, :, 0]]
@@ -564,13 +566,16 @@ def test_special_matrix_objects():
 
 
 def test_dense_signature(doc):
-    from pybind11_tests import double_col, double_row, double_mat_rm
+    from pybind11_tests import double_col, double_row, double_complex, double_mat_rm
 
     assert doc(double_col) == """
         double_col(arg0: numpy.ndarray[float32[m, 1]]) -> numpy.ndarray[float32[m, 1]]
     """
     assert doc(double_row) == """
         double_row(arg0: numpy.ndarray[float32[1, n]]) -> numpy.ndarray[float32[1, n]]
+    """
+    assert doc(double_complex) == """
+        double_complex(arg0: numpy.ndarray[complex64[m, 1]]) -> numpy.ndarray[complex64[m, 1]]
     """
     assert doc(double_mat_rm) == """
         double_mat_rm(arg0: numpy.ndarray[float32[m, n]]) -> numpy.ndarray[float32[m, n]]


### PR DESCRIPTION
Just a missing `typename`. The new test function produces the compilation error (the `std::complex` variant of `npy_format_descriptor` wasn't being compiled before).