### PR TITLE
Remove extraneous `enum_` python constructor

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1143,7 +1143,6 @@ public:
             return m;
         }, return_value_policy::copy);
         def("__init__", [](Type& value, Scalar i) { value = (Type)i; });
-        def("__init__", [](Type& value, Scalar i) { new (&value) Type((Type) i); });
         def("__int__", [](Type value) { return (Scalar) value; });
         def("__eq__", [](const Type &value, Type *value2) { return value2 && value == *value2; });
         def("__ne__", [](const Type &value, Type *value2) { return !value2 || value != *value2; });


### PR DESCRIPTION
Added in 6fb48490ef9da9ecddea0c7b6de81b2aed6c762c

The second constructor can't be doing anything—the signatures are exactly the same, and so the first is always going to be the one invoked by the dispatcher.