### PR TITLE
VS 2017 AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,16 +1,22 @@
 version: 1.0.{build}
-os: Visual Studio 2015
+image:
+- Visual Studio 2017
+- Visual Studio 2015
 test: off
 platform:
-- x86
 - x64
+- x86
 environment:
   matrix:
+  - CONDA: 36
   - CONDA: 27
-  - CONDA: 35
+matrix:
+  fast_finish: true  # Stop remaining jobs after a job failure
 install:
 - ps: |
     if ($env:PLATFORM -eq "x64") { $env:CMAKE_ARCH = "x64" }
+    if ($env:APPVEYOR_JOB_NAME -like "*Visual Studio 2017*") { $env:CMAKE_GENERATOR = "Visual Studio 15 2017" }
+    else { $env:CMAKE_GENERATOR = "Visual Studio 14 2015" }
     if ($env:PYTHON) {
       if ($env:PLATFORM -eq "x64") { $env:PYTHON = "$env:PYTHON-x64" }
       $env:PATH = "C:\Python$env:PYTHON\;C:\Python$env:PYTHON\Scripts\;$env:PATH"
@@ -27,8 +33,8 @@ install:
     7z x 3.3.0.zip -y > $null
     $env:CMAKE_INCLUDE_PATH = "eigen-eigen-26667be4f70b"
 build_script:
-- cmake -A "%CMAKE_ARCH%" -DPYBIND11_WERROR=ON
+- cmake -G "%CMAKE_GENERATOR%" -A "%CMAKE_ARCH%" -DPYBIND11_WERROR=ON
 - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - cmake --build . --config Release --target pytest -- /v:m /logger:%MSBuildLogger%
 - cmake --build . --config Release --target test_cmake_build -- /v:m /logger:%MSBuildLogger%
-on_failure: type tests\test_cmake_build\*.log
+on_failure: if exist "tests\test_cmake_build" type tests\test_cmake_build\*.log


### PR DESCRIPTION
This adds VS 2017 to the build matrix, updates the appveyor Python version we build against to 3.6, and adds a workaround for one ICE that is triggered under VS 2017.

The appveyor build matrix support is a bit annoying: unlike travis, there is no ability to exclude some builds other than a dirty hack of making them fail early, and the 1.5 year old [appveyor bug](https://github.com/appveyor/ci/issues/386) has nothing from AppVeyor itself other than a suggestion to use this dirty hack.  I've done that here by marking the "skipped" tests as allow_failures.

The VS 2017 builds are still a bit slow to queue (they take a couple minutes to start), even for the "skipped" ones, but that should improve sometime next week once Appveyor migrates the 2017 builds to more efficient build infrastructure.

I'm not sure whether we should do it this way (i.e. with fake failures for skipped tests), or else just go ahead with enlarging the build matrix to 8 jobs (2 archs × 2 compilers × 2 python versions) since upstream apparently doesn't care to make it practical to incur a lighter build load.