### PR TITLE
Fix pydoc failure because of missing __module__

### DIFF
--- a/include/pybind11/class_support.h
+++ b/include/pybind11/class_support.h
@@ -57,6 +57,8 @@ inline PyTypeObject *make_static_property_type() {
     if (PyType_Ready(type) < 0)
         pybind11_fail("make_static_property_type(): failure in PyType_Ready()!");
 
+    setattr((PyObject *) type, "__module__", str("pybind11_builtins"));
+
     return type;
 }
 
@@ -170,6 +172,8 @@ inline PyTypeObject* make_default_metaclass() {
     if (PyType_Ready(type) < 0)
         pybind11_fail("make_default_metaclass(): failure in PyType_Ready()!");
 
+    setattr((PyObject *) type, "__module__", str("pybind11_builtins"));
+
     return type;
 }
 
@@ -269,6 +273,8 @@ inline PyObject *make_object_base_type(size_t instance_size) {
 
     if (PyType_Ready(type) < 0)
         pybind11_fail("PyType_Ready failed in make_object_base_type():" + error_string());
+
+    setattr((PyObject *) type, "__module__", str("pybind11_builtins"));
 
     assert(!PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC));
     return (PyObject *) heap_type;

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -52,3 +52,11 @@ def test_importing():
 
     assert OD is OrderedDict
     assert str(OD([(1, 'a'), (2, 'b')])) == "OrderedDict([(1, 'a'), (2, 'b')])"
+
+
+def test_pydoc():
+    """Pydoc needs to be able to provide help() for everything inside a pybind11 module"""
+    import pybind11_tests
+    import pydoc
+
+    assert pydoc.text.docmodule(pybind11_tests)


### PR DESCRIPTION
Fixes #728.

The `__module__` for all pybind11 types is set to `pybind11_builtins`, analogous to Python's own `builtins`.