### PR TITLE
Stop forcing c-contiguous in py::vectorize

### DIFF
--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -38,4 +38,17 @@ test_initializer numpy_vectorize([](py::module &m) {
     m.def("selective_func", [](py::array_t<int, py::array::c_style>) { return "Int branch taken."; });
     m.def("selective_func", [](py::array_t<float, py::array::c_style>) { return "Float branch taken."; });
     m.def("selective_func", [](py::array_t<std::complex<float>, py::array::c_style>) { return "Complex float branch taken."; });
+
+
+    // Internal optimization test for whether the input is trivially broadcastable:
+    m.def("vectorized_is_trivial", [](
+                py::array_t<int, py::array::forcecast> arg1,
+                py::array_t<float, py::array::forcecast> arg2,
+                py::array_t<double, py::array::forcecast> arg3
+                ) {
+        size_t ndim;
+        std::vector<size_t> shape;
+        std::array<py::buffer_info, 3> buffers {{ arg1.request(), arg2.request(), arg3.request() }};
+        return py::detail::broadcast(buffers, ndim, shape);
+    });
 });

--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -41,6 +41,10 @@ test_initializer numpy_vectorize([](py::module &m) {
 
 
     // Internal optimization test for whether the input is trivially broadcastable:
+    py::enum_<py::detail::broadcast_trivial>(m, "trivial")
+        .value("f_trivial", py::detail::broadcast_trivial::f_trivial)
+        .value("c_trivial", py::detail::broadcast_trivial::c_trivial)
+        .value("non_trivial", py::detail::broadcast_trivial::non_trivial);
     m.def("vectorized_is_trivial", [](
                 py::array_t<int, py::array::forcecast> arg1,
                 py::array_t<float, py::array::forcecast> arg2,

--- a/tests/test_numpy_vectorize.py
+++ b/tests/test_numpy_vectorize.py
@@ -25,6 +25,20 @@ def test_vectorize(capture):
             my_func(x:int=3, y:float=4, z:float=3)
         """
         with capture:
+            a = np.array([[1, 2], [3, 4]], order='F')
+            b = np.array([[10, 20], [30, 40]], order='F')
+            c = 3
+            result = f(a, b, c)
+            assert np.allclose(result, a * b * c)
+            assert result.flags.f_contiguous
+        # All inputs are F order and full or singletons, so we the result is in col-major order:
+        assert capture == """
+            my_func(x:int=1, y:float=10, z:float=3)
+            my_func(x:int=3, y:float=30, z:float=3)
+            my_func(x:int=2, y:float=20, z:float=3)
+            my_func(x:int=4, y:float=40, z:float=3)
+        """
+        with capture:
             a, b, c = np.array([[1, 3, 5], [7, 9, 11]]), np.array([[2, 4, 6], [8, 10, 12]]), 3
             assert np.allclose(f(a, b, c), a * b * c)
         assert capture == """
@@ -105,29 +119,43 @@ def test_docs(doc):
 
 
 def test_trivial_broadcasting():
-    from pybind11_tests import vectorized_is_trivial
+    from pybind11_tests import vectorized_is_trivial, trivial, vectorized_func
 
-    assert vectorized_is_trivial(1, 2, 3)
-    assert vectorized_is_trivial(np.array(1), np.array(2), 3)
-    assert vectorized_is_trivial(np.array([1, 3]), np.array([2, 4]), 3)
-    assert vectorized_is_trivial(
+    assert vectorized_is_trivial(1, 2, 3) == trivial.c_trivial
+    assert vectorized_is_trivial(np.array(1), np.array(2), 3) == trivial.c_trivial
+    assert vectorized_is_trivial(np.array([1, 3]), np.array([2, 4]), 3) == trivial.c_trivial
+    assert trivial.c_trivial == vectorized_is_trivial(
         np.array([[1, 3, 5], [7, 9, 11]]), np.array([[2, 4, 6], [8, 10, 12]]), 3)
-    assert not vectorized_is_trivial(
-        np.array([[1, 2, 3], [4, 5, 6]]), np.array([2, 3, 4]), 2)
-    assert not vectorized_is_trivial(
-        np.array([[1, 2, 3], [4, 5, 6]]), np.array([[2], [3]]), 2)
+    assert vectorized_is_trivial(
+        np.array([[1, 2, 3], [4, 5, 6]]), np.array([2, 3, 4]), 2) == trivial.non_trivial
+    assert vectorized_is_trivial(
+        np.array([[1, 2, 3], [4, 5, 6]]), np.array([[2], [3]]), 2) == trivial.non_trivial
     z1 = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype='int32')
     z2 = np.array(z1, dtype='float32')
     z3 = np.array(z1, dtype='float64')
-    assert vectorized_is_trivial(z1, z2, z3)
-    assert not vectorized_is_trivial(z1[::2, ::2], 1, 1)
-    assert vectorized_is_trivial(1, 1, z1[::2, ::2])
-    assert not vectorized_is_trivial(1, 1, z3[::2, ::2])
-    assert vectorized_is_trivial(z1, 1, z3[1::4, 1::4])
+    assert vectorized_is_trivial(z1, z2, z3) == trivial.c_trivial
+    assert vectorized_is_trivial(1, z2, z3) == trivial.c_trivial
+    assert vectorized_is_trivial(z1, 1, z3) == trivial.c_trivial
+    assert vectorized_is_trivial(z1, z2, 1) == trivial.c_trivial
+    assert vectorized_is_trivial(z1[::2, ::2], 1, 1) == trivial.non_trivial
+    assert vectorized_is_trivial(1, 1, z1[::2, ::2]) == trivial.c_trivial
+    assert vectorized_is_trivial(1, 1, z3[::2, ::2]) == trivial.non_trivial
+    assert vectorized_is_trivial(z1, 1, z3[1::4, 1::4]) == trivial.c_trivial
 
     y1 = np.array(z1, order='F')
     y2 = np.array(y1)
     y3 = np.array(y1)
-    assert not vectorized_is_trivial(y1, y2, y3)
-    assert not vectorized_is_trivial(y1, z2, z3)
-    assert not vectorized_is_trivial(y1, 1, 1)
+    assert vectorized_is_trivial(y1, y2, y3) == trivial.f_trivial
+    assert vectorized_is_trivial(y1, 1, 1) == trivial.f_trivial
+    assert vectorized_is_trivial(1, y2, 1) == trivial.f_trivial
+    assert vectorized_is_trivial(1, 1, y3) == trivial.f_trivial
+    assert vectorized_is_trivial(y1, z2, 1) == trivial.non_trivial
+    assert vectorized_is_trivial(z1[1::4, 1::4], y2, 1) == trivial.f_trivial
+    assert vectorized_is_trivial(y1[1::4, 1::4], z2, 1) == trivial.c_trivial
+
+    assert vectorized_func(z1, z2, z3).flags.c_contiguous
+    assert vectorized_func(y1, y2, y3).flags.f_contiguous
+    assert vectorized_func(z1, 1, 1).flags.c_contiguous
+    assert vectorized_func(1, y2, 1).flags.f_contiguous
+    assert vectorized_func(z1[1::4, 1::4], y2, 1).flags.f_contiguous
+    assert vectorized_func(y1[1::4, 1::4], z2, 1).flags.c_contiguous


### PR DESCRIPTION
The only part of the vectorize code that actually needs c-contiguous storage is the "trivial" broadcast; for non-trivial arguments, the code already uses strides properly (and so handles C-style, F-style, neither, slices, etc.)

This commit rewrites `broadcast` to additionally check for C-contiguous storage, then takes off the `c_style` flag for the arguments, which will keep the functionality more or less the same, except for no longer requiring an array copy for non-c-contiguous input arrays.

Fixes #671 

Edit: this also enables trivial broadcasting on full-size F-contiguous inputs.