### PR TITLE
Fail to compile if attempting to specifying MI bases via `class_` ctor parameters

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -333,7 +333,7 @@ template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
     }
 };
 
-/// Process a parent class attribute
+/// Process a parent class attribute.  Single inheritance only (class_ itself already guarantees that)
 template <typename T>
 struct process_attribute<T, enable_if_t<is_pyobject<T>::value>> : process_attribute_default<handle> {
     static void init(const handle &h, type_record *r) { r->bases.append(h); }

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -31,18 +31,27 @@ struct MIType : Base12 {
 };
 
 test_initializer multiple_inheritance([](py::module &m) {
-    py::class_<Base1>(m, "Base1")
-        .def(py::init<int>())
-        .def("foo", &Base1::foo);
+    py::class_<Base1> b1(m, "Base1");
+    b1.def(py::init<int>())
+      .def("foo", &Base1::foo);
 
-    py::class_<Base2>(m, "Base2")
-        .def(py::init<int>())
-        .def("bar", &Base2::bar);
+    py::class_<Base2> b2(m, "Base2");
+    b2.def(py::init<int>())
+      .def("bar", &Base2::bar);
 
     py::class_<Base12, Base1, Base2>(m, "Base12");
 
     py::class_<MIType, Base12>(m, "MIType")
         .def(py::init<int, int>());
+
+    // Uncommenting this should result in a compile time failure (MI can only be specified via
+    // template parameters because pybind has to know the types involved; see discussion in #742 for
+    // details).
+//    struct Base12v2 : Base1, Base2 {
+//        Base12v2(int i, int j) : Base1(i), Base2(j) { }
+//    };
+//    py::class_<Base12v2>(m, "Base12v2", b1, b2)
+//        .def(py::init<int, int>());
 });
 
 /* Test the case where not all base classes are specified,


### PR DESCRIPTION
~~Currently we only allow multiple inheritance via `class_` template parameters; this extends the support to `class_` instances passed via the derived `class_` constructor arguments as well.~~

Edit: see discussion below.  We *can't* support MI via parameters in [the most useful case](http://pybind11.readthedocs.io/en/latest/advanced/misc.html#partitioning-code-over-multiple-extension-modules), so produce a compile time error instead.

Fixes #741