### PR TITLE
Use C++17 fold expression macro

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -405,7 +405,7 @@ template <class T> using negation = bool_constant<!T::value>;
 #endif
 
 /// Compile-time all/any/none of that check the boolean value of all template types
-#ifdef PYBIND11_CPP17
+#ifdef __cpp_fold_expressions
 template <class... Ts> using all_of = bool_constant<(Ts::value && ...)>;
 template <class... Ts> using any_of = bool_constant<(Ts::value || ...)>;
 #elif !defined(_MSC_VER)
@@ -448,9 +448,13 @@ struct void_type { };
 template <typename...> struct type_list { };
 
 /// Compile-time integer sum
+#ifdef __cpp_fold_expressions
+template <typename... Ts> constexpr size_t constexpr_sum(Ts... ns) { return (0 + ... + size_t{ns}); }
+#else
 constexpr size_t constexpr_sum() { return 0; }
 template <typename T, typename... Ts>
 constexpr size_t constexpr_sum(T n, Ts... ns) { return size_t{n} + constexpr_sum(ns...); }
+#endif
 
 NAMESPACE_BEGIN(constexpr_impl)
 /// Implementation details for constexpr functions


### PR DESCRIPTION
This puts the fold expressions behind the feature macro instead of a general C++17 macro.

It also adds a fold expression optimization to `constexpr_sum` (guarded by the same feature macro).