### PR TITLE
Eigen: don't require conformability on length-1 dimensions

### DIFF
--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -79,11 +79,17 @@ template <bool EigenRowMajor> struct EigenConformable {
                EigenRowMajor ? cstride : rstride /* inner stride */)
         {}
     // Vector type:
-    EigenConformable(EigenIndex r, EigenIndex c, EigenIndex stride) : EigenConformable(r, c, r == 1 ? c*stride : stride, c == 1 ? r : r*stride) {}
+    EigenConformable(EigenIndex r, EigenIndex c, EigenIndex stride)
+        : EigenConformable(r, c, r == 1 ? c*stride : stride, c == 1 ? r : r*stride) {}
+
     template <typename props> bool stride_compatible() const {
+        // To have compatible strides, we need (on both dimensions) one of fully dynamic strides,
+        // matching strides, or a dimension size of 1 (in which case the stride value is irrelevant)
         return
-            (props::inner_stride == Eigen::Dynamic || props::inner_stride == stride.inner()) &&
-            (props::outer_stride == Eigen::Dynamic || props::outer_stride == stride.outer());
+            (props::inner_stride == Eigen::Dynamic || props::inner_stride == stride.inner() ||
+                (EigenRowMajor ? cols : rows) == 1) &&
+            (props::outer_stride == Eigen::Dynamic || props::outer_stride == stride.outer() ||
+                (EigenRowMajor ? rows : cols) == 1);
     }
     operator bool() const { return conformable; }
 };

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -604,3 +604,13 @@ def test_sparse_signature(doc):
     assert doc(sparse_copy_c) == """
         sparse_copy_c(arg0: scipy.sparse.csc_matrix[float32]) -> scipy.sparse.csc_matrix[float32]
     """  # noqa: E501 line too long
+
+
+def test_issue738():
+    from pybind11_tests import iss738_f1, iss738_f2
+
+    assert np.all(iss738_f1(np.array([[1., 2, 3]])) == np.array([[1., 102, 203]]))
+    assert np.all(iss738_f1(np.array([[1.], [2], [3]])) == np.array([[1.], [12], [23]]))
+
+    assert np.all(iss738_f2(np.array([[1., 2, 3]])) == np.array([[1., 102, 203]]))
+    assert np.all(iss738_f2(np.array([[1.], [2], [3]])) == np.array([[1.], [12], [23]]))


### PR DESCRIPTION
Fixes #738

The current check for conformability fails when given a 2D, 1xN or Nx1 input to a row-major or column-major, respectively, `Eigen::Ref`, leading to a copy-required state in the type_caster, but this later failed because the copy was also non-conformable because it had the same shape and strides (because a 1xN or Nx1 is both F and C contiguous).

In such cases we can safely ignore the stride on the "1" dimension since it'll never be used: only the "N" dimension stride needs to match the `Eigen::Ref` stride, which both fixes the non-conformable copy problem, but also avoids a copy entirely in most cases (as long as the "N" dimension has a compatible stride).