### PR TITLE
Add unchecked array access via proxy object

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -336,7 +336,7 @@ where ``N`` gives the required dimensionality of the array:
             for (size_t j = 0; j < r.shape(1); j++)
                 for (size_t k = 0; k < r.shape(2); k++)
                     r(i, j, k) += 1.0;
-    });
+    }, py::arg().noconvert());
 
 To obtain the proxy from an ``array`` object, you must specify both the data
 type and number of dimensions as a template argument, such as ``auto r =
@@ -346,3 +346,8 @@ Note that the returned proxy object directly references the array's data,
 shape, and strides: you must take care to ensure that the referenced array
 object is not destroyed or reshaped for the duration of the returned object,
 typically by limiting the scope of the returned instance.
+
+.. seealso::
+
+    The file :file:`tests/test_numpy_array.cpp` contains additional examples
+    demonstrating the use of this feature.

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -330,8 +330,6 @@ where ``N`` gives the required dimensionality of the array:
     });
     m.def("increment_3d", [](py::array_t<double> x) {
         auto r = x.unchecked<3>(); // Will throw if ndim != 3 or flags.writeable is false
-        if (x.ndim() != 3)
-            throw std::runtime_error("error: 3D array required");
         for (size_t i = 0; i < r.shape(0); i++)
             for (size_t j = 0; j < r.shape(1); j++)
                 for (size_t k = 0; k < r.shape(2); k++)

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -314,13 +314,13 @@ is often desirable to directly access array elements without internal checking
 of dimensions and bounds on every access when indices are known to be already
 valid.  To avoid such checks, the ``array`` class and ``array_t<T>`` template
 class offer an unchecked proxy object that can be used for this unchecked
-access through the ``unchecked<N>`` and ``unchecked_readonly<N>`` methods,
+access through the ``unchecked<N>`` and ``mutable_unchecked<N>`` methods,
 where ``N`` gives the required dimensionality of the array:
 
 .. code-block:: cpp
 
     m.def("sum_3d", [](py::array_t<double> x) {
-        auto r = x.unchecked_readonly<3>(); // x must have ndim = 3; can be non-writeable
+        auto r = x.unchecked<3>(); // x must have ndim = 3; can be non-writeable
         double sum = 0;
         for (size_t i = 0; i < r.shape(0); i++)
             for (size_t j = 0; j < r.shape(1); j++)
@@ -329,7 +329,7 @@ where ``N`` gives the required dimensionality of the array:
         return sum;
     });
     m.def("increment_3d", [](py::array_t<double> x) {
-        auto r = x.unchecked<3>(); // Will throw if ndim != 3 or flags.writeable is false
+        auto r = x.mutable_unchecked<3>(); // Will throw if ndim != 3 or flags.writeable is false
         for (size_t i = 0; i < r.shape(0); i++)
             for (size_t j = 0; j < r.shape(1); j++)
                 for (size_t k = 0; k < r.shape(2); k++)
@@ -337,8 +337,8 @@ where ``N`` gives the required dimensionality of the array:
     }, py::arg().noconvert());
 
 To obtain the proxy from an ``array`` object, you must specify both the data
-type and number of dimensions as a template argument, such as ``auto r =
-myarray.unchecked<float, 2>()``.
+type and number of dimensions as template arguments, such as ``auto r =
+myarray.mutable_unchecked<float, 2>()``.
 
 Note that the returned proxy object directly references the array's data, and
 only reads its shape, strides, and writeable flag when constructed.  You must

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -342,10 +342,11 @@ To obtain the proxy from an ``array`` object, you must specify both the data
 type and number of dimensions as a template argument, such as ``auto r =
 myarray.unchecked<float, 2>()``.
 
-Note that the returned proxy object directly references the array's data,
-shape, and strides: you must take care to ensure that the referenced array
-object is not destroyed or reshaped for the duration of the returned object,
-typically by limiting the scope of the returned instance.
+Note that the returned proxy object directly references the array's data, and
+only reads its shape, strides, and writeable flag when constructed.  You must
+take care to ensure that the referenced array is not destroyed or reshaped for
+the duration of the returned object, typically by limiting the scope of the
+returned instance.
 
 .. seealso::
 

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -340,11 +340,38 @@ To obtain the proxy from an ``array`` object, you must specify both the data
 type and number of dimensions as template arguments, such as ``auto r =
 myarray.mutable_unchecked<float, 2>()``.
 
+If the number of dimensions is not known at compile time, you can omit the
+dimensions template parameter (i.e. calling ``arr_t.unchecked()`` or
+``arr.unchecked<T>()``.  This will give you a proxy object that works in the
+same way, but results in less optimizable code and thus a small efficiency
+loss in tight loops.
+
 Note that the returned proxy object directly references the array's data, and
 only reads its shape, strides, and writeable flag when constructed.  You must
 take care to ensure that the referenced array is not destroyed or reshaped for
 the duration of the returned object, typically by limiting the scope of the
 returned instance.
+
+The returned proxy object supports some of the same methods as ``py::array`` so
+that it can be used as a drop-in replacement for some existing, index-checked
+uses of ``py::array``:
+
+- ``r.ndim()`` returns the number of dimensions
+
+- ``r.data(1, 2, ...)`` and ``r.mutable_data(1, 2, ...)``` returns a pointer to
+  the ``const T`` or ``T`` data, respectively, at the given indices.  The
+  latter is only available to proxies obtained via ``a.mutable_unchecked()``.
+
+- ``itemsize()`` returns the size of an item in bytes, i.e. ``sizeof(T)``.
+
+- ``ndim()`` returns the number of dimensions.
+
+- ``shape(n)`` returns the size of dimension ``n``
+
+- ``size()`` returns the total number of elements (i.e. the product of the shapes).
+
+- ``nbytes()`` returns the number of bytes used by the referenced elements
+  (i.e. ``itemsize()`` times ``size()``).
 
 .. seealso::
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -272,7 +272,7 @@ public:
     /** Unchecked const reference access to data; this operator only participates if the reference
      * is to a 1-dimensional array.  When present, this is exactly equivalent to `obj(index)`.
      */
-    template <typename = enable_if_t<Dims == 1>>
+    template <size_t D = Dims, typename = enable_if_t<D == 1>>
     const T &operator[](size_t index) const { return operator()(index); }
 
     /// Returns the shape (i.e. size) of dimension `dim`
@@ -295,7 +295,7 @@ public:
     /** Mutable, unchecked access data at the given index; this operator only participates if the
      * reference is to a 1-dimensional array.  When present, this is exactly equivalent to `obj(index)`.
      */
-    template <typename = enable_if_t<Dims == 1>>
+    template <size_t D = Dims, typename = enable_if_t<D == 1>>
     T &operator[](size_t index) { return operator()(index); }
 };
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -334,8 +334,8 @@ private:
     }
 };
 
-/** Class provide unsafe, unchecked const access to array data.  This is constructed through the
- * `unchecked<T, N>()` method of `array` or the `unchecked<N>()` method of `array_t<T>`.
+/** Proxy class providing unsafe, unchecked const access to array data.  This is constructed through
+ * the `unchecked<T, N>()` method of `array` or the `unchecked<N>()` method of `array_t<T>`.
  */
 template <typename T, size_t Dims>
 class unchecked_const_reference {
@@ -391,6 +391,17 @@ public:
     template <typename = detail::enable_if_t<Dims == 1>>
     T &operator[](size_t index) { return operator()(index); }
 };
+
+NAMESPACE_BEGIN(detail)
+
+template <typename T, size_t Dim>
+struct type_caster<unchecked_const_reference<T, Dim>> {
+    static_assert(Dim == (size_t) -1 /* always fail */, "unchecked array proxy object is not castable");
+};
+template <typename T, size_t Dim>
+struct type_caster<unchecked_reference<T, Dim>> : type_caster<unchecked_const_reference<T, Dim>> {};
+
+NAMESPACE_END(detail)
 
 class array : public buffer {
 public:

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -186,14 +186,14 @@ test_initializer numpy_array([](py::module &m) {
     sm.def("issue685", [](py::object) { return "other"; });
 
     sm.def("proxy_add2", [](py::array_t<double> a, double v) {
-        auto r = a.unchecked<2>();
+        auto r = a.mutable_unchecked<2>();
         for (size_t i = 0; i < r.shape(0); i++)
             for (size_t j = 0; j < r.shape(1); j++)
                 r(i, j) += v;
     }, py::arg().noconvert(), py::arg());
     sm.def("proxy_init3", [](double start) {
         py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
-        auto r = a.unchecked<3>();
+        auto r = a.mutable_unchecked<3>();
         for (size_t i = 0; i < r.shape(0); i++)
         for (size_t j = 0; j < r.shape(1); j++)
         for (size_t k = 0; k < r.shape(2); k++)
@@ -202,7 +202,7 @@ test_initializer numpy_array([](py::module &m) {
     });
     sm.def("proxy_init3F", [](double start) {
         py::array_t<double, py::array::f_style> a({ 3, 3, 3 });
-        auto r = a.unchecked<3>();
+        auto r = a.mutable_unchecked<3>();
         for (size_t k = 0; k < r.shape(2); k++)
         for (size_t j = 0; j < r.shape(1); j++)
         for (size_t i = 0; i < r.shape(0); i++)
@@ -210,14 +210,7 @@ test_initializer numpy_array([](py::module &m) {
         return a;
     });
     sm.def("proxy_squared_L2_norm", [](py::array_t<double> a) {
-        auto r = a.unchecked_readonly<1>();
-        double sumsq = 0;
-        for (size_t i = 0; i < r.shape(0); i++)
-            sumsq += r[i] * r(i); // Either notation works for a 1D array
-        return sumsq;
-    });
-    sm.def("proxy_squared_L2_norm_v2", [](const py::array_t<double> &a) {
-        auto r = a.unchecked<1>(); // equivalent to unchecked_readonly when `a` is const
+        auto r = a.unchecked<1>();
         double sumsq = 0;
         for (size_t i = 0; i < r.shape(0); i++)
             sumsq += r[i] * r(i); // Either notation works for a 1D array

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -191,6 +191,7 @@ test_initializer numpy_array([](py::module &m) {
             for (size_t j = 0; j < r.shape(1); j++)
                 r(i, j) += v;
     }, py::arg().noconvert(), py::arg());
+
     sm.def("proxy_init3", [](double start) {
         py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
         auto r = a.mutable_unchecked<3>();
@@ -215,5 +216,56 @@ test_initializer numpy_array([](py::module &m) {
         for (size_t i = 0; i < r.shape(0); i++)
             sumsq += r[i] * r(i); // Either notation works for a 1D array
         return sumsq;
+    });
+
+    sm.def("proxy_auxiliaries2", [](py::array_t<double> a) {
+        auto r = a.unchecked<2>();
+        auto r2 = a.mutable_unchecked<2>();
+        py::list l;
+        l.append(*r.data(0, 0));
+        l.append(*r2.mutable_data(0, 0));
+        l.append(r.data(0, 1) == r2.mutable_data(0, 1));
+        l.append(r.ndim());
+        l.append(r.itemsize());
+        l.append(r.shape(0));
+        l.append(r.shape(1));
+        l.append(r.size());
+        l.append(r.nbytes());
+        return l.release();
+    });
+
+    // Same as the above, but without a compile-time dimensions specification:
+    sm.def("proxy_add2_dyn", [](py::array_t<double> a, double v) {
+        auto r = a.mutable_unchecked();
+        if (r.ndim() != 2) throw std::domain_error("error: ndim != 2");
+        for (size_t i = 0; i < r.shape(0); i++)
+            for (size_t j = 0; j < r.shape(1); j++)
+                r(i, j) += v;
+    }, py::arg().noconvert(), py::arg());
+    sm.def("proxy_init3_dyn", [](double start) {
+        py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
+        auto r = a.mutable_unchecked();
+        if (r.ndim() != 3) throw std::domain_error("error: ndim != 3");
+        for (size_t i = 0; i < r.shape(0); i++)
+        for (size_t j = 0; j < r.shape(1); j++)
+        for (size_t k = 0; k < r.shape(2); k++)
+            r(i, j, k) = start++;
+        return a;
+    });
+    sm.def("proxy_auxiliaries2_dyn", [](py::array_t<double> a) {
+        auto r = a.unchecked();
+        if (r.ndim() != 2) throw std::domain_error("error: ndim != 2");
+        auto r2 = a.mutable_unchecked();
+        py::list l;
+        l.append(*r.data(0, 0));
+        l.append(*r2.mutable_data(0, 0));
+        l.append(r.data(0, 1) == r2.mutable_data(0, 1));
+        l.append(r.ndim());
+        l.append(r.itemsize());
+        l.append(r.shape(0));
+        l.append(r.shape(1));
+        l.append(r.size());
+        l.append(r.nbytes());
+        return l.release();
     });
 });

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -184,4 +184,43 @@ test_initializer numpy_array([](py::module &m) {
     sm.def("issue685", [](std::string) { return "string"; });
     sm.def("issue685", [](py::array) { return "array"; });
     sm.def("issue685", [](py::object) { return "other"; });
+
+    sm.def("proxy_add2", [](py::array_t<double> a, double v) {
+        auto r = a.unchecked<2>();
+        for (size_t i = 0; i < r.shape(0); i++)
+            for (size_t j = 0; j < r.shape(1); j++)
+                r(i, j) += v;
+    }, py::arg().noconvert(), py::arg());
+    sm.def("proxy_init3", [](double start) {
+        py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
+        auto r = a.unchecked<3>();
+        for (size_t i = 0; i < r.shape(0); i++)
+        for (size_t j = 0; j < r.shape(1); j++)
+        for (size_t k = 0; k < r.shape(2); k++)
+            r(i, j, k) = start++;
+        return a;
+    });
+    sm.def("proxy_init3F", [](double start) {
+        py::array_t<double, py::array::f_style> a({ 3, 3, 3 });
+        auto r = a.unchecked<3>();
+        for (size_t k = 0; k < r.shape(2); k++)
+        for (size_t j = 0; j < r.shape(1); j++)
+        for (size_t i = 0; i < r.shape(0); i++)
+            r(i, j, k) = start++;
+        return a;
+    });
+    sm.def("proxy_squared_L2_norm", [](py::array_t<double> a) {
+        auto r = a.unchecked_readonly<1>();
+        double sumsq = 0;
+        for (size_t i = 0; i < r.shape(0); i++)
+            sumsq += r[i] * r(i); // Either notation works for a 1D array
+        return sumsq;
+    });
+    sm.def("proxy_squared_L2_norm_v2", [](const py::array_t<double> &a) {
+        auto r = a.unchecked<1>(); // equivalent to unchecked_readonly when `a` is const
+        double sumsq = 0;
+        for (size_t i = 0; i < r.shape(0); i++)
+            sumsq += r[i] * r(i); // Either notation works for a 1D array
+        return sumsq;
+    });
 });

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -342,8 +342,7 @@ def test_greedy_string_overload():  # issue 685
 
 
 def test_array_unchecked(msg):
-    from pybind11_tests.array import (proxy_add2, proxy_init3F, proxy_init3,
-                                      proxy_squared_L2_norm, proxy_squared_L2_norm_v2)
+    from pybind11_tests.array import proxy_add2, proxy_init3F, proxy_init3, proxy_squared_L2_norm
 
     z1 = np.array([[1, 2], [3, 4]], dtype='float64')
     proxy_add2(z1, 10)
@@ -360,5 +359,3 @@ def test_array_unchecked(msg):
 
     assert proxy_squared_L2_norm(np.array(range(6))) == 55
     assert proxy_squared_L2_norm(np.array(range(6), dtype="float64")) == 55
-    assert proxy_squared_L2_norm_v2(np.array(range(6))) == 55
-    assert proxy_squared_L2_norm_v2(np.array(range(6), dtype="float64")) == 55

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -343,7 +343,7 @@ def test_greedy_string_overload():  # issue 685
 
 def test_array_unchecked_fixed_dims(msg):
     from pybind11_tests.array import (proxy_add2, proxy_init3F, proxy_init3, proxy_squared_L2_norm,
-                                      proxy_auxiliaries2)
+                                      proxy_auxiliaries2, array_auxiliaries2)
 
     z1 = np.array([[1, 2], [3, 4]], dtype='float64')
     proxy_add2(z1, 10)
@@ -362,10 +362,12 @@ def test_array_unchecked_fixed_dims(msg):
     assert proxy_squared_L2_norm(np.array(range(6), dtype="float64")) == 55
 
     assert proxy_auxiliaries2(z1) == [11, 11, True, 2, 8, 2, 2, 4, 32]
+    assert proxy_auxiliaries2(z1) == array_auxiliaries2(z1)
 
 
 def test_array_unchecked_dyn_dims(msg):
-    from pybind11_tests.array import proxy_add2_dyn, proxy_init3_dyn, proxy_auxiliaries2_dyn
+    from pybind11_tests.array import (proxy_add2_dyn, proxy_init3_dyn, proxy_auxiliaries2_dyn,
+                                      array_auxiliaries2)
     z1 = np.array([[1, 2], [3, 4]], dtype='float64')
     proxy_add2_dyn(z1, 10)
     assert np.all(z1 == [[11, 12], [13, 14]])
@@ -374,3 +376,4 @@ def test_array_unchecked_dyn_dims(msg):
     assert np.all(proxy_init3_dyn(3.0) == expect_c)
 
     assert proxy_auxiliaries2_dyn(z1) == [11, 11, True, 2, 8, 2, 2, 4, 32]
+    assert proxy_auxiliaries2_dyn(z1) == array_auxiliaries2(z1)

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -341,8 +341,9 @@ def test_greedy_string_overload():  # issue 685
     assert issue685(123) == "other"
 
 
-def test_array_unchecked(msg):
-    from pybind11_tests.array import proxy_add2, proxy_init3F, proxy_init3, proxy_squared_L2_norm
+def test_array_unchecked_fixed_dims(msg):
+    from pybind11_tests.array import (proxy_add2, proxy_init3F, proxy_init3, proxy_squared_L2_norm,
+                                      proxy_auxiliaries2)
 
     z1 = np.array([[1, 2], [3, 4]], dtype='float64')
     proxy_add2(z1, 10)
@@ -359,3 +360,17 @@ def test_array_unchecked(msg):
 
     assert proxy_squared_L2_norm(np.array(range(6))) == 55
     assert proxy_squared_L2_norm(np.array(range(6), dtype="float64")) == 55
+
+    assert proxy_auxiliaries2(z1) == [11, 11, True, 2, 8, 2, 2, 4, 32]
+
+
+def test_array_unchecked_dyn_dims(msg):
+    from pybind11_tests.array import proxy_add2_dyn, proxy_init3_dyn, proxy_auxiliaries2_dyn
+    z1 = np.array([[1, 2], [3, 4]], dtype='float64')
+    proxy_add2_dyn(z1, 10)
+    assert np.all(z1 == [[11, 12], [13, 14]])
+
+    expect_c = np.ndarray(shape=(3, 3, 3), buffer=np.array(range(3, 30)), dtype='int')
+    assert np.all(proxy_init3_dyn(3.0) == expect_c)
+
+    assert proxy_auxiliaries2_dyn(z1) == [11, 11, True, 2, 8, 2, 2, 4, 32]

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -339,3 +339,26 @@ def test_greedy_string_overload():  # issue 685
     assert issue685("abc") == "string"
     assert issue685(np.array([97, 98, 99], dtype='b')) == "array"
     assert issue685(123) == "other"
+
+
+def test_array_unchecked(msg):
+    from pybind11_tests.array import (proxy_add2, proxy_init3F, proxy_init3,
+                                      proxy_squared_L2_norm, proxy_squared_L2_norm_v2)
+
+    z1 = np.array([[1, 2], [3, 4]], dtype='float64')
+    proxy_add2(z1, 10)
+    assert np.all(z1 == [[11, 12], [13, 14]])
+
+    with pytest.raises(ValueError) as excinfo:
+        proxy_add2(np.array([1., 2, 3]), 5.0)
+    assert msg(excinfo.value) == "array has incorrect number of dimensions: 1; expected 2"
+
+    expect_c = np.ndarray(shape=(3, 3, 3), buffer=np.array(range(3, 30)), dtype='int')
+    assert np.all(proxy_init3(3.0) == expect_c)
+    expect_f = np.transpose(expect_c)
+    assert np.all(proxy_init3F(3.0) == expect_f)
+
+    assert proxy_squared_L2_norm(np.array(range(6))) == 55
+    assert proxy_squared_L2_norm(np.array(range(6), dtype="float64")) == 55
+    assert proxy_squared_L2_norm_v2(np.array(range(6))) == 55
+    assert proxy_squared_L2_norm_v2(np.array(range(6), dtype="float64")) == 55


### PR DESCRIPTION
My stab at addressing #599/#617.

This adds bounds-unchecked access to arrays through a `a.unchecked<Type, Dimensions>()` method which returns a proxy object (after checking dimensionality and mutability).  For `array_t<T>`, the `Type` template parameter is omitted.  A readonly version (which doesn't require mutability when being created) is available as `a.unchecked_readonly<...>()`.

(I chose the name `unchecked` rather than `unsafe` because it isn't exactly unsafe to use this, it's just potentially unsafe if not done carefully).

The one slightly unusual addition from @dean0x7d 's simple example is specifying the `Dimensions` as a template parameter.  I did this because it allows storage of the strides and shape in `std::array`s; having them stored that way (as opposed to storing a copy of the array's strides/shape pointers) allows the
compiler to make significant optimizations that it can't make with a pointer; testing with nested loops of the form:

```C++
    for (size_t i0 = 0; i0 < r.shape(0); i0++)
        for (size_t i1 = 0; i1 < r.shape(1); i1++)
            ...
                r(i0, i1, ...) += 1;
```

over a 10 million element array gave me around a 25% speedup (versus using a pointer) for the 1D case, 33% for 2D, and saw the 5D case run about 2.5 times as fast; the latter, in particular, was a pretty remarkably speedup.

Since the primary purpose of this interface is for unfettered, high-performance access, requiring a compile-time dimensionality seems worthwhile given the gains it can achieve.  As a nice side effect, it also lets us catch an invalid number of indices at compile time, and allows `operator []` access to be enabled only for 1D arrays.

I haven't added the tests into the PR yet; I wanted to invite comments on the proposal first.