### PR TITLE
Support class-specific operator new and delete

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -174,6 +174,9 @@ struct type_record {
     /// How large is pybind11::instance<type>?
     size_t instance_size = 0;
 
+    /// The global operator new can be overridden with a class-specific variant
+    void *(*operator_new)(size_t) = ::operator new;
+
     /// Function pointer to class_<..>::init_holder
     void (*init_holder)(PyObject *, const void *) = nullptr;
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -25,6 +25,7 @@ inline PyTypeObject *make_default_metaclass();
 struct type_info {
     PyTypeObject *type;
     size_t type_size;
+    void *(*operator_new)(size_t);
     void (*init_holder)(PyObject *, const void *);
     void (*dealloc)(PyObject *);
     std::vector<PyObject *(*)(PyObject *, PyTypeObject *)> implicit_conversions;

--- a/include/pybind11/class_support.h
+++ b/include/pybind11/class_support.h
@@ -183,7 +183,7 @@ extern "C" inline PyObject *pybind11_object_new(PyTypeObject *type, PyObject *, 
     PyObject *self = type->tp_alloc(type, 0);
     auto instance = (instance_essentials<void> *) self;
     auto tinfo = get_type_info(type);
-    instance->value = ::operator new(tinfo->type_size);
+    instance->value = tinfo->operator_new(tinfo->type_size);
     instance->owned = true;
     instance->holder_constructed = false;
     get_internals().registered_instances.emplace(instance->value, self);

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -427,6 +427,13 @@ template<size_t N> using make_index_sequence = typename make_index_sequence_impl
 template <bool B> using bool_constant = std::integral_constant<bool, B>;
 template <typename T> struct negation : bool_constant<!T::value> { };
 
+#ifdef __cpp_lib_void_t
+using std::void_t;
+#else
+template <typename...> struct void_t_impl { using type = void; };
+template <typename... Ts> using void_t = typename void_t_impl<Ts...>::type;
+#endif
+
 /// Compile-time all/any/none of that check the boolean value of all template types
 #ifdef __cpp_fold_expressions
 template <class... Ts> using all_of = bool_constant<(Ts::value && ...)>;

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -60,6 +60,15 @@ template <typename MatrixArgType> Eigen::MatrixXd adjust_matrix(MatrixArgType m)
     return ret;
 }
 
+struct CustomOperatorNew {
+    CustomOperatorNew() = default;
+
+    Eigen::Matrix4d a = Eigen::Matrix4d::Zero();
+    Eigen::Matrix4d b = Eigen::Matrix4d::Identity();
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+};
+
 test_initializer eigen([](py::module &m) {
     typedef Eigen::Matrix<float, 5, 6, Eigen::RowMajor> FixedMatrixR;
     typedef Eigen::Matrix<float, 5, 6> FixedMatrixC;
@@ -277,4 +286,9 @@ test_initializer eigen([](py::module &m) {
     // requiring a copy!) because the stride value can be safely ignored on a size-1 dimension.
     m.def("iss738_f1", &adjust_matrix<const Eigen::Ref<const Eigen::MatrixXd> &>, py::arg().noconvert());
     m.def("iss738_f2", &adjust_matrix<const Eigen::Ref<const Eigen::Matrix<double, -1, -1, Eigen::RowMajor>> &>, py::arg().noconvert());
+
+    py::class_<CustomOperatorNew>(m, "CustomOperatorNew")
+        .def(py::init<>())
+        .def_readonly("a", &CustomOperatorNew::a)
+        .def_readonly("b", &CustomOperatorNew::b);
 });

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -614,3 +614,13 @@ def test_issue738():
 
     assert np.all(iss738_f2(np.array([[1., 2, 3]])) == np.array([[1., 102, 203]]))
     assert np.all(iss738_f2(np.array([[1.], [2], [3]])) == np.array([[1.], [12], [23]]))
+
+
+def test_custom_operator_new():
+    """Using Eigen types as member variables requires a class-specific
+    operator new with proper alignment"""
+    from pybind11_tests import CustomOperatorNew
+
+    o = CustomOperatorNew()
+    np.testing.assert_allclose(o.a, 0.0)
+    np.testing.assert_allclose(o.b.diagonal(), 1.0)


### PR DESCRIPTION
Fixes #754.

`void_t` was needed to work around a GCC 4.8 issue, but it's pretty useful to have anyway.