### PR TITLE
Support raw string literals as input for py::eval

### DIFF
--- a/docs/advanced/pycpp/utilities.rst
+++ b/docs/advanced/pycpp/utilities.rst
@@ -56,7 +56,9 @@ is always ``none``).
     // Evaluate the statements in an separate Python file on disk
     py::eval_file("script.py", scope);
 
-C++11 raw string literals are also supported and quite handy for this purpose:
+C++11 raw string literals are also supported and quite handy for this purpose.
+The only requirement is that the first statement must be on a new line following
+the raw string delimiter ``R"(``, ensuring all lines have common leading indent:
 
 .. code-block:: cpp
 

--- a/docs/advanced/pycpp/utilities.rst
+++ b/docs/advanced/pycpp/utilities.rst
@@ -55,3 +55,16 @@ is always ``none``).
 
     // Evaluate the statements in an separate Python file on disk
     py::eval_file("script.py", scope);
+
+C++11 raw string literals are also supported and quite handy for this purpose:
+
+.. code-block:: cpp
+
+    py::eval<py::eval_statements>(R"(
+        x = get_answer()
+        if x == 42:
+            print('Hello World!')
+        else:
+            print('Bye!')
+        )", scope
+    );

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -11,8 +11,6 @@
 
 #pragma once
 
-#pragma once
-
 #include "pybind11.h"
 
 NAMESPACE_BEGIN(pybind11)
@@ -37,6 +35,9 @@ object eval(str expr, object global = object(), object local = object()) {
     }
     if (!local)
         local = global;
+
+    /* Support raw string literals by removing common leading whitespace */
+    expr = module::import("textwrap").attr("dedent")(expr);
 
     /* PyRun_String does not accept a PyObject / encoding specifier,
        this seems to be the only alternative */

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -36,9 +36,6 @@ object eval(str expr, object global = object(), object local = object()) {
     if (!local)
         local = global;
 
-    /* Support raw string literals by removing common leading whitespace */
-    expr = module::import("textwrap").attr("dedent")(expr);
-
     /* PyRun_String does not accept a PyObject / encoding specifier,
        this seems to be the only alternative */
     std::string buffer = "# -*- coding: utf-8 -*-\n" + (std::string) expr;
@@ -55,6 +52,14 @@ object eval(str expr, object global = object(), object local = object()) {
     if (!result)
         throw error_already_set();
     return reinterpret_steal<object>(result);
+}
+
+template <eval_mode mode = eval_expr, size_t N>
+object eval(const char (&s)[N], object global = object(), object local = object()) {
+    /* Support raw string literals by removing common leading whitespace */
+    auto expr = (s[0] == '\n') ? str(module::import("textwrap").attr("dedent")(s))
+                               : str(s);
+    return eval<mode>(expr, global, local);
 }
 
 template <eval_mode mode = eval_statements>

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -20,12 +20,19 @@ test_initializer eval([](py::module &m) {
             return 42;
         });
 
+        // Regular string literal
+        py::eval<py::eval_statements>(
+            "message = 'Hello World!'\n"
+            "x = call_test()",
+            global, local
+        );
+
+        // Multi-line raw string literal
         auto result = py::eval<py::eval_statements>(R"(
-            x = call_test()
             if x == 42:
-                print('Hello World!')
+                print(message)
             else:
-                print('Bye!')
+                raise RuntimeError
             )", global, local
         );
         auto x = local["x"].cast<int>();

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -20,10 +20,13 @@ test_initializer eval([](py::module &m) {
             return 42;
         });
 
-        auto result = py::eval<py::eval_statements>(
-            "print('Hello World!');\n"
-            "x = call_test();",
-            global, local
+        auto result = py::eval<py::eval_statements>(R"(
+            x = call_test()
+            if x == 42:
+                print('Hello World!')
+            else:
+                print('Bye!')
+            )", global, local
         );
         auto x = local["x"].cast<int>();
 


### PR DESCRIPTION
A small convenience feature for `py::eval`.

**Before:**
```c++
py::eval<py::eval_statements>(
    "x = call_test();\n"
    "if x == 42:\n"
    "    print('Hello World!');\n"
    "else:\n"
    "    print('Bye!')",
    global, local
);
```

**After:**
```c++
py::eval<py::eval_statements>(R"(
    x = call_test()
    if x == 42:
        print('Hello World!')
    else:
        print('Bye!')
    )", global, local
);
```