### PR TITLE
Missing CMakelist in source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include include/pybind11/*.h
-include LICENSE README.md CONTRIBUTING.md
+include LICENSE README.md CONTRIBUTING.md CMakeLists.txt


### PR DESCRIPTION
Another possibility is to have conda-forge fetch the tarball from GH.

@wjakob thoughts?