### PR TITLE
Skip VS2015/x86 builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,9 @@ environment:
   - CONDA: 27
 matrix:
   fast_finish: true  # Stop remaining jobs after a job failure
+  exclude:
+    - image: Visual Studio 2015
+      platform: x86
 install:
 - ps: |
     if ($env:PLATFORM -eq "x64") { $env:CMAKE_ARCH = "x64" }


### PR DESCRIPTION
AppVeyor just added support for excluding specific jobs; this commit cuts the number of builds down to 6 from 8 by eliminating the VS2015 x86 builds.