### PR TITLE
WIP: Python 3 enums

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -443,3 +443,46 @@ The entries defined by the enumeration type are exposed in the ``__members__`` p
            ...
 
     By default, these are omitted to conserve space.
+
+Python 3 enumerations
+=====================
+
+Python 3 provides support for rich enumeration types in ``enum`` module [#enum]_ of the
+standard library; it can be also used in Python 2 by installing ``enum34`` backport package.
+
+In order to expose a C++ enumeration type as a subclass of ``enum.IntEnum`` in Python,
+one can use the :class:`py3_enum` wrapper whose interface is similar to that of :class:`enum_`:
+
+.. code-block:: cpp
+
+    enum class Captain {
+        Kirk = 0,
+        Picard
+    };
+
+The binding code will look like this:
+
+.. code-block:: cpp
+
+    py::py3_enum<Captain>(m, "Captain")
+        .value("Kirk", Captain::Kirk)
+        .value("Picard", Captain::Picard);
+
+The corresponding Python type is a subclass of ``enum.IntEnum`` and, as a result, is also
+a subclass of ``int``:
+
+.. code-block:: pycon
+
+    >>> Captain.mro()
+    [<enum 'Captain'>, <enum 'IntEnum'>, int, <enum 'Enum'>, object]
+    >>> list(Captain)
+    [<Captain.Kirk: 0>, <Captain.Picard: 1>]
+    >>> int(Captain.Picard)
+    1
+    >>> Captain.Kirk.name, Captain.Kirk.value
+    ('Kirk', 0)
+
+For more details on ``IntEnum`` functionality, see the official docs [#intenum]_.
+
+.. [#enum] https://docs.python.org/3/library/enum.html
+.. [#intenum] https://docs.python.org/3/library/enum.html#intenum

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -950,6 +950,77 @@ protected:
     std::tuple<make_caster<Tuple>...> value;
 };
 
+struct py3_enum_info {
+    handle type = {};
+    std::unordered_map<long long, handle> values = {};
+
+    py3_enum_info() = default;
+
+    py3_enum_info(handle type, const dict& values) : type(type) {
+        for (auto item : values)
+            this->values[static_cast<long long>(item.second.cast<int>())] = type.attr(item.first);
+    }
+
+    static std::unordered_map<std::type_index, py3_enum_info>& registry() {
+        static std::unordered_map<std::type_index, py3_enum_info> map = {};
+        return map;
+    }
+
+    template<typename T>
+    static void bind(handle type, const dict& values) {
+        registry()[typeid(T)] = py3_enum_info(type, values);
+    }
+
+    template<typename T>
+    static const py3_enum_info* get() {
+        auto it = registry().find(typeid(T));
+        return it == registry().end() ? nullptr : &it->second;
+    }
+};
+
+template<typename T>
+struct type_caster<T, enable_if_t<std::is_enum<T>::value>> {
+private:
+    using base_caster = type_caster_base<T>;
+    base_caster caster;
+    bool py3 = false;
+    T value;
+
+public:
+    template<typename U> using cast_op_type = pybind11::detail::cast_op_type<U>;
+
+    operator T*() { return py3 ? &value : static_cast<T*>(caster); }
+    operator T&() { return py3 ? value : static_cast<T&>(caster); }
+
+    static handle cast(const T& src, return_value_policy rvp, handle parent) {
+        if (auto info = py3_enum_info::get<T>()) {
+            auto it = info->values.find(static_cast<long long>(src));
+            if (it == info->values.end())
+                return {};
+            return it->second.inc_ref();
+        }
+        return base_caster::cast(src, rvp, parent);
+    }
+
+    bool load(handle src, bool convert) {
+        if (!src)
+            return false;
+        if (auto info = py3_enum_info::get<T>()) {
+            py3 = true;
+            if (!isinstance(src, info->type))
+                return false;
+            value = static_cast<T>(src.cast<long long>());
+            return true;
+        }
+        py3 = false;
+        return caster.load(src, convert);
+    }
+
+    static PYBIND11_DESCR name() {
+        return base_caster::name();
+    }
+};
+
 /// Helper class which abstracts away certain actions. Users can provide specializations for
 /// custom holders, but it's only necessary if the type has a non-standard interface.
 template <typename T>

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1282,10 +1282,18 @@ public:
         update();
     }
 
-    py3_enum& value(const char* name, T value) {
-        entries[name] = cast(static_cast<underlying_type>(value));
-        update();
+    py3_enum& value(const char* name, T value) & {
+        add_entry(name, value);
         return *this;
+    }
+
+    py3_enum&& value(const char* name, T value) && {
+        add_entry(name, value);
+        return std::move(*this);
+    }
+
+    class_<T> extend() && {
+        return cast<class_<T>>(type);
     }
 
 private:
@@ -1295,9 +1303,15 @@ private:
     object ctor;
     object unique;
     dict kwargs;
+    object type;
+
+    void add_entry(const char *name, T value) {
+        entries[name] = cast(static_cast<underlying_type>(value));
+        update();
+    }
 
     void update() {
-        object type = unique(ctor(**kwargs));
+        type = unique(ctor(**kwargs));
         setattr(scope, name, type);
         detail::type_caster<T>::bind(type, entries);
     }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1274,6 +1274,10 @@ public:
                 kwargs["module"] = scope.attr("__module__");
             else if (hasattr(scope, "__name__"))
                 kwargs["module"] = scope.attr("__name__");
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 3
+            if (hasattr(scope, "__qualname__"))
+                kwargs["qualname"] = scope.attr("__qualname__").cast<std::string>() + "." + name;
+#endif
         }
         update();
     }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1262,8 +1262,8 @@ class py3_enum {
 public:
     using underlying_type = typename std::underlying_type<T>::type;
 
-    py3_enum(handle scope, const char* name)
-    : name(name),
+    py3_enum(handle scope, const char* enum_name)
+    : name(enum_name),
       parent(scope),
       ctor(module::import("enum").attr("IntEnum")),
       unique(module::import("enum").attr("unique")) {
@@ -1286,7 +1286,7 @@ private:
     void update() {
         object type = unique(ctor(name, entries));
         setattr(parent, name, type);
-        detail::py3_enum_info::bind<T>(type, entries);
+        detail::type_caster<T>::bind(type, entries);
     }
 };
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,6 +200,7 @@ def pytest_namespace():
     except ImportError:
         have_eigen = False
     pypy = platform.python_implementation() == "PyPy"
+    py3 = sys.version_info.major == 3
 
     skipif = pytest.mark.skipif
     return {
@@ -211,7 +212,8 @@ def pytest_namespace():
         'requires_eigen_and_scipy': skipif(not have_eigen or not scipy,
                                            reason="eigen and/or scipy are not installed"),
         'unsupported_on_pypy': skipif(pypy, reason="unsupported on PyPy"),
-        'gc_collect': gc_collect
+        'gc_collect': gc_collect,
+        'requires_py3': skipif(not py3, reason='requires Python 3')
     }
 
 

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -79,8 +79,7 @@ test_initializer enums([](py::module &m) {
         .export_values();
 
 #if PY_VERSION_HEX >= 0x03000000
-    auto scope = py::class_<DummyScope>(m, "DummyScope");
-    py::py3_enum<Py3EnumEmpty>(scope, "Py3EnumEmpty");
+    py::py3_enum<Py3EnumEmpty>(m, "Py3EnumEmpty");
 
     auto e = py::py3_enum<Py3Enum>(m, "Py3Enum")
         .value("A", Py3Enum::A)
@@ -90,8 +89,11 @@ test_initializer enums([](py::module &m) {
         .def_property_readonly("is_b", [](Py3Enum e) { return e == Py3Enum::B; })
         .def_property_readonly_static("ultimate_answer", [](py::object) { return 42; });
 
-    py::py3_enum<Py3EnumScoped>(m, "Py3EnumScoped")
+    auto scope = py::class_<DummyScope>(m, "DummyScope");
+
+    py::py3_enum<Py3EnumScoped>(scope, "Py3EnumScoped")
         .value("X", Py3EnumScoped::X)
+        .export_values()
         .value("Y", Py3EnumScoped::Y);
 
     m.def("make_py3_enum", [](bool x) {

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -82,10 +82,14 @@ test_initializer enums([](py::module &m) {
     auto scope = py::class_<DummyScope>(m, "DummyScope");
     py::py3_enum<Py3EnumEmpty>(scope, "Py3EnumEmpty");
 
-    py::py3_enum<Py3Enum>(m, "Py3Enum")
+    auto e = py::py3_enum<Py3Enum>(m, "Py3Enum")
         .value("A", Py3Enum::A)
         .value("B", Py3Enum::B)
-        .value("C", Py3Enum::C);
+        .value("C", Py3Enum::C)
+        .extend()
+        .def("add", [](Py3Enum x, int y) { return static_cast<int>(x) + y; })
+        .def_property_readonly("is_b", [](Py3Enum e) { return e == Py3Enum::B; })
+        .def_property_readonly_static("ultimate_answer", [](py::object) { return 42; });
 
     py::py3_enum<Py3EnumScoped>(m, "Py3EnumScoped")
         .value("X", Py3EnumScoped::X)

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -54,6 +54,8 @@ enum class Py3EnumNonUnique {
     X = 1
 };
 
+class DummyScope {};
+
 std::string test_scoped_enum(ScopedEnum z) {
     return "ScopedEnum::" + std::string(z == ScopedEnum::Two ? "Two" : "Three");
 }
@@ -77,7 +79,8 @@ test_initializer enums([](py::module &m) {
         .export_values();
 
 #if PY_VERSION_HEX >= 0x03000000
-    py::py3_enum<Py3EnumEmpty>(m, "Py3EnumEmpty");
+    auto scope = py::class_<DummyScope>(m, "DummyScope");
+    py::py3_enum<Py3EnumEmpty>(scope, "Py3EnumEmpty");
 
     py::py3_enum<Py3Enum>(m, "Py3Enum")
         .value("A", Py3Enum::A)

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -37,6 +37,23 @@ public:
     }
 };
 
+enum Py3Enum {
+    A = -42,
+    B = 1,
+    C = 42,
+};
+
+enum class Py3EnumScoped : short {
+    X = 10,
+    Y = -1024,
+};
+
+enum class Py3EnumEmpty {};
+
+enum class Py3EnumNonUnique {
+    X = 1
+};
+
 std::string test_scoped_enum(ScopedEnum z) {
     return "ScopedEnum::" + std::string(z == ScopedEnum::Two ? "Two" : "Three");
 }
@@ -58,6 +75,33 @@ test_initializer enums([](py::module &m) {
         .value("Write", Flags::Write)
         .value("Execute", Flags::Execute)
         .export_values();
+
+#if PY_VERSION_HEX >= 0x03000000
+    py::py3_enum<Py3EnumEmpty>(m, "Py3EnumEmpty");
+
+    py::py3_enum<Py3Enum>(m, "Py3Enum")
+        .value("A", Py3Enum::A)
+        .value("B", Py3Enum::B)
+        .value("C", Py3Enum::C);
+
+    py::py3_enum<Py3EnumScoped>(m, "Py3EnumScoped")
+        .value("X", Py3EnumScoped::X)
+        .value("Y", Py3EnumScoped::Y);
+
+    m.def("make_py3_enum", [](bool x) {
+        return x ? Py3EnumScoped::X : Py3EnumScoped::Y;
+    });
+
+    m.def("take_py3_enum", [](Py3EnumScoped x) {
+        return x == Py3EnumScoped::X;
+    });
+
+    m.def("non_unique_py3_enum", [=]() {
+        py::py3_enum<Py3EnumNonUnique>(m, "Py3EnumNonUnique")
+            .value("X", Py3EnumNonUnique::X)
+            .value("Y", Py3EnumNonUnique::X);
+    });
+#endif
 
     py::class_<ClassWithUnscopedEnum> exenum_class(m, "ClassWithUnscopedEnum");
     exenum_class.def_static("test_function", &ClassWithUnscopedEnum::test_function);

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -86,7 +86,6 @@ test_initializer enums([](py::module &m) {
         .value("A", Py3Enum::A)
         .value("B", Py3Enum::B)
         .value("C", Py3Enum::C)
-        .extend()
         .def("add", [](Py3Enum x, int y) { return static_cast<int>(x) + y; })
         .def_property_readonly("is_b", [](Py3Enum e) { return e == Py3Enum::B; })
         .def_property_readonly_static("ultimate_answer", [](py::object) { return 42; });

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -147,6 +147,7 @@ def test_py3_enum():
     for tp, entries in expected.items():
         assert issubclass(tp, IntEnum)
         assert sorted(tp.__members__.items()) == entries
+        assert tp.__module__ == 'pybind11_tests'
 
     assert make_py3_enum(True) is Py3EnumScoped.X
     assert make_py3_enum(False) is Py3EnumScoped.Y

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -136,7 +136,7 @@ def test_py3_enum():
         make_py3_enum, take_py3_enum, non_unique_py3_enum
     )
 
-    Py3EnumEmpty = DummyScope.Py3EnumEmpty
+    Py3EnumEmpty = DummyScope.Py3EnumEmpty  # noqa
 
     from enum import IntEnum
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -132,9 +132,11 @@ def test_enum_to_int():
 @pytest.requires_py3
 def test_py3_enum():
     from pybind11_tests import (
-        Py3Enum, Py3EnumEmpty, Py3EnumScoped,
+        Py3Enum, DummyScope, Py3EnumScoped,
         make_py3_enum, take_py3_enum, non_unique_py3_enum
     )
+
+    Py3EnumEmpty = DummyScope.Py3EnumEmpty
 
     from enum import IntEnum
 
@@ -148,6 +150,10 @@ def test_py3_enum():
         assert issubclass(tp, IntEnum)
         assert sorted(tp.__members__.items()) == entries
         assert tp.__module__ == 'pybind11_tests'
+
+    assert Py3Enum.__qualname__ == 'Py3Enum'
+    assert Py3EnumEmpty.__qualname__ == 'DummyScope.Py3EnumEmpty'
+    assert Py3EnumScoped.__qualname__ == 'Py3EnumScoped'
 
     assert make_py3_enum(True) is Py3EnumScoped.X
     assert make_py3_enum(False) is Py3EnumScoped.Y

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -127,3 +127,33 @@ def test_enum_to_int():
     test_enum_to_uint(ClassWithUnscopedEnum.EMode.EFirstMode)
     test_enum_to_long_long(Flags.Read)
     test_enum_to_long_long(ClassWithUnscopedEnum.EMode.EFirstMode)
+
+
+@pytest.requires_py3
+def test_py3_enum():
+    from pybind11_tests import (
+        Py3Enum, Py3EnumEmpty, Py3EnumScoped,
+        make_py3_enum, take_py3_enum, non_unique_py3_enum
+    )
+
+    from enum import IntEnum
+
+    expected = {
+        Py3Enum: [('A', -42), ('B', 1), ('C', 42)],
+        Py3EnumEmpty: [],
+        Py3EnumScoped: [('X', 10), ('Y', -1024)]
+    }
+
+    for tp, entries in expected.items():
+        assert issubclass(tp, IntEnum)
+        assert sorted(tp.__members__.items()) == entries
+
+    assert make_py3_enum(True) is Py3EnumScoped.X
+    assert make_py3_enum(False) is Py3EnumScoped.Y
+
+    assert take_py3_enum(Py3EnumScoped.X)
+    assert not take_py3_enum(Py3EnumScoped.Y)
+
+    with pytest.raises(ValueError) as excinfo:
+        non_unique_py3_enum()
+    assert 'duplicate values found' in str(excinfo.value)

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -164,3 +164,7 @@ def test_py3_enum():
     with pytest.raises(ValueError) as excinfo:
         non_unique_py3_enum()
     assert 'duplicate values found' in str(excinfo.value)
+
+    assert Py3Enum.ultimate_answer == 42
+    assert not Py3Enum.A.is_b and Py3Enum.B.is_b and not Py3Enum.C.is_b
+    assert Py3Enum.A.add(10) == -32 and Py3Enum.C.add(-1) == 41

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -132,11 +132,11 @@ def test_enum_to_int():
 @pytest.requires_py3
 def test_py3_enum():
     from pybind11_tests import (
-        Py3Enum, DummyScope, Py3EnumScoped,
+        Py3Enum, DummyScope, Py3EnumEmpty,
         make_py3_enum, take_py3_enum, non_unique_py3_enum
     )
 
-    Py3EnumEmpty = DummyScope.Py3EnumEmpty  # noqa
+    Py3EnumScoped = DummyScope.Py3EnumScoped # noqa
 
     from enum import IntEnum
 
@@ -151,9 +151,12 @@ def test_py3_enum():
         assert sorted(tp.__members__.items()) == entries
         assert tp.__module__ == 'pybind11_tests'
 
+    assert DummyScope.X is Py3EnumScoped.X
+    assert DummyScope.Y is Py3EnumScoped.Y
+
     assert Py3Enum.__qualname__ == 'Py3Enum'
-    assert Py3EnumEmpty.__qualname__ == 'DummyScope.Py3EnumEmpty'
-    assert Py3EnumScoped.__qualname__ == 'Py3EnumScoped'
+    assert Py3EnumEmpty.__qualname__ == 'Py3EnumEmpty'
+    assert Py3EnumScoped.__qualname__ == 'DummyScope.Py3EnumScoped'
 
     assert make_py3_enum(True) is Py3EnumScoped.X
     assert make_py3_enum(False) is Py3EnumScoped.Y


### PR DESCRIPTION
This adds support for wrapping C/C++ enums as Python 3's `enum.IntEnum` (with `@unique` decorator applied). It would also work with `enum34` backport. If neither is available, `ImportError` will be thrown. The existing `enum_` wrappers are untouched and should work as before.

- [ ] Don't derive `enum_` from `class_`
- [x] Allow `value().value().def().def()` API, like the existing `enum_<>`
- [ ] Add full tests for `class_interface<>` API
- [ ] Add support for `py::arithmetic`
- [x] Add support for `.export_values()`
- [ ] Rename to `enum34`
- [ ] Implement automatic compile-time selection between `enum_` and `enum34`
- [ ] Update docs

(Closes #530)