### PR TITLE
Fix overriding static properties in derived classes

### DIFF
--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -75,6 +75,13 @@ struct TestProperties {
 
 int TestProperties::static_value = 1;
 
+struct TestPropertiesOverride : TestProperties {
+    int value = 99;
+    static int static_value;
+};
+
+int TestPropertiesOverride::static_value = 99;
+
 struct SimpleValue { int value = 1; };
 
 struct TestPropRVP {
@@ -218,6 +225,11 @@ test_initializer methods_and_attributes([](py::module &m) {
         .def_property_static("static_cls",
                              [](py::object cls) { return cls; },
                              [](py::object cls, py::function f) { f(cls); });
+
+    py::class_<TestPropertiesOverride, TestProperties>(m, "TestPropertiesOverride")
+        .def(py::init<>())
+        .def_readonly("def_readonly", &TestPropertiesOverride::value)
+        .def_readonly_static("def_readonly_static", &TestPropertiesOverride::static_value);
 
     py::class_<SimpleValue>(m, "SimpleValue")
         .def_readwrite("value", &SimpleValue::value);

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -110,6 +110,12 @@ def test_static_properties():
     assert Type.def_readwrite_static == 2
     assert instance.def_readwrite_static == 2
 
+    # It should be possible to override properties in derived classes
+    from pybind11_tests import TestPropertiesOverride as TypeOverride
+
+    assert TypeOverride().def_readonly == 99
+    assert TypeOverride.def_readonly_static == 99
+
 
 def test_static_cls():
     """Static property getter and setters expect the type object as the their only argument"""


### PR DESCRIPTION
Fixes #775.

Assignments of the form `Type.static_prop = value` should be translated to `Type.static_prop.__set__(value)` except when `isinstance(value, static_prop)`.