### PR TITLE
Add static_assert to holder casters

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -902,6 +902,8 @@ template <typename type, typename holder_type>
 struct copyable_holder_caster : public type_caster_base<type> {
 public:
     using base = type_caster_base<type>;
+    static_assert(std::is_base_of<base, type_caster<type>>::value,
+            "Holder classes are only supported for custom types");
     using base::base;
     using base::cast;
     using base::typeinfo;
@@ -1018,6 +1020,9 @@ class type_caster<std::shared_ptr<T>> : public copyable_holder_caster<T, std::sh
 
 template <typename type, typename holder_type>
 struct move_only_holder_caster {
+    static_assert(std::is_base_of<type_caster_base<type>, type_caster<type>>::value,
+            "Holder classes are only supported for custom types");
+
     static handle cast(holder_type &&src, return_value_policy, handle) {
         auto *ptr = holder_helper<holder_type>::get(src);
         return type_caster_base<type>::cast_holder(ptr, &src);


### PR DESCRIPTION
The holder casters assume but don't check that a `holder<type>`'s `type` is really a `type_caster_base<type>`; this adds a `static_assert` to make sure this is really the case, to turn things like `std::shared_ptr<array>` into a compilation failure.

Fixes #785

There is some merit to making the holder casters use a proper `type_caster<type>` rather than a `type_caster_base<type>` so that you could, for example, have a `std::shared_ptr<std::string>` or `std::unique_ptr<Eigen::MatrixXd>`.  With this commit, holder arguments around non-generic type casters fails at compile time; before this commit, those failures show up in strange runtime failures (due to invoking the generic type caster rather than the specialized type caster).