### PR TITLE
array: always enable compile-time optimized 1D unchecked proxy for contiguous arrays

### DIFF
--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -264,4 +264,13 @@ test_initializer numpy_array([](py::module &m) {
     sm.def("array_auxiliaries2", [](py::array_t<double> a) {
         return auxiliaries(a, a);
     });
+
+    sm.def("proxy_init3_ct", [](double start) {
+        py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
+        auto r = a.mutable_unchecked<1>();
+        if (r.ndim() != 1) throw std::domain_error("error: ndim != 1, no compile-time opt");
+        for (size_t i = 0; i < r.shape(0); i++)
+            r(i) = start++;
+        return a;
+    });
 });

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -367,13 +367,14 @@ def test_array_unchecked_fixed_dims(msg):
 
 def test_array_unchecked_dyn_dims(msg):
     from pybind11_tests.array import (proxy_add2_dyn, proxy_init3_dyn, proxy_auxiliaries2_dyn,
-                                      array_auxiliaries2)
+                                      array_auxiliaries2, proxy_init3_ct)
     z1 = np.array([[1, 2], [3, 4]], dtype='float64')
     proxy_add2_dyn(z1, 10)
     assert np.all(z1 == [[11, 12], [13, 14]])
 
     expect_c = np.ndarray(shape=(3, 3, 3), buffer=np.array(range(3, 30)), dtype='int')
     assert np.all(proxy_init3_dyn(3.0) == expect_c)
+    assert np.all(proxy_init3_ct(3.0) == expect_c)
 
     assert proxy_auxiliaries2_dyn(z1) == [11, 11, True, 2, 8, 2, 2, 4, 32]
     assert proxy_auxiliaries2_dyn(z1) == array_auxiliaries2(z1)


### PR DESCRIPTION
Rationale: every C or Fortran contiguous array can be viewed as
1D-vector. Therefore if 1D unchecked proxy is requested for such
an array, skip dimensions checking and always return compile-time optimized
proxy object (strides and sizes stored in std::array).