### PR TITLE
Travis: switch to trusty, pip and libc++ caching, pypy numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,40 +94,40 @@ before_install:
       export CXX=clang++-$CLANG CC=clang-$CLANG
       COMPILER_PACKAGES="clang-$CLANG llvm-$CLANG-dev"
     else
-      if [ -z "$GCC" ]; then export GCC=4.8
-      else export COMPILER_PACKAGES=g++-$GCC
+      if [ -z "$GCC" ]; then GCC=4.8
+      else COMPILER_PACKAGES=g++-$GCC
       fi
       export CXX=g++-$GCC CC=gcc-$GCC
     fi
-    if [ "$GCC" = "6" ] || [ "$CLANG" = "3.9" ]; then export DOCKER=${ARCH:+$ARCH/}debian:testing
-    elif [ "$GCC" = "7" ]; then export DOCKER=debian:experimental APT_GET_EXTRA="-t experimental"
+    if [ "$GCC" = "6" ] || [ "$CLANG" = "3.9" ]; then DOCKER=${ARCH:+$ARCH/}debian:testing
+    elif [ "$GCC" = "7" ]; then DOCKER=debian:experimental APT_GET_EXTRA="-t experimental"
     fi
   elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     export CXX=clang++ CC=clang;
   fi
-  if [ -n "$CPP" ]; then export CPP=-std=c++$CPP; fi
-  if [ "${PYTHON:0:1}" = "3" ]; then export PY=3; fi
-  if [ -n "$DEBUG" ]; then export CMAKE_EXTRA_ARGS="-DCMAKE_BUILD_TYPE=Debug"; fi
+  if [ -n "$CPP" ]; then CPP=-std=c++$CPP; fi
+  if [ "${PYTHON:0:1}" = "3" ]; then PY=3; fi
+  if [ -n "$DEBUG" ]; then CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_BUILD_TYPE=Debug"; fi
 - |
   # Initialize environment
   set -e
   if [ -n "$DOCKER" ]; then
     docker pull $DOCKER
 
-    export containerid=$(docker run --detach --tty \
+    containerid=$(docker run --detach --tty \
       --volume="$PWD":/pybind11 --workdir=/pybind11 \
       --env="CC=$CC" --env="CXX=$CXX" --env="DEBIAN_FRONTEND=$DEBIAN_FRONTEND" \
       --env=GCC_COLORS=\  \
       $DOCKER)
-    export SCRIPT_RUN_PREFIX="docker exec --tty $containerid"
+    SCRIPT_RUN_PREFIX="docker exec --tty $containerid"
     $SCRIPT_RUN_PREFIX sh -c 'for s in 0 15; do sleep $s; apt-get update && apt-get -qy dist-upgrade && break; done'
   else
     if [ "$PYPY" = "5.7" ]; then
-      curl -fSL https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-linux64.tar.bz2 | tar -xj
-      export PY_CMD=$(echo `pwd`/pypy2-v5.7.1-linux64/bin/pypy)
-      export CMAKE_EXTRA_ARGS="-DPYTHON_EXECUTABLE:FILEPATH=$PY_CMD"
+      curl -fSL https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-linux64.tar.bz2 | tar xj
+      PY_CMD=$(echo `pwd`/pypy2-v5.7.1-linux64/bin/pypy)
+      CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DPYTHON_EXECUTABLE:FILEPATH=$PY_CMD"
     else
-      export PY_CMD=python$PYTHON
+      PY_CMD=python$PYTHON
       if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         if [ "$PY" = "3" ]; then
           brew update; brew install python$PY;
@@ -149,7 +149,7 @@ install:
   if [ -n "$DOCKER" ]; then
     if [ -n "$DEBUG" ]; then
       PY_DEBUG="python$PY-dbg python$PY-scipy-dbg"
-      export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DPYTHON_EXECUTABLE=/usr/bin/python${PYTHON}dm"
+      CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DPYTHON_EXECUTABLE=/usr/bin/python${PYTHON}dm"
     fi
     $SCRIPT_RUN_PREFIX sh -c "for s in 0 15; do sleep \$s; \
       apt-get -qy --no-install-recommends $APT_GET_EXTRA install \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: trusty
 sudo: false
 matrix:
   include:
@@ -6,14 +7,13 @@ matrix:
     env: PYTHON=2.7 CPP=11 GCC=4.8
     addons:
       apt:
-        sources: [ubuntu-toolchain-r-test, kubuntu-backports]
-        packages: [g++-4.8, cmake]
+        packages: [cmake=2.\*, cmake-data=2.\*]
   - os: linux
-    env: PYTHON=3.5 CPP=11 GCC=4.8
+    env: PYTHON=3.6 CPP=11 GCC=4.8
     addons:
       apt:
-        sources: [ubuntu-toolchain-r-test, kubuntu-backports, deadsnakes]
-        packages: [g++-4.8, cmake, python3.5-dev]
+        sources: [deadsnakes]
+        packages: [python3.6-dev python3.6-venv, cmake=2.\*, cmake-data=2.\*]
   - sudo: true
     services: docker
     env: PYTHON=2.7 CPP=14 GCC=6
@@ -34,11 +34,10 @@ matrix:
     env: PYTHON=3.6 CPP=14 CLANG
   # Test a PyPy 2.7 build
   - os: linux
-    dist: trusty
     env: PYPY=5.7 PYTHON=2.7 CPP=11 GCC=4.8
     addons:
       apt:
-        packages: [g++-4.8, cmake]
+        packages: [libblas-dev, liblapack-dev, gfortran]
   - sudo: true
     services: docker
     env: ARCH=i386 PYTHON=3.5 CPP=14 GCC=6
@@ -58,22 +57,19 @@ matrix:
   # A barebones build makes sure everything still works without optional deps (numpy/scipy/eigen)
   # and also tests the automatic discovery functions in CMake (Python version, C++ standard).
   - os: linux
-    env: BAREBONES
-    addons:
-      apt:
-        sources: [ubuntu-toolchain-r-test, kubuntu-backports]
-        packages: [g++-4.8, cmake]
-    install: pip install pytest
+    env: BAREBONES PYTHON=3.5
+    install: $PY_CMD -m pip install --user --upgrade pytest
   # Documentation build:
   - os: linux
     language: docs
     env: DOCS STYLE LINT
     install:
-    - pip install --upgrade sphinx sphinx_rtd_theme flake8 pep8-naming
+    - export PATH="~/.local/bin:$PATH"
+    - $PY_CMD -m pip install --user --upgrade sphinx sphinx_rtd_theme flake8 pep8-naming
     - |
       curl -fsSL ftp://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.12.linux.bin.tar.gz | tar xz
       export PATH="$PWD/doxygen-1.8.12/bin:$PATH"
-      pip install https://github.com/michaeljones/breathe/archive/master.zip
+      $PY_CMD -m pip install --user --upgrade https://github.com/michaeljones/breathe/archive/master.zip
     script:
     - make -C docs html SPHINX_OPTIONS=-W
     - tools/check-style.sh
@@ -83,8 +79,9 @@ matrix:
     - env: PYTHON=3.5 CPP=17 CLANG=4.0
 cache:
   directories:
-  - $HOME/.cache/pip
-  - $HOME/Library/Caches/pip
+  - $HOME/.local/bin
+  - $HOME/.local/lib
+  - $HOME/Library/Python
 before_install:
 - |
   # Configure build variables
@@ -107,18 +104,11 @@ before_install:
   fi
   if [ -n "$CPP" ]; then export CPP=-std=c++$CPP; fi
   if [ "${PYTHON:0:1}" = "3" ]; then export PY=3; fi
-  if [ "$PYPY" = "5.7" ]; then
-    curl -fSL https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-linux64.tar.bz2 | tar -xj
-    export PYPY_BINARY=$(echo `pwd`/pypy2-v5.7.0-linux64/bin/pypy)
-    export CMAKE_EXTRA_ARGS="-DPYTHON_EXECUTABLE:FILEPATH=$PYPY_BINARY"
-  fi
   if [ -n "$DEBUG" ]; then export CMAKE_EXTRA_ARGS="-DCMAKE_BUILD_TYPE=Debug"; fi
 - |
   # Initialize environment
-  if [ -n "$PYPY" ]; then
-    $PYPY_BINARY -m ensurepip
-    $PYPY_BINARY -m pip install pytest
-  elif [ -n "$DOCKER" ]; then
+  set -e
+  if [ -n "$DOCKER" ]; then
     docker pull $DOCKER
 
     export containerid=$(docker run --detach --tty \
@@ -130,24 +120,30 @@ before_install:
     export SCRIPT_RUN_PREFIX="docker exec --tty $containerid"
     $SCRIPT_RUN_PREFIX sh -c 'for s in 0 15; do sleep $s; apt-get update && apt-get -qy dist-upgrade && break; done'
   else
-    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      pip install --user --upgrade pip virtualenv
-      virtualenv -p python$PYTHON venv
-    elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      if [ "$PY" = "3" ]; then
-        brew update; brew install python$PY;
-      else
-        curl -fsSL -O https://bootstrap.pypa.io/get-pip.py
-        sudo -H python get-pip.py
+    if [ "$PYPY" = "5.7" ]; then
+      curl -fSL https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-linux64.tar.bz2 | tar -xj
+      export PY_CMD=$(echo `pwd`/pypy2-v5.7.1-linux64/bin/pypy)
+      export CMAKE_EXTRA_ARGS="-DPYTHON_EXECUTABLE:FILEPATH=$PY_CMD"
+    else
+      export PY_CMD=python$PYTHON
+      if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        if [ "$PY" = "3" ]; then
+          brew update; brew install python$PY;
+        else
+          curl -fsSL https://bootstrap.pypa.io/get-pip.py | $PY_CMD - --user
+        fi
       fi
-      pip$PY install --user --upgrade pip virtualenv
-      python$PY -m virtualenv venv
     fi
-    source venv/bin/activate
+    if [ "$PY" = 3 ] || [ -n "$PYPY" ]; then
+      $PY_CMD -m ensurepip --user
+    fi
+    $PY_CMD -m pip install --user --upgrade pip wheel
   fi
+  set +e
 install:
 - |
   # Install dependencies
+  set -e
   if [ -n "$DOCKER" ]; then
     if [ -n "$DEBUG" ]; then
       PY_DEBUG="python$PY-dbg python$PY-scipy-dbg"
@@ -171,13 +167,17 @@ install:
 
       if [ "$CPP" = "-std=c++17" ]; then export CPP="-std=c++1z"; fi
     fi
-  elif [ -z "$PYPY" ]; then
-    pip install numpy scipy pytest
+  else
+    export NPY_NUM_BUILD_JOBS=2
+    echo "Installing pytest, numpy, scipy..."
+    ${PYPY:+travis_wait 30} $PY_CMD -m pip install --user --upgrade --quiet pytest numpy scipy
+    echo "done."
 
-    wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.3.0.tar.gz
+    wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.3.3.tar.gz
     tar xzf eigen.tar.gz
-    export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=$PWD/eigen-eigen-26667be4f70b"
+    export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=$PWD/eigen-eigen-67e894c6cd8f"
   fi
+  set +e
 script:
 - $SCRIPT_RUN_PREFIX cmake ${CMAKE_EXTRA_ARGS}
     -DPYBIND11_PYTHON_VERSION=$PYTHON

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,12 @@ matrix:
   - sudo: true
     services: docker
     env: PYTHON=3.5 CPP=17 GCC=7
-  - sudo: true
-    services: docker
-    env: PYTHON=3.5 CPP=17 CLANG=4.0
+  - os: linux
+    env: PYTHON=3.6 CPP=17 CLANG=4.0
+    addons:
+      apt:
+        sources: [deadsnakes, llvm-toolchain-trusty-4.0]
+        packages: [python3.6-dev python3.6-venv clang-4.0 llvm-4.0-dev]
   - os: osx
     osx_image: xcode7.3
     env: PYTHON=2.7 CPP=14 CLANG
@@ -76,27 +79,27 @@ matrix:
     - flake8
   allow_failures:
     - env: PYTHON=3.5 CPP=17 GCC=7
-    - env: PYTHON=3.5 CPP=17 CLANG=4.0
+    - env: PYTHON=3.6 CPP=17 CLANG=4.0
 cache:
   directories:
   - $HOME/.local/bin
   - $HOME/.local/lib
+  - $HOME/.local/include
   - $HOME/Library/Python
 before_install:
 - |
   # Configure build variables
   if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     if [ -n "$CLANG" ]; then
-      export CXX=clang++-$CLANG CC=clang-$CLANG COMPILER_PACKAGES="clang-$CLANG llvm-$CLANG-dev"
-      if [ "$CLANG" = "4.0" ]; then export CXXFLAGS="-stdlib=libc++"; fi
+      export CXX=clang++-$CLANG CC=clang-$CLANG
+      COMPILER_PACKAGES="clang-$CLANG llvm-$CLANG-dev"
     else
       if [ -z "$GCC" ]; then export GCC=4.8
       else export COMPILER_PACKAGES=g++-$GCC
       fi
       export CXX=g++-$GCC CC=gcc-$GCC
     fi
-    if [ "$CLANG" = "4.0" ]; then export DOCKER=debian:sid
-    elif [ "$GCC" = "6" ] || [ -n "$CLANG" ]; then export DOCKER=${ARCH:+$ARCH/}debian:testing
+    if [ "$GCC" = "6" ] || [ "$CLANG" = "3.9" ]; then export DOCKER=${ARCH:+$ARCH/}debian:testing
     elif [ "$GCC" = "7" ]; then export DOCKER=debian:experimental APT_GET_EXTRA="-t experimental"
     fi
   elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
@@ -113,7 +116,6 @@ before_install:
 
     export containerid=$(docker run --detach --tty \
       --volume="$PWD":/pybind11 --workdir=/pybind11 \
-      --env="CXXFLAGS=$CXXFLAGS" \
       --env="CC=$CC" --env="CXX=$CXX" --env="DEBIAN_FRONTEND=$DEBIAN_FRONTEND" \
       --env=GCC_COLORS=\  \
       $DOCKER)
@@ -153,21 +155,30 @@ install:
       apt-get -qy --no-install-recommends $APT_GET_EXTRA install \
         $PY_DEBUG python$PY-dev python$PY-pytest python$PY-scipy \
         libeigen3-dev cmake make ${COMPILER_PACKAGES} && break; done"
+  else
 
     if [ "$CLANG" = "4.0" ]; then
-      # Neither debian nor llvm provide a libc++ deb; luckily it's fairly quick
-      # to build and install, so do it ourselves:
-      git clone --depth=1 https://github.com/llvm-mirror/llvm.git llvm-source
-      git clone https://github.com/llvm-mirror/libcxx.git llvm-source/projects/libcxx -b release_40
-      git clone https://github.com/llvm-mirror/libcxxabi.git llvm-source/projects/libcxxabi -b release_40
-      $SCRIPT_RUN_PREFIX sh -c "mkdir llvm-build && cd llvm-build && \
-        CXXFLAGS= cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr ../llvm-source && \
-        make -j2 install-cxxabi install-cxx && \
-        cp -a include/c++/v1/*cxxabi*.h /usr/include/c++/v1"
-
-      if [ "$CPP" = "-std=c++17" ]; then export CPP="-std=c++1z"; fi
+      if ! [ -d ~/.local/include/c++/v1 ]; then
+        # Neither debian nor llvm provide a libc++ 4.0 deb; luckily it's fairly quick
+        # to build, install (and cache), so do it ourselves:
+        git clone --depth=1 https://github.com/llvm-mirror/llvm.git llvm-source
+        git clone https://github.com/llvm-mirror/libcxx.git llvm-source/projects/libcxx -b release_40
+        git clone https://github.com/llvm-mirror/libcxxabi.git llvm-source/projects/libcxxabi -b release_40
+        mkdir llvm-build && cd llvm-build
+        # Building llvm requires a newer cmake than is provided by the trusty container:
+        CMAKE=cmake-3.8.0-Linux-x86_64
+        curl https://cmake.org/files/v3.8/$CMAKE.tar.gz | tar xz
+        ./$CMAKE/bin/cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/.local ../llvm-source
+        make -j2 install-cxxabi install-cxx
+        cp -a include/c++/v1/*cxxabi*.h ~/.local/include/c++/v1
+        cd ..
+      fi
+      export CXXFLAGS="-isystem $HOME/.local/include/c++/v1 -stdlib=libc++"
+      export LDFLAGS="-L$HOME/.local/lib"
+      export LD_LIBRARY_PATH="$HOME/.local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      if [ "$CPP" = "-std=c++17" ]; then CPP="-std=c++1z"; fi
     fi
-  else
+
     export NPY_NUM_BUILD_JOBS=2
     echo "Installing pytest, numpy, scipy..."
     ${PYPY:+travis_wait 30} $PY_CMD -m pip install --user --upgrade --quiet pytest numpy scipy
@@ -175,7 +186,7 @@ install:
 
     wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.3.3.tar.gz
     tar xzf eigen.tar.gz
-    export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_INCLUDE_PATH=$PWD/eigen-eigen-67e894c6cd8f"
+    export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH:+:}$PWD/eigen-eigen-67e894c6cd8f"
   fi
   set +e
 script:

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -33,6 +33,8 @@ def test_vector_int():
     assert v_int2 == VectorInt([0, 99, 2, 3])
 
 
+# As of pypy 5.7.1, running this and the next test seems to trigger a segfault
+# related to the PyPy's buffer protocol.
 @pytest.unsupported_on_pypy
 def test_vector_buffer():
     from pybind11_tests import VectorUChar, create_undeclstruct
@@ -53,6 +55,7 @@ def test_vector_buffer():
         create_undeclstruct()  # Undeclared struct contents, no buffer interface
 
 
+@pytest.unsupported_on_pypy
 @pytest.requires_numpy
 def test_vector_buffer_numpy():
     from pybind11_tests import VectorInt, VectorStruct, get_vectorstruct


### PR DESCRIPTION
This applies several changes to the non-docker (and the C++17 clang docker) travis-ci builds:

- Make all non-docker linux builds use *trusty* rather than *precise*.  pybind can't actually build in *precise* anyway (we install essentially the entire toolchain backported from *trusty* on every build), and so this saves needing to install all the backported packages during the build setup.
- Updated the 3.5 build to 3.6 (via deadsnakes, which didn't backport 3.6 to ubuntu releases earlier than trusty).
- As a result of the switch to trusty, the BAREBONES build now picks up the (default-installed) python 3.5 installation.
- `pip` is now invoked everywhere via `$PY_CMD -m pip` (where `PY_CMD` is the python binary name) rather than the `pip` executable, which saves us having to figure out what the pip executable is (e.g. `pip` vs `pip3`), and ensures that we are always using the correct `pip`.
- Add the local user python package archive to the travis-ci cache (rather than the pip cache).  This saves needing to install packages during installation (unless there are updates, in which case the package and the cache are updated), and saves a huge amount of time for the pypy and clang 4.0 builds (see below).
- Install packages with `pip --user` rather than in a virtualenv.  This makes the caching a bit easier: we can just cache `~/.local/{lib,bin}`.  (We could alternatively cache a `virtualenv` directory, but caching things under .local/ make it easier to also cache the local libc++ install, below).
- Install numpy and scipy on the pypy build.  This has to build from source (which adds about 8 minutes to the job time), but due to the above caching, this only happens *once* per numpy/scipy release.  I think this testing is quite valuable: numpy has various behaviour differences under pypy (I'm anticipating that this is going to break #795, which will need to skip some tests on pypy).
- Enable numpy tests for pypy exposed a segfault in the stl_binder test: it was previously skipped because it was marked as requiring numpy, but I'm fairly sure this is the same issue as on the other test here, which didn't require numpy and had an explicit pypy skip.
- Added `set -e`/`+e` around the before_install/install blocks so that a failure here (e.g. a pip install failure or dependency download failure) triggers a build failure.  Previously such failures during dependency installation were just silently ignored.
- Update eigen version to latest (3.3.3), mainly to be consistent with the appveyor build.
- Switch the c++17 clang build from docker to trusty (for which clang builds are available from LLVM); the container setup is faster than docker to begin with, but it also makes caching the local libc++ installation possible, which saves a good chunk of time on every build.
- Various small cleanups; the most notable is getting rid of the all `export`s on script variables (e.g. `PY`, `GCC`) which are just local script variables that don't need to be exported.  The remaining `export`s are only for things like `CXX` which we *do* need to be exported to cmake.