### PR TITLE
Don't let `PyInstanceMethod` hide itself

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -135,6 +135,8 @@
 
 #if PY_MAJOR_VERSION >= 3 /// Compatibility macros for various Python versions
 #define PYBIND11_INSTANCE_METHOD_NEW(ptr, class_) PyInstanceMethod_New(ptr)
+#define PYBIND11_INSTANCE_METHOD_CHECK PyInstanceMethod_Check
+#define PYBIND11_INSTANCE_METHOD_GET_FUNCTION PyInstanceMethod_GET_FUNCTION
 #define PYBIND11_BYTES_CHECK PyBytes_Check
 #define PYBIND11_BYTES_FROM_STRING PyBytes_FromString
 #define PYBIND11_BYTES_FROM_STRING_AND_SIZE PyBytes_FromStringAndSize
@@ -153,6 +155,8 @@
     extern "C" PYBIND11_EXPORT PyObject *PyInit_##name()
 #else
 #define PYBIND11_INSTANCE_METHOD_NEW(ptr, class_) PyMethod_New(ptr, nullptr, class_)
+#define PYBIND11_INSTANCE_METHOD_CHECK PyMethod_Check
+#define PYBIND11_INSTANCE_METHOD_GET_FUNCTION PyMethod_GET_FUNCTION
 #define PYBIND11_BYTES_CHECK PyString_Check
 #define PYBIND11_BYTES_FROM_STRING PyString_FromString
 #define PYBIND11_BYTES_FROM_STRING_AND_SIZE PyString_FromStringAndSize

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -268,10 +268,8 @@ protected:
         rec->is_constructor = !strcmp(rec->name, "__init__") || !strcmp(rec->name, "__setstate__");
         rec->nargs = (std::uint16_t) args;
 
-#if PY_MAJOR_VERSION < 3
-        if (rec->sibling && PyMethod_Check(rec->sibling.ptr()))
-            rec->sibling = PyMethod_GET_FUNCTION(rec->sibling.ptr());
-#endif
+        if (rec->sibling && PYBIND11_INSTANCE_METHOD_CHECK(rec->sibling.ptr()))
+            rec->sibling = PYBIND11_INSTANCE_METHOD_GET_FUNCTION(rec->sibling.ptr());
 
         detail::function_record *chain = nullptr, *chain_start = rec;
         if (rec->sibling) {

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -163,8 +163,8 @@ public:
 class NotRegistered {};
 
 test_initializer methods_and_attributes([](py::module &m) {
-    py::class_<ExampleMandA>(m, "ExampleMandA")
-        .def(py::init<>())
+    py::class_<ExampleMandA> emna(m, "ExampleMandA");
+    emna.def(py::init<>())
         .def(py::init<int>())
         .def(py::init<const ExampleMandA&>())
         .def("add1", &ExampleMandA::add1)
@@ -221,6 +221,9 @@ test_initializer methods_and_attributes([](py::module &m) {
         })
         .def("__str__", &ExampleMandA::toString)
         .def_readwrite("value", &ExampleMandA::value);
+
+    // Issue #443: can't call copied methods in Python 3
+    emna.attr("add2b") = emna.attr("add2");
 
     py::class_<TestProperties>(m, "TestProperties")
         .def(py::init<>())

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -80,6 +80,24 @@ def test_properties():
     assert instance.def_property == 3
 
 
+def test_copy_method():
+    """Issue #443: calling copied methods fails in Python 3"""
+    from pybind11_tests import ExampleMandA
+
+    ExampleMandA.add2c = ExampleMandA.add2
+    ExampleMandA.add2d = ExampleMandA.add2b
+    a = ExampleMandA(123)
+    assert a.value == 123
+    a.add2(ExampleMandA(-100))
+    assert a.value == 23
+    a.add2b(ExampleMandA(20))
+    assert a.value == 43
+    a.add2c(ExampleMandA(6))
+    assert a.value == 49
+    a.add2d(ExampleMandA(-7))
+    assert a.value == 42
+
+
 def test_static_properties():
     from pybind11_tests import TestProperties as Type
 


### PR DESCRIPTION
Python 3's `PyInstanceMethod_Type` hides itself via its `tp_descr_get`, which prevents aliasing methods via `cls.attr("m2") = cls.attr("m1")`: instead the `tp_descr_get` returns a plain function, when called on a
class, or a `PyMethod`, when called on an instance.  Override that behaviour for pybind11 types with a special bypass for `PyInstanceMethod_Types`.

Fixes #443.