### PR TITLE
Add `static_assert`-raising error for overload_cast in c++11

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -655,6 +655,11 @@ static constexpr detail::overload_cast_impl<Args...> overload_cast = {};
 ///  - sweet:   overload_cast<Arg>(&Class::func, const_)
 static constexpr auto const_ = std::true_type{};
 
+#else // no overload_cast: providing something that static_assert-fails:
+template <typename... Args> struct overload_cast {
+    static_assert(detail::deferred_t<std::false_type, Args...>::value,
+                  "pybind11::overload_cast<...> requires compiling in C++14 mode");
+};
 #endif // overload_cast
 
 NAMESPACE_BEGIN(detail)


### PR DESCRIPTION
I got some unexpected errors from code using `overload_cast` until I realized that I'd configured the build with -std=c++11.

This commit adds a fake `overload_cast` class in C++11 mode that triggers a static_assert failure indicating that C++14 is needed.