### PR TITLE
Make slice::compute return signed integers

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -991,12 +991,11 @@ public:
         m_ptr = PySlice_New(start.ptr(), stop.ptr(), step.ptr());
         if (!m_ptr) pybind11_fail("Could not allocate slice object!");
     }
-    bool compute(size_t length, size_t *start, size_t *stop, size_t *step,
-                 size_t *slicelength) const {
+    bool compute(size_t length, ssize_t *start, ssize_t *stop, ssize_t *step,
+                 ssize_t *slicelength) const {
         return PySlice_GetIndicesEx((PYBIND11_SLICE_OBJECT *) m_ptr,
-                                    (ssize_t) length, (ssize_t *) start,
-                                    (ssize_t *) stop, (ssize_t *) step,
-                                    (ssize_t *) slicelength) == 0;
+                                    (ssize_t) length, start,
+                                     stop, step, slicelength) == 0;
     }
 };
 


### PR DESCRIPTION
Signed results are necessary for at least the step, which may be negative.

If unsigned results are needed for the others, this should be done with a `static_cast`; the result of a `reintepret_cast` between signed and unsigned is compiler-defined.  I think it's better to just pass the ssize_t values directly to the user and let them handle a conversion to unsigned if needed.