### PR TITLE
Add type caster for std::variant and other variant-like classes

### DIFF
--- a/docs/advanced/cast/overview.rst
+++ b/docs/advanced/cast/overview.rst
@@ -144,6 +144,8 @@ as arguments and return values, refer to the section on binding :ref:`classes`.
 +------------------------------------+---------------------------+-------------------------------+
 | ``std::experimental::optional<T>`` | STL optional type (exp.)  | :file:`pybind11/stl.h`        |
 +------------------------------------+---------------------------+-------------------------------+
+| ``std::variant<...>``              | Type-safe union (C++17)   | :file:`pybind11/stl.h`        |
++------------------------------------+---------------------------+-------------------------------+
 | ``std::function<...>``             | STL polymorphic function  | :file:`pybind11/functional.h` |
 +------------------------------------+---------------------------+-------------------------------+
 | ``std::chrono::duration<...>``     | STL time duration         | :file:`pybind11/chrono.h`     |

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -354,6 +354,23 @@ test_initializer python_types([](py::module &m) {
     m.attr("has_optional") = has_optional;
     m.attr("has_exp_optional") = has_exp_optional;
 
+#ifdef PYBIND11_HAS_VARIANT
+    struct visitor {
+        const char *operator()(int) { return "int"; }
+        const char *operator()(std::string) { return "std::string"; }
+        const char *operator()(double) { return "double"; }
+    };
+
+    m.def("load_variant", [](std::variant<int, std::string, double> v) {
+        return std::visit(visitor(), v);
+    });
+
+    m.def("cast_variant", []() {
+        using V = std::variant<int, std::string>;
+        return py::make_tuple(V(5), V("Hello"));
+    });
+#endif
+
     m.def("test_default_constructors", []() {
         return py::dict(
             "str"_a=py::str(),

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -1,5 +1,6 @@
 # Python < 3 needs this: coding=utf-8
 import pytest
+import pybind11_tests
 
 from pybind11_tests import ExamplePythonTypes, ConstructorStats, has_optional, has_exp_optional
 
@@ -368,6 +369,18 @@ def test_exp_optional():
     assert test_nullopt_exp(None) == 42
     assert test_nullopt_exp(42) == 42
     assert test_nullopt_exp(43) == 43
+
+
+@pytest.mark.skipif(not hasattr(pybind11_tests, "load_variant"), reason='no <variant>')
+def test_variant(doc):
+    from pybind11_tests import load_variant, cast_variant
+
+    assert load_variant(1) == "int"
+    assert load_variant("1") == "std::string"
+    assert load_variant(1.0) == "double"
+    assert cast_variant() == (5, "Hello")
+
+    assert doc(load_variant) == "load_variant(arg0: Union[int, str, float]) -> str"
 
 
 def test_constructors():


### PR DESCRIPTION
C++17 `std::variant` is supported automatically, but custom variants can also be added easily. See the explanation in the docs.

For conforming C++11/14 `std::variant` implementations (like `mpark::variant`) a `variant_caster` specialization is enough. For implementations with a different `visit()` function (like `boost::variant`) the `visit_helper` is also required.

Resolves #810.