### PR TITLE
Multiple inheritance fixes

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -266,7 +266,7 @@ struct type_record {
             dynamic_attr = true;
 
         if (caster)
-            base_info->implicit_casts.push_back(std::make_pair(type, caster));
+            base_info->implicit_casts.emplace_back(type, caster);
     }
 };
 

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -41,7 +41,15 @@ void bind_ConstructorStats(py::module &m) {
         .def_readwrite("move_assignments", &ConstructorStats::move_assignments)
         .def_readwrite("copy_constructions", &ConstructorStats::copy_constructions)
         .def_readwrite("move_constructions", &ConstructorStats::move_constructions)
-        .def_static("get", (ConstructorStats &(*)(py::object)) &ConstructorStats::get, py::return_value_policy::reference_internal);
+        .def_static("get", (ConstructorStats &(*)(py::object)) &ConstructorStats::get, py::return_value_policy::reference_internal)
+
+        // Not exactly ConstructorStats, but related: expose the internal pybind number of registered instances
+        // to allow instance cleanup checks (invokes a GC first)
+        .def_static("detail_reg_inst", []() {
+            ConstructorStats::gc();
+            return py::detail::get_internals().registered_instances.size();
+        })
+        ;
 }
 
 PYBIND11_PLUGIN(pybind11_tests) {

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -107,8 +107,16 @@ test_initializer multiple_inheritance_casting([](py::module &m) {
     py::class_<I801C, I801B1, I801B2, std::shared_ptr<I801C>>(m, "I801C").def(py::init<>());
     py::class_<I801D, I801C, std::shared_ptr<I801D>>(m, "I801D").def(py::init<>());
 
-    // When returned a base class pointer to a derived instance, we cannot assume that the
-    // pointer is `reinterpret_cast`able to the derived pointer because the base class
+    // Two separate issues here: first, we want to recognize a pointer to a base type as being a
+    // known instance even when the pointer value is unequal (i.e. due to a non-first
+    // multiple-inheritance base class):
+    m.def("i801b1_c", [](I801C *c) { return static_cast<I801B1 *>(c); });
+    m.def("i801b2_c", [](I801C *c) { return static_cast<I801B2 *>(c); });
+    m.def("i801b1_d", [](I801D *d) { return static_cast<I801B1 *>(d); });
+    m.def("i801b2_d", [](I801D *d) { return static_cast<I801B2 *>(d); });
+
+    // Second, when returned a base class pointer to a derived instance, we cannot assume that the
+    // pointer is `reinterpret_cast`able to the derived pointer because, like above, the base class
     // pointer could be offset.
     m.def("i801c_b1", []() -> I801B1 * { return new I801C(); });
     m.def("i801c_b2", []() -> I801B2 * { return new I801C(); });

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -9,6 +9,7 @@
 */
 
 #include "pybind11_tests.h"
+#include "constructor_stats.h"
 
 struct Base1 {
     Base1(int i) : i(i) { }
@@ -90,6 +91,36 @@ test_initializer multiple_inheritance_nonexplicit([](py::module &m) {
     m.def("bar_base2a", [](Base2a *b) { return b->bar(); });
     m.def("bar_base2a_sharedptr", [](std::shared_ptr<Base2a> b) { return b->bar(); });
 });
+
+// Issue #801: invalid casting to derived type with MI bases
+struct I801B1 { int a = 1; virtual ~I801B1() = default; };
+struct I801B2 { int b = 2; virtual ~I801B2() = default; };
+struct I801C : I801B1, I801B2 {};
+struct I801D : I801C {}; // Indirect MI
+// Unregistered classes:
+struct I801B3 { int c = 3; virtual ~I801B3() = default; };
+struct I801E : I801B3, I801D {};
+
+test_initializer multiple_inheritance_casting([](py::module &m) {
+    py::class_<I801B1, std::shared_ptr<I801B1>>(m, "I801B1").def(py::init<>()).def_readonly("a", &I801B1::a);
+    py::class_<I801B2, std::shared_ptr<I801B2>>(m, "I801B2").def(py::init<>()).def_readonly("b", &I801B2::b);
+    py::class_<I801C, I801B1, I801B2, std::shared_ptr<I801C>>(m, "I801C").def(py::init<>());
+    py::class_<I801D, I801C, std::shared_ptr<I801D>>(m, "I801D").def(py::init<>());
+
+    // When returned a base class pointer to a derived instance, we cannot assume that the
+    // pointer is `reinterpret_cast`able to the derived pointer because the base class
+    // pointer could be offset.
+    m.def("i801c_b1", []() -> I801B1 * { return new I801C(); });
+    m.def("i801c_b2", []() -> I801B2 * { return new I801C(); });
+    m.def("i801d_b1", []() -> I801B1 * { return new I801D(); });
+    m.def("i801d_b2", []() -> I801B2 * { return new I801D(); });
+
+    // Return a base class pointer to a pybind-registered type when the actual derived type
+    // isn't pybind-registered (and uses multiple-inheritance to offset the pybind base)
+    m.def("i801e_c", []() -> I801C * { return new I801E(); });
+    m.def("i801e_b2", []() -> I801B2 * { return new I801E(); });
+});
+
 
 struct Vanilla {
     std::string vanilla() { return "Vanilla"; };

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -1,4 +1,5 @@
 import pytest
+from pybind11_tests import ConstructorStats
 
 
 def test_multiple_inheritance_cpp():
@@ -109,3 +110,52 @@ def test_mi_dynamic_attributes():
     for d in (mi.VanillaDictMix1(), mi.VanillaDictMix2()):
         d.dynamic = 1
         assert d.dynamic == 1
+
+
+def test_mi_base_return():
+    """Tests returning an offset (non-first MI) base class pointer to a derived instance"""
+    from pybind11_tests import (I801B2, I801C, I801D, i801c_b1, i801c_b2, i801d_b1, i801d_b2,
+                                i801e_c, i801e_b2)
+
+    n_inst = ConstructorStats.detail_reg_inst()
+
+    c1 = i801c_b1()
+    assert type(c1) is I801C
+    assert c1.a == 1
+    assert c1.b == 2
+
+    d1 = i801d_b1()
+    assert type(d1) is I801D
+    assert d1.a == 1
+    assert d1.b == 2
+
+    assert ConstructorStats.detail_reg_inst() == n_inst + 2
+
+    c2 = i801c_b2()
+    assert type(c2) is I801C
+    assert c2.a == 1
+    assert c2.b == 2
+
+    d2 = i801d_b2()
+    assert type(d2) is I801D
+    assert d2.a == 1
+    assert d2.b == 2
+
+    assert ConstructorStats.detail_reg_inst() == n_inst + 4
+
+    del c2
+    assert ConstructorStats.detail_reg_inst() == n_inst + 3
+    del c1, d1, d2
+    assert ConstructorStats.detail_reg_inst() == n_inst
+
+    # Returning an unregistered derived type with a registered base; we won't
+    # pick up the derived type, obviously, but should still work (as an object
+    # of whatever type was returned).
+    e1 = i801e_c()
+    assert type(e1) is I801C
+    assert e1.a == 1
+    assert e1.b == 2
+
+    e2 = i801e_b2()
+    assert type(e2) is I801B2
+    assert e2.b == 2

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -112,6 +112,32 @@ def test_mi_dynamic_attributes():
         assert d.dynamic == 1
 
 
+def test_mi_unaligned_base():
+    """Returning an offset (non-first MI) base class pointer should recognize the instance"""
+    from pybind11_tests import I801C, I801D, i801b1_c, i801b2_c, i801b1_d, i801b2_d
+
+    n_inst = ConstructorStats.detail_reg_inst()
+
+    c = I801C()
+    d = I801D()
+    # + 4 below because we have the two instances, and each instance has offset base I801B2
+    assert ConstructorStats.detail_reg_inst() == n_inst + 4
+    b1c = i801b1_c(c)
+    assert b1c is c
+    b2c = i801b2_c(c)
+    assert b2c is c
+    b1d = i801b1_d(d)
+    assert b1d is d
+    b2d = i801b2_d(d)
+    assert b2d is d
+
+    assert ConstructorStats.detail_reg_inst() == n_inst + 4  # no extra instances
+    del c, b1c, b2c
+    assert ConstructorStats.detail_reg_inst() == n_inst + 2
+    del d, b1d, b2d
+    assert ConstructorStats.detail_reg_inst() == n_inst
+
+
 def test_mi_base_return():
     """Tests returning an offset (non-first MI) base class pointer to a derived instance"""
     from pybind11_tests import (I801B2, I801C, I801D, i801c_b1, i801c_b2, i801d_b1, i801d_b2,
@@ -129,7 +155,7 @@ def test_mi_base_return():
     assert d1.a == 1
     assert d1.b == 2
 
-    assert ConstructorStats.detail_reg_inst() == n_inst + 2
+    assert ConstructorStats.detail_reg_inst() == n_inst + 4
 
     c2 = i801c_b2()
     assert type(c2) is I801C
@@ -141,10 +167,10 @@ def test_mi_base_return():
     assert d2.a == 1
     assert d2.b == 2
 
-    assert ConstructorStats.detail_reg_inst() == n_inst + 4
+    assert ConstructorStats.detail_reg_inst() == n_inst + 8
 
     del c2
-    assert ConstructorStats.detail_reg_inst() == n_inst + 3
+    assert ConstructorStats.detail_reg_inst() == n_inst + 6
     del c1, d1, d2
     assert ConstructorStats.detail_reg_inst() == n_inst
 


### PR DESCRIPTION
This fixes two issues with multiple inheritance.

The first is that when we cast a base class pointer, we correctly detect (via a `typeid`) the derived class, but then do (in essense) a reinterpret_cast on it, which is wrong when the base class is offset (due to multiple inheritance).  The fix is to dynamic_cast to the most derived type before passing the pointer on.

The second fix is that we can often end up with multiple Python instances around the same C++ instance when we are given a base class pointer in the same situation as above: the pointer doesn't match anything in `registered_instances`, so we treat it as a new type, even though, internally, it is really wrapping the same type.  The commit to fix this adds into `registered_instances` all the base type pointers (for base types that we know about) that aren't equal to the derived pointer.  This is a bit of extra work as we have to do it recursively, and both during registering the instance and deregistering, but this is only done for types that actually have multiple bases somewhere above them in their inheritance tree.

Fixes #801.

@uentity - I think this should fix at least some of your multiple inheritance issues; your feedback here would be very valuable.