### PR TITLE
functional: support bound methods

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -355,6 +355,7 @@ inline handle get_function(handle value) {
 #if PY_MAJOR_VERSION >= 3
         if (PyInstanceMethod_Check(value.ptr()))
             value = PyInstanceMethod_GET_FUNCTION(value.ptr());
+        else
 #endif
         if (PyMethod_Check(value.ptr()))
             value = PyMethod_GET_FUNCTION(value.ptr());
@@ -1133,10 +1134,13 @@ public:
 class function : public object {
 public:
     PYBIND11_OBJECT_DEFAULT(function, object, PyCallable_Check)
-    bool is_cpp_function() const {
+    handle cpp_function() const {
         handle fun = detail::get_function(m_ptr);
-        return fun && PyCFunction_Check(fun.ptr());
+        if (fun && PyCFunction_Check(fun.ptr()))
+            return fun;
+        return handle();
     }
+    bool is_cpp_function() const { return (bool) cpp_function(); }
 };
 
 class buffer : public object {

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -179,4 +179,9 @@ test_initializer callbacks([](py::module &m) {
         f(x); // lvalue reference shouldn't move out object
         return x.valid; // must still return `true`
       });
+
+    struct CppBoundMethodTest {};
+    py::class_<CppBoundMethodTest>(m, "CppBoundMethodTest")
+        .def(py::init<>())
+        .def("triple", [](CppBoundMethodTest &, int val) { return 3 * val; });
 });

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -27,6 +27,21 @@ def test_callbacks():
     assert f(number=43) == 44
 
 
+def test_bound_method_callback():
+    from pybind11_tests import test_callback3, CppBoundMethodTest
+
+    # Bound Python method:
+    class MyClass:
+        def double(self, val):
+            return 2 * val
+
+    z = MyClass()
+    assert test_callback3(z.double) == "func(43) = 86"
+
+    z = CppBoundMethodTest()
+    assert test_callback3(z.triple) == "func(43) = 129"
+
+
 def test_keyword_args_and_generalized_unpacking():
     from pybind11_tests import (test_tuple_unpacking, test_dict_unpacking, test_keyword_args,
                                 test_unpacking_and_keywords1, test_unpacking_and_keywords2,


### PR DESCRIPTION
If a bound std::function is invoked with a bound method, the implicit bound self is lost; the method is called with the first argument as self.  This commits adds bound method detection and re-adds the
implicit `self` into the call arguments for bound methods.

Fixes #814.