### PR TITLE
enum_: fix implicit conversion on Python 2.7

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -561,7 +561,7 @@ public:
             (std::is_integral<T>::value && sizeof(py_type) != sizeof(T) &&
                (py_value < (py_type) std::numeric_limits<T>::min() ||
                 py_value > (py_type) std::numeric_limits<T>::max()))) {
-#if PY_VERSION_HEX < 0x03000000
+#if PY_VERSION_HEX < 0x03000000 && !defined(PYPY_VERSION)
             bool type_error = PyErr_ExceptionMatches(PyExc_SystemError);
 #else
             bool type_error = PyErr_ExceptionMatches(PyExc_TypeError);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1199,6 +1199,9 @@ public:
         }, return_value_policy::copy);
         def("__init__", [](Type& value, Scalar i) { value = (Type)i; });
         def("__int__", [](Type value) { return (Scalar) value; });
+        #if PY_MAJOR_VERSION < 3
+            def("__long__", [](Type value) { return (Scalar) value; });
+        #endif
         def("__eq__", [](const Type &value, Type *value2) { return value2 && value == *value2; });
         def("__ne__", [](const Type &value, Type *value2) { return !value2 || value != *value2; });
         if (is_arithmetic) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -162,9 +162,15 @@ if(NOT PYBIND11_PYTEST_FOUND)
   set(PYBIND11_PYTEST_FOUND TRUE CACHE INTERNAL "")
 endif()
 
+if(CMAKE_VERSION VERSION_LESS 3.2)
+  set(PYBIND11_USES_TERMINAL "")
+else()
+  set(PYBIND11_USES_TERMINAL "USES_TERMINAL")
+endif()
+
 # A single command to compile and run the tests
 add_custom_target(pytest COMMAND ${PYTHON_EXECUTABLE} -m pytest ${PYBIND11_PYTEST_FILES}
-                  DEPENDS pybind11_tests WORKING_DIRECTORY ${testdir})
+                  DEPENDS pybind11_tests WORKING_DIRECTORY ${testdir} ${PYBIND11_USES_TERMINAL})
 
 if(PYBIND11_TEST_OVERRIDE)
   add_custom_command(TARGET pytest POST_BUILD

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -65,4 +65,8 @@ test_initializer enums([](py::module &m) {
         .value("EFirstMode", ClassWithUnscopedEnum::EFirstMode)
         .value("ESecondMode", ClassWithUnscopedEnum::ESecondMode)
         .export_values();
+
+    m.def("test_enum_to_int", [](int) { });
+    m.def("test_enum_to_uint", [](uint32_t) { });
+    m.def("test_enum_to_long_long", [](long long) { });
 });

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -116,6 +116,7 @@ def test_binary_operators():
     assert state2 == -7
     assert int(state ^ state2) == -1
 
+
 def test_enum_to_int():
     from pybind11_tests import Flags, ClassWithUnscopedEnum
     from pybind11_tests import test_enum_to_int, test_enum_to_uint, test_enum_to_long_long

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -115,3 +115,14 @@ def test_binary_operators():
     state2 = ~state
     assert state2 == -7
     assert int(state ^ state2) == -1
+
+def test_enum_to_int():
+    from pybind11_tests import Flags, ClassWithUnscopedEnum
+    from pybind11_tests import test_enum_to_int, test_enum_to_uint, test_enum_to_long_long
+
+    test_enum_to_int(Flags.Read)
+    test_enum_to_int(ClassWithUnscopedEnum.EMode.EFirstMode)
+    test_enum_to_uint(Flags.Read)
+    test_enum_to_uint(ClassWithUnscopedEnum.EMode.EFirstMode)
+    test_enum_to_long_long(Flags.Read)
+    test_enum_to_long_long(ClassWithUnscopedEnum.EMode.EFirstMode)


### PR DESCRIPTION
Enumerations on Python 2.7 were not always implicitly converted to
integers (depending on the target size). This patch adds a `__long__`
conversion function (only enabled on 2.7) which fixes this issue.

The attached test case fails without this patch.