### PR TITLE
Deprecate handle::operator== in favor of object_api::is

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -58,7 +58,7 @@ struct metaclass {
     handle value;
 
     PYBIND11_DEPRECATED("py::metaclass() is no longer required. It's turned on by default now.")
-    metaclass() = default;
+    metaclass() {}
 
     /// Override pybind11's default metaclass
     explicit metaclass(handle value) : value(value) { }

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -69,14 +69,10 @@
 #  define PYBIND11_NOINLINE __attribute__ ((noinline))
 #endif
 
-#if defined(PYBIND11_CPP14)
+#if defined(PYBIND11_CPP14) || defined(_MSC_VER)
 #  define PYBIND11_DEPRECATED(reason) [[deprecated(reason)]]
-#elif defined(__clang__)
+#else
 #  define PYBIND11_DEPRECATED(reason) __attribute__((deprecated(reason)))
-#elif defined(__GNUG__)
-#  define PYBIND11_DEPRECATED(reason) __attribute__((deprecated))
-#elif defined(_MSC_VER)
-#  define PYBIND11_DEPRECATED(reason) __declspec(deprecated)
 #endif
 
 #define PYBIND11_VERSION_MAJOR 2

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -531,7 +531,7 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
         object matrix_type = sparse_module.attr(
             rowMajor ? "csr_matrix" : "csc_matrix");
 
-        if (obj.get_type() != matrix_type.ptr()) {
+        if (!obj.get_type().is(matrix_type)) {
             try {
                 obj = matrix_type(obj);
             } catch (const error_already_set &) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -278,7 +278,7 @@ protected:
                 chain = (detail::function_record *) rec_capsule;
                 /* Never append a method to an overload chain of a parent class;
                    instead, hide the parent's overloads in this case */
-                if (chain->scope != rec->scope)
+                if (!chain->scope.is(rec->scope))
                     chain = nullptr;
             }
             // Don't trigger for things like the default __init__, which are wrapper_descriptors that we are intentionally replacing
@@ -1274,7 +1274,7 @@ template <typename... Args> struct init {
         using Alias = typename Class::type_alias;
         handle cl_type = cl;
         cl.def("__init__", [cl_type](handle self_, Args... args) {
-                if (self_.get_type() == cl_type)
+                if (self_.get_type().is(cl_type))
                     new (self_.cast<Base *>()) Base(args...);
                 else
                     new (self_.cast<Alias *>()) Alias(args...);
@@ -1708,7 +1708,7 @@ inline function get_type_overload(const void *this_ptr, const detail::type_info 
         Py_file_input, d.ptr(), d.ptr());
     if (result == nullptr)
         throw error_already_set();
-    if ((handle) d["self"] == Py_None)
+    if (d["self"].is_none())
         return function();
     Py_DECREF(result);
 #endif

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -110,6 +110,8 @@ public:
     PYBIND11_DEPRECATED("call(...) was deprecated in favor of operator()(...)")
         object call(Args&&... args) const;
 
+    /// Equivalent to ``obj is other`` in Python.
+    bool is(object_api const& other) const { return derived().ptr() == other.derived().ptr(); }
     /// Equivalent to ``obj is None`` in Python.
     bool is_none() const { return derived().ptr() == Py_None; }
     PYBIND11_DEPRECATED("Use py::str(obj) instead")
@@ -167,10 +169,12 @@ public:
     /// Return ``true`` when the `handle` wraps a valid Python object
     explicit operator bool() const { return m_ptr != nullptr; }
     /** \rst
-        Check that the underlying pointers are the same.
+        Deprecated: Check that the underlying pointers are the same.
         Equivalent to ``obj1 is obj2`` in Python.
     \endrst */
+    PYBIND11_DEPRECATED("Use obj1.is(obj2) instead")
     bool operator==(const handle &h) const { return m_ptr == h.m_ptr; }
+    PYBIND11_DEPRECATED("Use !obj1.is(obj2) instead")
     bool operator!=(const handle &h) const { return m_ptr != h.m_ptr; }
     PYBIND11_DEPRECATED("Use handle::operator bool() instead")
     bool check() const { return m_ptr != nullptr; }

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -37,7 +37,7 @@ test_initializer eval([](py::module &m) {
         );
         auto x = local["x"].cast<int>();
 
-        return result == py::none() && x == 42;
+        return result.is_none() && x == 42;
     });
 
     m.def("test_eval", [global]() {
@@ -55,7 +55,7 @@ test_initializer eval([](py::module &m) {
 
         auto result = py::eval<py::eval_single_statement>("x = call_test()", py::dict(), local);
         auto x = local["x"].cast<int>();
-        return result == py::none() && x == 42;
+        return result.is_none() && x == 42;
     });
 
     m.def("test_eval_file", [global](py::str filename) {
@@ -66,7 +66,7 @@ test_initializer eval([](py::module &m) {
         local["call_test2"] = py::cpp_function([&](int value) { val_out = value; });
 
         auto result = py::eval_file(filename, global, local);
-        return val_out == 43 && result == py::none();
+        return val_out == 43 && result.is_none();
     });
 
     m.def("test_eval_failure", []() {


### PR DESCRIPTION
Working with `py::object`s, it really seems confusing that `obj1 == obj2` does pointer comparison instead of actual object equality. ~~Explicitly writing `obj1.ptr() == obj2.ptr()` is easy enough and much clearer.~~ Edit: Switched to `obj1.is(obj2)` as suggested.

I propose deprecating `handle::opeator==` now so that the syntax can be freed up for Python's rich comparison methods at some point in the future. The changes to pybind11 are minimal since the operator is actually used very sparsely.

This PR also adds messages for deprecation warnings to all compilers (the `= default` to `{}` constructor change is due to a VS2015 bug).