### PR TITLE
Allow std::complex field with PYBIND11_NUMPY_DTYPE

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -198,6 +198,12 @@ expects the type followed by field names:
         /* now both A and B can be used as template arguments to py::array_t */
     }
 
+The structure should consist of fundamental arithmetic types, ``std::complex``,
+and previously registered substructures. While there is a static assertion to
+prevent many types of unsupported structures, it is still the user's
+responsibility to use only "plain" structures that can be safely manipulated as
+raw memory without violating invariants.
+
 Vectorizing functions
 =====================
 

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -607,25 +607,14 @@ template <typename T> struct is_fmt_numeric<T, enable_if_t<std::is_arithmetic<T>
 };
 NAMESPACE_END(detail)
 
-template <typename T> struct format_descriptor<T, detail::enable_if_t<detail::is_fmt_numeric<T>::value>> {
-    static constexpr const char c1 = "?bBhHiIqQfdgZZZ"[detail::is_fmt_numeric<T>::index];
-    static constexpr const char c2 = "\0\0\0\0\0\0\0\0\0\0\0\0fdg"[detail::is_fmt_numeric<T>::index];
-    static constexpr const char value[3] = { c1, c2, '\0' };
-    static std::string format() {
-#if !defined(_MSC_VER) || _MSC_VER >= 1910
-        return std::string(value);
-#else
-        // MSVC 2015 has trouble constructing std::string from value
-        std::string out(1, c1);
-        if (c2)
-            out += c2;
-        return out;
-#endif
-    }
+template <typename T> struct format_descriptor<T, detail::enable_if_t<std::is_arithmetic<T>::value>> {
+    static constexpr const char c = "?bBhHiIqQfdg"[detail::is_fmt_numeric<T>::index];
+    static constexpr const char value[2] = { c, '\0' };
+    static std::string format() { return std::string(1, c); }
 };
 
 template <typename T> constexpr const char format_descriptor<
-    T, detail::enable_if_t<detail::is_fmt_numeric<T>::value>>::value[3];
+    T, detail::enable_if_t<std::is_arithmetic<T>::value>>::value[2];
 
 /// RAII wrapper that temporarily clears any Python error state
 struct error_scope {

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -608,13 +608,14 @@ template <typename T> struct is_fmt_numeric<T, enable_if_t<std::is_arithmetic<T>
 NAMESPACE_END(detail)
 
 template <typename T> struct format_descriptor<T, detail::enable_if_t<detail::is_fmt_numeric<T>::value>> {
-    static constexpr const char c = "?bBhHiIqQfdgFDG"[detail::is_fmt_numeric<T>::index];
-    static constexpr const char value[2] = { c, '\0' };
-    static std::string format() { return std::string(1, c); }
+    static constexpr const char c1 = "?bBhHiIqQfdgZZZ"[detail::is_fmt_numeric<T>::index];
+    static constexpr const char c2 = "\0\0\0\0\0\0\0\0\0\0\0\0fdg"[detail::is_fmt_numeric<T>::index];
+    static constexpr const char value[3] = { c1, c2, '\0' };
+    static std::string format() { return std::string(value); }
 };
 
 template <typename T> constexpr const char format_descriptor<
-    T, detail::enable_if_t<detail::is_fmt_numeric<T>::value>>::value[2];
+    T, detail::enable_if_t<detail::is_fmt_numeric<T>::value>>::value[3];
 
 /// RAII wrapper that temporarily clears any Python error state
 struct error_scope {

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -611,7 +611,17 @@ template <typename T> struct format_descriptor<T, detail::enable_if_t<detail::is
     static constexpr const char c1 = "?bBhHiIqQfdgZZZ"[detail::is_fmt_numeric<T>::index];
     static constexpr const char c2 = "\0\0\0\0\0\0\0\0\0\0\0\0fdg"[detail::is_fmt_numeric<T>::index];
     static constexpr const char value[3] = { c1, c2, '\0' };
-    static std::string format() { return std::string(value); }
+    static std::string format() {
+#if !defined(_MSC_VER) || _MSC_VER >= 1910
+        return std::string(value);
+#else
+        // MSVC 2015 has trouble constructing std::string from value
+        std::string out(1, c1);
+        if (c2)
+            out += c2;
+        return out;
+#endif
+    }
 };
 
 template <typename T> constexpr const char format_descriptor<

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -18,10 +18,19 @@
 #endif
 
 NAMESPACE_BEGIN(pybind11)
+
+template <typename T> struct format_descriptor<std::complex<T>, detail::enable_if_t<std::is_floating_point<T>::value>> {
+    static constexpr const char c = format_descriptor<T>::c;
+    static constexpr const char value[3] = { 'Z', c, '\0' };
+    static std::string format() { return std::string(value); }
+};
+
+template <typename T> constexpr const char format_descriptor<
+    std::complex<T>, detail::enable_if_t<std::is_floating_point<T>::value>>::value[3];
+
 NAMESPACE_BEGIN(detail)
 
-// The format codes are already in the string in common.h, we just need to provide a specialization
-template <typename T> struct is_fmt_numeric<std::complex<T>> {
+template <typename T> struct is_fmt_numeric<std::complex<T>, detail::enable_if_t<std::is_floating_point<T>::value>> {
     static constexpr bool value = true;
     static constexpr int index = is_fmt_numeric<T>::index + 3;
 };

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -245,7 +245,14 @@ template <typename T> struct is_complex<std::complex<T>> : std::true_type { };
 
 template <typename T> using is_pod_struct = all_of<
     std::is_standard_layout<T>,     // since we're accessing directly in memory we need a standard layout type
+#if !defined(__GNUG__) || defined(__clang__) || __GNUC__ >= 5
     std::is_trivially_copyable<T>,
+#else
+    // GCC 4 doesn't implement is_trivially_copyable, so approximate it
+    std::is_trivially_destructible<T>,
+    std::has_trivial_copy_constructor<T>,
+    std::has_trivial_copy_assign<T>,
+#endif
     satisfies_none_of<T, std::is_reference, std::is_array, is_std_array, std::is_arithmetic, is_complex, std::is_enum>
 >;
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -991,14 +991,15 @@ inline PYBIND11_NOINLINE void register_structured_dtype(
         [](const field_descriptor &a, const field_descriptor &b) { return a.offset < b.offset; });
     size_t offset = 0;
     std::ostringstream oss;
-    oss << "T{";
+    // mark the structure as unaligned with '^', because numpy and C++ don't
+    // always agree about alignment (particularly for complex), and we're
+    // explicitly listing all our padding. This depends on none of the fields
+    // overriding the endianness. Putting the ^ in front of individual fields
+    // isn't guaranteed to work due to https://github.com/numpy/numpy/issues/9049
+    oss << "^T{";
     for (auto& field : ordered_fields) {
         if (field.offset > offset)
             oss << (field.offset - offset) << 'x';
-        // mark all fields with '^' (unaligned native type), because numpy
-        // and C++ don't always agree about alignment (particularly for
-        // complex, and we're explicitly listing all padding.
-        oss << '^';
         oss << field.format << ':' << field.name << ':';
         offset = field.offset + field.size;
     }

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -250,8 +250,7 @@ template <typename T> using is_pod_struct = all_of<
 #else
     // GCC 4 doesn't implement is_trivially_copyable, so approximate it
     std::is_trivially_destructible<T>,
-    std::has_trivial_copy_constructor<T>,
-    std::has_trivial_copy_assign<T>,
+    satisfies_any_of<T, std::has_trivial_copy_constructor, std::has_trivial_copy_assign>,
 #endif
     satisfies_none_of<T, std::is_reference, std::is_array, is_std_array, std::is_arithmetic, is_complex, std::is_enum>
 >;

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -72,22 +72,22 @@ def test_format_descriptors():
     assert re.match('^NumPy type info missing for .*UnboundStruct.*$', str(excinfo.value))
 
     ld = np.dtype('longdouble')
-    ldbl_fmt = ('4x' if ld.alignment > 4 else '') + '^' + ld.char
-    ss_fmt = "T{^?:bool_:3x^I:uint_:^f:float_:" + ldbl_fmt + ":ldbl_:}"
+    ldbl_fmt = ('4x' if ld.alignment > 4 else '') + ld.char
+    ss_fmt = "^T{?:bool_:3xI:uint_:f:float_:" + ldbl_fmt + ":ldbl_:}"
     dbl = np.dtype('double')
-    partial_fmt = ("T{^?:bool_:3x^I:uint_:^f:float_:" +
+    partial_fmt = ("^T{?:bool_:3xI:uint_:f:float_:" +
                    str(4 * (dbl.alignment > 4) + dbl.itemsize + 8 * (ld.alignment > 8)) +
-                   "x^g:ldbl_:}")
+                   "xg:ldbl_:}")
     nested_extra = str(max(8, ld.alignment))
     assert print_format_descriptors() == [
         ss_fmt,
-        "T{^?:bool_:^I:uint_:^f:float_:^g:ldbl_:}",
-        "T{^" + ss_fmt + ":a:^T{^?:bool_:^I:uint_:^f:float_:^g:ldbl_:}:b:}",
+        "^T{?:bool_:I:uint_:f:float_:g:ldbl_:}",
+        "^T{" + ss_fmt + ":a:^T{?:bool_:I:uint_:f:float_:g:ldbl_:}:b:}",
         partial_fmt,
-        "T{" + nested_extra + "x^" + partial_fmt + ":a:" + nested_extra + "x}",
-        "T{^3s:a:^3s:b:}",
-        'T{^q:e1:^B:e2:}',
-        'T{^Zf:cflt:^Zd:cdbl:}'
+        "^T{" + nested_extra + "x" + partial_fmt + ":a:" + nested_extra + "x}",
+        "^T{3s:a:3s:b:}",
+        '^T{q:e1:B:e2:}',
+        '^T{Zf:cflt:Zd:cdbl:}'
     ]
 
 

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -72,21 +72,22 @@ def test_format_descriptors():
     assert re.match('^NumPy type info missing for .*UnboundStruct.*$', str(excinfo.value))
 
     ld = np.dtype('longdouble')
-    ldbl_fmt = ('4x' if ld.alignment > 4 else '') + ld.char
-    ss_fmt = "T{?:bool_:3xI:uint_:f:float_:" + ldbl_fmt + ":ldbl_:}"
+    ldbl_fmt = ('4x' if ld.alignment > 4 else '') + '^' + ld.char
+    ss_fmt = "T{^?:bool_:3x^I:uint_:^f:float_:" + ldbl_fmt + ":ldbl_:}"
     dbl = np.dtype('double')
-    partial_fmt = ("T{?:bool_:3xI:uint_:f:float_:" +
+    partial_fmt = ("T{^?:bool_:3x^I:uint_:^f:float_:" +
                    str(4 * (dbl.alignment > 4) + dbl.itemsize + 8 * (ld.alignment > 8)) +
-                   "xg:ldbl_:}")
+                   "x^g:ldbl_:}")
     nested_extra = str(max(8, ld.alignment))
     assert print_format_descriptors() == [
         ss_fmt,
-        "T{?:bool_:^I:uint_:^f:float_:^g:ldbl_:}",
-        "T{" + ss_fmt + ":a:T{?:bool_:^I:uint_:^f:float_:^g:ldbl_:}:b:}",
+        "T{^?:bool_:^I:uint_:^f:float_:^g:ldbl_:}",
+        "T{^" + ss_fmt + ":a:^T{^?:bool_:^I:uint_:^f:float_:^g:ldbl_:}:b:}",
         partial_fmt,
-        "T{" + nested_extra + "x" + partial_fmt + ":a:" + nested_extra + "x}",
-        "T{3s:a:3s:b:}",
-        'T{q:e1:B:e2:}'
+        "T{" + nested_extra + "x^" + partial_fmt + ":a:" + nested_extra + "x}",
+        "T{^3s:a:^3s:b:}",
+        'T{^q:e1:^B:e2:}',
+        'T{^Zf:cflt:^Zd:cdbl:}'
     ]
 
 
@@ -104,7 +105,8 @@ def test_dtype(simple_dtype):
         partial_nested_fmt(),
         "[('a', 'S3'), ('b', 'S3')]",
         "[('e1', '" + e + "i8'), ('e2', 'u1')]",
-        "[('x', 'i1'), ('y', '" + e + "u8')]"
+        "[('x', 'i1'), ('y', '" + e + "u8')]",
+        "[('cflt', '" + e + "c8'), ('cdbl', '" + e + "c16')]"
     ]
 
     d1 = np.dtype({'names': ['a', 'b'], 'formats': ['int32', 'float64'],
@@ -229,6 +231,24 @@ def test_enum_array():
     assert arr['e1'].tolist() == [-1, 1, -1]
     assert arr['e2'].tolist() == [1, 2, 1]
     assert create_enum_array(0).dtype == dtype
+
+
+def test_complex_array():
+    from pybind11_tests import create_complex_array, print_complex_array
+    from sys import byteorder
+    e = '<' if byteorder == 'little' else '>'
+
+    arr = create_complex_array(3)
+    dtype = arr.dtype
+    assert dtype == np.dtype([('cflt', e + 'c8'), ('cdbl', e + 'c16')])
+    assert print_complex_array(arr) == [
+        "c:(0,0.25),(0.5,0.75)",
+        "c:(1,1.25),(1.5,1.75)",
+        "c:(2,2.25),(2.5,2.75)"
+    ]
+    assert arr['cflt'].tolist() == [0.0 + 0.25j, 1.0 + 1.25j, 2.0 + 2.25j]
+    assert arr['cdbl'].tolist() == [0.5 + 0.75j, 1.5 + 1.75j, 2.5 + 2.75j]
+    assert create_complex_array(0).dtype == dtype
 
 
 def test_signature(doc):


### PR DESCRIPTION
This exposed a few underlying issues:

1. is_pod_struct was too strict to allow this. I've relaxed it to
require only trivially copyable and standard layout, rather than POD
(which additionally requires a trivial constructor, which std::complex
violates). Should the name be changed too? There might also need to be
some documentation to warn the user not to do something stupid with a
class that has invariants.

2. format_descriptor<std::complex<T>>::format() returned numpy format
strings instead of PEP3118 format strings, but register_dtype
feeds format codes of its fields to _dtype_from_pep3118. I've changed it
to return PEP3118 format codes. format_descriptor is a public type, so
this may be considered an incompatible change.

3. register_structured_dtype tried to be smart about whether to mark
fields as unaligned (with ^). However, it's examining the C++ alignment,
rather than what numpy (or possibly PEP3118) thinks the alignment should
be. For complex values those are different. I've made it mark all fields
as ^ unconditionally, which should always be safe even if they are
aligned, because we explicitly mark the padding.

This addresses #799.