### PR TITLE
Support arrays inside PYBIND11_NUMPY_DTYPE

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -198,6 +198,13 @@ expects the type followed by field names:
         /* now both A and B can be used as template arguments to py::array_t */
     }
 
+The structure should consist of fundamental arithmetic types, ``std::complex``,
+previously registered substructures, and arrays of any of the above. Both C++
+arrays and ``std::array`` are supported. While there is a static assertion to
+prevent many types of unsupported structures, it is still the user's
+responsibility to use only "plain" structures that can be safely manipulated as
+raw memory without violating invariants.
+
 Vectorizing functions
 =====================
 

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -198,12 +198,9 @@ expects the type followed by field names:
         /* now both A and B can be used as template arguments to py::array_t */
     }
 
-The structure should consist of fundamental arithmetic types, ``std::complex``,
-previously registered substructures, and arrays of any of the above. Both C++
-arrays and ``std::array`` are supported. While there is a static assertion to
-prevent many types of unsupported structures, it is still the user's
-responsibility to use only "plain" structures that can be safely manipulated as
-raw memory without violating invariants.
+The structure should consist of fundamental arithmetic types, previously
+registered substructures, and arrays of any of the above. Both C++ arrays and
+``std::array`` are supported.
 
 Vectorizing functions
 =====================

--- a/include/pybind11/descr.h
+++ b/include/pybind11/descr.h
@@ -72,8 +72,6 @@ template <size_t...Digits> struct int_to_str<0, Digits...> {
     static constexpr const descr<sizeof...(Digits), 0> digits{{ ('0' + Digits)..., '\0' }, { nullptr }};
 };
 
-template <size_t... Digits> constexpr descr<sizeof...(Digits), 0> int_to_str<0, Digits...>::digits;
-
 // Ternary description (like std::conditional)
 template <bool B, size_t Size1, size_t Size2>
 constexpr enable_if_t<B, descr<Size1 - 1, 0>> _(char const(&text1)[Size1], char const(&)[Size2]) {

--- a/include/pybind11/descr.h
+++ b/include/pybind11/descr.h
@@ -69,8 +69,10 @@ template <size_t Size> constexpr descr<Size - 1, 0> _(char const(&text)[Size]) {
 
 template <size_t Rem, size_t... Digits> struct int_to_str : int_to_str<Rem/10, Rem%10, Digits...> { };
 template <size_t...Digits> struct int_to_str<0, Digits...> {
-    static constexpr auto digits = descr<sizeof...(Digits), 0>({ ('0' + Digits)..., '\0' }, { nullptr });
+    static constexpr const descr<sizeof...(Digits), 0> digits{{ ('0' + Digits)..., '\0' }, { nullptr }};
 };
+
+template <size_t... Digits> constexpr descr<sizeof...(Digits), 0> int_to_str<0, Digits...>::digits;
 
 // Ternary description (like std::conditional)
 template <bool B, size_t Size1, size_t Size2>

--- a/include/pybind11/descr.h
+++ b/include/pybind11/descr.h
@@ -69,7 +69,7 @@ template <size_t Size> constexpr descr<Size - 1, 0> _(char const(&text)[Size]) {
 
 template <size_t Rem, size_t... Digits> struct int_to_str : int_to_str<Rem/10, Rem%10, Digits...> { };
 template <size_t...Digits> struct int_to_str<0, Digits...> {
-    static constexpr const descr<sizeof...(Digits), 0> digits{{ ('0' + Digits)..., '\0' }, { nullptr }};
+    static constexpr auto digits = descr<sizeof...(Digits), 0>({ ('0' + Digits)..., '\0' }, { nullptr });
 };
 
 // Ternary description (like std::conditional)

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -247,7 +247,7 @@ template <typename T> struct array_info_scalar {
     typedef T type;
     static constexpr const bool is_array = false;
     static PYBIND11_DESCR extents() { return _(""); }
-    static void extents(list& /* shape */) { }
+    static void append_extents(list& /* shape */) { }
 };
 // Computes underlying type and a comma-separated list of extents for array
 // types (any mix of std::array and built-in arrays). An array of char is
@@ -259,9 +259,9 @@ template <typename T, size_t N> struct array_info<T[N]> {
     static constexpr const size_t extent = N;
 
     // appends the extents to shape
-    static void extents(list& shape) {
+    static void append_extents(list& shape) {
         shape.append(N);
-        array_info<T>::extents(shape);
+        array_info<T>::append_extents(shape);
     }
 
     template<typename T2 = T, enable_if_t<!array_info<T2>::is_array, int> = 0>
@@ -990,7 +990,7 @@ public:
     static PYBIND11_DESCR name() { return _("(") + array_info<T>::extents() + _(")") + base_descr::name(); }
     static pybind11::dtype dtype() {
         list shape;
-        array_info<T>::extents(shape);
+        array_info<T>::append_extents(shape);
         return pybind11::dtype::from_args(pybind11::make_tuple(base_descr::dtype(), shape));
     }
 };

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -255,7 +255,7 @@ template <typename T> struct array_info_scalar {
 // treated as scalar because it gets special handling.
 template <typename T> struct array_info : array_info_scalar<T> { };
 template <typename T, size_t N> struct array_info<std::array<T, N>> {
-    typedef typename array_info<T>::type type;
+    using type = typename array_info<T>::type;
     static constexpr bool is_array = true;
     static constexpr bool is_empty = (N == 0) || array_info<T>::is_empty;
     static constexpr size_t extent = N;

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -245,8 +245,8 @@ template <typename T> struct is_complex<std::complex<T>> : std::true_type { };
 
 template <typename T> struct array_info_scalar {
     typedef T type;
-    static constexpr const bool is_array = false;
-    static constexpr const bool is_empty = false;
+    static constexpr bool is_array = false;
+    static constexpr bool is_empty = false;
     static PYBIND11_DESCR extents() { return _(""); }
     static void append_extents(list& /* shape */) { }
 };
@@ -256,9 +256,9 @@ template <typename T> struct array_info_scalar {
 template <typename T> struct array_info : array_info_scalar<T> { };
 template <typename T, size_t N> struct array_info<std::array<T, N>> {
     typedef typename array_info<T>::type type;
-    static constexpr const bool is_array = true;
-    static constexpr const bool is_empty = (N == 0) || array_info<T>::is_empty;
-    static constexpr const size_t extent = N;
+    static constexpr bool is_array = true;
+    static constexpr bool is_empty = (N == 0) || array_info<T>::is_empty;
+    static constexpr size_t extent = N;
 
     // appends the extents to shape
     static void append_extents(list& shape) {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -785,6 +785,8 @@ protected:
 
 template <typename T, int ExtraFlags = array::forcecast> class array_t : public array {
 public:
+    static_assert(!detail::array_info<T>::is_array, "Array types cannot be used with array_t");
+
     using value_type = T;
 
     array_t() : array(0, static_cast<const T *>(nullptr)) {}

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -912,8 +912,8 @@ template <typename T>
 struct format_descriptor<T, detail::enable_if_t<detail::array_info<T>::is_array>> {
     static std::string format() {
         using detail::_;
-        return (_("(") + detail::array_info<T>::extents() + _(")")).text()
-            + format_descriptor<detail::remove_all_extents_t<T>>::format();
+        PYBIND11_DESCR extents = _("(") + detail::array_info<T>::extents() + _(")");
+        return extents.text() + format_descriptor<detail::remove_all_extents_t<T>>::format();
     }
 };
 

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -72,8 +72,8 @@ struct StringStruct {
 
 struct ArrayStruct {
     char a[3][4];
-    int b[2];
-    std::array<int, 3> c;
+    int32_t b[2];
+    std::array<uint8_t, 3> c;
     std::array<float, 2> d[4];
 };
 
@@ -109,7 +109,7 @@ std::ostream& operator<<(std::ostream& os, const ArrayStruct& v) {
         os << v.a[i][3] << '}';
     }
     os << "},b={" << v.b[0] << ',' << v.b[1];
-    os << "},c={" << v.c[0] << ',' << v.c[1] << ',' << v.c[2];
+    os << "},c={" << int(v.c[0]) << ',' << int(v.c[1]) << ',' << int(v.c[2]);
     os << "},d={";
     for (int i = 0; i < 4; i++) {
         if (i > 0)
@@ -199,9 +199,9 @@ py::array_t<ArrayStruct, 0> create_array_array(size_t n) {
             for (size_t k = 0; k < 4; k++)
                 ptr[i].a[j][k] = char('A' + (i * 100 + j * 10 + k) % 26);
         for (size_t j = 0; j < 2; j++)
-            ptr[i].b[j] = int(i * 1000 + j);
+            ptr[i].b[j] = int32_t(i * 1000 + j);
         for (size_t j = 0; j < 3; j++)
-            ptr[i].c[j] = int(i * 10 + j);
+            ptr[i].c[j] = uint8_t(i * 10 + j);
         for (size_t j = 0; j < 4; j++)
             for (size_t k = 0; k < 2; k++)
                 ptr[i].d[j][k] = float(i) * 100.0f + float(j) * 10.0f + float(k);

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -98,50 +98,25 @@ std::ostream& operator<<(std::ostream& os, const StringStruct& v) {
     return os << "'";
 }
 
-template<typename T>
-struct ArrayPrinter {
-    static void print(std::ostream& os, const T& v) { os << v; }
-};
-
-template<typename T, size_t N>
-struct ArrayPrinter<T[N]> {
-    static void print(std::ostream& os, const T v[N]) {
-        os << "{";
-        for (size_t i = 0; i < N; i++) {
-            if (i > 0) os << ",";
-            ArrayPrinter<T>::print(os, v[i]);
-        }
-        os << "}";
-    }
-};
-
-template<typename T, size_t N>
-struct ArrayPrinter<std::array<T, N>> {
-    static void print(std::ostream& os, const std::array<T, N>& v) {
-        os << "{";
-        for (size_t i = 0; i < N; i++) {
-            if (i > 0) os << ",";
-            ArrayPrinter<T>::print(os, v[i]);
-        }
-        os << "}";
-    }
-};
-
-template<typename T>
-void print_array(std::ostream& os, const T& v) {
-    ArrayPrinter<T>::print(os, v);
-}
-
 std::ostream& operator<<(std::ostream& os, const ArrayStruct& v) {
-    os << "a=";
-    print_array(os, v.a);
-    os << ",b=";
-    print_array(os, v.b);
-    os << ",c=";
-    print_array(os, v.c);
-    os << ",d=";
-    print_array(os, v.d);
-    return os;
+    os << "a={";
+    for (int i = 0; i < 3; i++) {
+        if (i > 0)
+            os << ',';
+        os << '{';
+        for (int j = 0; j < 3; j++)
+            os << v.a[i][j] << ',';
+        os << v.a[i][3] << '}';
+    }
+    os << "},b={" << v.b[0] << ',' << v.b[1];
+    os << "},c={" << v.c[0] << ',' << v.c[1] << ',' << v.c[2];
+    os << "},d={";
+    for (int i = 0; i < 4; i++) {
+        if (i > 0)
+            os << ',';
+        os << '{' << v.d[i][0] << ',' << v.d[i][1] << '}';
+    }
+    return os << '}';
 }
 
 std::ostream& operator<<(std::ostream& os, const EnumStruct& v) {

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -104,7 +104,8 @@ def test_dtype(simple_dtype):
         partial_dtype_fmt(),
         partial_nested_fmt(),
         "[('a', 'S3'), ('b', 'S3')]",
-        "[('a', 'S4', (3,)), ('b', '{e}i4', (2,)), ('c', '<i4', (3,)), ('d', '{e}f4', (4, 2))]".format(e=e),
+        ("[('a', 'S4', (3,)), ('b', '{e}i4', (2,)), " +
+         "('c', '<i4', (3,)), ('d', '{e}f4', (4, 2))]").format(e=e),
         "[('e1', '" + e + "i8'), ('e2', 'u1')]",
         "[('x', 'i1'), ('y', '" + e + "u8')]"
     ]
@@ -221,13 +222,19 @@ def test_array_array():
     e = '<' if byteorder == 'little' else '>'
 
     arr = create_array_array(3)
-    assert str(arr.dtype) == "[('a', 'S4', (3,)), ('b', '{e}i4', (2,)), ('c', '<i4', (3,)), ('d', '{e}f4', (4, 2))]".format(e=e)
+    assert str(arr.dtype) == ("[('a', 'S4', (3,)), ('b', '{e}i4', (2,)), " +
+                              "('c', '<i4', (3,)), ('d', '{e}f4', (4, 2))]").format(e=e)
     assert print_array_array(arr) == [
-        "a={{A,B,C,D},{K,L,M,N},{U,V,W,X}},b={0,1},c={0,1,2},d={{0,1},{10,11},{20,21},{30,31}}",
-        "a={{W,X,Y,Z},{G,H,I,J},{Q,R,S,T}},b={1000,1001},c={10,11,12},d={{100,101},{110,111},{120,121},{130,131}}",
-        "a={{S,T,U,V},{C,D,E,F},{M,N,O,P}},b={2000,2001},c={20,21,22},d={{200,201},{210,211},{220,221},{230,231}}",
+        "a={{A,B,C,D},{K,L,M,N},{U,V,W,X}},b={0,1}," +
+        "c={0,1,2},d={{0,1},{10,11},{20,21},{30,31}}",
+        "a={{W,X,Y,Z},{G,H,I,J},{Q,R,S,T}},b={1000,1001}," +
+        "c={10,11,12},d={{100,101},{110,111},{120,121},{130,131}}",
+        "a={{S,T,U,V},{C,D,E,F},{M,N,O,P}},b={2000,2001}," +
+        "c={20,21,22},d={{200,201},{210,211},{220,221},{230,231}}",
     ]
-    assert arr['a'].tolist() == [[b'ABCD', b'KLMN', b'UVWX'], [b'WXYZ', b'GHIJ', b'QRST'], [b'STUV', b'CDEF', b'MNOP']]
+    assert arr['a'].tolist() == [[b'ABCD', b'KLMN', b'UVWX'],
+                                 [b'WXYZ', b'GHIJ', b'QRST'],
+                                 [b'STUV', b'CDEF', b'MNOP']]
     assert arr['b'].tolist() == [[0, 1], [1000, 1001], [2000, 2001]]
     assert create_array_array(0).dtype == arr.dtype
 

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -86,7 +86,7 @@ def test_format_descriptors():
         partial_fmt,
         "T{" + nested_extra + "x" + partial_fmt + ":a:" + nested_extra + "x}",
         "T{3s:a:3s:b:}",
-        "T{(3)4s:a:(2)i:b:(3)i:c:(4, 2)f:d:}",
+        "T{(3)4s:a:(2)i:b:(3)B:c:1x(4, 2)f:d:}",
         'T{q:e1:B:e2:}'
     ]
 
@@ -104,8 +104,9 @@ def test_dtype(simple_dtype):
         partial_dtype_fmt(),
         partial_nested_fmt(),
         "[('a', 'S3'), ('b', 'S3')]",
-        ("[('a', 'S4', (3,)), ('b', '{e}i4', (2,)), " +
-         "('c', '<i4', (3,)), ('d', '{e}f4', (4, 2))]").format(e=e),
+        ("{{'names':['a','b','c','d'], " +
+         "'formats':[('S4', (3,)),('<i4', (2,)),('u1', (3,)),('<f4', (4, 2))], " +
+         "'offsets':[0,12,20,24], 'itemsize':56}}").format(e=e),
         "[('e1', '" + e + "i8'), ('e2', 'u1')]",
         "[('x', 'i1'), ('y', '" + e + "u8')]"
     ]
@@ -222,8 +223,10 @@ def test_array_array():
     e = '<' if byteorder == 'little' else '>'
 
     arr = create_array_array(3)
-    assert str(arr.dtype) == ("[('a', 'S4', (3,)), ('b', '{e}i4', (2,)), " +
-                              "('c', '<i4', (3,)), ('d', '{e}f4', (4, 2))]").format(e=e)
+    assert str(arr.dtype) == (
+        "{{'names':['a','b','c','d'], " +
+        "'formats':[('S4', (3,)),('<i4', (2,)),('u1', (3,)),('{e}f4', (4, 2))], " +
+        "'offsets':[0,12,20,24], 'itemsize':56}}").format(e=e)
     assert print_array_array(arr) == [
         "a={{A,B,C,D},{K,L,M,N},{U,V,W,X}},b={0,1}," +
         "c={0,1,2},d={{0,1},{10,11},{20,21},{30,31}}",

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -86,6 +86,7 @@ def test_format_descriptors():
         partial_fmt,
         "T{" + nested_extra + "x" + partial_fmt + ":a:" + nested_extra + "x}",
         "T{3s:a:3s:b:}",
+        "T{(3)4s:a:(2)i:b:(3)i:c:(4, 2)f:d:}",
         'T{q:e1:B:e2:}'
     ]
 
@@ -103,6 +104,7 @@ def test_dtype(simple_dtype):
         partial_dtype_fmt(),
         partial_nested_fmt(),
         "[('a', 'S3'), ('b', 'S3')]",
+        "[('a', 'S4', (3,)), ('b', '{e}i4', (2,)), ('c', '<i4', (3,)), ('d', '{e}f4', (4, 2))]".format(e=e),
         "[('e1', '" + e + "i8'), ('e2', 'u1')]",
         "[('x', 'i1'), ('y', '" + e + "u8')]"
     ]
@@ -211,6 +213,23 @@ def test_string_array():
     assert arr['b'].tolist() == [b'', b'a', b'ab', b'abc']
     arr = create_string_array(False)
     assert dtype == arr.dtype
+
+
+def test_array_array():
+    from pybind11_tests import create_array_array, print_array_array
+    from sys import byteorder
+    e = '<' if byteorder == 'little' else '>'
+
+    arr = create_array_array(3)
+    assert str(arr.dtype) == "[('a', 'S4', (3,)), ('b', '{e}i4', (2,)), ('c', '<i4', (3,)), ('d', '{e}f4', (4, 2))]".format(e=e)
+    assert print_array_array(arr) == [
+        "a={{A,B,C,D},{K,L,M,N},{U,V,W,X}},b={0,1},c={0,1,2},d={{0,1},{10,11},{20,21},{30,31}}",
+        "a={{W,X,Y,Z},{G,H,I,J},{Q,R,S,T}},b={1000,1001},c={10,11,12},d={{100,101},{110,111},{120,121},{130,131}}",
+        "a={{S,T,U,V},{C,D,E,F},{M,N,O,P}},b={2000,2001},c={20,21,22},d={{200,201},{210,211},{220,221},{230,231}}",
+    ]
+    assert arr['a'].tolist() == [[b'ABCD', b'KLMN', b'UVWX'], [b'WXYZ', b'GHIJ', b'QRST'], [b'STUV', b'CDEF', b'MNOP']]
+    assert arr['b'].tolist() == [[0, 1], [1000, 1001], [2000, 2001]]
+    assert create_array_array(0).dtype == arr.dtype
 
 
 def test_enum_array():


### PR DESCRIPTION
This implements pybind/pybind11#800.

Both C++ arrays and std::array are supported, including mixtures like
std::array<int, 2>[4]. In a multi-dimensional array of char, the last
dimension is used to construct a numpy string type.

There are some things I'm not sure about:
- Is there a better name for array_info? The "array" could easily be
  misinterpreted as referring to py::array rather than std::array.
- Should array_info be split into separate classes for the different
  traits, or is it okay to have this uber traits class?
- When constructing the dtype, the shape should really be a tuple rather
  than a list, but I'm not sure how to dynamically construct a tuple (or
  how to convert the list to a tuple). numpy seems to accept a list.
- Should the array dtypes be registered in some way? At present two
  structures embedding the same array type will each construct a
  separate dtype object to represent that array type. That's already the
  case for char[N] though.
- Should I add tests to use an array type directly e.g.
  py::array_t<int[2]>?