### PR TITLE
buffer_info.h is missing from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ if os.environ.get('PYBIND11_USE_CMAKE'):
 else:
     headers = [
         'include/pybind11/attr.h',
+        'include/pybind11/buffer_info.h',
         'include/pybind11/cast.h',
         'include/pybind11/chrono.h',
         'include/pybind11/class_support.h',


### PR DESCRIPTION
It seems everyone is using cmake, but unfortunately I am still using distutils ... :)  Without this line the pybind11 package installed by `pip install -U https://github.com/pybind/pybind11/archive/master.zip` doesn't work with distutils.