### PR TITLE
Do not derive enum_ from class_

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -443,3 +443,14 @@ The entries defined by the enumeration type are exposed in the ``__members__`` p
            ...
 
     By default, these are omitted to conserve space.
+
+In order to define additional methods on the enum class in Python, use `into_class()`
+method of the `enum_` object which will yield a `class_` instance:
+
+.. code-block:: cpp
+
+    py::enum_<Pet::Kind>(pet, "Kind")
+        .value("Dog", Pet::Kind::Dog)
+        .value("Cat", Pet::Kind::Cat)
+        .into_class()
+        .def("is_cat", [](const Pet::Kind& kind) { return kind == Pet::Kind::Cat; });

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1274,6 +1274,10 @@ public:
         return cls;
     }
 
+    operator handle() & {
+        return cls;
+    }
+
 private:
     class_<Type> cls;
     dict m_entries;

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -47,9 +47,15 @@ test_initializer enums([](py::module &m) {
     py::enum_<UnscopedEnum>(m, "UnscopedEnum", py::arithmetic())
         .value("EOne", EOne)
         .value("ETwo", ETwo)
-        .export_values();
+        .export_values()
+        .into_class()
+        .def("x", [](const UnscopedEnum& e) { return static_cast<int>(e) + 1; })
+        .def_property_readonly("y", [](const UnscopedEnum& e) { return static_cast<int>(e) + 2; })
+        .def_static("a", []() { return 41; })
+        .def_property_readonly_static("b", [](py::object /* unused */) { return 42; });
 
-    py::enum_<ScopedEnum>(m, "ScopedEnum", py::arithmetic())
+    auto scoped_enum = py::enum_<ScopedEnum>(m, "ScopedEnum", py::arithmetic());
+    scoped_enum
         .value("Two", ScopedEnum::Two)
         .value("Three", ScopedEnum::Three);
 

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -44,7 +44,7 @@ std::string test_scoped_enum(ScopedEnum z) {
 test_initializer enums([](py::module &m) {
     m.def("test_scoped_enum", &test_scoped_enum);
 
-    py::enum_<UnscopedEnum>(m, "UnscopedEnum", py::arithmetic())
+    auto e = py::enum_<UnscopedEnum>(m, "UnscopedEnum", py::arithmetic())
         .value("EOne", EOne)
         .value("ETwo", ETwo)
         .export_values()
@@ -58,6 +58,8 @@ test_initializer enums([](py::module &m) {
     scoped_enum
         .value("Two", ScopedEnum::Two)
         .value("Three", ScopedEnum::Three);
+
+    py::setattr(e, "Alias", scoped_enum);
 
     py::enum_<Flags>(m, "Flags", py::arithmetic())
         .value("Read", Flags::Read)

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -40,6 +40,11 @@ def test_unscoped_enum():
     assert not (2 < UnscopedEnum.EOne)
 
 
+def test_enum_as_handle():
+    from pybind11_tests import UnscopedEnum, ScopedEnum
+    assert UnscopedEnum.Alias is ScopedEnum
+
+
 def test_extra_defs():
     from pybind11_tests import UnscopedEnum
     assert UnscopedEnum.EOne.x() == 2 and UnscopedEnum.ETwo.x() == 3

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -40,6 +40,14 @@ def test_unscoped_enum():
     assert not (2 < UnscopedEnum.EOne)
 
 
+def test_extra_defs():
+    from pybind11_tests import UnscopedEnum
+    assert UnscopedEnum.EOne.x() == 2 and UnscopedEnum.ETwo.x() == 3
+    assert UnscopedEnum.EOne.y == 3 and UnscopedEnum.ETwo.y == 4
+    assert UnscopedEnum.a() == 41
+    assert UnscopedEnum.b == 42
+
+
 def test_scoped_enum():
     from pybind11_tests import ScopedEnum, test_scoped_enum
 


### PR DESCRIPTION
(This is related to work on Python 3 enums in #781)

- Using `class_` API now requires calling `.into_class()` or doing a rvalue cast
- `.value()` and `.export_values()` now return rvalue `*this` instead of lvalue
- As a result of changing this, no existing tests were broken
- Added a few additional tests; updated the docs
 
Note: this is technically a breaking change, but the consensus seems to be that this functionality was more of a side-effect (of deriving from `class_`) rather than an intended feature.