### PR TITLE
Fix compilation error with std::nullptr_t caster

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -653,7 +653,7 @@ private:
     void *value = nullptr;
 };
 
-template <> class type_caster<std::nullptr_t> : public type_caster<void_type> { };
+template <> class type_caster<std::nullptr_t> : public void_caster<std::nullptr_t> { };
 
 template <> class type_caster<bool> {
 public:

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -602,7 +602,11 @@ public:
 
 template<typename T> struct void_caster {
 public:
-    bool load(handle, bool) { return false; }
+    bool load(handle src, bool) {
+        if (src && src.is_none())
+            return true;
+        return false;
+    }
     static handle cast(T, return_value_policy /* policy */, handle /* parent */) {
         return none().inc_ref();
     }

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -516,6 +516,9 @@ test_initializer python_types([](py::module &m) {
             });
         }
     );
+
+    m.def("load_nullptr_t", [](std::nullptr_t) {}); // not useful, but it should still compile
+    m.def("cast_nullptr_t", []() -> std::nullptr_t { return {}; });
 });
 
 #if defined(_MSC_VER)

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -359,9 +359,10 @@ test_initializer python_types([](py::module &m) {
         const char *operator()(int) { return "int"; }
         const char *operator()(std::string) { return "std::string"; }
         const char *operator()(double) { return "double"; }
+        const char *operator()(std::nullptr_t) { return "std::nullptr_t"; }
     };
 
-    m.def("load_variant", [](std::variant<int, std::string, double> v) {
+    m.def("load_variant", [](std::variant<int, std::string, double, std::nullptr_t> v) {
         return std::visit(visitor(), v);
     });
 
@@ -518,7 +519,7 @@ test_initializer python_types([](py::module &m) {
     );
 
     m.def("load_nullptr_t", [](std::nullptr_t) {}); // not useful, but it should still compile
-    m.def("cast_nullptr_t", []() -> std::nullptr_t { return {}; });
+    m.def("cast_nullptr_t", []() { return std::nullptr_t{}; });
 });
 
 #if defined(_MSC_VER)

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -378,9 +378,10 @@ def test_variant(doc):
     assert load_variant(1) == "int"
     assert load_variant("1") == "std::string"
     assert load_variant(1.0) == "double"
+    assert load_variant(None) == "std::nullptr_t"
     assert cast_variant() == (5, "Hello")
 
-    assert doc(load_variant) == "load_variant(arg0: Union[int, str, float]) -> str"
+    assert doc(load_variant) == "load_variant(arg0: Union[int, str, float, None]) -> str"
 
 
 def test_constructors():
@@ -573,8 +574,5 @@ def test_capsule_with_destructor(capture):
 def test_void_caster():
     import pybind11_tests as m
 
-    with pytest.raises(TypeError) as excinfo:
-        m.load_nullptr_t(None)
-    assert "incompatible function arguments" in str(excinfo)
-
+    assert m.load_nullptr_t(None) is None
     assert m.cast_nullptr_t() is None

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -568,3 +568,13 @@ def test_capsule_with_destructor(capture):
         creating capsule
         destructing capsule: 1234
     """
+
+
+def test_void_caster():
+    import pybind11_tests as m
+
+    with pytest.raises(TypeError) as excinfo:
+        m.load_nullptr_t(None)
+    assert "incompatible function arguments" in str(excinfo)
+
+    assert m.cast_nullptr_t() is None


### PR DESCRIPTION
Fixes #839.

Note that `void_caster::load()` always returns `false`, even for `None`. This applies to `std::nullptr_t` and `std::nullopt_t`. ~~Is there be a valid use case to make conversion from `None` work?~~