### PR TITLE
Set PYBIND11_CPP1{4,7} macros for MSVC

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,10 +11,19 @@ platform:
 environment:
   matrix:
   - CONDA: 36
+    CPP: 14
   - CONDA: 27
+    CPP: 14
+  - CONDA: 36
+    CPP: latest
 matrix:
   exclude:
     - image: Visual Studio 2015
+      platform: x86
+    - image: Visual Studio 2015
+      CPP: latest
+    - image: Visual Studio 2017
+      CPP: latest
       platform: x86
 install:
 - ps: |
@@ -37,7 +46,7 @@ install:
     7z x 3.3.3.zip -y > $null
     $env:CMAKE_INCLUDE_PATH = "eigen-eigen-67e894c6cd8f"
 build_script:
-- cmake -G "%CMAKE_GENERATOR%" -A "%CMAKE_ARCH%" -DPYBIND11_WERROR=ON -DCMAKE_SUPPRESS_REGENERATION=1
+- cmake -G "%CMAKE_GENERATOR%" -A "%CMAKE_ARCH%" -DPYBIND11_CPP_STANDARD=/std:c++%CPP% -DPYBIND11_WERROR=ON -DCMAKE_SUPPRESS_REGENERATION=1
 - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - cmake --build . --config Release --target pytest -- /v:m /logger:%MSBuildLogger%
 - cmake --build . --config Release --target test_cmake_build -- /v:m /logger:%MSBuildLogger%

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -92,17 +92,28 @@ regular LTO if ``-flto=thin`` is not available.
 Configuration variables
 -----------------------
 
-By default, pybind11 will compile modules with the latest C++ standard
-available on the target compiler. To override this, the standard flag can
-be given explicitly in ``PYBIND11_CPP_STANDARD``:
+By default, pybind11 will compile modules with the C++14 standard, if available
+on the target compiler, falling back to C++11 if C++14 support is not
+available.  Note, however, that this default is subject to change: future
+pybind11 releases are expected to migrate to newer C++ standards as they become
+available.  To override this, the standard flag can be given explicitly in
+``PYBIND11_CPP_STANDARD``:
 
 .. code-block:: cmake
 
+    # Use just one of these:
+    # GCC/clang:
     set(PYBIND11_CPP_STANDARD -std=c++11)
+    set(PYBIND11_CPP_STANDARD -std=c++14)
+    set(PYBIND11_CPP_STANDARD -std=c++1z) # Experimental C++17 support
+    # MSVC:
+    set(PYBIND11_CPP_STANDARD /std:c++14)
+    set(PYBIND11_CPP_STANDARD /std:c++latest) # Enables some MSVC C++17 features
+
     add_subdirectory(pybind11)  # or find_package(pybind11)
 
 Note that this and all other configuration variables must be set **before** the
-call to ``add_subdiretory`` or ``find_package``. The variables can also be set
+call to ``add_subdirectory`` or ``find_package``. The variables can also be set
 when calling CMake from the command line using the ``-D<variable>=<value>`` flag.
 
 The target Python version can be selected by setting ``PYBIND11_PYTHON_VERSION``

--- a/include/pybind11/descr.h
+++ b/include/pybind11/descr.h
@@ -15,7 +15,9 @@
 NAMESPACE_BEGIN(pybind11)
 NAMESPACE_BEGIN(detail)
 
-#if defined(PYBIND11_CPP14) /* Concatenate type signatures at compile time using C++14 */
+/* Concatenate type signatures at compile time using C++14 */
+#if defined(PYBIND11_CPP14) && !defined(_MSC_VER)
+#define PYBIND11_CONSTEXPR_DESCR
 
 template <size_t Size1, size_t Size2> class descr {
     template <size_t Size1_, size_t Size2_> friend class descr;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -252,7 +252,7 @@ protected:
         if (type_depth != 0 || types[type_index] != nullptr)
             pybind11_fail("Internal error while parsing type signature (2)");
 
-        #if !defined(PYBIND11_CPP14)
+        #if !defined(PYBIND11_CONSTEXPR_DESCR)
             delete[] types;
             delete[] text;
         #endif

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -41,6 +41,11 @@
 #    include <variant>
 #    define PYBIND11_HAS_VARIANT 1
 #  endif
+#elif defined(_MSC_VER) && defined(PYBIND11_CPP17)
+#  include <optional>
+#  include <variant>
+#  define PYBIND11_HAS_OPTIONAL 1
+#  define PYBIND11_HAS_VARIANT 1
 #endif
 
 NAMESPACE_BEGIN(pybind11)

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -19,20 +19,24 @@ include(CheckCXXCompilerFlag)
 include(CMakeParseArguments)
 
 function(select_cxx_standard)
-  if(NOT MSVC AND NOT PYBIND11_CPP_STANDARD)
-    check_cxx_compiler_flag("-std=c++14" HAS_CPP14_FLAG)
-    check_cxx_compiler_flag("-std=c++11" HAS_CPP11_FLAG)
+  if(NOT PYBIND11_CPP_STANDARD)
+    if(NOT MSVC)
+      check_cxx_compiler_flag("-std=c++14" HAS_CPP14_FLAG)
+      check_cxx_compiler_flag("-std=c++11" HAS_CPP11_FLAG)
 
-    if (HAS_CPP14_FLAG)
-      set(PYBIND11_CPP_STANDARD -std=c++14)
-    elseif (HAS_CPP11_FLAG)
-      set(PYBIND11_CPP_STANDARD -std=c++11)
-    else()
-      message(FATAL_ERROR "Unsupported compiler -- pybind11 requires C++11 support!")
+      if (HAS_CPP14_FLAG)
+        set(PYBIND11_CPP_STANDARD -std=c++14)
+      elseif (HAS_CPP11_FLAG)
+        set(PYBIND11_CPP_STANDARD -std=c++11)
+      else()
+        message(FATAL_ERROR "Unsupported compiler -- pybind11 requires C++11 support!")
+      endif()
+    elseif(MSVC)
+      set(PYBIND11_CPP_STANDARD /std:c++14)
     endif()
 
     set(PYBIND11_CPP_STANDARD ${PYBIND11_CPP_STANDARD} CACHE STRING
-        "C++ standard flag, e.g. -std=c++11 or -std=c++14. Defaults to latest available." FORCE)
+        "C++ standard flag, e.g. -std=c++11, -std=c++14, /std:c++14.  Defaults to C++14 mode." FORCE)
   endif()
 endfunction()
 
@@ -162,10 +166,8 @@ function(pybind11_add_module target_name)
   endif()
 
   select_cxx_standard()
-  if(NOT MSVC)
-    # Make sure C++11/14 are enabled
-    target_compile_options(${target_name} PUBLIC ${PYBIND11_CPP_STANDARD})
-  endif()
+  # Make sure C++11/14 are enabled
+  target_compile_options(${target_name} PUBLIC ${PYBIND11_CPP_STANDARD})
 
   if(ARG_NO_EXTRAS)
     return()


### PR DESCRIPTION
We currently don't set `PYBIND11_CPP14` or `_CPP17` for MSVC because MSVC doesn't support the code in `descr.h`.  Originally, that's all the `_CPP14` flag guarded, but it now enables several other things as well (most of which are `#ifdef CPP14 || MSVC`).  This flips that, setting `CPP14` and `CPP17` (the latter only when compiling under MSVC 2017 with `/std:c++latest`), then changing the `descr.h` code to require `CPP14 && !MSVC`.

This PR also enables the `PYBIND11_CPP_STANDARD` cmake variable under MSVC, defaulting it to `/std:c++14`, then uses it to add a `/std:c++latest` appveyor job which runs the optional and variant tests.

Fixes #833.