### PR TITLE
Add tests for pointer defaults.

### DIFF
--- a/tests/test_issues.cpp
+++ b/tests/test_issues.cpp
@@ -394,6 +394,9 @@ void init_issues(py::module &m) {
 #elif defined(PYBIND11_HAS_EXP_OPTIONAL)
     m2.def("tpl_constr_optional", [](std::experimental::optional<TplConstrClass> &) {});
 #endif
+
+    m2.def("test_default_set_null", [](std::unordered_set<std::uint64_t>*) {}, "ids"_a = nullptr);
+    m2.def("test_default_set_none", [](std::unordered_set<std::uint64_t>*) {}, "ids"_a = py::none());
 }
 
 // MSVC workaround: trying to use a lambda here crashes MSVC

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -249,3 +249,9 @@ def test_inheritance_override_def_static():
     assert isinstance(b, MyBase)
     assert isinstance(d1, MyDerived)
     assert isinstance(d2, MyDerived)
+
+def test_default_set():
+    from pybind11_tests.issues import test_default_set_null, test_default_set_none
+
+    test_default_set_null()
+    test_default_set_none()

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -253,5 +253,14 @@ def test_inheritance_override_def_static():
 def test_default_set():
     from pybind11_tests.issues import test_default_set_null, test_default_set_none
 
-    test_default_set_null()
-    test_default_set_none()
+    try:
+        test_default_set_null()
+        assert False, "Defaulting to nullptr is not intended to work"
+    except TypeError:
+        assert True
+
+    try:
+        test_default_set_none()
+        assert False, "Defaulting to None is not intended to work"
+    except TypeError:
+        assert True


### PR DESCRIPTION
Not sure whether these are intended to work or not.

In 2.1.1 currently throws exceptions.