### PR TITLE
Fix gcc 7 warning

### DIFF
--- a/include/pybind11/descr.h
+++ b/include/pybind11/descr.h
@@ -113,20 +113,20 @@ public:
         memcpy(m_types, types, nTypes * sizeof(const std::type_info *));
     }
 
-    PYBIND11_NOINLINE descr friend operator+(descr &&d1, descr &&d2) {
+    PYBIND11_NOINLINE descr operator+(descr &&d2) && {
         descr r;
 
-        size_t nChars1 = len(d1.m_text), nTypes1 = len(d1.m_types);
+        size_t nChars1 = len(m_text),    nTypes1 = len(m_types);
         size_t nChars2 = len(d2.m_text), nTypes2 = len(d2.m_types);
 
         r.m_text  = new char[nChars1 + nChars2 - 1];
         r.m_types = new const std::type_info *[nTypes1 + nTypes2 - 1];
-        memcpy(r.m_text, d1.m_text, (nChars1-1) * sizeof(char));
+        memcpy(r.m_text, m_text, (nChars1-1) * sizeof(char));
         memcpy(r.m_text + nChars1 - 1, d2.m_text, nChars2 * sizeof(char));
-        memcpy(r.m_types, d1.m_types, (nTypes1-1) * sizeof(std::type_info *));
+        memcpy(r.m_types, m_types, (nTypes1-1) * sizeof(std::type_info *));
         memcpy(r.m_types + nTypes1 - 1, d2.m_types, nTypes2 * sizeof(std::type_info *));
 
-        delete[] d1.m_text; delete[] d1.m_types;
+        delete[] m_text;    delete[] m_types;
         delete[] d2.m_text; delete[] d2.m_types;
 
         return r;


### PR DESCRIPTION
Under gcc 7 with -std=c++11, compilation results in several of the following warnings:

```
    In file included from /home/jagerman/src/pybind11/tests/test_sequences_and_iterators.cpp:13:0:
    /home/jagerman/src/pybind11/include/pybind11/operators.h: In function ‘pybind11::detail::op_<(pybind11::detail::op_id)0, (pybind11::detail::op_type)0, pybind11::detail::self_t, pybind11::detail::self_t> pybind11::detail::operator+(const pybind11::detail::self_t&, const pybind11::detail::self_t&)’:
    /home/jagerman/src/pybind11/include/pybind11/operators.h:78:76: warning: inline declaration of ‘pybind11::detail::op_<(pybind11::detail::op_id)0, (pybind11::detail::op_type)0, pybind11::detail::self_t, pybind11::detail::self_t> pybind11::detail::operator+(const pybind11::detail::self_t&, const pybind11::detail::self_t&)’ follows declaration with attribute noinline [-Wattributes]
     inline op_<op_##id, op_l, self_t, self_t> op(const self_t &, const self_t &) {         \
                                                                                ^
    /home/jagerman/src/pybind11/include/pybind11/operators.h:109:1: note: in expansion of macro ‘PYBIND11_BINARY_OPERATOR’
     PYBIND11_BINARY_OPERATOR(add,       radd,         operator+,    l + r)
     ^~~~~~~~~~~~~~~~~~~~~~~~
    In file included from /home/jagerman/src/pybind11/include/pybind11/cast.h:15:0,
                     from /home/jagerman/src/pybind11/include/pybind11/attr.h:13,
                     from /home/jagerman/src/pybind11/include/pybind11/pybind11.h:36,
                     from /home/jagerman/src/pybind11/tests/pybind11_tests.h:2,
                     from /home/jagerman/src/pybind11/tests/test_sequences_and_iterators.cpp:11:
    /home/jagerman/src/pybind11/include/pybind11/descr.h:116:36: note: previous definition of ‘pybind11::detail::descr pybind11::detail::operator+(pybind11::detail::descr&&, pybind11::detail::descr&&)’ was here
         PYBIND11_NOINLINE descr friend operator+(descr &&d1, descr &&d2) {
                                        ^~~~~~~~
```
This appears to be happening because gcc is considering implicit construction of `descr` in some places using addition of two `descr`-compatible arguments in the `descr.h` c++11 fallback code.  There's no particular reason that this operator needs to be a friend function: this commit changes it to an rvalue-context member function operator, which avoids the warning.