### PR TITLE
Fix Eigen shape assertion error in dense matrix caster

### DIFF
--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -265,6 +265,9 @@ struct type_caster<Type, enable_if_t<is_eigen_dense_plain<Type>::value>> {
             return false;
 
         auto fits = props::conformable(buf);
+        if (!fits)
+            return false;
+
         // Allocate the new type, then build a numpy reference into it
         value = Type(fits.rows, fits.cols);
         auto ref = reinterpret_steal<array>(eigen_ref_array<props>(value));

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -63,6 +63,16 @@ def test_partially_fixed():
     np.testing.assert_array_equal(
         partial_copy_four_cm_c(ref2[(3, 1, 2), :]), ref2[(3, 1, 2), :])
 
+    # TypeError should be raise for a shape mismatch
+    functions = [partial_copy_four_rm_r, partial_copy_four_rm_c,
+                 partial_copy_four_cm_r, partial_copy_four_cm_c]
+    matrix_with_wrong_shape = [[1, 2],
+                               [3, 4]]
+    for f in functions:
+        with pytest.raises(TypeError) as excinfo:
+            f(matrix_with_wrong_shape)
+        assert "incompatible function arguments" in str(excinfo.value)
+
 
 def test_mutator_descriptors():
     from pybind11_tests import fixed_mutator_r, fixed_mutator_c, fixed_mutator_a


### PR DESCRIPTION
Missing conformability check was causing Eigen to create a 0x0 matrix with an error in debug mode and silent corruption in release mode.