### PR TITLE
std::reference_wrapper: (some) non-generic type support; failure on None

### DIFF
--- a/tests/test_issues.cpp
+++ b/tests/test_issues.cpp
@@ -117,19 +117,6 @@ void init_issues(py::module &m) {
         .def(py::init<int>())
         .def("__repr__", [](const Placeholder &p) { return "Placeholder[" + std::to_string(p.i) + "]"; });
 
-    // #171: Can't return reference wrappers (or STL datastructures containing them)
-    m2.def("return_vec_of_reference_wrapper", [](std::reference_wrapper<Placeholder> p4) {
-        Placeholder *p1 = new Placeholder{1};
-        Placeholder *p2 = new Placeholder{2};
-        Placeholder *p3 = new Placeholder{3};
-        std::vector<std::reference_wrapper<Placeholder>> v;
-        v.push_back(std::ref(*p1));
-        v.push_back(std::ref(*p2));
-        v.push_back(std::ref(*p3));
-        v.push_back(p4);
-        return v;
-    });
-
     // #181: iterator passthrough did not compile
     m2.def("iterator_passthrough", [](py::iterator s) -> py::iterator {
         return py::make_iterator(std::begin(s), std::end(s));

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -32,14 +32,6 @@ def test_dispatch_issue(msg):
     assert dispatch_issue_go(b) == "Yay.."
 
 
-def test_reference_wrapper():
-    """#171: Can't return reference wrappers (or STL data structures containing them)"""
-    from pybind11_tests.issues import Placeholder, return_vec_of_reference_wrapper
-
-    assert str(return_vec_of_reference_wrapper(Placeholder(4))) == \
-        "[Placeholder[1], Placeholder[2], Placeholder[3], Placeholder[4]]"
-
-
 def test_iterator_passthrough():
     """#181: iterator passthrough did not compile"""
     from pybind11_tests.issues import iterator_passthrough

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -560,6 +560,25 @@ test_initializer python_types([](py::module &m) {
 
     m.def("load_nullptr_t", [](std::nullptr_t) {}); // not useful, but it should still compile
     m.def("cast_nullptr_t", []() { return std::nullptr_t{}; });
+
+    struct IntWrapper { int i; IntWrapper(int i) : i(i) { } };
+    py::class_<IntWrapper>(m, "IntWrapper")
+        .def(py::init<int>())
+        .def("__repr__", [](const IntWrapper &p) { return "IntWrapper[" + std::to_string(p.i) + "]"; });
+
+    // #171: Can't return reference wrappers (or STL datastructures containing them)
+    m.def("return_vec_of_reference_wrapper", [](std::reference_wrapper<IntWrapper> p4) {
+        IntWrapper *p1 = new IntWrapper{1};
+        IntWrapper *p2 = new IntWrapper{2};
+        IntWrapper *p3 = new IntWrapper{3};
+        std::vector<std::reference_wrapper<IntWrapper>> v;
+        v.push_back(std::ref(*p1));
+        v.push_back(std::ref(*p2));
+        v.push_back(std::ref(*p3));
+        v.push_back(p4);
+        return v;
+    });
+
 });
 
 #if defined(_MSC_VER)

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -606,3 +606,15 @@ def test_void_caster():
 
     assert m.load_nullptr_t(None) is None
     assert m.cast_nullptr_t() is None
+
+
+def test_reference_wrapper():
+    """std::reference_wrapper<T> tests.
+
+    #171: Can't return reference wrappers (or STL data structures containing them)
+    """
+    from pybind11_tests import IntWrapper, return_vec_of_reference_wrapper
+
+    # 171:
+    assert str(return_vec_of_reference_wrapper(IntWrapper(4))) == \
+        "[IntWrapper[1], IntWrapper[2], IntWrapper[3], IntWrapper[4]]"


### PR DESCRIPTION
This reimplements the `std::reference_wrapper<T>` caster to be a shell around the underlying `T` caster (rather than assuming `T` is a generic type), which lets it work for things like `std::reference_wrapper<int>` or anything else custom type caster with a lvalue cast operator.

Fixes #848: this also makes it properly fail when `None` is provided, just as an ordinary lvalue reference argument would similarly fail.

This also adds a static assert to test that `T` has an appropriate type caster.  It triggers for casters like `std::pair`, which have return-by-value cast operators.  (In theory this could be supported by storing a local temporary for such types, but that's beyond the scope of this PR).  This shouldn't break anything in terms of backwards compatibility: currently `reference_wrapper` only actually works for generic types, which always have an lvalue cast operator.