### PR TITLE
Improve support for std::optional-like classes

### DIFF
--- a/docs/advanced/cast/stl.rst
+++ b/docs/advanced/cast/stl.rst
@@ -46,8 +46,23 @@ types:
     }}
 
 The above should be placed in a header file and included in all translation units
-where automatic conversion is needed. Similarly, a specialization can be provided
-for custom variant types:
+where automatic conversion is needed. If the type provides a ``reset`` member
+function, that is used to clear the stored value; otherwise, it is cleared by
+assigning ``{}`` to it. If neither approach is suitable, ``optional_reset`` can
+be specialized to provide an alternative. Here is how pybind11 specializes it for
+``std::experimental::optional<>`` (which does not have a ``reset`` method):
+
+.. code-block:: cpp
+
+    namespace pybind11 { namespace detail {
+        template<typename T> struct optional_reset<std::experimental::optional<T>> {
+            static void reset(std::experimental::optional<T> &value) {
+                value = std::experimental::nullopt;
+            }
+        };
+    }} // namespace pybind11::detail
+
+Similarly, a specialization can be provided for custom variant types:
 
 .. code-block:: cpp
 

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -270,7 +270,7 @@ template<typename T> struct optional_caster {
         if (!inner_caster.load(src, convert))
             return false;
 
-        value.emplace(std::move(cast_op<typename T::value_type>(inner_caster)));
+        value.emplace(cast_op<typename T::value_type>(inner_caster));
         return true;
     }
 

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -353,8 +353,8 @@ test_initializer python_types([](py::module &m) {
         return x.value_or(42);
     }, py::arg_v("x", std::nullopt, "None"));
     m.def("test_no_move_assign", [](const opt_no_move_assign &x) {
-        return x ? x.value : 42;
-    }, py::argv_("x", std::nullopt, "None"));
+        return x ? x->value : 42;
+    }, py::arg_v("x", std::nullopt, "None"));
 #endif
 
 #ifdef PYBIND11_HAS_EXP_OPTIONAL

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -188,16 +188,16 @@ struct MoveOutContainer {
 
 struct UnregisteredType { };
 
-// Class that can be move-constructed, but not copied or move-assigned
-struct NoMoveAssign {
+// Class that can be move- and copy-constructed, but not assigned
+struct NoAssign {
     int value;
 
-    explicit NoMoveAssign(int value = 0) : value(value) {}
-    NoMoveAssign(NoMoveAssign &&) = default;
+    explicit NoAssign(int value = 0) : value(value) {}
+    NoAssign(const NoAssign &) = default;
+    NoAssign(NoAssign &&) = default;
 
-    NoMoveAssign(const NoMoveAssign &) = delete;
-    NoMoveAssign &operator=(const NoMoveAssign &) = delete;
-    NoMoveAssign &operator=(NoMoveAssign &&) = delete;
+    NoAssign &operator=(const NoAssign &) = delete;
+    NoAssign &operator=(NoAssign &&) = delete;
 };
 
 test_initializer python_types([](py::module &m) {
@@ -248,7 +248,7 @@ test_initializer python_types([](py::module &m) {
         py::print("{a} + {b} = {c}"_s.format("a"_a="py::print", "b"_a="str.format", "c"_a="this"));
     });
 
-    py::class_<NoMoveAssign>(m, "NoMoveAssign", "Class that can only be move constructed")
+    py::class_<NoAssign>(m, "NoAssign", "Class with no C++ assignment operators")
         .def(py::init<>())
         .def(py::init<int>());
 
@@ -342,7 +342,7 @@ test_initializer python_types([](py::module &m) {
 #ifdef PYBIND11_HAS_OPTIONAL
     has_optional = true;
     using opt_int = std::optional<int>;
-    using opt_no_move_assign = std::optional<NoMoveAssign>;
+    using opt_no_assign = std::optional<NoAssign>;
     m.def("double_or_zero", [](const opt_int& x) -> int {
         return x.value_or(0) * 2;
     });
@@ -352,7 +352,7 @@ test_initializer python_types([](py::module &m) {
     m.def("test_nullopt", [](opt_int x) {
         return x.value_or(42);
     }, py::arg_v("x", std::nullopt, "None"));
-    m.def("test_no_move_assign", [](const opt_no_move_assign &x) {
+    m.def("test_no_assign", [](const opt_no_assign &x) {
         return x ? x->value : 42;
     }, py::arg_v("x", std::nullopt, "None"));
 #endif
@@ -360,7 +360,7 @@ test_initializer python_types([](py::module &m) {
 #ifdef PYBIND11_HAS_EXP_OPTIONAL
     has_exp_optional = true;
     using exp_opt_int = std::experimental::optional<int>;
-    using exp_opt_no_move_assign = std::experimental::optional<NoMoveAssign>;
+    using exp_opt_no_assign = std::experimental::optional<NoAssign>;
     m.def("double_or_zero_exp", [](const exp_opt_int& x) -> int {
         return x.value_or(0) * 2;
     });
@@ -370,7 +370,7 @@ test_initializer python_types([](py::module &m) {
     m.def("test_nullopt_exp", [](exp_opt_int x) {
         return x.value_or(42);
     }, py::arg_v("x", std::experimental::nullopt, "None"));
-    m.def("test_no_move_assign_exp", [](const exp_opt_no_move_assign &x) {
+    m.def("test_no_assign_exp", [](const exp_opt_no_assign &x) {
         return x ? x->value : 42;
     }, py::arg_v("x", std::experimental::nullopt, "None"));
 #endif

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -337,7 +337,8 @@ def test_accessors():
 
 @pytest.mark.skipif(not has_optional, reason='no <optional>')
 def test_optional():
-    from pybind11_tests import double_or_zero, half_or_none, test_nullopt
+    from pybind11_tests import (double_or_zero, half_or_none, test_nullopt,
+                                test_no_move_assign, NoMoveAssign)
 
     assert double_or_zero(None) == 0
     assert double_or_zero(42) == 84
@@ -352,10 +353,16 @@ def test_optional():
     assert test_nullopt(42) == 42
     assert test_nullopt(43) == 43
 
+    assert test_no_move_assign() == 42
+    assert test_no_move_assign(None) == 42
+    assert test_no_move_assign(NoMoveAssign(43)) == 43
+    pytest.raises(TypeError, test_no_move_assign, 43)
+
 
 @pytest.mark.skipif(not has_exp_optional, reason='no <experimental/optional>')
 def test_exp_optional():
-    from pybind11_tests import double_or_zero_exp, half_or_none_exp, test_nullopt_exp
+    from pybind11_tests import (double_or_zero_exp, half_or_none_exp, test_nullopt_exp,
+                                test_no_move_assign_exp, NoMoveAssign)
 
     assert double_or_zero_exp(None) == 0
     assert double_or_zero_exp(42) == 84
@@ -369,6 +376,11 @@ def test_exp_optional():
     assert test_nullopt_exp(None) == 42
     assert test_nullopt_exp(42) == 42
     assert test_nullopt_exp(43) == 43
+
+    assert test_no_move_assign_exp() == 42
+    assert test_no_move_assign_exp(None) == 42
+    assert test_no_move_assign_exp(NoMoveAssign(43)) == 43
+    pytest.raises(TypeError, test_no_move_assign_exp, 43)
 
 
 @pytest.mark.skipif(not hasattr(pybind11_tests, "load_variant"), reason='no <variant>')

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -338,7 +338,7 @@ def test_accessors():
 @pytest.mark.skipif(not has_optional, reason='no <optional>')
 def test_optional():
     from pybind11_tests import (double_or_zero, half_or_none, test_nullopt,
-                                test_no_move_assign, NoMoveAssign)
+                                test_no_assign, NoAssign)
 
     assert double_or_zero(None) == 0
     assert double_or_zero(42) == 84
@@ -353,16 +353,16 @@ def test_optional():
     assert test_nullopt(42) == 42
     assert test_nullopt(43) == 43
 
-    assert test_no_move_assign() == 42
-    assert test_no_move_assign(None) == 42
-    assert test_no_move_assign(NoMoveAssign(43)) == 43
-    pytest.raises(TypeError, test_no_move_assign, 43)
+    assert test_no_assign() == 42
+    assert test_no_assign(None) == 42
+    assert test_no_assign(NoAssign(43)) == 43
+    pytest.raises(TypeError, test_no_assign, 43)
 
 
 @pytest.mark.skipif(not has_exp_optional, reason='no <experimental/optional>')
 def test_exp_optional():
     from pybind11_tests import (double_or_zero_exp, half_or_none_exp, test_nullopt_exp,
-                                test_no_move_assign_exp, NoMoveAssign)
+                                test_no_assign_exp, NoAssign)
 
     assert double_or_zero_exp(None) == 0
     assert double_or_zero_exp(42) == 84
@@ -377,10 +377,10 @@ def test_exp_optional():
     assert test_nullopt_exp(42) == 42
     assert test_nullopt_exp(43) == 43
 
-    assert test_no_move_assign_exp() == 42
-    assert test_no_move_assign_exp(None) == 42
-    assert test_no_move_assign_exp(NoMoveAssign(43)) == 43
-    pytest.raises(TypeError, test_no_move_assign_exp, 43)
+    assert test_no_assign_exp() == 42
+    assert test_no_assign_exp(None) == 42
+    assert test_no_assign_exp(NoAssign(43)) == 43
+    pytest.raises(TypeError, test_no_assign_exp, 43)
 
 
 @pytest.mark.skipif(not hasattr(pybind11_tests, "load_variant"), reason='no <variant>')


### PR DESCRIPTION
With older versions of Boost, `value = {}` can fail to compile because
the interpretation of `{}` is ambiguous (could construct `boost::none`
or the value type). It can also fail with `std::experimental::optional`,
at least on GCC 5.4, because it would construct an instance of the
optional type and then move-assign it, and if the value type isn't move
assignable this would fail.

This is replaced by preferring `.reset` if the type supports it, and
also providing a traits class that can be extended to override the
behaviour where necessary (which is done for
std::experimental::optional).

Additionally, the assignment of the value from the inner caster was by
copy rather than move, which prevented use with uncopyable types.

Closes #847.