### PR TITLE
Support pointer-to-member-function in def_buffer

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1020,6 +1020,16 @@ public:
         return *this;
     }
 
+    template <typename Return, typename Class, typename... Args>
+    class_ &def_buffer(Return (Class::*func)(Args...)) {
+        return def_buffer([func] (type &obj) { return (obj.*func)(); });
+    }
+
+    template <typename Return, typename Class, typename... Args>
+    class_ &def_buffer(Return (Class::*func)(Args...) const) {
+        return def_buffer([func] (const type &obj) { return (obj.*func)(); });
+    }
+
     template <typename C, typename D, typename... Extra>
     class_ &def_readwrite(const char *name, D C::*pm, const Extra&... extra) {
         cpp_function fget([pm](const C &c) -> const D &{ return c.*pm; }, is_method(*this)),

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,5 +1,6 @@
+import struct
 import pytest
-from pybind11_tests import Matrix, ConstructorStats
+from pybind11_tests import Matrix, ConstructorStats, PTMFBuffer, ConstPTMFBuffer, DerivedPTMFBuffer
 
 pytestmark = pytest.requires_numpy
 
@@ -60,3 +61,12 @@ def test_to_python():
     # assert cstats.move_constructions >= 0  # Don't invoke any
     assert cstats.copy_assignments == 0
     assert cstats.move_assignments == 0
+
+
+@pytest.unsupported_on_pypy
+def test_ptmf():
+    for cls in [PTMFBuffer, ConstPTMFBuffer, DerivedPTMFBuffer]:
+        buf = cls()
+        buf.value = 0x12345678
+        value = struct.unpack('i', bytearray(buf))[0]
+        assert value == 0x12345678


### PR DESCRIPTION
Closes #857. Instead of calling the function object directly, it wraps
it in std::bind and then immediately calls that. This is a poor-man's
form of std::invoke (not available in C++11 or C++14).