### PR TITLE
Add py::arg().none(false) class attribute

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -123,9 +123,10 @@ struct argument_record {
     const char *descr; ///< Human-readable version of the argument value
     handle value;      ///< Associated Python object
     bool convert : 1;  ///< True if the argument is allowed to convert when loading
+    bool none : 1;     ///< True if None is allowed when loading
 
-    argument_record(const char *name, const char *descr, handle value, bool convert)
-        : name(name), descr(descr), value(value), convert(convert) { }
+    argument_record(const char *name, const char *descr, handle value, bool convert, bool none)
+        : name(name), descr(descr), value(value), convert(convert), none(none) { }
 };
 
 /// Internal data structure which holds metadata about a bound function (signature, overloads, etc.)
@@ -338,8 +339,8 @@ template <> struct process_attribute<is_operator> : process_attribute_default<is
 template <> struct process_attribute<arg> : process_attribute_default<arg> {
     static void init(const arg &a, function_record *r) {
         if (r->is_method && r->args.empty())
-            r->args.emplace_back("self", nullptr, handle(), true /*convert*/);
-        r->args.emplace_back(a.name, nullptr, handle(), !a.flag_noconvert);
+            r->args.emplace_back("self", nullptr, handle(), true /*convert*/, false /*none not allowed*/);
+        r->args.emplace_back(a.name, nullptr, handle(), !a.flag_noconvert, a.flag_none);
     }
 };
 
@@ -347,7 +348,7 @@ template <> struct process_attribute<arg> : process_attribute_default<arg> {
 template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
     static void init(const arg_v &a, function_record *r) {
         if (r->is_method && r->args.empty())
-            r->args.emplace_back("self", nullptr /*descr*/, handle() /*parent*/, true /*convert*/);
+            r->args.emplace_back("self", nullptr /*descr*/, handle() /*parent*/, true /*convert*/, false /*none not allowed*/);
 
         if (!a.value) {
 #if !defined(NDEBUG)
@@ -370,7 +371,7 @@ template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
                           "Compile in debug mode for more information.");
 #endif
         }
-        r->args.emplace_back(a.name, a.descr, a.value.inc_ref(), !a.flag_noconvert);
+        r->args.emplace_back(a.name, a.descr, a.value.inc_ref(), !a.flag_noconvert, a.flag_none);
     }
 };
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1353,14 +1353,17 @@ template <return_value_policy policy = return_value_policy::automatic_reference,
 /// Annotation for arguments
 struct arg {
     /// Constructs an argument with the name of the argument; if null or omitted, this is a positional argument.
-    constexpr explicit arg(const char *name = nullptr) : name(name), flag_noconvert(false) { }
+    constexpr explicit arg(const char *name = nullptr) : name(name), flag_noconvert(false), flag_none(true) { }
     /// Assign a value to this argument
     template <typename T> arg_v operator=(T &&value) const;
     /// Indicate that the type should not be converted in the type caster
     arg &noconvert(bool flag = true) { flag_noconvert = flag; return *this; }
+    /// Indicates that the argument should/shouldn't allow None (e.g. for nullable pointer args)
+    arg &none(bool flag = true) { flag_none = flag; return *this; }
 
     const char *name; ///< If non-null, this is a named kwargs argument
     bool flag_noconvert : 1; ///< If set, do not allow conversion (requires a supporting type caster!)
+    bool flag_none : 1; ///< If set (the default), allow None to be passed to this argument
 };
 
 /// \ingroup annotations
@@ -1392,6 +1395,9 @@ public:
 
     /// Same as `arg::noconvert()`, but returns *this as arg_v&, not arg&
     arg_v &noconvert(bool flag = true) { arg::noconvert(flag); return *this; }
+
+    /// Same as `arg::nonone()`, but returns *this as arg_v&, not arg&
+    arg_v &none(bool flag = true) { arg::none(flag); return *this; }
 
     /// The default value
     object value;

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -162,6 +162,14 @@ public:
 /// Issue/PR #648: bad arg default debugging output
 class NotRegistered {};
 
+// Test None-allowed py::arg argument policy
+class NoneTester { public: int answer = 42; };
+int none1(const NoneTester &obj) { return obj.answer; }
+int none2(NoneTester *obj) { return obj ? obj->answer : -1; }
+int none3(std::shared_ptr<NoneTester> &obj) { return obj ? obj->answer : -1; }
+int none4(std::shared_ptr<NoneTester> *obj) { return obj && *obj ? (*obj)->answer : -1; }
+int none5(std::shared_ptr<NoneTester> obj) { return obj ? obj->answer : -1; }
+
 test_initializer methods_and_attributes([](py::module &m) {
     py::class_<ExampleMandA> emna(m, "ExampleMandA");
     emna.def(py::init<>())
@@ -322,4 +330,18 @@ test_initializer methods_and_attributes([](py::module &m) {
         auto m = py::module::import("pybind11_tests");
         m.def("should_fail", [](int, NotRegistered) {}, py::arg(), py::arg() = NotRegistered());
     });
+
+    py::class_<NoneTester, std::shared_ptr<NoneTester>>(m, "NoneTester")
+        .def(py::init<>());
+    m.def("no_none1", &none1, py::arg().none(false));
+    m.def("no_none2", &none2, py::arg().none(false));
+    m.def("no_none3", &none3, py::arg().none(false));
+    m.def("no_none4", &none4, py::arg().none(false));
+    m.def("no_none5", &none5, py::arg().none(false));
+    m.def("ok_none1", &none1);
+    m.def("ok_none2", &none2, py::arg().none(true));
+    m.def("ok_none3", &none3);
+    m.def("ok_none4", &none4, py::arg().none(true));
+    m.def("ok_none5", &none5);
+
 });

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -369,3 +369,47 @@ def test_bad_arg_default(msg):
         "arg(): could not convert default argument into a Python object (type not registered "
         "yet?). Compile in debug mode for more information."
     )
+
+
+def test_accepts_none():
+    from pybind11_tests import (NoneTester,
+                                no_none1, no_none2, no_none3, no_none4, no_none5,
+                                ok_none1, ok_none2, ok_none3, ok_none4, ok_none5)
+
+    a = NoneTester()
+    assert no_none1(a) == 42
+    assert no_none2(a) == 42
+    assert no_none3(a) == 42
+    assert no_none4(a) == 42
+    assert no_none5(a) == 42
+    assert ok_none1(a) == 42
+    assert ok_none2(a) == 42
+    assert ok_none3(a) == 42
+    assert ok_none4(a) == 42
+    assert ok_none5(a) == 42
+
+    with pytest.raises(TypeError) as excinfo:
+        no_none1(None)
+    assert "incompatible function arguments" in str(excinfo.value)
+    with pytest.raises(TypeError) as excinfo:
+        no_none2(None)
+    assert "incompatible function arguments" in str(excinfo.value)
+    with pytest.raises(TypeError) as excinfo:
+        no_none3(None)
+    assert "incompatible function arguments" in str(excinfo.value)
+    with pytest.raises(TypeError) as excinfo:
+        no_none4(None)
+    assert "incompatible function arguments" in str(excinfo.value)
+    with pytest.raises(TypeError) as excinfo:
+        no_none5(None)
+    assert "incompatible function arguments" in str(excinfo.value)
+
+    # The first one still raises because you can't pass None as a lvalue reference arg:
+    with pytest.raises(TypeError) as excinfo:
+        assert ok_none1(None) == -1
+    assert "incompatible function arguments" in str(excinfo.value)
+    # The rest take the argument as pointer or holder, and accept None:
+    assert ok_none2(None) == -1
+    assert ok_none3(None) == -1
+    assert ok_none4(None) == -1
+    assert ok_none5(None) == -1


### PR DESCRIPTION
Edit: revamped; see below.

Old description:

---

This new class attribute lets you specify that a pointer or copyable holder type should not be constructed with a `nullptr` when given `None`, but rather that `None` should result in an incompatible function call error.

Enabling this by default would break backwards compatibility, so this is an opt-in feature, to be used as:

```C++
    py::class_<C>(m, "C", !py::accepts_none())
```

but I think that eventually (i.e. when we break backwards compatibility, 3.0) we should consider making this the default, requiring:

```C++
    py::class_<C>(m, "C", py::accepts_none())
```

in cases where `None` -> `nullptr` conversion is explicitly wanted.  This PR accepts that to explicitly request None conversion in a way that will continue to work if the default changes.