### PR TITLE
Convenience constructor templates for buffer_info

### DIFF
--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -35,8 +35,17 @@ struct buffer_info {
             size *= shape[i];
     }
 
+    template <typename T>
+    buffer_info(T *ptr, detail::any_container<ssize_t> shape_in, detail::any_container<ssize_t> strides_in)
+    // Brace-initialization of the base class ensures left-to-right evaluation order of parameters (i.e. getting ndim before moving the shape container)
+    : buffer_info{ptr, sizeof(T), format_descriptor<T>::format(), static_cast<ssize_t>(shape_in->size()), std::move(shape_in), std::move(strides_in)} { }
+
     buffer_info(void *ptr, ssize_t itemsize, const std::string &format, ssize_t size)
     : buffer_info(ptr, itemsize, format, 1, {size}, {itemsize}) { }
+
+    template <typename T>
+    buffer_info(T *ptr, ssize_t size)
+    : buffer_info(ptr, sizeof(T), format_descriptor<T>::format(), size) { }
 
     explicit buffer_info(Py_buffer *view, bool ownview = true)
     : buffer_info(view->buf, view->itemsize, view->format, view->ndim,

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -27,14 +27,20 @@ struct buffer_info {
 
     buffer_info(void *ptr, ssize_t itemsize, const std::string &format, ssize_t ndim,
                 detail::any_container<ssize_t> shape_in, detail::any_container<ssize_t> strides_in)
-    : buffer_info(private_ctr_tag(), ptr, itemsize, format, ndim, std::move(shape_in), std::move(strides_in)) { }
+    : ptr(ptr), itemsize(itemsize), size(1), format(format), ndim(ndim),
+      shape(std::move(shape_in)), strides(std::move(strides_in)) {
+        if (ndim != (ssize_t) shape.size() || ndim != (ssize_t) strides.size())
+            pybind11_fail("buffer_info: ndim doesn't match shape and/or strides length");
+        for (size_t i = 0; i < (size_t) ndim; ++i)
+            size *= shape[i];
+    }
 
     template <typename T>
     buffer_info(T *ptr, detail::any_container<ssize_t> shape_in, detail::any_container<ssize_t> strides_in)
     : buffer_info(private_ctr_tag(), ptr, sizeof(T), format_descriptor<T>::format(), static_cast<ssize_t>(shape_in->size()), std::move(shape_in), std::move(strides_in)) { }
 
     buffer_info(void *ptr, ssize_t itemsize, const std::string &format, ssize_t size)
-    : buffer_info(private_ctr_tag(), ptr, itemsize, format, 1, {size}, {itemsize}) { }
+    : buffer_info(ptr, itemsize, format, 1, {size}, {itemsize}) { }
 
     template <typename T>
     buffer_info(T *ptr, ssize_t size)
@@ -72,17 +78,11 @@ struct buffer_info {
     }
 
 private:
-    struct private_ctr_tag { explicit private_ctr_tag() = default; };
+    struct private_ctr_tag { };
 
     buffer_info(private_ctr_tag, void *ptr, ssize_t itemsize, const std::string &format, ssize_t ndim,
                 detail::any_container<ssize_t> &&shape_in, detail::any_container<ssize_t> &&strides_in)
-    : ptr(ptr), itemsize(itemsize), size(1), format(format), ndim(ndim),
-      shape(std::move(shape_in)), strides(std::move(strides_in)) {
-        if (ndim != (ssize_t) shape.size() || ndim != (ssize_t) strides.size())
-            pybind11_fail("buffer_info: ndim doesn't match shape and/or strides length");
-        for (size_t i = 0; i < (size_t) ndim; ++i)
-            size *= shape[i];
-    }
+    : buffer_info(ptr, itemsize, format, ndim, std::move(shape_in), std::move(strides_in)) { }
 
     Py_buffer *view = nullptr;
     bool ownview = false;

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -105,9 +105,6 @@ test_initializer buffers([](py::module &m) {
        .def_buffer([](Matrix &m) -> py::buffer_info {
             return py::buffer_info(
                 m.data(),                               /* Pointer to buffer */
-                sizeof(float),                          /* Size of one scalar */
-                py::format_descriptor<float>::format(), /* Python struct-style format descriptor */
-                2,                                      /* Number of dimensions */
                 { m.rows(), m.cols() },                 /* Buffer dimensions */
                 { sizeof(float) * size_t(m.rows()),     /* Strides (in bytes) for each index */
                   sizeof(float) }


### PR DESCRIPTION
In order to reduce the amount of error-prone constructor arguments, `buffer_info` would now have a constructor template similar to `array` to automatically get the item size, default format string and number of dimensions.