### PR TITLE
Use dynamic cast for shared_from_this holder init

### DIFF
--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -166,7 +166,7 @@ def test_shared_ptr_and_references():
 
 
 def test_shared_ptr_from_this_and_references():
-    from pybind11_tests.smart_ptr import SharedFromThisRef, B
+    from pybind11_tests.smart_ptr import SharedFromThisRef, B, SharedFromThisVirt
 
     s = SharedFromThisRef()
     stats = ConstructorStats.get(B)
@@ -201,6 +201,10 @@ def test_shared_ptr_from_this_and_references():
 
     del ref, bad_wp, copy, holder_ref, holder_copy, s
     assert stats.alive() == 0
+
+    z = SharedFromThisVirt.get()
+    y = SharedFromThisVirt.get()
+    assert y is z
 
 
 def test_move_only_holder():


### PR DESCRIPTION
Using a `dynamic_cast` instead of a `static_cast` is needed to safely cast from a base to a derived type.  The previous `static_pointer_cast` isn't safe, however, when downcasting (and fails to compile when downcasting with virtual inheritance).

Switching this to always use a `dynamic_pointer_cast` shouldn't incur any additional overhead when a `static_pointer_cast` is safe (i.e. when upcasting, or self-casting): compilers don't need RTTI checks in those cases.

Fixes #865