### PR TITLE
Operator fixes

### DIFF
--- a/include/pybind11/operators.h
+++ b/include/pybind11/operators.h
@@ -49,22 +49,22 @@ template <op_id, op_type, typename B, typename L, typename R> struct op_impl { }
 /// Operator implementation generator
 template <op_id id, op_type ot, typename L, typename R> struct op_ {
     template <typename Class, typename... Extra> void execute(Class &cl, const Extra&... extra) const {
-        typedef typename Class::type Base;
-        typedef typename std::conditional<std::is_same<L, self_t>::value, Base, L>::type L_type;
-        typedef typename std::conditional<std::is_same<R, self_t>::value, Base, R>::type R_type;
-        typedef op_impl<id, ot, Base, L_type, R_type> op;
+        using Base = typename Class::type;
+        using L_type = conditional_t<std::is_same<L, self_t>::value, Base, L>;
+        using R_type = conditional_t<std::is_same<R, self_t>::value, Base, R>;
+        using op = op_impl<id, ot, Base, L_type, R_type>;
         cl.def(op::name(), &op::execute, is_operator(), extra...);
     }
     template <typename Class, typename... Extra> void execute_cast(Class &cl, const Extra&... extra) const {
-        typedef typename Class::type Base;
-        typedef typename std::conditional<std::is_same<L, self_t>::value, Base, L>::type L_type;
-        typedef typename std::conditional<std::is_same<R, self_t>::value, Base, R>::type R_type;
-        typedef op_impl<id, ot, Base, L_type, R_type> op;
+        using Base = typename Class::type;
+        using L_type = conditional_t<std::is_same<L, self_t>::value, Base, L>;
+        using R_type = conditional_t<std::is_same<R, self_t>::value, Base, R>;
+        using op = op_impl<id, ot, Base, L_type, R_type>;
         cl.def(op::name(), &op::execute_cast, is_operator(), extra...);
     }
 };
 
-#define PYBIND11_BINARY_OPERATOR(id, rid, op, expr)                                      \
+#define PYBIND11_BINARY_OPERATOR(id, rid, op, expr)                                    \
 template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L, R> { \
     static char const* name() { return "__" #id "__"; }                                \
     static auto execute(const L &l, const R &r) -> decltype(expr) { return (expr); }   \
@@ -85,7 +85,7 @@ template <typename T> op_<op_##id, op_r, T, self_t> op(const T &, const self_t &
     return op_<op_##id, op_r, T, self_t>();                                            \
 }
 
-#define PYBIND11_INPLACE_OPERATOR(id, op, expr)                                          \
+#define PYBIND11_INPLACE_OPERATOR(id, op, expr)                                        \
 template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L, R> { \
     static char const* name() { return "__" #id "__"; }                                \
     static auto execute(L &l, const R &r) -> decltype(expr) { return expr; }           \
@@ -95,7 +95,7 @@ template <typename T> op_<op_##id, op_l, self_t, T> op(const self_t &, const T &
     return op_<op_##id, op_l, self_t, T>();                                            \
 }
 
-#define PYBIND11_UNARY_OPERATOR(id, op, expr)                                            \
+#define PYBIND11_UNARY_OPERATOR(id, op, expr)                                          \
 template <typename B, typename L> struct op_impl<op_##id, op_u, B, L, undefined_t> {   \
     static char const* name() { return "__" #id "__"; }                                \
     static auto execute(const L &l) -> decltype(expr) { return expr; }                 \

--- a/include/pybind11/operators.h
+++ b/include/pybind11/operators.h
@@ -25,7 +25,7 @@ enum op_id : int {
     op_int, op_long, op_float, op_str, op_cmp, op_gt, op_ge, op_lt, op_le,
     op_eq, op_ne, op_iadd, op_isub, op_imul, op_idiv, op_imod, op_ilshift,
     op_irshift, op_iand, op_ixor, op_ior, op_complex, op_bool, op_nonzero,
-    op_repr, op_truediv
+    op_repr, op_truediv, op_itruediv
 };
 
 enum op_type : int {
@@ -129,7 +129,11 @@ PYBIND11_BINARY_OPERATOR(le,        ge,           operator<=,   l <= r)
 PYBIND11_INPLACE_OPERATOR(iadd,     operator+=,   l += r)
 PYBIND11_INPLACE_OPERATOR(isub,     operator-=,   l -= r)
 PYBIND11_INPLACE_OPERATOR(imul,     operator*=,   l *= r)
+#if PY_MAJOR_VERSION >= 3
+PYBIND11_INPLACE_OPERATOR(itruediv, operator/=,   l /= r)
+#else
 PYBIND11_INPLACE_OPERATOR(idiv,     operator/=,   l /= r)
+#endif
 PYBIND11_INPLACE_OPERATOR(imod,     operator%=,   l %= r)
 PYBIND11_INPLACE_OPERATOR(ilshift,  operator<<=,  l <<= r)
 PYBIND11_INPLACE_OPERATOR(irshift,  operator>>=,  l >>= r)

--- a/tests/test_operator_overloading.cpp
+++ b/tests/test_operator_overloading.cpp
@@ -39,10 +39,14 @@ public:
     Vector2 operator+(float value) const { return Vector2(x + value, y + value); }
     Vector2 operator*(float value) const { return Vector2(x * value, y * value); }
     Vector2 operator/(float value) const { return Vector2(x / value, y / value); }
+    Vector2 operator*(const Vector2 &v) const { return Vector2(x * v.x, y * v.y); }
+    Vector2 operator/(const Vector2 &v) const { return Vector2(x / v.x, y / v.y); }
     Vector2& operator+=(const Vector2 &v) { x += v.x; y += v.y; return *this; }
     Vector2& operator-=(const Vector2 &v) { x -= v.x; y -= v.y; return *this; }
     Vector2& operator*=(float v) { x *= v; y *= v; return *this; }
     Vector2& operator/=(float v) { x /= v; y /= v; return *this; }
+    Vector2& operator*=(const Vector2 &v) { x *= v.x; y *= v.y; return *this; }
+    Vector2& operator/=(const Vector2 &v) { x /= v.x; y /= v.y; return *this; }
 
     friend Vector2 operator+(float f, const Vector2 &v) { return Vector2(f + v.x, f + v.y); }
     friend Vector2 operator-(float f, const Vector2 &v) { return Vector2(f - v.x, f - v.y); }
@@ -61,10 +65,14 @@ test_initializer operator_overloading([](py::module &m) {
         .def(py::self - float())
         .def(py::self * float())
         .def(py::self / float())
+        .def(py::self * py::self)
+        .def(py::self / py::self)
         .def(py::self += py::self)
         .def(py::self -= py::self)
         .def(py::self *= float())
         .def(py::self /= float())
+        .def(py::self *= py::self)
+        .def(py::self /= py::self)
         .def(float() + py::self)
         .def(float() - py::self)
         .def(float() * py::self)

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -16,10 +16,21 @@ def test_operator_overloading():
     assert str(8 + v1) == "[9.000000, 10.000000]"
     assert str(8 * v1) == "[8.000000, 16.000000]"
     assert str(8 / v1) == "[8.000000, 4.000000]"
+    assert str(v1 * v2) == "[3.000000, -2.000000]"
+    assert str(v2 / v1) == "[3.000000, -0.500000]"
 
-    v1 += v2
+    v1 += 2 * v2
+    assert str(v1) == "[7.000000, 0.000000]"
+    v1 -= v2
+    assert str(v1) == "[4.000000, 1.000000]"
     v1 *= 2
     assert str(v1) == "[8.000000, 2.000000]"
+    v1 /= 16
+    assert str(v1) == "[0.500000, 0.125000]"
+    v1 *= v2
+    assert str(v1) == "[1.500000, -0.125000]"
+    v2 /= v1
+    assert str(v2) == "[2.000000, 8.000000]"
 
     cstats = ConstructorStats.get(Vector2)
     assert cstats.alive() == 2
@@ -32,7 +43,9 @@ def test_operator_overloading():
                                '[-7.000000, -6.000000]', '[9.000000, 10.000000]',
                                '[8.000000, 16.000000]', '[0.125000, 0.250000]',
                                '[7.000000, 6.000000]', '[9.000000, 10.000000]',
-                               '[8.000000, 16.000000]', '[8.000000, 4.000000]']
+                               '[8.000000, 16.000000]', '[8.000000, 4.000000]',
+                               '[3.000000, -2.000000]', '[3.000000, -0.500000]',
+                               '[6.000000, -2.000000]']
     assert cstats.default_constructions == 0
     assert cstats.copy_constructions == 0
     assert cstats.move_constructions >= 10


### PR DESCRIPTION
This fixes a couple issues in `operators.h`.

The first is that `/=` isn't being defined properly under Python 3 (`__idiv__` is set rather than `__itruediv__`) so it doesn't get called.  Instead Python converts `x /= 3` to `x = x / 3` and ends up create a new object via `__truediv__`, which probably works in some cases, but isn't correct.

The second issue (third commit) is that the `__truediv__` (and variants) are needed under Python 2 with `from __future__ import division`, otherwise division will fail (it does *not* fall back to calling an available `__div__`).  The fix here adds a second binding under the alternate names under Python 2.