### PR TITLE
Fix invalid memory access in vector insert method

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -146,6 +146,8 @@ void vector_modifiers(enable_if_t<std::is_copy_constructible<typename Vector::va
 
     cl.def("insert",
         [](Vector &v, SizeType i, const T &x) {
+            if (i > v.size())
+                throw index_error();
             v.insert(v.begin() + (DiffType) i, x);
         },
         arg("i") , arg("x"),

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -18,11 +18,13 @@ def test_vector_int():
     assert v_int != v_int2
 
     v_int2.append(2)
-    v_int2.append(3)
     v_int2.insert(0, 1)
     v_int2.insert(0, 2)
     v_int2.insert(0, 3)
+    v_int2.insert(6, 3)
     assert str(v_int2) == "VectorInt[3, 2, 1, 0, 1, 2, 3]"
+    with pytest.raises(IndexError):
+        v_int2.insert(8, 4)
 
     v_int.append(99)
     v_int2[2:-2] = v_int


### PR DESCRIPTION
The stl_bind.h wrapper for `Vector.insert` neglected to do a bounds
check.