### PR TITLE
Correct error in numpy.rst

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -99,7 +99,7 @@ buffer objects (e.g. a NumPy matrix).
                 info.strides[rowMajor ? 1 : 0] / (py::ssize_t)sizeof(Scalar));
 
             auto map = Eigen::Map<Matrix, 0, Strides>(
-                static_cat<Scalar *>(info.ptr), info.shape[0], info.shape[1], strides);
+                static_cast<Scalar *>(info.ptr), info.shape[0], info.shape[1], strides);
 
             new (&m) Matrix(map);
         });


### PR DESCRIPTION
When follow the instruction in [http://pybind11.readthedocs.io/en/master/advanced/pycpp/numpy.html] , error occurs as following. 

> error:  ‘static_cat’ was not declared in this scope

This PR correct the mistake in documentation.