### PR TITLE
Make instance_essentials hold references to patients

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -405,6 +405,8 @@ struct instance {
     bool simple_layout : 1;
     /// For simple layout, tracks whether the holder has been constructed
     bool simple_holder_constructed : 1;
+    /// If true, get_internals().patients has an entry for this object
+    bool has_patients : 1;
 
     /// Initializes all of the above type/values/holders data
     void allocate_layout();
@@ -469,6 +471,7 @@ struct internals {
     std::unordered_multimap<const void *, instance*> registered_instances; // void * -> instance*
     std::unordered_set<std::pair<const PyObject *, const char *>, overload_hash> inactive_overload_cache;
     type_map<std::vector<bool (*)(PyObject *, void *&)>> direct_conversions;
+    std::unordered_map<const PyObject *, std::vector<PyObject *>> patients;
     std::forward_list<void (*) (std::exception_ptr)> registered_exception_translators;
     std::unordered_map<std::string, void *> shared_data; // Custom data to be shared across extensions
     PyTypeObject *static_property_type;

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -24,6 +24,13 @@ public:
     Child *returnNullChild() { return nullptr; }
 };
 
+#if !defined(PYPY_VERSION)
+class ParentGC : public Parent {
+public:
+    using Parent::Parent;
+};
+#endif
+
 test_initializer keep_alive([](py::module &m) {
     py::class_<Parent>(m, "Parent")
         .def(py::init<>())
@@ -33,6 +40,11 @@ test_initializer keep_alive([](py::module &m) {
         .def("returnChildKeepAlive", &Parent::returnChild, py::keep_alive<1, 0>())
         .def("returnNullChildKeepAliveChild", &Parent::returnNullChild, py::keep_alive<1, 0>())
         .def("returnNullChildKeepAliveParent", &Parent::returnNullChild, py::keep_alive<0, 1>());
+
+#if !defined(PYPY_VERSION)
+    py::class_<ParentGC, Parent>(m, "ParentGC", py::dynamic_attr())
+        .def(py::init<>());
+#endif
 
     py::class_<Child>(m, "Child")
         .def(py::init<>());


### PR DESCRIPTION
This is a first attempt to address #856. There is still a bit of work to do (e.g., some tests, and double-checking that I'm not leaking references). At this point I'm looking for feedback on whether the idea
is sound and would be accepted.

Instead of the weakref trick, every pybind-managed object holds a (Python) list of references, which gets cleared in `clear_instance`. The list is only constructed the first time it is needed.

The one downside I can see is that every pybind object will get bigger by `sizeof(PyObject *)`, even if no keep_alive is used. On the other hand, it should significantly reduce the overhead of using keep_alive,
since there is no need to construct a weakref object and a callback object.

One thing I'm not sure about is whether the call to `Py_CLEAR(instance->patients);` belongs inside or outside the `has_value` test. At the moment it's inside, but that's cargo culting rather than from an understanding of the conditions under which an instance might not have a value.