### PR TITLE
Fix buffer protocol inheritance

### DIFF
--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -74,6 +74,11 @@ private:
     float *m_data;
 };
 
+class SquareMatrix : public Matrix {
+public:
+    SquareMatrix(ssize_t n) : Matrix(n, n) { }
+};
+
 struct PTMFBuffer {
     int32_t value = 0;
 
@@ -140,6 +145,10 @@ test_initializer buffers([](py::module &m) {
             );
         })
         ;
+
+    // Derived classes inherit the buffer protocol and the buffer access function
+    py::class_<SquareMatrix, Matrix>(m, "SquareMatrix")
+        .def(py::init<ssize_t>());
 
     py::class_<PTMFBuffer>(m, "PTMFBuffer", py::buffer_protocol())
         .def(py::init<>())

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -36,6 +36,7 @@ def test_from_python():
 @pytest.unsupported_on_pypy
 def test_to_python():
     m = Matrix(5, 5)
+    assert memoryview(m).shape == (5, 5)
 
     assert m[2, 3] == 0
     m[2, 3] = 4
@@ -61,6 +62,16 @@ def test_to_python():
     # assert cstats.move_constructions >= 0  # Don't invoke any
     assert cstats.copy_assignments == 0
     assert cstats.move_assignments == 0
+
+
+@pytest.unsupported_on_pypy
+def test_inherited_protocol():
+    """SquareMatrix is derived from Matrix and inherits the buffer protocol"""
+    from pybind11_tests import SquareMatrix
+
+    matrix = SquareMatrix(5)
+    assert memoryview(matrix).shape == (5, 5)
+    assert np.asarray(matrix).shape == (5, 5)
 
 
 @pytest.unsupported_on_pypy


### PR DESCRIPTION
Fixes #878.

Resolved by looking for the first valid implementation of `get_buffer` in a types' MRO.