### PR TITLE
Filter warnings on pytest >= v3.1

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,3 +5,10 @@ addopts =
     -rs
     # capture only Python print and C++ py::print, but not C output (low-level Python errors)
     --capture=sys
+filterwarnings =
+    # make warnings into errors but ignore certain third-party extension issues
+    error
+    # importing scipy submodules on some version of Python
+    ignore::ImportWarning
+    # bogus numpy ABI warning (see numpy/#432)
+    ignore:.*numpy.dtype size changed.*:RuntimeWarning


### PR DESCRIPTION
The new version of pytest now reports Python warnings by default. For example: [Python 2.7](https://travis-ci.org/pybind/pybind11/jobs/237007056#L409) and [3.6](https://travis-ci.org/pybind/pybind11/jobs/237007057#L477). This PR filters out some warnings generated by third-party extensions which are not useful for pybind11 tests. Alternatively, all warnings could be ignored, but I think it's good to do it selectively in case something in pybind11 really does create an issue. 

(The `filterwarnings` entry in `pytest.ini` is ignored by older versions so pytest 3.0 still works.)