### PR TITLE
Allowed multiple types in brace-enclosed initializer list constructor of any_container

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -755,8 +755,7 @@ public:
 
     // initializer_list's aren't deducible, so don't get matched by the above template; we need this
     // to explicitly allow implicit conversion from one:
-    template <typename TIn, typename = enable_if_t<std::is_convertible<TIn, T>::value>>
-    any_container(const std::initializer_list<TIn> &c) : any_container(c.begin(), c.end()) { }
+    any_container(const std::initializer_list<T> &c) : any_container(c.begin(), c.end()) { }
 
     // Avoid copying if given an rvalue vector of the correct type.
     any_container(std::vector<T> &&v) : v(std::move(v)) { }


### PR DESCRIPTION
With the previous templated initializer_list<TIn>, TIn could only be deduced if all values had the same type.  By accepting initializer_list<T> instead, arguments passed in can be of different types, so long as each type can be converted to type T.

As tested on my machine, this passes all unit tests, along with a new one added to test the new behavior.  Without the new change, the new test fails to compile.  The change also causes a large number of `-Wnarrowing` warnings, calling out the conversions from `unsigned long int` to `long int`.  I'm not sure how best to fix this, other than changing all of the call sites.  I have currently left them uncorrected, in order to keep the pull request small.