### PR TITLE
Explicitly define move constructor for accessor

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -393,6 +393,7 @@ public:
     // to replace default compiler-generated assignments).
     void operator=(const accessor &a) && { std::move(*this).operator=(handle(a)); }
     void operator=(const accessor &a) & { operator=(handle(a)); }
+    accessor(accessor &&a) = default;
 
     template <typename T> void operator=(T &&value) && {
         Policy::set(obj, key, object_or_cast(std::forward<T>(value)));

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -393,6 +393,7 @@ public:
     // to replace default compiler-generated assignments).
     void operator=(const accessor &a) && { std::move(*this).operator=(handle(a)); }
     void operator=(const accessor &a) & { operator=(handle(a)); }
+    accessor(accessor &a) = default;
     accessor(accessor &&a) = default;
 
     template <typename T> void operator=(T &&value) && {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -388,13 +388,13 @@ class accessor : public object_api<accessor<Policy>> {
 
 public:
     accessor(handle obj, key_type key) : obj(obj), key(std::move(key)) { }
+    accessor(const accessor &a) = default;
+    accessor(accessor &&a) = default;
 
     // accessor overload required to override default assignment operator (templates are not allowed
     // to replace default compiler-generated assignments).
     void operator=(const accessor &a) && { std::move(*this).operator=(handle(a)); }
     void operator=(const accessor &a) & { operator=(handle(a)); }
-    accessor(accessor &a) = default;
-    accessor(accessor &&a) = default;
 
     template <typename T> void operator=(T &&value) && {
         Policy::set(obj, key, object_or_cast(std::forward<T>(value)));


### PR DESCRIPTION
I suppose it depends on when template instantiation occurs or something, but in my case,
I want to avoid the following compiler warning.

```
pybind11/include/pybind11/pytypes.h:385:10: warning: definition of implicit copy constructor for 'accessor<pybind11::detail::accessor_policies::str_attr>' is deprecated because it has a
      user-declared copy assignment operator [-Wdeprecated]
    void operator=(const accessor &a) && { std::move(*this).operator=(handle(a)); }
         ^
pybind11/include/pybind11/pybind11.h:1480:18: note: implicit copy constructor for 'accessor<pybind11::detail::accessor_policies::str_attr>' first required here
    auto write = file.attr("write");
```