### PR TITLE
Enable detection of private operator new on MSVC

### DIFF
--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -98,6 +98,12 @@ public:
 };
 }}
 
+struct PrivateOpNew {
+    int value = 1;
+
+private:
+    void *operator new(size_t bytes);
+};
 
 test_initializer copy_move_policies([](py::module &m) {
     py::class_<lacking_copy_ctor>(m, "lacking_copy_ctor")
@@ -174,4 +180,11 @@ test_initializer copy_move_policies([](py::module &m) {
     m.attr("has_optional") = false;
 #endif
 
+    // #70 compilation issue if operator new is not public
+    py::class_<PrivateOpNew>(m, "PrivateOpNew").def_readonly("value", &PrivateOpNew::value);
+    m.def("private_op_new_value", []() { return PrivateOpNew(); });
+    m.def("private_op_new_reference", []() -> const PrivateOpNew & {
+        static PrivateOpNew x{};
+        return x;
+    }, py::return_value_policy::reference);
 });

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -98,3 +98,14 @@ def test_move_and_copy_load_optional():
     assert c_c.copy_assignments == 2
     assert c_c.copy_constructions == 5
     assert c_m.alive() + c_mc.alive() + c_c.alive() == 0
+
+
+def test_private_op_new():
+    """An object with a private `operator new` cannot be returned by value"""
+    import pybind11_tests as m
+
+    with pytest.raises(RuntimeError) as excinfo:
+        m.private_op_new_value()
+    assert "the object is neither movable nor copyable" in str(excinfo.value)
+
+    assert m.private_op_new_reference().value == 1

--- a/tests/test_issues.cpp
+++ b/tests/test_issues.cpp
@@ -77,16 +77,6 @@ template <> struct hash<TplConstrClass> { size_t operator()(const TplConstrClass
 void init_issues(py::module &m) {
     py::module m2 = m.def_submodule("issues");
 
-#if !defined(_MSC_VER)
-    // Visual Studio 2015 currently cannot compile this test
-    // (see the comment in type_caster_base::make_copy_constructor)
-    // #70 compilation issue if operator new is not public
-    class NonConstructible { private: void *operator new(size_t bytes) throw(); };
-    py::class_<NonConstructible>(m, "Foo");
-    m2.def("getstmt", []() -> NonConstructible * { return nullptr; },
-        py::return_value_policy::reference);
-#endif
-
     // #137: const char* isn't handled properly
     m2.def("print_cchar", [](const char *s) { return std::string(s); });
 


### PR DESCRIPTION
MSVC 2015 Update 3 and 2017 can handle enough expression SFINAE to make this work now.