### PR TITLE
Fix py::make_iterator's __next__() for past-the-end calls

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 minversion = 3.0
+norecursedirs = test_cmake_build test_embed
 addopts =
     # show summary of skipped tests
     -rs

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -21,6 +21,17 @@ def test_generalized_iterators():
     assert list(IntPairs([(1, 2), (2, 0), (0, 3), (4, 5)]).nonzero_keys()) == [1]
     assert list(IntPairs([(0, 3), (1, 2), (3, 4)]).nonzero_keys()) == []
 
+    # __next__ must continue to raise StopIteration
+    it = IntPairs([(0, 0)]).nonzero()
+    for _ in range(3):
+        with pytest.raises(StopIteration):
+            next(it)
+
+    it = IntPairs([(0, 0)]).nonzero_keys()
+    for _ in range(3):
+        with pytest.raises(StopIteration):
+            next(it)
+
 
 def test_sequence():
     from pybind11_tests import ConstructorStats
@@ -45,6 +56,12 @@ def test_sequence():
     rev2 = s[::-1]
     assert cstats.values() == ['of size', '5']
 
+    it = iter(Sequence(0))
+    for _ in range(3):  # __next__ must continue to raise StopIteration
+        with pytest.raises(StopIteration):
+            next(it)
+    assert cstats.values() == ['of size', '0']
+
     expected = [0, 56.78, 0, 0, 12.34]
     assert allclose(rev, expected)
     assert allclose(rev2, expected)
@@ -55,6 +72,8 @@ def test_sequence():
 
     assert allclose(rev, [2, 56.78, 2, 0, 2])
 
+    assert cstats.alive() == 4
+    del it
     assert cstats.alive() == 3
     del s
     assert cstats.alive() == 2
@@ -89,6 +108,11 @@ def test_map_iterator():
         assert m[k] == expected[k]
     for k, v in m.items():
         assert v == expected[k]
+
+    it = iter(StringMap({}))
+    for _ in range(3):  # __next__ must continue to raise StopIteration
+        with pytest.raises(StopIteration):
+            next(it)
 
 
 def test_python_iterator_in_cpp():


### PR DESCRIPTION
Fixes #896.

From Python docs: Once an iterator’s `__next__()` method raises `StopIteration`, it must continue to do so on subsequent calls. Implementations that do not obey this property are deemed broken.