### PR TITLE
Help CLion IDE evaluate PYBIND11_NUMPY_DTYPE

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1147,6 +1147,11 @@ private:
     }
 };
 
+#ifdef __CLION_IDE__ // replace heavy macro with dummy code for the IDE (doesn't affect code)
+# define PYBIND11_NUMPY_DTYPE(Type, ...) ((void)0)
+# define PYBIND11_NUMPY_DTYPE_EX(Type, ...) ((void)0)
+#else
+
 #define PYBIND11_FIELD_DESCRIPTOR_EX(T, Field, Name)                                          \
     ::pybind11::detail::field_descriptor {                                                    \
         Name, offsetof(T, Field), sizeof(decltype(std::declval<T>().Field)),                  \
@@ -1213,6 +1218,8 @@ private:
 #define PYBIND11_NUMPY_DTYPE_EX(Type, ...) \
     ::pybind11::detail::npy_format_descriptor<Type>::register_dtype \
         ({PYBIND11_MAP2_LIST (PYBIND11_FIELD_DESCRIPTOR_EX, Type, __VA_ARGS__)})
+
+#endif // __CLION_IDE__
 
 template  <class T>
 using array_iterator = typename std::add_pointer<T>::type;


### PR DESCRIPTION
I'm a bit hesitant to propose this PR since it's really a problem which should be taken care of by the IDE. The issue is that [CLion](https://www.jetbrains.com/clion/) slows to a crawl when its static analysis hits the intricate `PYBIND11_NUMPY_DTYPE` macro -- making it unresponsive while it churns through the recursive preprocessor replacements. I've raised [the issue in their bug tracker](https://youtrack.jetbrains.com/issue/CPP-7452) but it doesn't look like it's getting fixed anytime soon, so I'm proposing a quick workaround here.

This PR adds a special `#ifdef` for the IDE to replace the macro cascade with a simple `(void)0` to ease evaluation. This doesn't affect any actual code compilation, just the IDE's static analysis (but `PYBIND11_NUMPY_DTYPE` doesn't have any static side effects anyway). 

Adding workarounds to the code is always ugly so I don't want to push this if it's deemed too much of a nuisance, but the macro performance hiccups have gotten bad enough that I had to at least propose it.