### PR TITLE
add the capsule name to the py::capsule constructor

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1016,8 +1016,8 @@ public:
     PYBIND11_DEPRECATED("Use reinterpret_borrow<capsule>() or reinterpret_steal<capsule>()")
     capsule(PyObject *ptr, bool is_borrowed) : object(is_borrowed ? object(ptr, borrowed_t{}) : object(ptr, stolen_t{})) { }
 
-    explicit capsule(const void *value)
-        : object(PyCapsule_New(const_cast<void *>(value), nullptr, nullptr), stolen_t{}) {
+    explicit capsule(const void *value, const char *name = nullptr, void (*destructor)(PyObject *) = nullptr)
+        : object(PyCapsule_New(const_cast<void *>(value), name, destructor), stolen_t{}) {
         if (!m_ptr)
             pybind11_fail("Could not allocate capsule object!");
     }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1054,10 +1054,13 @@ public:
     }
 
     template <typename T> operator T *() const {
-        T * result = static_cast<T *>(PyCapsule_GetPointer(m_ptr, nullptr));
+        auto name = this->name();
+        T * result = static_cast<T *>(PyCapsule_GetPointer(m_ptr, name));
         if (!result) pybind11_fail("Unable to extract capsule contents!");
         return result;
     }
+
+    const char *name() const { return PyCapsule_GetName(m_ptr); }
 };
 
 class tuple : public object {

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -578,7 +578,7 @@ test_initializer python_types([](py::module &m) {
             py::print("creating capsule");
             auto capsule=py::capsule((void *) 1234, "pointer type description",
                 [](PyObject *ptr) {
-                 if (ptr){
+                 if (ptr) {
                     py::print("destructing capsule");
                  }
             });

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -578,7 +578,7 @@ test_initializer python_types([](py::module &m) {
             py::print("creating capsule");
             auto capsule=py::capsule((void *) 1234, "pointer type description",
                 [](PyObject *ptr) {
-                 if(ptr){
+                 if (ptr){
                     py::print("destructing capsule");
                  }
             });
@@ -588,7 +588,7 @@ test_initializer python_types([](py::module &m) {
             return capsule;
         }
     );
-    
+
     m.def("load_nullptr_t", [](std::nullptr_t) {}); // not useful, but it should still compile
     m.def("cast_nullptr_t", []() { return std::nullptr_t{}; });
 

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -575,6 +575,7 @@ test_initializer python_types([](py::module &m) {
 
     m.def("return_capsule_with_name_and_destructor_3",
         []() {
+            py::print("creating capsule");
             auto capsule=py::capsule((void *) 1234, "pointer type description",
                 [](PyObject *ptr) {
                  if(ptr){

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -573,6 +573,18 @@ test_initializer python_types([](py::module &m) {
         }
     );
 
+    m.def("return_capsule_with_name_and_destructor_3",
+        []() {
+            py::print("creating capsule");
+            auto capsule=py::object(py::capsule((void *) 1234, "pointer type description",
+                [](PyObject *ptr) {py::print("destructing capsule");}));
+            auto name=PyCapsule_GetName(capsule.ptr());
+            py::print(name);
+            return capsule;
+        }
+    );
+
+    
     m.def("load_nullptr_t", [](std::nullptr_t) {}); // not useful, but it should still compile
     m.def("cast_nullptr_t", []() { return std::nullptr_t{}; });
 

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -575,14 +575,14 @@ test_initializer python_types([](py::module &m) {
 
     m.def("return_capsule_with_name_and_destructor_3",
         []() {
-            auto capsule=py::object(py::capsule((void *) 1234, "pointer type description",
+            auto capsule=py::capsule((void *) 1234, "pointer type description",
                 [](PyObject *ptr) {
                  if(ptr){
                     py::print("destructing capsule");
                  }
-            }));
-            auto name=PyCapsule_GetName(capsule.ptr());
-            auto contents=PyCapsule_GetPointer(capsule.ptr(),name);
+            });
+            auto name = capsule.name();
+            void *contents = capsule;
             py::print("created capsule with name --{}-- and contents {}"_s.format(name,(size_t) contents));
             return capsule;
         }

--- a/tests/test_python_types.cpp
+++ b/tests/test_python_types.cpp
@@ -575,15 +575,18 @@ test_initializer python_types([](py::module &m) {
 
     m.def("return_capsule_with_name_and_destructor_3",
         []() {
-            py::print("creating capsule");
             auto capsule=py::object(py::capsule((void *) 1234, "pointer type description",
-                [](PyObject *ptr) {py::print("destructing capsule");}));
+                [](PyObject *ptr) {
+                 if(ptr){
+                    py::print("destructing capsule");
+                 }
+            }));
             auto name=PyCapsule_GetName(capsule.ptr());
-            py::print(name);
+            auto contents=PyCapsule_GetPointer(capsule.ptr(),name);
+            py::print("created capsule with name --{}-- and contents {}"_s.format(name,(size_t) contents));
             return capsule;
         }
     );
-
     
     m.def("load_nullptr_t", [](std::nullptr_t) {}); // not useful, but it should still compile
     m.def("cast_nullptr_t", []() { return std::nullptr_t{}; });

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -615,7 +615,6 @@ def test_capsule_with_destructor(capture):
 
 def test_void_caster():
     import pybind11_tests as m
-
     assert m.load_nullptr_t(None) is None
     assert m.cast_nullptr_t() is None
 

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -613,8 +613,6 @@ def test_capsule_with_destructor(capture):
         destructing capsule
     """
 
-    
-
 def test_void_caster():
     import pybind11_tests as m
 

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -613,6 +613,7 @@ def test_capsule_with_destructor(capture):
         destructing capsule
     """
 
+
 def test_void_caster():
     import pybind11_tests as m
     assert m.load_nullptr_t(None) is None

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -608,8 +608,8 @@ def test_capsule_with_destructor(capture):
         del a
         pytest.gc_collect()
     assert capture.unordered == """
+        created capsule with name --pointer type description-- and contents 1234
         creating capsule
-        pointer type description
         destructing capsule
     """
 

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -603,6 +603,17 @@ def test_capsule_with_destructor(capture):
         destructing capsule: 1234
     """
 
+    with capture:
+        a = m.return_capsule_with_name_and_destructor_3()
+        del a
+        pytest.gc_collect()
+    assert capture.unordered == """
+        creating capsule
+        pointer type description
+        destructing capsule
+    """
+
+    
 
 def test_void_caster():
     import pybind11_tests as m


### PR DESCRIPTION
Here's a first attempt at adding a name to py::capsule

I've only changed the first constructor, because trying to add an optional name to the other two constructors produces an error message:

    ValueError: PyCapsule_GetPointer called with incorrect name