### PR TITLE
Update build commands for Linux / OS X in the docs

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -120,47 +120,10 @@ generates binding code that exposes the ``add()`` function to Python.
     approach and the used syntax are borrowed from Boost.Python, though the
     underlying implementation is very different.
 
-pybind11 is a header-only-library, hence it is not necessary to link against
-any special libraries (other than Python itself). On Windows, use the CMake
-build file discussed in section :ref:`cmake`.
-
-On Linux, the above example can be compiled using the following command:
-
-.. code-block:: bash
-
-    $ c++ -O3 -Wall -shared -std=c++11 -fPIC -I$PYBIND11_INCLUDE `python3-config --includes` example.cpp -o example`python3-config --extension-suffix`
-
-where ``PYBIND11_INCLUDE`` is the path to the include folder of pybind11.
-If pybind11 installed as a Python package, it can be obtained as follows:
-
-.. code-block:: bash
-
-   $ PYBIND11_INCLUDE=`python -c 'import pybind11; print(pybind11.get_include())'`
-
-Note that for some Python distributions the list of Python's system include
-folders contains the one where pybind11 gets installed, in which case
-passing ``-I$PYBIND11_INCLUDE`` is optional.
-
-On Python 2.7.x: ``python-config`` has to be used instead of ``python3-config``
-in the command above. Besides, ``--extension-suffix`` option may or may not
-be available, depending on the distribution; in the latter case, the module
-extension can be manually set to ``.so``.
-
-On Mac OS: the build command is almost the same but it also requires passing
-the ``-undefined dynamic_lookup`` flag so as to ignore missing symbols when
-building the module:
-
-.. code-block:: bash
-
-    $ c++ -O3 -Wall -shared -std=c++11 -undefined dynamic_lookup -I$PYBIND11_INCLUDE `python3-config --includes` example.cpp -o example`python3-config --extension-suffix`
-
-In general, it is advisable to include several additional build parameters
-that can considerably reduce the size of the created binary. Refer to section
-:ref:`cmake` for a detailed example of a suitable cross-platform CMake-based
-build system.
-
-Assuming that the compiled module is located in the current directory, the
-following interactive Python session shows how to load and execute the example.
+Building the above C++ code (refer to :ref:`compiling` for details) will produce
+a binary module file that can be imported to Python. Assuming that the compiled
+module is located in the current directory, the following interactive Python
+session shows how to load and execute the example:
 
 .. code-block:: pycon
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -122,21 +122,45 @@ generates binding code that exposes the ``add()`` function to Python.
 
 pybind11 is a header-only-library, hence it is not necessary to link against
 any special libraries (other than Python itself). On Windows, use the CMake
-build file discussed in section :ref:`cmake`. On Linux and Mac OS, the above
-example can be compiled using the following command
+build file discussed in section :ref:`cmake`.
+
+On Linux, the above example can be compiled using the following command:
 
 .. code-block:: bash
 
-    $ c++ -O3 -shared -std=c++11 -I <path-to-pybind11>/include `python-config --cflags --ldflags` example.cpp -o example.so
+    $ c++ -O3 -Wall -shared -std=c++11 -fPIC -I$PYBIND11_INCLUDE `python3-config --includes` example.cpp -o example`python3-config --extension-suffix`
+
+where ``PYBIND11_INCLUDE`` is the path to the include folder of pybind11.
+If pybind11 installed as a Python package, it can be obtained as follows:
+
+.. code-block:: bash
+
+   $ PYBIND11_INCLUDE=`python -c 'import pybind11; print(pybind11.get_include())'`
+
+Note that for some Python distributions the list of Python's system include
+folders contains the one where pybind11 gets installed, in which case
+passing ``-I$PYBIND11_INCLUDE`` is optional.
+
+On Python 2.7.x: ``python-config`` has to be used instead of ``python3-config``
+in the command above. Besides, ``--extension-suffix`` option may or may not
+be available, depending on the distribution; in the latter case, the module
+extension can be manually set to ``.so``.
+
+On Mac OS: the build command is almost the same but it also requires passing
+the ``-undefined dynamic_lookup`` flag so as to ignore missing symbols when
+building the module:
+
+.. code-block:: bash
+
+    $ c++ -O3 -Wall -shared -std=c++11 -undefined dynamic_lookup -I$PYBIND11_INCLUDE `python3-config --includes` example.cpp -o example`python3-config --extension-suffix`
 
 In general, it is advisable to include several additional build parameters
 that can considerably reduce the size of the created binary. Refer to section
 :ref:`cmake` for a detailed example of a suitable cross-platform CMake-based
 build system.
 
-Assuming that the created file :file:`example.so` (:file:`example.pyd` on Windows)
-is located in the current directory, the following interactive Python session
-shows how to load and execute the example.
+Assuming that the compiled module is located in the current directory, the
+following interactive Python session shows how to load and execute the example.
 
 .. code-block:: pycon
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -73,6 +73,8 @@ For brevity, all code examples assume that the following two lines are present:
 
 Some features may require additional headers, but those will be specified as needed.
 
+.. _simple_example:
+
 Creating bindings for a simple function
 =======================================
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -122,10 +122,31 @@ generates binding code that exposes the ``add()`` function to Python.
     approach and the used syntax are borrowed from Boost.Python, though the
     underlying implementation is very different.
 
-Building the above C++ code (refer to :ref:`compiling` for details) will produce
-a binary module file that can be imported to Python. Assuming that the compiled
-module is located in the current directory, the following interactive Python
-session shows how to load and execute the example:
+pybind11 is a header-only library, hence it is not necessary to link against
+any special libraries and there are no intermediate (magic) translation steps.
+On Linux, the above example can be compiled using the following command:
+
+.. code-block:: bash
+
+    $ c++ -O3 -Wall -shared -std=c++11 -fPIC `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+
+For more details on the required compiler flags on Linux and MacOS, see
+:ref:`building_manually`. For complete cross-platform compilation instructions,
+refer to the :ref:`compiling` page.
+
+The `python_example`_ and `cmake_example`_ repositories are also a good place
+to start. They are both complete project examples with cross-platform build
+systems. The only difference between the two is that `python_example`_ uses
+Python's ``setuptools`` to build the module, while `cmake_example`_ uses CMake
+(which may be preferable for existing C++ projects).
+
+.. _python_example: https://github.com/pybind/python_example
+.. _cmake_example: https://github.com/pybind/cmake_example
+
+Building the above C++ code will produce a binary module file that can be
+imported to Python. Assuming that the compiled module is located in the
+current directory, the following interactive Python session shows how to
+load and execute the example:
 
 .. code-block:: pycon
 

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -249,6 +249,17 @@ that can considerably reduce the size of the created binary. Refer to section
 :ref:`cmake` for a detailed example of a suitable cross-platform CMake-based
 build system that works on all platforms including Windows.
 
+.. note::
+
+    On Linux and macOS, it's better to (intentionally) not link against
+    ``libpython``. The symbols will be resolved when the extension library
+    is loaded into a Python binary. This is preferable because you might
+    have several different installations of a given Python version (e.g. the
+    system-provided Python, and one that ships with a piece of commercial
+    software). In this way, the plugin will work with both versions, instead
+    of possibly importing a second Python library into a process that already
+    contains one (which will lead to a segfault).
+
 Generating binding code automatically
 =====================================
 

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -14,7 +14,14 @@ On Linux, you can compile an example such as the ones given in
 
 .. code-block:: bash
 
-    $ c++ -O3 -Wall -shared -std=c++11 -fPIC `python -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+    $ c++ -O3 -Wall -shared -std=c++11 -fPIC `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+
+Here, the ``python3 -m pybind11 --includes`` fetches the include paths for
+Python and pybind11 headers. It assumes that you're using Python 3 and have
+the pybind11 module installed. If you're using Python 2, just change the
+executable appropriately. If the pybind11 module isn't available, you can
+replace this command with manually specified include paths:
+``-I <path-to-python-includes>`` and  ``-I <path-to-pybind11>/include``.
 
 Note that Python 2.7 modules don't use a special suffix, so you should simply
 use ``example.so`` instead of ``example`python3-config --extension-suffix```.
@@ -28,7 +35,7 @@ building the module:
 
 .. code-block:: bash
 
-    $ c++ -O3 -Wall -shared -std=c++11 -undefined dynamic_lookup `python -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+    $ c++ -O3 -Wall -shared -std=c++11 -undefined dynamic_lookup `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
 
 In general, it is advisable to include several additional build parameters
 that can considerably reduce the size of the created binary. Refer to section

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -213,8 +213,8 @@ information about usage in C++, see :doc:`/advanced/embedding`.
 Building manually
 =================
 
-pybind11 is a header-only-library, hence it is not necessary to link against
-any special libraries (other than Python itself).
+pybind11 is a header-only library, hence it is not necessary to link against
+any special libraries and there are no intermediate (magic) translation steps.
 
 On Linux, you can compile an example such as the one given in
 :ref:`simple_example` using the following command:

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -223,16 +223,18 @@ On Linux, you can compile an example such as the one given in
 
     $ c++ -O3 -Wall -shared -std=c++11 -fPIC `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
 
-Here, the ``python3 -m pybind11 --includes`` fetches the include paths for
-Python and pybind11 headers. It assumes that you're using Python 3 and have
-the pybind11 module installed. If you're using Python 2, just change the
-executable appropriately. If the pybind11 module isn't available, you can
-replace this command with manually specified include paths:
-``-I <path-to-python-includes>`` and  ``-I <path-to-pybind11>/include``.
+The flags given here assume that you're using Python 3. For Python 2, just
+change the executable appropriately (to ``python`` or ``python2``).
+
+The ``python3 -m pybind11 --includes`` command fetches the include paths for
+both pybind11 and Python headers. This assumes that pybind11 has been installed
+using ``pip`` or ``conda``. If it hasn't, you can also manually specify
+``-I <path-to-pybind11>/include`` together with the Python includes path
+``python3-config --includes``.
 
 Note that Python 2.7 modules don't use a special suffix, so you should simply
 use ``example.so`` instead of ``example`python3-config --extension-suffix```.
-Besides, ``--extension-suffix`` option may or may not be available, depending
+Besides, the ``--extension-suffix`` option may or may not be available, depending
 on the distribution; in the latter case, the module extension can be manually
 set to ``.so``.
 

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -1,5 +1,37 @@
+.. _compiling:
+
 Build systems
 #############
+
+Building manually
+=================
+
+pybind11 is a header-only-library, hence it is not necessary to link against
+any special libraries (other than Python itself).
+
+On Linux, the above example can be compiled using the following command:
+
+.. code-block:: bash
+
+    $ c++ -O3 -Wall -shared -std=c++11 -fPIC `python -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+
+Note that on Python 2.7.x ``python-config`` has to be used instead of
+``python3-config`` in the command above. Besides, ``--extension-suffix``
+option may or may not be available, depending on the distribution; in the latter
+case, the module extension can be manually set to ``.so``.
+
+On Mac OS: the build command is almost the same but it also requires passing
+the ``-undefined dynamic_lookup`` flag so as to ignore missing symbols when
+building the module:
+
+.. code-block:: bash
+
+    $ c++ -O3 -Wall -shared -std=c++11 -undefined dynamic_lookup `python -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+
+In general, it is advisable to include several additional build parameters
+that can considerably reduce the size of the created binary. Refer to section
+:ref:`cmake` for a detailed example of a suitable cross-platform CMake-based
+build system that works on all platforms including Windows.
 
 Building with setuptools
 ========================

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -3,45 +3,6 @@
 Build systems
 #############
 
-Building manually
-=================
-
-pybind11 is a header-only-library, hence it is not necessary to link against
-any special libraries (other than Python itself).
-
-On Linux, you can compile an example such as the ones given in
-:ref:`simple_example` using the following command:
-
-.. code-block:: bash
-
-    $ c++ -O3 -Wall -shared -std=c++11 -fPIC `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
-
-Here, the ``python3 -m pybind11 --includes`` fetches the include paths for
-Python and pybind11 headers. It assumes that you're using Python 3 and have
-the pybind11 module installed. If you're using Python 2, just change the
-executable appropriately. If the pybind11 module isn't available, you can
-replace this command with manually specified include paths:
-``-I <path-to-python-includes>`` and  ``-I <path-to-pybind11>/include``.
-
-Note that Python 2.7 modules don't use a special suffix, so you should simply
-use ``example.so`` instead of ``example`python3-config --extension-suffix```.
-Besides, ``--extension-suffix`` option may or may not be available, depending
-on the distribution; in the latter case, the module extension can be manually
-set to ``.so``.
-
-On Mac OS: the build command is almost the same but it also requires passing
-the ``-undefined dynamic_lookup`` flag so as to ignore missing symbols when
-building the module:
-
-.. code-block:: bash
-
-    $ c++ -O3 -Wall -shared -std=c++11 -undefined dynamic_lookup `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
-
-In general, it is advisable to include several additional build parameters
-that can considerably reduce the size of the created binary. Refer to section
-:ref:`cmake` for a detailed example of a suitable cross-platform CMake-based
-build system that works on all platforms including Windows.
-
 Building with setuptools
 ========================
 
@@ -247,6 +208,46 @@ information about usage in C++, see :doc:`/advanced/embedding`.
     add_executable(example main.cpp)
     target_link_libraries(example PRIVATE pybind11::embed)
 
+.. _building_manually:
+
+Building manually
+=================
+
+pybind11 is a header-only-library, hence it is not necessary to link against
+any special libraries (other than Python itself).
+
+On Linux, you can compile an example such as the one given in
+:ref:`simple_example` using the following command:
+
+.. code-block:: bash
+
+    $ c++ -O3 -Wall -shared -std=c++11 -fPIC `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+
+Here, the ``python3 -m pybind11 --includes`` fetches the include paths for
+Python and pybind11 headers. It assumes that you're using Python 3 and have
+the pybind11 module installed. If you're using Python 2, just change the
+executable appropriately. If the pybind11 module isn't available, you can
+replace this command with manually specified include paths:
+``-I <path-to-python-includes>`` and  ``-I <path-to-pybind11>/include``.
+
+Note that Python 2.7 modules don't use a special suffix, so you should simply
+use ``example.so`` instead of ``example`python3-config --extension-suffix```.
+Besides, ``--extension-suffix`` option may or may not be available, depending
+on the distribution; in the latter case, the module extension can be manually
+set to ``.so``.
+
+On Mac OS: the build command is almost the same but it also requires passing
+the ``-undefined dynamic_lookup`` flag so as to ignore missing symbols when
+building the module:
+
+.. code-block:: bash
+
+    $ c++ -O3 -Wall -shared -std=c++11 -undefined dynamic_lookup `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+
+In general, it is advisable to include several additional build parameters
+that can considerably reduce the size of the created binary. Refer to section
+:ref:`cmake` for a detailed example of a suitable cross-platform CMake-based
+build system that works on all platforms including Windows.
 
 Generating binding code automatically
 =====================================

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -9,16 +9,18 @@ Building manually
 pybind11 is a header-only-library, hence it is not necessary to link against
 any special libraries (other than Python itself).
 
-On Linux, the above example can be compiled using the following command:
+On Linux, you can compile an example such as the ones given in
+:ref:`simple_example` using the following command:
 
 .. code-block:: bash
 
     $ c++ -O3 -Wall -shared -std=c++11 -fPIC `python -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
 
-Note that on Python 2.7.x ``python-config`` has to be used instead of
-``python3-config`` in the command above. Besides, ``--extension-suffix``
-option may or may not be available, depending on the distribution; in the latter
-case, the module extension can be manually set to ``.so``.
+Note that Python 2.7 modules don't use a special suffix, so you should simply
+use ``example.so`` instead of ``example`python3-config --extension-suffix```.
+Besides, ``--extension-suffix`` option may or may not be available, depending
+on the distribution; in the latter case, the module extension can be manually
+set to ``.so``.
 
 On Mac OS: the build command is almost the same but it also requires passing
 the ``-undefined dynamic_lookup`` flag so as to ignore missing symbols when


### PR DESCRIPTION
Please correct me if I'm wrong; I've double-checked this today on ubuntu's python3-dev and pyenv Python on OS X:

- On Linux, it doesn't build without `-fPIC` explicitly specified
- `python-config --ldflags` is unnecessary
- On Python 3, one has to use `python3-config`
- On Mac OS, it doesn't build without `-undefined dynamic_lookup`

The changes to the docs reflect all of the above points.