### PR TITLE
def_readwrite/readonly: bind using class type, not inferred type

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1042,15 +1042,17 @@ public:
 
     template <typename C, typename D, typename... Extra>
     class_ &def_readwrite(const char *name, D C::*pm, const Extra&... extra) {
-        cpp_function fget([pm](const C &c) -> const D &{ return c.*pm; }, is_method(*this)),
-                     fset([pm](C &c, const D &value) { c.*pm = value; }, is_method(*this));
+        static_assert(std::is_base_of<C, type>::value, "def_readwrite() requires a class member (or base class member)");
+        cpp_function fget([pm](const type &c) -> const D &{ return c.*pm; }, is_method(*this)),
+                     fset([pm](type &c, const D &value) { c.*pm = value; }, is_method(*this));
         def_property(name, fget, fset, return_value_policy::reference_internal, extra...);
         return *this;
     }
 
     template <typename C, typename D, typename... Extra>
     class_ &def_readonly(const char *name, const D C::*pm, const Extra& ...extra) {
-        cpp_function fget([pm](const C &c) -> const D &{ return c.*pm; }, is_method(*this));
+        static_assert(std::is_base_of<C, type>::value, "def_readonly() requires a class member (or base class member)");
+        cpp_function fget([pm](const type &c) -> const D &{ return c.*pm; }, is_method(*this));
         def_property_readonly(name, fget, return_value_policy::reference_internal, extra...);
         return *this;
     }

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -61,7 +61,7 @@ def test_methods_and_attributes():
 
 
 def test_properties():
-    from pybind11_tests import TestProperties
+    from pybind11_tests import TestProperties, RegisteredDerivedInheritsMember
 
     instance = TestProperties()
 
@@ -78,6 +78,12 @@ def test_properties():
 
     instance.def_property = 3
     assert instance.def_property == 3
+
+    z = RegisteredDerivedInheritsMember()
+    assert z.ro == 6
+    assert z.rw == 13
+    z.rw += z.ro
+    assert z.ro == 6 and z.rw == 19
 
 
 def test_copy_method():


### PR DESCRIPTION
Current `def_readwrite`/`def_readonly` create getter/setter lambdas that
take the inferred type `C` as the first argument, but this is a problem
if the member is actually a base class member (e.g.

    derived.def_readonly("x", &Base::x)

because this ends up creating a setter/getter that aren't callable with
a derived instance when `Base` isn't registered: it invariably produces
an invalid argument failure when attempting to access the property due
to the `D` instance/`B` argument mismatch.

This commit changes the generated lambdas to use the `type` (as given in
`class_<type>`) rather than the inferred `C` for the lambdas, and adds a
static_assert failure for an attempt to call it with a member that isn't
part of `type` (or a base class).

Fixes #910