### PR TITLE
Avoid std::type_info pointer comparison

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -243,17 +243,17 @@ struct type_record {
     /// Is the default (unique_ptr) holder type used?
     bool default_holder : 1;
 
-    PYBIND11_NOINLINE void add_base(const std::type_info *base, void *(*caster)(void *)) {
-        auto base_info = detail::get_type_info(*base, false);
+    PYBIND11_NOINLINE void add_base(const std::type_info &base, void *(*caster)(void *)) {
+        auto base_info = detail::get_type_info(base, false);
         if (!base_info) {
-            std::string tname(base->name());
+            std::string tname(base.name());
             detail::clean_type_id(tname);
             pybind11_fail("generic_type: type \"" + std::string(name) +
                           "\" referenced unknown base type \"" + tname + "\"");
         }
 
         if (default_holder != base_info->default_holder) {
-            std::string tname(base->name());
+            std::string tname(base.name());
             detail::clean_type_id(tname);
             pybind11_fail("generic_type: type \"" + std::string(name) + "\" " +
                     (default_holder ? "does not have" : "has") +
@@ -384,7 +384,7 @@ struct process_attribute<T, enable_if_t<is_pyobject<T>::value>> : process_attrib
 /// Process a parent class attribute (deprecated, does not support multiple inheritance)
 template <typename T>
 struct process_attribute<base<T>> : process_attribute_default<base<T>> {
-    static void init(const base<T> &, type_record *r) { r->add_base(&typeid(T), nullptr); }
+    static void init(const base<T> &, type_record *r) { r->add_base(typeid(T), nullptr); }
 };
 
 /// Process a multiple inheritance attribute

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -646,14 +646,14 @@ protected:
     // isn't needed or can't be used.  If the type is unknown, sets the error and returns a pair
     // with .second = nullptr.  (p.first = nullptr is not an error: it becomes None).
     PYBIND11_NOINLINE static std::pair<const void *, const type_info *> src_and_type(
-            const void *src, const std::type_info *cast_type, const std::type_info *rtti_type = nullptr) {
+            const void *src, const std::type_info &cast_type, const std::type_info *rtti_type = nullptr) {
         auto &internals = get_internals();
-        auto it = internals.registered_types_cpp.find(std::type_index(*cast_type));
+        auto it = internals.registered_types_cpp.find(std::type_index(cast_type));
         if (it != internals.registered_types_cpp.end())
             return {src, (const type_info *) it->second};
 
         // Not found, set error:
-        std::string tname = (rtti_type ? rtti_type : cast_type)->name();
+        std::string tname = rtti_type ? rtti_type->name() : cast_type.name();
         detail::clean_type_id(tname);
         std::string msg = "Unregistered type : " + tname;
         PyErr_SetString(PyExc_TypeError, msg.c_str());
@@ -730,11 +730,11 @@ public:
     static std::pair<const void *, const type_info *> src_and_type(const itype *src) {
         const void *vsrc = src;
         auto &internals = get_internals();
-        auto cast_type = &typeid(itype);
+        auto &cast_type = typeid(itype);
         const std::type_info *instance_type = nullptr;
         if (vsrc) {
             instance_type = &typeid(*src);
-            if (instance_type != cast_type) {
+            if (*instance_type != cast_type) {
                 // This is a base pointer to a derived type; if it is a pybind11-registered type, we
                 // can get the correct derived pointer (which may be != base pointer) by a
                 // dynamic_cast to most derived type:
@@ -751,7 +751,7 @@ public:
     // Non-polymorphic type, so no dynamic casting; just call the generic version directly
     template <typename T = itype, enable_if_t<!std::is_polymorphic<T>::value, int> = 0>
     static std::pair<const void *, const type_info *> src_and_type(const itype *src) {
-        return type_caster_generic::src_and_type(src, &typeid(itype));
+        return type_caster_generic::src_and_type(src, typeid(itype));
     }
 
     static handle cast(const itype *src, return_value_policy policy, handle parent) {
@@ -1700,7 +1700,7 @@ constexpr arg operator"" _a(const char *name, size_t) { return arg(name); }
 
 NAMESPACE_BEGIN(detail)
 
-// forward declaration
+// forward declaration (definition in attr.h)
 struct function_record;
 
 /// Internal data associated with a single function call

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -46,7 +46,8 @@ public:
             auto c = reinterpret_borrow<capsule>(PyCFunction_GET_SELF(cfunc.ptr()));
             auto rec = (function_record *) c;
 
-            if (rec && rec->is_stateless && rec->data[1] == &typeid(function_type)) {
+            if (rec && rec->is_stateless &&
+                    typeid(function_type) == *reinterpret_cast<const std::type_info *>(rec->data[1])) {
                 struct capture { function_type f; };
                 value = ((capture *) &rec->data)->f;
                 return true;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -968,7 +968,7 @@ public:
 
     template <typename Base, detail::enable_if_t<is_base<Base>::value, int> = 0>
     static void add_base(detail::type_record &rec) {
-        rec.add_base(&typeid(Base), [](void *src) -> void * {
+        rec.add_base(typeid(Base), [](void *src) -> void * {
             return static_cast<Base *>(reinterpret_cast<type *>(src));
         });
     }


### PR DESCRIPTION
Type equality needs to be done with `operator==` on the
`std::type_info` object; we do this in some places, but in a few places
use pointer equality (i.e. the equivalent of &typeid(A) == &typeid(B)).
This replaces all such cases with std::type_info equality comparisons.

I noticed this in investigation of #912, but it does *not* fix that issue.