### PR TITLE
Fix GIL release and acquire when embedding the interpreter

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1661,9 +1661,13 @@ private:
 class gil_scoped_release {
 public:
     explicit gil_scoped_release(bool disassoc = false) : disassoc(disassoc) {
+        // `get_internals()` must be called here unconditionally in order to initialize
+        // `internals.tstate` for subsequent `gil_scoped_acquire` calls. Otherwise, an
+        // initialization race could occur as multiple threads try `gil_scoped_acquire`.
+        const auto &internals = detail::get_internals();
         tstate = PyEval_SaveThread();
         if (disassoc) {
-            auto key = detail::get_internals().tstate;
+            auto key = internals.tstate;
             #if PY_MAJOR_VERSION < 3
                 PyThread_delete_key_value(key);
             #else

--- a/tests/test_embed/CMakeLists.txt
+++ b/tests/test_embed/CMakeLists.txt
@@ -26,6 +26,9 @@ else()
   target_link_libraries(test_embed PRIVATE ${PYTHON_LIBRARIES})
 endif()
 
+find_package(Threads REQUIRED)
+target_link_libraries(test_embed PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+
 add_custom_target(cpptest COMMAND $<TARGET_FILE:test_embed>
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_dependencies(check cpptest)


### PR DESCRIPTION
This fixes a race condition when multiple threads try to acquire the GIL before `detail::internals` have been initialized. `gil_scoped_release` is now tasked with initializing `internals` (guaranteed single-threaded) to ensure the safety of subsequent `acquire` calls from multiple threads.

An alternative would be to have `py::initialize_interpreter()` do this, but strictly single-threaded programs don't need to initialize the GIL at all (which slows down the interpreter in general). Another way would be to ensure thread safety by locking in `detail::get_internals()`, but that's overkill.