### PR TITLE
`python -m pybind11 --includes` prints include paths

### DIFF
--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+
+import argparse
+import sys
+import sysconfig
+
+from . import get_include
+
+
+def print_includes():
+    dirs = [sysconfig.get_path('include')]
+    if sysconfig.get_path('platinclude') not in dirs:
+        dirs.append(sysconfig.get_path('platinclude'))
+    if get_include() not in dirs:
+        dirs.append(get_include())
+    print(' '.join('-I' + d for d in dirs))
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='python -m pybind11')
+    parser.add_argument('--includes', action='store_true',
+                        help='Include flags for both pybind11 and Python headers.')
+    args = parser.parse_args()
+    if not sys.argv[1:]:
+        parser.print_help()
+    if args.includes:
+        print_includes()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
A very minor/cosmetic addition, makes building modules manually slightly easier:

```sh
$ c++ -I `python -m pybind11`
```

instead of

```sh
$ c++ -I `python -c 'import pybind11; print(pybind11.get_include())'`
```

The docs in #907 could also get updated if this gets accepted.