### PR TITLE
Add a life support system for type_caster temporaries (+ binary size reduction)

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -474,6 +474,7 @@ struct internals {
     std::unordered_map<const PyObject *, std::vector<PyObject *>> patients;
     std::forward_list<void (*) (std::exception_ptr)> registered_exception_translators;
     std::unordered_map<std::string, void *> shared_data; // Custom data to be shared across extensions
+    std::vector<PyObject *> loader_patient_stack; // Used by `loader_life_support`
     PyTypeObject *static_property_type;
     PyTypeObject *default_metaclass;
     PyObject *instance_base;

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -462,6 +462,7 @@ public:
             if (!fits || !fits.template stride_compatible<props>())
                 return false;
             copy_or_ref = std::move(copy);
+            loader_life_support::add_patient(copy_or_ref);
         }
 
         ref.reset();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -573,6 +573,7 @@ protected:
 
                 // 6. Call the function.
                 try {
+                    loader_life_support guard{};
                     result = func.impl(call);
                 } catch (reference_cast_error &) {
                     result = PYBIND11_TRY_NEXT_OVERLOAD;
@@ -601,6 +602,7 @@ protected:
                 // The no-conversion pass finished without success, try again with conversion allowed
                 for (auto &call : second_pass) {
                     try {
+                        loader_life_support guard{};
                         result = call.func.impl(call);
                     } catch (reference_cast_error &) {
                         result = PYBIND11_TRY_NEXT_OVERLOAD;

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -119,3 +119,11 @@ def test_override_static():
     assert isinstance(b, m.MyBase)
     assert isinstance(d1, m.MyDerived)
     assert isinstance(d2, m.MyDerived)
+
+
+def test_implicit_conversion_life_support():
+    """Ensure the lifetime of temporary objects created for implicit conversions"""
+    assert m.implicitly_convert_argument(UserType(5)) == 5
+    assert m.implicitly_convert_variable(UserType(5)) == 5
+
+    assert "outside a bound function" in m.implicitly_convert_variable_fail(UserType(5))

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -602,6 +602,21 @@ def test_nocopy_wrapper():
             ', flags.c_contiguous' in str(excinfo.value))
 
 
+def test_eigen_ref_life_support():
+    """Ensure the lifetime of temporary arrays created by the `Ref` caster
+
+    The `Ref` caster sometimes creates a copy which needs to stay alive. This needs to
+    happen both for directs casts (just the array) or indirectly (e.g. list of arrays).
+    """
+    from pybind11_tests import get_elem_direct, get_elem_indirect
+
+    a = np.full(shape=10, fill_value=8, dtype=np.int8)
+    assert get_elem_direct(a) == 8
+
+    list_of_a = [a]
+    assert get_elem_indirect(list_of_a) == 8
+
+
 def test_special_matrix_objects():
     from pybind11_tests import incr_diag, symmetric_upper, symmetric_lower
 


### PR DESCRIPTION
The first commit here changes the handling of temporary objects created by `type_caster::load()`. It uses an RAII `loader_life_support` class, placed in `dispatcher`, which holds a list of patients only for the lifetime of the function call. This has two nice advantages:

1. Supercasters don't need to care about maintaining the life of their subcasters.
2. Switching `type_caster_generic` to this system reduced the binary size of the test module by 3-4% (!), depending on the compiler. The main reason seems to be the removal of `object temp` from `type_caster_generic`, which makes the struct trivially copyable.

The second commit fixes #916 (alternative to #917) by using the new system in the `Eigen::Ref` caster.