### PR TITLE
tuple/pair/stl.h casters: use rvalue subcasting when casting an rvalue tuple/pair/container

### DIFF
--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -86,6 +86,16 @@ TEST_SUBMODULE(builtin_casters, m) {
         return std::make_tuple(std::get<2>(input), std::get<1>(input), std::get<0>(input));
     }, "Return a triple in reversed order");
     m.def("empty_tuple", []() { return std::tuple<>(); });
+    static std::pair<RValueCaster, RValueCaster> lvpair;
+    static std::tuple<RValueCaster, RValueCaster, RValueCaster> lvtuple;
+    static std::pair<RValueCaster, std::tuple<RValueCaster, std::pair<RValueCaster, RValueCaster>>> lvnested;
+    m.def("rvalue_pair", []() { return std::make_pair(RValueCaster{}, RValueCaster{}); });
+    m.def("lvalue_pair", []() -> const decltype(lvpair) & { return lvpair; });
+    m.def("rvalue_tuple", []() { return std::make_tuple(RValueCaster{}, RValueCaster{}, RValueCaster{}); });
+    m.def("lvalue_tuple", []() -> const decltype(lvtuple) & { return lvtuple; });
+    m.def("rvalue_nested", []() {
+        return std::make_pair(RValueCaster{}, std::make_tuple(RValueCaster{}, std::make_pair(RValueCaster{}, RValueCaster{}))); });
+    m.def("lvalue_nested", []() -> const decltype(lvnested) & { return lvnested; });
 
     // test_builtins_cast_return_none
     m.def("return_none_string", []() -> std::string * { return nullptr; });

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -85,7 +85,7 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("tuple_passthrough", [](std::tuple<bool, std::string, int> input) {
         return std::make_tuple(std::get<2>(input), std::get<1>(input), std::get<0>(input));
     }, "Return a triple in reversed order");
-
+    m.def("empty_tuple", []() { return std::tuple<>(); });
 
     // test_builtins_cast_return_none
     m.def("return_none_string", []() -> std::string * { return nullptr; });

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -201,6 +201,13 @@ def test_tuple(doc):
         Return a triple in reversed order
     """
 
+    assert m.rvalue_pair() == ("rvalue", "rvalue")
+    assert m.lvalue_pair() == ("lvalue", "lvalue")
+    assert m.rvalue_tuple() == ("rvalue", "rvalue", "rvalue")
+    assert m.lvalue_tuple() == ("lvalue", "lvalue", "lvalue")
+    assert m.rvalue_nested() == ("rvalue", ("rvalue", ("rvalue", "rvalue")))
+    assert m.lvalue_nested() == ("lvalue", ("lvalue", ("lvalue", "lvalue")))
+
 
 def test_builtins_cast_return_none():
     """Casters produced with PYBIND11_TYPE_CASTER() should convert nullptr to None"""

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -188,6 +188,7 @@ def test_tuple(doc):
     # Any sequence can be cast to a std::pair or std::tuple
     assert m.pair_passthrough([True, "test"]) == ("test", True)
     assert m.tuple_passthrough([True, "test", 5]) == (5, "test", True)
+    assert m.empty_tuple() == ()
 
     assert doc(m.pair_passthrough) == """
         pair_passthrough(arg0: Tuple[bool, str]) -> Tuple[str, bool]

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -58,6 +58,25 @@ def test_set(doc):
     assert doc(m.load_set) == "load_set(arg0: Set[str]) -> bool"
 
 
+def test_recursive_casting():
+    """Tests that stl casters preserve lvalue/rvalue context for container values"""
+    assert m.cast_rv_vector() == ["rvalue", "rvalue"]
+    assert m.cast_lv_vector() == ["lvalue", "lvalue"]
+    assert m.cast_rv_array() == ["rvalue", "rvalue", "rvalue"]
+    assert m.cast_lv_array() == ["lvalue", "lvalue"]
+    assert m.cast_rv_map() == {"a": "rvalue"}
+    assert m.cast_lv_map() == {"a": "lvalue", "b": "lvalue"}
+    assert m.cast_rv_nested() == [[[{"b": "rvalue", "c": "rvalue"}], [{"a": "rvalue"}]]]
+    assert m.cast_lv_nested() == {
+        "a": [[["lvalue", "lvalue"]], [["lvalue", "lvalue"]]],
+        "b": [[["lvalue", "lvalue"], ["lvalue", "lvalue"]]]
+    }
+
+    # Issue #853 test case:
+    z = m.cast_unique_ptr_vector()
+    assert z[0].value == 7 and z[1].value == 42
+
+
 def test_move_out_container():
     """Properties use the `reference_internal` policy by default. If the underlying function
     returns an rvalue, the policy is automatically changed to `move` to avoid referencing

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -15,11 +15,6 @@
 #include <deque>
 #include <unordered_map>
 
-#ifdef _MSC_VER
-// We get some really long type names here which causes MSVC to emit warnings
-#  pragma warning(disable: 4503) // warning C4503: decorated name length exceeded, name was truncated
-#endif
-
 class El {
 public:
     El() = delete;


### PR DESCRIPTION
The tuple caster had only a const-lvalue-ref cast method, which meant
that subcaster casts couldn't distinguish between an lvalue and rvalue
cast; this caused Eigen values in a tuple, for instance, to end up with
a readonly flag.

This fixes it by adding an rvalue versions of `cast()` and `cast_impl()`
that move the tuple values when subcasting them.

Fixes #935 and #853 

Edit: I've updated this PR to also consolidate the tuple/pair casters into a single `tuple_caster` implementation.  It is essentially just the `std::tuple` implementation, which works perfectly well with `std::pair`s.  Thus the fix here also gets applied to `std::pair`.

Edit 2: Also `stl.h` casters get the same treatment, which (incidentally) also fixes #853.