### PR TITLE
Fix compilation with Intel's compiler

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -846,7 +846,7 @@ protected:
     }
 
     template <typename T, typename = enable_if_t<std::is_move_constructible<T>::value>>
-    static auto make_move_constructor(const T *x) -> decltype(new T(std::move(*(T *) x)), Constructor{}) {
+    static auto make_move_constructor(const T *x) -> decltype(new T(std::move(*const_cast<T *>(x))), Constructor{}) {
         return [](const void *arg) -> void * {
             return new T(std::move(*const_cast<T *>(reinterpret_cast<const T *>(arg))));
         };
@@ -1438,7 +1438,7 @@ protected:
         return false;
     }
 
-    static constexpr bool try_direct_conversions(handle) { return false; }
+    static bool try_direct_conversions(handle) { return false; }
 
 
     holder_type holder;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -21,8 +21,12 @@
 #  pragma warning(disable: 4522) // warning C4522: multiple assignment operators specified
 #elif defined(__INTEL_COMPILER)
 #  pragma warning(push)
+#  pragma warning(disable: 68)    // integer conversion resulted in a change of sign
 #  pragma warning(disable: 186)   // pointless comparison of unsigned integer with zero
+#  pragma warning(disable: 878)   // incompatible exception specifications
 #  pragma warning(disable: 1334)  // the "template" keyword used for syntactic disambiguation may only be used within a template
+#  pragma warning(disable: 1682)  // implicit conversion of a 64-bit integral type to a smaller integral type (potential portability problem)
+#  pragma warning(disable: 1875)  // offsetof applied to non-POD (Plain Old Data) types is nonstandard
 #  pragma warning(disable: 2196)  // warning #2196: routine is both "inline" and "noinline"
 #elif defined(__GNUG__) && !defined(__clang__)
 #  pragma GCC diagnostic push


### PR DESCRIPTION
ICC failed to compile and was reporting that `try_direct_conversions()` cannot be `constexpr` because `handle` is not a literal type (it is, ICC just doesn't know it). The fix removes `constexpr` from the function since it isn't strictly needed.

This commit also suppresses new false positive warnings which mostly appear in `constexpr` contexts (where the compiler knows conversions are safe). Suppressing all of these may seem heavy-handed, but these really are false positives -- other compilers have the same warnings enabled without any of the issues for compile-time constants.