### PR TITLE
Added *.class to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ MANIFEST
 /docs/.build
 *.py[co]
 *.egg-info
+*.class
 *~
 .DS_Store
 /dist


### PR DESCRIPTION
Some IDEs such as NetBeans use Jython as its internal Python interpreter/parser, which causes `*.class` files to appear seemingly out of nowhere. This diff adds it to `.gitignore` so that they don't creep in `git status` all the time, which is especially annoying when `pybind11` is used as a Git submodule.