### PR TITLE
Detect c++ standard unconditionally (needed for embed target)

### DIFF
--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -90,7 +90,6 @@ if(NOT TARGET ${PN}::pybind11)
       set_property(TARGET ${PN}::module APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${PYTHON_LIBRARIES})
     endif()
 
-    select_cxx_standard()
     set_property(TARGET ${PN}::pybind11 APPEND PROPERTY INTERFACE_COMPILE_OPTIONS "${PYBIND11_CPP_STANDARD}")
 
     get_property(_iid TARGET ${PN}::pybind11 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -18,27 +18,27 @@ find_package(PythonLibsNew ${PYBIND11_PYTHON_VERSION} REQUIRED)
 include(CheckCXXCompilerFlag)
 include(CMakeParseArguments)
 
-function(select_cxx_standard)
-  if(NOT PYBIND11_CPP_STANDARD)
-    if(NOT MSVC)
-      check_cxx_compiler_flag("-std=c++14" HAS_CPP14_FLAG)
-      check_cxx_compiler_flag("-std=c++11" HAS_CPP11_FLAG)
+if(NOT PYBIND11_CPP_STANDARD)
+  if(NOT MSVC)
+    check_cxx_compiler_flag("-std=c++14" HAS_CPP14_FLAG)
 
-      if (HAS_CPP14_FLAG)
-        set(PYBIND11_CPP_STANDARD -std=c++14)
-      elseif (HAS_CPP11_FLAG)
+    if (HAS_CPP14_FLAG)
+      set(PYBIND11_CPP_STANDARD -std=c++14)
+    else()
+      check_cxx_compiler_flag("-std=c++11" HAS_CPP11_FLAG)
+      if (HAS_CPP11_FLAG)
         set(PYBIND11_CPP_STANDARD -std=c++11)
       else()
         message(FATAL_ERROR "Unsupported compiler -- pybind11 requires C++11 support!")
       endif()
-    elseif(MSVC)
-      set(PYBIND11_CPP_STANDARD /std:c++14)
     endif()
-
-    set(PYBIND11_CPP_STANDARD ${PYBIND11_CPP_STANDARD} CACHE STRING
-        "C++ standard flag, e.g. -std=c++11, -std=c++14, /std:c++14.  Defaults to C++14 mode." FORCE)
+  elseif(MSVC)
+    set(PYBIND11_CPP_STANDARD /std:c++14)
   endif()
-endfunction()
+
+  set(PYBIND11_CPP_STANDARD ${PYBIND11_CPP_STANDARD} CACHE STRING
+      "C++ standard flag, e.g. -std=c++11, -std=c++14, /std:c++14.  Defaults to C++14 mode." FORCE)
+endif()
 
 # Checks whether the given CXX/linker flags can compile and link a cxx file.  cxxflags and
 # linkerflags are lists of flags to use.  The result variable is a unique variable name for each set
@@ -165,7 +165,6 @@ function(pybind11_add_module target_name)
     endif()
   endif()
 
-  select_cxx_standard()
   # Make sure C++11/14 are enabled
   target_compile_options(${target_name} PUBLIC ${PYBIND11_CPP_STANDARD})
 


### PR DESCRIPTION
Currently `select_cxx_standard()`, which sets `PYBIND11_CPP_STANDARD` when not externally set, is only called from `pybind11_add_module()`, but the `embed` target setup (which runs unconditionally) makes use of `${PYBIND11_CPP_STANDARD}`, which isn't set yet.  This commit removes the `select_cxx_standard` function completely and just always runs the standard detection code.

This also tweaks the detection code to not bothering checking for the `-std=c++11` flag when the `-std=c++14` detection succeeded.

Fixes #943.

One odd thing about #943 is that when `pybind11_add_module` was never called at all (and hence `select_cxx_standard()` was never called at all), an embedded target *would* get the `std=c++14` flag, but it's a mystery to me how that was happening.