### PR TITLE
Simplify error_already_set

### DIFF
--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -51,7 +51,6 @@
             pybind11_init_##name(m);                                          \
             return m.ptr();                                                   \
         } catch (pybind11::error_already_set &e) {                            \
-            e.clear();                                                        \
             PyErr_SetString(PyExc_ImportError, e.what());                     \
             return nullptr;                                                   \
         } catch (const std::exception &e) {                                   \

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1754,9 +1754,11 @@ class gil_scoped_release { };
 #endif
 
 error_already_set::~error_already_set() {
-    if (value) {
+    if (type) {
         gil_scoped_acquire gil;
-        clear();
+        type.release().dec_ref();
+        value.release().dec_ref();
+        trace.release().dec_ref();
     }
 }
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -279,6 +279,42 @@ template <typename T> T reinterpret_borrow(handle h) { return {h, object::borrow
 \endrst */
 template <typename T> T reinterpret_steal(handle h) { return {h, object::stolen_t{}}; }
 
+NAMESPACE_BEGIN(detail)
+inline std::string error_string();
+NAMESPACE_END(detail)
+
+/// Fetch and hold an error which was already set in Python.  An instance of this is typically
+/// thrown to propagate python-side errors back through C++ which can either be caught manually or
+/// else falls back to the function dispatcher (which then raises the captured error back to
+/// python).
+class error_already_set : public std::runtime_error {
+public:
+    /// Constructs a new exception from the current Python error indicator, if any.  The current
+    /// Python error indicator will be cleared.
+    error_already_set() : std::runtime_error(detail::error_string()) {
+        PyErr_Fetch(&type.ptr(), &value.ptr(), &trace.ptr());
+    }
+
+    inline ~error_already_set();
+
+    /// Give the currently-held error back to Python, if any.  If there is currently a Python error
+    /// already set it is cleared first.  After this call, the current object no longer stores the
+    /// error variables (but the `.what()` string is still available).
+    void restore() { PyErr_Restore(type.release().ptr(), value.release().ptr(), trace.release().ptr()); }
+
+    // Does nothing; provided for backwards compatibility.
+    PYBIND11_DEPRECATED("Use of error_already_set.clear() is deprecated")
+    void clear() {}
+
+    /// Check if the currently trapped error type matches the given Python exception class (or a
+    /// subclass thereof).  May also be passed a tuple to search for any exception class matches in
+    /// the given tuple.
+    bool matches(handle ex) const { return PyErr_GivenExceptionMatches(ex.ptr(), type.ptr()); }
+
+private:
+    object type, value, trace;
+};
+
 /** \defgroup python_builtins _
     Unless stated otherwise, the following C++ functions behave the same
     as their Python counterparts.

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -120,10 +120,7 @@ TEST_SUBMODULE(exceptions, m) {
         py::dict foo;
         try { foo["bar"]; }
         catch (py::error_already_set& ex) {
-            if (ex.matches(PyExc_KeyError))
-                ex.clear();
-            else
-                throw;
+            if (!ex.matches(PyExc_KeyError)) throw;
         }
     });
 
@@ -156,4 +153,16 @@ TEST_SUBMODULE(exceptions, m) {
         }
         return false;
     });
+
+    // test_nested_throws
+    m.def("try_catch", [m](py::object exc_type, py::function f, py::args args) {
+        try { f(*args); }
+        catch (py::error_already_set &ex) {
+            if (ex.matches(exc_type))
+                py::print(ex.what());
+            else
+                throw;
+        }
+    });
+
 }

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,87 +1,78 @@
 import pytest
 
+from pybind11_tests import exceptions as m
+
 
 def test_std_exception(msg):
-    from pybind11_tests import throw_std_exception
-
     with pytest.raises(RuntimeError) as excinfo:
-        throw_std_exception()
+        m.throw_std_exception()
     assert msg(excinfo.value) == "This exception was intentionally thrown."
 
 
 def test_error_already_set(msg):
-    from pybind11_tests import throw_already_set
-
     with pytest.raises(RuntimeError) as excinfo:
-        throw_already_set(False)
+        m.throw_already_set(False)
     assert msg(excinfo.value) == "Unknown internal error occurred"
 
     with pytest.raises(ValueError) as excinfo:
-        throw_already_set(True)
+        m.throw_already_set(True)
     assert msg(excinfo.value) == "foo"
 
 
 def test_python_call_in_catch():
-    from pybind11_tests import python_call_in_destructor
-
     d = {}
-    assert python_call_in_destructor(d) is True
+    assert m.python_call_in_destructor(d) is True
     assert d["good"] is True
 
 
 def test_exception_matches():
-    from pybind11_tests import exception_matches
-    exception_matches()
+    m.exception_matches()
 
 
 def test_custom(msg):
-    from pybind11_tests import (MyException, MyException5, MyException5_1,
-                                throws1, throws2, throws3, throws4, throws5, throws5_1,
-                                throws_logic_error)
-
-    # Can we catch a MyException?"
-    with pytest.raises(MyException) as excinfo:
-        throws1()
+    # Can we catch a MyException?
+    with pytest.raises(m.MyException) as excinfo:
+        m.throws1()
     assert msg(excinfo.value) == "this error should go to a custom type"
 
     # Can we translate to standard Python exceptions?
     with pytest.raises(RuntimeError) as excinfo:
-        throws2()
+        m.throws2()
     assert msg(excinfo.value) == "this error should go to a standard Python exception"
 
     # Can we handle unknown exceptions?
     with pytest.raises(RuntimeError) as excinfo:
-        throws3()
+        m.throws3()
     assert msg(excinfo.value) == "Caught an unknown exception!"
 
     # Can we delegate to another handler by rethrowing?
-    with pytest.raises(MyException) as excinfo:
-        throws4()
+    with pytest.raises(m.MyException) as excinfo:
+        m.throws4()
     assert msg(excinfo.value) == "this error is rethrown"
 
-    # "Can we fall-through to the default handler?"
+    # Can we fall-through to the default handler?
     with pytest.raises(RuntimeError) as excinfo:
-        throws_logic_error()
+        m.throws_logic_error()
     assert msg(excinfo.value) == "this error should fall through to the standard handler"
 
     # Can we handle a helper-declared exception?
-    with pytest.raises(MyException5) as excinfo:
-        throws5()
+    with pytest.raises(m.MyException5) as excinfo:
+        m.throws5()
     assert msg(excinfo.value) == "this is a helper-defined translated exception"
 
     # Exception subclassing:
-    with pytest.raises(MyException5) as excinfo:
-        throws5_1()
+    with pytest.raises(m.MyException5) as excinfo:
+        m.throws5_1()
     assert msg(excinfo.value) == "MyException5 subclass"
-    assert isinstance(excinfo.value, MyException5_1)
+    assert isinstance(excinfo.value, m.MyException5_1)
 
-    with pytest.raises(MyException5_1) as excinfo:
-        throws5_1()
+    with pytest.raises(m.MyException5_1) as excinfo:
+        m.throws5_1()
     assert msg(excinfo.value) == "MyException5 subclass"
 
-    with pytest.raises(MyException5) as excinfo:
+    with pytest.raises(m.MyException5) as excinfo:
         try:
-            throws5()
-        except MyException5_1:
+            m.throws5()
+        except m.MyException5_1:
             raise RuntimeError("Exception error: caught child from parent")
     assert msg(excinfo.value) == "this is a helper-defined translated exception"


### PR DESCRIPTION
`error_already_set` is more complicated than it needs to be, partly because it manages reference counts itself rather than using `py::object`, and partly because it tries to do more exception clearing than is needed.  This commit greatly simplifies it, and (hopefully) fixes #927.

I hope I'm not overlooking something, but I think the simplifications I'm making here make sense.

First, using `py::object` instead of `PyObject *` means we can rely on implicit copy/move constructors.  (This necessitated a move into `pytypes.h`, but that doesn't seem a terrible fit given the purpose of `error_already_set`).

The current logic did both a `PyErr_Clear` on deletion *and* a `PyErr_Fetch` on creation.  I can't see how the `PyErr_Clear` on deletion is ever useful: the `Fetch` on creation itself clears the error, so the only way doing a `PyErr_Clear` on deletion could do anything if is something else set the current python exception while the `error_already_set` object was alive--but in that case, clearing some potentially-unrelated other exception seems wrong.  (Code that is worried about an exception handler raising another exception would already catch a second `error_already_set` from exception code).

The destructor itself called `clear()`, but `clear()` was a little bit convoluted: it called `restore()` to restore the currently captured error, but then immediately cleared it with `PyErr_Clear();`.  The only point seems to be because `PyErr_Restore` decrements the reference counts on the held objects, but we can simply do that manually and avoid restoring the error just to clear it again.  Or, actually, we can just *not* decrement them at all and let them be unreferenced (via the `py::object` destructor) when the `error_already_set` is itself destroyed.

`clear()` also had the side effect of clearing the current error, even if the current `error_already_set` didn't have a current error (e.g. because of a previous `restore()` or `clear()` call).  I don't really see how clearing the error here is ever the right thing to do: since the error is cleared on construction, the only way there could be a current error is if you called `restore()` (in which case the current stored error-related members have already been released), or if some *other* code raised the error, in which case `clear()` on *this* object is clearing an error for which it shouldn't be responsible.

Neither of those seem like intentional or desirable features, and manually requesting deletion of the stored references similarly seems pointless, so I've just made `clear()` an empty method and marked it
deprecated in case any code out there is calling it.