### PR TITLE
Registered type fixes

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -216,8 +216,8 @@ struct type_record {
     /// The global operator new can be overridden with a class-specific variant
     void *(*operator_new)(size_t) = ::operator new;
 
-    /// Function pointer to class_<..>::init_holder
-    void (*init_holder)(instance *, const void *) = nullptr;
+    /// Function pointer to class_<..>::init_instance
+    void (*init_instance)(instance *, const void *) = nullptr;
 
     /// Function pointer to class_<..>::dealloc
     void (*dealloc)(const detail::value_and_holder &) = nullptr;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -44,7 +44,7 @@ struct type_info {
     const std::type_info *cpptype;
     size_t type_size, holder_size_in_ptrs;
     void *(*operator_new)(size_t);
-    void (*init_holder)(instance *, const void *);
+    void (*init_instance)(instance *, const void *);
     void (*dealloc)(const value_and_holder &v_h);
     std::vector<PyObject *(*)(PyObject *, PyTypeObject *)> implicit_conversions;
     std::vector<std::pair<const std::type_info *, void *(*)(void *)>> implicit_casts;
@@ -515,7 +515,6 @@ inline PyThreadState *get_thread_state_unchecked() {
 
 // Forward declarations
 inline void keep_alive_impl(handle nurse, handle patient);
-inline void register_instance(instance *self, void *valptr, const type_info *tinfo);
 inline PyObject *make_new_instance(PyTypeObject *type, bool allocate_value = true);
 
 class type_caster_generic {
@@ -595,8 +594,7 @@ public:
                 throw cast_error("unhandled return_value_policy: should not happen!");
         }
 
-        register_instance(wrapper, valueptr, tinfo);
-        tinfo->init_holder(wrapper, existing_holder);
+        tinfo->init_instance(wrapper, existing_holder);
 
         return inst.release();
     }

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -116,7 +116,9 @@ def test_alive_gc_multi_derived(capture):
     from pybind11_tests import Parent, Child, ConstructorStats
 
     class Derived(Parent, Child):
-        pass
+        def __init__(self):
+            Parent.__init__(self)
+            Child.__init__(self)
 
     n_inst = ConstructorStats.detail_reg_inst()
     p = Derived()
@@ -130,6 +132,7 @@ def test_alive_gc_multi_derived(capture):
         assert ConstructorStats.detail_reg_inst() == n_inst
     assert capture == """
         Releasing parent.
+        Releasing child.
         Releasing child.
     """
 

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -201,4 +201,20 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     py::class_<VanillaDictMix1, Vanilla, WithDict>(m, "VanillaDictMix1").def(py::init<>());
     py::class_<VanillaDictMix2, WithDict, Vanilla>(m, "VanillaDictMix2").def(py::init<>());
 #endif
+
+    // test_diamond_inheritance
+    // Issue #959: segfault when constructing diamond inheritance instance
+    // All of these have int members so that there will be various unequal pointers involved.
+    struct B { int b; virtual ~B() = default; };
+    struct C0 : public virtual B { int c0; };
+    struct C1 : public virtual B { int c1; };
+    struct D : public C0, public C1 { int d; };
+    py::class_<B>(m, "B")
+        .def("b", [](B *self) { return self; });
+    py::class_<C0, B>(m, "C0")
+        .def("c0", [](C0 *self) { return self; });
+    py::class_<C1, B>(m, "C1")
+        .def("c1", [](C1 *self) { return self; });
+    py::class_<D, C0, C1>(m, "D")
+        .def(py::init<>());
 }

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -331,3 +331,18 @@ def test_mi_base_return():
     e2 = m.i801e_b2()
     assert type(e2) is m.I801B2
     assert e2.b == 2
+
+
+def test_diamond_inheritance():
+    """Tests that diamond inheritance works as expected (issue #959)"""
+
+    # Issue #959: this shouldn't segfault:
+    d = m.D()
+
+    # Make sure all the various distinct pointers are all recognized as registered instances:
+    assert d is d.c0()
+    assert d is d.c1()
+    assert d is d.b()
+    assert d is d.c0().b()
+    assert d is d.c1().b()
+    assert d is d.c0().c1().b().c0().b()

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -1,19 +1,16 @@
 import pytest
 from pybind11_tests import ConstructorStats
+from pybind11_tests import multiple_inheritance as m
 
 
 def test_multiple_inheritance_cpp():
-    from pybind11_tests import MIType
-
-    mt = MIType(3, 4)
+    mt = m.MIType(3, 4)
 
     assert mt.foo() == 3
     assert mt.bar() == 4
 
 
 def test_multiple_inheritance_mix1():
-    from pybind11_tests import Base2
-
     class Base1:
         def __init__(self, i):
             self.i = i
@@ -21,10 +18,10 @@ def test_multiple_inheritance_mix1():
         def foo(self):
             return self.i
 
-    class MITypePy(Base1, Base2):
+    class MITypePy(Base1, m.Base2):
         def __init__(self, i, j):
             Base1.__init__(self, i)
-            Base2.__init__(self, j)
+            m.Base2.__init__(self, j)
 
     mt = MITypePy(3, 4)
 
@@ -33,7 +30,6 @@ def test_multiple_inheritance_mix1():
 
 
 def test_multiple_inheritance_mix2():
-    from pybind11_tests import Base1
 
     class Base2:
         def __init__(self, i):
@@ -42,9 +38,9 @@ def test_multiple_inheritance_mix2():
         def bar(self):
             return self.i
 
-    class MITypePy(Base1, Base2):
+    class MITypePy(m.Base1, Base2):
         def __init__(self, i, j):
-            Base1.__init__(self, i)
+            m.Base1.__init__(self, i)
             Base2.__init__(self, j)
 
     mt = MITypePy(3, 4)
@@ -54,41 +50,40 @@ def test_multiple_inheritance_mix2():
 
 
 def test_multiple_inheritance_python():
-    from pybind11_tests import Base1, Base2
 
-    class MI1(Base1, Base2):
+    class MI1(m.Base1, m.Base2):
         def __init__(self, i, j):
-            Base1.__init__(self, i)
-            Base2.__init__(self, j)
+            m.Base1.__init__(self, i)
+            m.Base2.__init__(self, j)
 
     class B1(object):
         def v(self):
             return 1
 
-    class MI2(B1, Base1, Base2):
+    class MI2(B1, m.Base1, m.Base2):
         def __init__(self, i, j):
             B1.__init__(self)
-            Base1.__init__(self, i)
-            Base2.__init__(self, j)
+            m.Base1.__init__(self, i)
+            m.Base2.__init__(self, j)
 
     class MI3(MI2):
         def __init__(self, i, j):
             MI2.__init__(self, i, j)
 
-    class MI4(MI3, Base2):
+    class MI4(MI3, m.Base2):
         def __init__(self, i, j, k):
             MI2.__init__(self, j, k)
-            Base2.__init__(self, i)
+            m.Base2.__init__(self, i)
 
-    class MI5(Base2, B1, Base1):
+    class MI5(m.Base2, B1, m.Base1):
         def __init__(self, i, j):
             B1.__init__(self)
-            Base1.__init__(self, i)
-            Base2.__init__(self, j)
+            m.Base1.__init__(self, i)
+            m.Base2.__init__(self, j)
 
-    class MI6(Base2, B1):
+    class MI6(m.Base2, B1):
         def __init__(self, i):
-            Base2.__init__(self, i)
+            m.Base2.__init__(self, i)
             B1.__init__(self)
 
     class B2(B1):
@@ -160,47 +155,45 @@ def test_multiple_inheritance_python():
 
 
 def test_multiple_inheritance_python_many_bases():
-    from pybind11_tests import (BaseN1,  BaseN2,  BaseN3,  BaseN4,  BaseN5,  BaseN6,  BaseN7,
-                                BaseN8,  BaseN9,  BaseN10, BaseN11, BaseN12, BaseN13, BaseN14,
-                                BaseN15, BaseN16, BaseN17)
 
-    class MIMany14(BaseN1, BaseN2, BaseN3, BaseN4):
+    class MIMany14(m.BaseN1, m.BaseN2, m.BaseN3, m.BaseN4):
         def __init__(self):
-            BaseN1.__init__(self, 1)
-            BaseN2.__init__(self, 2)
-            BaseN3.__init__(self, 3)
-            BaseN4.__init__(self, 4)
+            m.BaseN1.__init__(self, 1)
+            m.BaseN2.__init__(self, 2)
+            m.BaseN3.__init__(self, 3)
+            m.BaseN4.__init__(self, 4)
 
-    class MIMany58(BaseN5, BaseN6, BaseN7, BaseN8):
+    class MIMany58(m.BaseN5, m.BaseN6, m.BaseN7, m.BaseN8):
         def __init__(self):
-            BaseN5.__init__(self, 5)
-            BaseN6.__init__(self, 6)
-            BaseN7.__init__(self, 7)
-            BaseN8.__init__(self, 8)
+            m.BaseN5.__init__(self, 5)
+            m.BaseN6.__init__(self, 6)
+            m.BaseN7.__init__(self, 7)
+            m.BaseN8.__init__(self, 8)
 
-    class MIMany916(BaseN9, BaseN10, BaseN11, BaseN12, BaseN13, BaseN14, BaseN15, BaseN16):
+    class MIMany916(m.BaseN9, m.BaseN10, m.BaseN11, m.BaseN12, m.BaseN13, m.BaseN14, m.BaseN15,
+                    m.BaseN16):
         def __init__(self):
-            BaseN9.__init__(self, 9)
-            BaseN10.__init__(self, 10)
-            BaseN11.__init__(self, 11)
-            BaseN12.__init__(self, 12)
-            BaseN13.__init__(self, 13)
-            BaseN14.__init__(self, 14)
-            BaseN15.__init__(self, 15)
-            BaseN16.__init__(self, 16)
+            m.BaseN9.__init__(self, 9)
+            m.BaseN10.__init__(self, 10)
+            m.BaseN11.__init__(self, 11)
+            m.BaseN12.__init__(self, 12)
+            m.BaseN13.__init__(self, 13)
+            m.BaseN14.__init__(self, 14)
+            m.BaseN15.__init__(self, 15)
+            m.BaseN16.__init__(self, 16)
 
-    class MIMany19(MIMany14, MIMany58, BaseN9):
+    class MIMany19(MIMany14, MIMany58, m.BaseN9):
         def __init__(self):
             MIMany14.__init__(self)
             MIMany58.__init__(self)
-            BaseN9.__init__(self, 9)
+            m.BaseN9.__init__(self, 9)
 
-    class MIMany117(MIMany14, MIMany58, MIMany916, BaseN17):
+    class MIMany117(MIMany14, MIMany58, MIMany916, m.BaseN17):
         def __init__(self):
             MIMany14.__init__(self)
             MIMany58.__init__(self)
             MIMany916.__init__(self)
-            BaseN17.__init__(self, 17)
+            m.BaseN17.__init__(self, 17)
 
     # Inherits from 4 registered C++ classes: can fit in one pointer on any modern arch:
     a = MIMany14()
@@ -224,31 +217,29 @@ def test_multiple_inheritance_python_many_bases():
 
 
 def test_multiple_inheritance_virtbase():
-    from pybind11_tests import Base12a, bar_base2a, bar_base2a_sharedptr
 
-    class MITypePy(Base12a):
+    class MITypePy(m.Base12a):
         def __init__(self, i, j):
-            Base12a.__init__(self, i, j)
+            m.Base12a.__init__(self, i, j)
 
     mt = MITypePy(3, 4)
     assert mt.bar() == 4
-    assert bar_base2a(mt) == 4
-    assert bar_base2a_sharedptr(mt) == 4
+    assert m.bar_base2a(mt) == 4
+    assert m.bar_base2a_sharedptr(mt) == 4
 
 
 def test_mi_static_properties():
     """Mixing bases with and without static properties should be possible
      and the result should be independent of base definition order"""
-    from pybind11_tests import mi
 
-    for d in (mi.VanillaStaticMix1(), mi.VanillaStaticMix2()):
+    for d in (m.VanillaStaticMix1(), m.VanillaStaticMix2()):
         assert d.vanilla() == "Vanilla"
         assert d.static_func1() == "WithStatic1"
         assert d.static_func2() == "WithStatic2"
         assert d.static_func() == d.__class__.__name__
 
-        mi.WithStatic1.static_value1 = 1
-        mi.WithStatic2.static_value2 = 2
+        m.WithStatic1.static_value1 = 1
+        m.WithStatic2.static_value2 = 2
         assert d.static_value1 == 1
         assert d.static_value2 == 2
         assert d.static_value == 12
@@ -264,30 +255,28 @@ def test_mi_static_properties():
 @pytest.unsupported_on_pypy
 def test_mi_dynamic_attributes():
     """Mixing bases with and without dynamic attribute support"""
-    from pybind11_tests import mi
 
-    for d in (mi.VanillaDictMix1(), mi.VanillaDictMix2()):
+    for d in (m.VanillaDictMix1(), m.VanillaDictMix2()):
         d.dynamic = 1
         assert d.dynamic == 1
 
 
 def test_mi_unaligned_base():
     """Returning an offset (non-first MI) base class pointer should recognize the instance"""
-    from pybind11_tests import I801C, I801D, i801b1_c, i801b2_c, i801b1_d, i801b2_d
 
     n_inst = ConstructorStats.detail_reg_inst()
 
-    c = I801C()
-    d = I801D()
+    c = m.I801C()
+    d = m.I801D()
     # + 4 below because we have the two instances, and each instance has offset base I801B2
     assert ConstructorStats.detail_reg_inst() == n_inst + 4
-    b1c = i801b1_c(c)
+    b1c = m.i801b1_c(c)
     assert b1c is c
-    b2c = i801b2_c(c)
+    b2c = m.i801b2_c(c)
     assert b2c is c
-    b1d = i801b1_d(d)
+    b1d = m.i801b1_d(d)
     assert b1d is d
-    b2d = i801b2_d(d)
+    b2d = m.i801b2_d(d)
     assert b2d is d
 
     assert ConstructorStats.detail_reg_inst() == n_inst + 4  # no extra instances
@@ -299,30 +288,28 @@ def test_mi_unaligned_base():
 
 def test_mi_base_return():
     """Tests returning an offset (non-first MI) base class pointer to a derived instance"""
-    from pybind11_tests import (I801B2, I801C, I801D, i801c_b1, i801c_b2, i801d_b1, i801d_b2,
-                                i801e_c, i801e_b2)
 
     n_inst = ConstructorStats.detail_reg_inst()
 
-    c1 = i801c_b1()
-    assert type(c1) is I801C
+    c1 = m.i801c_b1()
+    assert type(c1) is m.I801C
     assert c1.a == 1
     assert c1.b == 2
 
-    d1 = i801d_b1()
-    assert type(d1) is I801D
+    d1 = m.i801d_b1()
+    assert type(d1) is m.I801D
     assert d1.a == 1
     assert d1.b == 2
 
     assert ConstructorStats.detail_reg_inst() == n_inst + 4
 
-    c2 = i801c_b2()
-    assert type(c2) is I801C
+    c2 = m.i801c_b2()
+    assert type(c2) is m.I801C
     assert c2.a == 1
     assert c2.b == 2
 
-    d2 = i801d_b2()
-    assert type(d2) is I801D
+    d2 = m.i801d_b2()
+    assert type(d2) is m.I801D
     assert d2.a == 1
     assert d2.b == 2
 
@@ -336,11 +323,11 @@ def test_mi_base_return():
     # Returning an unregistered derived type with a registered base; we won't
     # pick up the derived type, obviously, but should still work (as an object
     # of whatever type was returned).
-    e1 = i801e_c()
-    assert type(e1) is I801C
+    e1 = m.i801e_c()
+    assert type(e1) is m.I801C
     assert e1.a == 1
     assert e1.b == 2
 
-    e2 = i801e_b2()
-    assert type(e2) is I801B2
+    e2 = m.i801e_b2()
+    assert type(e2) is m.I801B2
     assert e2.b == 2


### PR DESCRIPTION
The instance registration for offset base types fails (under macOS, with a segfault) in the presense of virtual base types.  The issue occurs when trying to `static_cast<Base *>(derived_ptr)` when `derived_ptr` has been allocated (via `operator new`) but not initialized.

This commit fixes the issue by moving the addition to `registered_instances` into `init_holder` rather than immediately after value pointer allocation.

This also renames it to `init_instance` since it does more than holder initialization now.  (I also further renamed `init_holder_helper` to `init_holder` since `init_holder` isn't used anymore).

Fixes #959.

The PR also adds a new test to `test_multiple_inheritance`, so I first converted that to the new test style.