### PR TITLE
Free created types' tp_name in default metaclass

### DIFF
--- a/include/pybind11/class_support.h
+++ b/include/pybind11/class_support.h
@@ -518,12 +518,11 @@ inline PyObject* make_new_python_type(const type_record &rec) {
             module = rec.scope.attr("__name__");
     }
 
+    auto full_name = c_str(
 #if !defined(PYPY_VERSION)
-    const auto full_name = module ? str(module).cast<std::string>() + "." + rec.name
-                                  : std::string(rec.name);
-#else
-    const auto full_name = std::string(rec.name);
+        module ? str(module).cast<std::string>() + "." + rec.name :
 #endif
+        rec.name);
 
     char *tp_doc = nullptr;
     if (rec.doc && options::show_user_defined_docstrings()) {
@@ -556,7 +555,7 @@ inline PyObject* make_new_python_type(const type_record &rec) {
 #endif
 
     auto type = &heap_type->ht_type;
-    type->tp_name = strdup(full_name.c_str());
+    type->tp_name = full_name;
     type->tp_doc = tp_doc;
     type->tp_base = type_incref((PyTypeObject *)base);
     type->tp_basicsize = static_cast<ssize_t>(sizeof(instance));

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -484,6 +484,7 @@ struct internals {
     std::forward_list<void (*) (std::exception_ptr)> registered_exception_translators;
     std::unordered_map<std::string, void *> shared_data; // Custom data to be shared across extensions
     std::vector<PyObject *> loader_patient_stack; // Used by `loader_life_support`
+    std::forward_list<std::string> static_strings; // Stores the std::strings backing detail::c_str()
     PyTypeObject *static_property_type;
     PyTypeObject *default_metaclass;
     PyObject *instance_base;
@@ -677,6 +678,16 @@ inline void ignore_unused(const int *) { }
 using expand_side_effects = bool[];
 #define PYBIND11_EXPAND_SIDE_EFFECTS(PATTERN) pybind11::detail::expand_side_effects{ ((PATTERN), void(), false)..., false }
 #endif
+
+/// Constructs a std::string with the given arguments, stores it in `internals`, and returns its
+/// `c_str()`.  Such strings objects have a long storage duration -- the internal strings are only
+/// cleared when the program exits or after interpreter shutdown (when embedding), and so are
+/// suitable for c-style strings needed by Python internals (such as PyTypeObject's tp_name).
+template <typename... Args> const char *c_str(Args &&...args) {
+    auto &strings = get_internals().static_strings;
+    strings.emplace_front(std::forward<Args>(args)...);
+    return strings.front().c_str();
+}
 
 NAMESPACE_END(detail)
 


### PR DESCRIPTION
Fixes #977, via a weakref added to the type.

This feels like a bit of overkill, though; the leak in #977 seems fairly minor.