### PR TITLE
Added catkin package definition

### DIFF
--- a/catkin/CMakeLists.txt
+++ b/catkin/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(pybind11)
+
+find_package(catkin REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+include(pybind)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+file(MAKE_DIRECTORY include)
+catkin_package(
+  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
+  LIBRARIES ${PYTHON_LIBRARIES}
+  CATKIN_DEPENDS
+  CFG_EXTRAS pybind.cmake
+)
+
+set(PYBIND11_HEADERS
+  include/pybind11/attr.h
+  include/pybind11/buffer_info.h
+  include/pybind11/cast.h
+  include/pybind11/chrono.h
+  include/pybind11/class_support.h
+  include/pybind11/common.h
+  include/pybind11/complex.h
+  include/pybind11/descr.h
+  include/pybind11/eigen.h
+  include/pybind11/embed.h
+  include/pybind11/eval.h
+  include/pybind11/functional.h
+  include/pybind11/numpy.h
+  include/pybind11/operators.h
+  include/pybind11/options.h
+  include/pybind11/pybind11.h
+  include/pybind11/pytypes.h
+  include/pybind11/stl.h
+  include/pybind11/stl_bind.h
+  include/pybind11/typeid.h
+)
+
+string(REPLACE "include/" "${CMAKE_CURRENT_SOURCE_DIR}/../include/"
+       PYBIND11_HEADERS "${PYBIND11_HEADERS}")
+
+# extract project version from source
+file(STRINGS "${PYBIND11_INCLUDE_DIR}/pybind11/common.h" pybind11_version_defines
+    REGEX "#define PYBIND11_VERSION_(MAJOR|MINOR|PATCH) ")
+foreach(ver ${pybind11_version_defines})
+ if (ver MATCHES "#define PYBIND11_VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
+   set(PYBIND11_VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
+ endif()
+endforeach()
+set(${PROJECT_NAME}_VERSION ${PYBIND11_VERSION_MAJOR}.${PYBIND11_VERSION_MINOR}.${PYBIND11_VERSION_PATCH})
+message(STATUS "pybind11 v${${PROJECT_NAME}_VERSION}")
+
+
+
+install(FILES ${PYBIND11_HEADERS}
+        DESTINATION include/pybind11)
+
+set(PYBIND11_CMAKECONFIG_INSTALL_DIR "${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake/" CACHE STRING "install path for pybind11Config.cmake")
+
+configure_package_config_file(../tools/${PROJECT_NAME}Config.cmake.in
+                              "${CMAKE_CURRENT_BINARY_DIR}/pybindConfig.cmake"
+                              INSTALL_DESTINATION ${PYBIND11_CMAKECONFIG_INSTALL_DIR})
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+                                 VERSION ${${PROJECT_NAME}_VERSION}
+                                 COMPATIBILITY AnyNewerVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pybindConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+              ../tools/FindPythonLibsNew.cmake
+              ../tools/pybind11Tools.cmake
+        DESTINATION ${PYBIND11_CMAKECONFIG_INSTALL_DIR})

--- a/catkin/cmake/pybind.cmake
+++ b/catkin/cmake/pybind.cmake
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+message(STATUS "Compiling using c++ 11 (required by PyBind11)")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../tools")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+set(TEMP_PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE})
+if(DEFINED PYBIND_PYTHON_EXECUTABLE)
+    set(PYTHON_EXECUTABLE ${PYBIND_PYTHON_EXECUTABLE} CACHE INTERNAL "")
+endif()
+
+include(pybind11Tools)
+
+# Cache variables so pybind11_add_module can be used in parent projects
+set(PYBIND11_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../include" CACHE INTERNAL "")
+set(PYTHON_LIBRARIES ${PYTHON_LIBRARIES} CACHE INTERNAL "")
+
+set(PYTHON_EXECUTABLE ${TEMP_PYTHON_EXECUTABLE} CACHE INTERNAL "")
+
+macro(pybind_add_module target_name other)
+    pybind11_add_module(${ARGV})
+    target_link_libraries(${target_name} PRIVATE ${PYTHON_LIBRARIES} ${catkin_LIBRARIES})
+    set_target_properties(${target_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_GLOBAL_PYTHON_DESTINATION})
+    set(PYTHON_LIB_DIR ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION})
+    add_custom_command(TARGET ${target_name}
+      POST_BUILD
+      COMMAND mkdir -p ${PYTHON_LIB_DIR} && cp $<TARGET_FILE:${target_name}> ${PYTHON_LIB_DIR}/${target_name}.so
+      WORKING_DIRECTORY ${CATKIN_DEVEL_PREFIX}
+  COMMENT "Copying library files to python directory" )
+
+endmacro(pybind_add_module)

--- a/catkin/package.xml
+++ b/catkin/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>pybind11</name>
+  <version>2.1.1</version>
+  <description>The pybind11 package</description>
+  <maintainer email="v.ivan@ed.ac.uk">Vladimir Ivan</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>python</depend>
+  <depend>python-numpy</depend>
+  <depend>eigen</depend>
+
+</package>


### PR DESCRIPTION
Adds native support for the Catkin build system (ROS compatibility)

Additions:
 - ```catkin/package.xml``` Package description.
 - ```catkin/CMakeLists.txt``` Replicates some of the top level CMakeLists but uses Catkin specific paths.
 - ```catkin/cmake/pybind.cmake``` Splits out the ```pybind_add_module``` macro and several other commands that have to be included in every package that depends on this code.

This will turn the code into a catkin package. I have found only [one](https://github.com/ethz-asl/voxblox) or two instance of pybind11 being used in ROS so far. Native support will make integration into ROS a lot easier.

Additional notes:
The list of header files has to be updated manually (same as in the top level ```CMakeLists.txt``` and in ```setup.py```). Version, maintainer info and other bit should also be updated in ```catkin/package.xml``` if they change in the future.

Catkin/ROS only support python2.7. To get around this, it is possible to compile the pybind11 package by setting the ```PYBIND_PYTHON_EXECUTABLE``` cmake variable to the path to desired python executable. This will only change the python executable/library paths for compilation of pybind11 modules while the rest of the build system will keep using python2.7. The result will be of limited use within ROS but the code will compile nonetheless.

There is no particular test that can be added and maintained cross platform since Catkin/ROS is compatible with only a handful OSs (mainly Ubuntu). To manually test the compatibility:
 1. Follow [these](http://catkin-tools.readthedocs.io/en/latest/quick_start.html) or [these](http://wiki.ros.org/catkin/Tutorials) instructions to create a catkin workspace.
 1. Clone pybind11 into the source directory.
 1. Create a second test package that will wrapp some c++ code.
     1. Make the test package depend on pybind11.
     1. Add a target using the ```pybind_add_module``` macro (instead of the native ```pybind11_add_module``` one).
 1. Compile and source the workspace (Catkin sets up the sys.path when the workspace is sourced).
 1. The package can now be imported into python and used.