### PR TITLE
reshape for numpy arrays

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -166,6 +166,8 @@ struct npy_api {
     PyObject *(*PyArray_Squeeze_)(PyObject *);
     int (*PyArray_SetBaseObject_)(PyObject *, PyObject *);
     PyObject* (*PyArray_Resize_)(PyObject*, PyArray_Dims*, int, int);
+    PyObject* (*PyArray_Newshape_)(PyObject*, PyArray_Dims*, int);
+
 private:
     enum functions {
         API_PyArray_GetNDArrayCFeatureVersion = 211,
@@ -176,6 +178,7 @@ private:
         API_PyArray_DescrFromScalar = 57,
         API_PyArray_FromAny = 69,
         API_PyArray_Resize = 80,
+        API_PyArray_Newshape = 135,
         API_PyArray_CopyInto = 82,
         API_PyArray_NewCopy = 85,
         API_PyArray_NewFromDescr = 94,
@@ -207,6 +210,7 @@ private:
         DECL_NPY_API(PyArray_DescrFromScalar);
         DECL_NPY_API(PyArray_FromAny);
         DECL_NPY_API(PyArray_Resize);
+        DECL_NPY_API(PyArray_Newshape);
         DECL_NPY_API(PyArray_CopyInto);
         DECL_NPY_API(PyArray_NewCopy);
         DECL_NPY_API(PyArray_NewFromDescr);
@@ -216,6 +220,7 @@ private:
         DECL_NPY_API(PyArray_GetArrayParamsFromObject);
         DECL_NPY_API(PyArray_Squeeze);
         DECL_NPY_API(PyArray_SetBaseObject);
+
 #undef DECL_NPY_API
         return api;
     }
@@ -730,6 +735,19 @@ public:
         if (!new_array) throw error_already_set();
         if (isinstance<array>(new_array)) { *this = std::move(new_array); }
     }
+
+    void reshape(ShapeContainer new_shape) {
+        detail::npy_api::PyArray_Dims d = {
+            new_shape->data(), int(new_shape->size())
+        };
+        // try to reshape, set ordering param to -1 cause it's not used anyway
+        object new_array = reinterpret_steal<object>(
+              detail::npy_api::get().PyArray_Newshape_(m_ptr, &d, 0)
+        );
+        if (!new_array) throw error_already_set();
+        if (isinstance<array>(new_array)) { *this = std::move(new_array); }
+    }
+    
 
     /// Ensure that the argument is a NumPy array
     /// In case of an error, nullptr is returned and the Python error is cleared.

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -292,4 +292,17 @@ TEST_SUBMODULE(numpy_array, sm) {
         std::fill(a.mutable_data(), a.mutable_data() + a.size(), 42.);
         return a;
     });
+
+    m.def("array_reshape1", [](py::array_t<double> a, size_t N) {
+        a.reshape({N, N, N});
+        return a;
+    });
+
+    m.def("create_and_reshape", [](size_t N, size_t M, size_t O) {
+        py::array_t<double> a;
+        a.resize({N*M*O});
+        std::fill(a.mutable_data(), a.mutable_data() + a.size(), 42.);
+        a.reshape({N, M, O});
+        return a;
+    });
 }

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -293,16 +293,20 @@ TEST_SUBMODULE(numpy_array, sm) {
         return a;
     });
 
-    m.def("array_reshape1", [](py::array_t<double> a, size_t N) {
+    sm.def("array_reshape1", [](py::array_t<double> a, size_t N) {
         a.reshape({N, N, N});
         return a;
     });
 
-    m.def("create_and_reshape", [](size_t N, size_t M, size_t O) {
+    sm.def("create_and_reshape", [](size_t N, size_t M, size_t O) {
         py::array_t<double> a;
         a.resize({N*M*O});
         std::fill(a.mutable_data(), a.mutable_data() + a.size(), 42.);
         a.reshape({N, M, O});
+        return a;
+    });
+    sm.def("reshape_tuple", [](py::array_t<double> a, std::vector<int> new_shape) {
+        a.reshape(new_shape);
         return a;
     });
 }

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -400,3 +400,12 @@ def test_array_create_and_resize(msg):
     a = m.create_and_resize(2)
     assert(a.size == 4)
     assert(np.all(a == 42.))
+
+def test_array_reshape(msg):
+    a = np.random.randn(10*10*10).astype('float64')
+    x = m.array_reshape1(a, 10)
+    assert (x.shape == (10,10,10))
+
+def test_create_and_reshape(msg):
+    x = m.create_and_reshape(10,20,30)
+    assert(x.shape == (10,20,30))

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -409,3 +409,8 @@ def test_array_reshape(msg):
 def test_create_and_reshape(msg):
     x = m.create_and_reshape(10,20,30)
     assert(x.shape == (10,20,30))
+
+def test_reshape_tuple(msg):
+    a = np.random.randn(10*10*10).astype('float64')
+    x = m.array_reshape1(a, (10,10,10))
+    assert (x.shape == (10,10,10))


### PR DESCRIPTION
implemented reshape, since `resize` is rarely useful and often fails.