### PR TITLE
view for numpy arrays

### DIFF
--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -292,4 +292,8 @@ TEST_SUBMODULE(numpy_array, sm) {
         std::fill(a.mutable_data(), a.mutable_data() + a.size(), 42.);
         return a;
     });
+    
+    m.def("array_view1", [](py::array_t<unsigned char> a, std::string dtype) {
+        return a.view(dtype);
+    });
 }

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -400,3 +400,13 @@ def test_array_create_and_resize(msg):
     a = m.create_and_resize(2)
     assert(a.size == 4)
     assert(np.all(a == 42.))
+
+def test_array_view1(msg):
+    a = np.ones(100*4).astype('uint8')
+    a_float_view = m.array_view1(a, "float32")
+    assert(a_float_view.shape == (100*1,)) # 1 / 4 bytes = 8 / 32
+
+    a_int16_view = m.array_view1(a, "int16") # 1 / 2 bytes = 16 / 32
+    assert(a_int16_view.shape == (100*2,))
+
+


### PR DESCRIPTION
this function is useful when you have numpy array buffers that need to be reinterpreted as different memory types.

For instance, I get an array buffer that's size 256x256x4 as uint8 and it needs to be "viewed" as 256x256 float. 

From numpy:
```
a.view(some_dtype) or a.view(dtype=some_dtype) constructs a view of the array’s memory with a different data-type. This can cause a reinterpretation of the bytes of memory.
```

Not sure if you like the std:string arg input or would rather have py::dtype or something.. 