### PR TITLE
Add test for mixing STL casters and local binders across modules

### DIFF
--- a/tests/local_bindings.h
+++ b/tests/local_bindings.h
@@ -21,6 +21,14 @@ using MixedLocalGlobal = LocalBase<4>;
 /// Mixed: global first, then local (which fails)
 using MixedGlobalLocal = LocalBase<5>;
 
+using LocalVec = std::vector<LocalType>;
+using LocalVec2 = std::vector<NonLocal2>;
+using LocalMap = std::unordered_map<std::string, LocalType>;
+using NonLocalVec = std::vector<NonLocalType>;
+using NonLocalVec2 = std::vector<NonLocal2>;
+using NonLocalMap = std::unordered_map<std::string, NonLocalType>;
+using NonLocalMap2 = std::unordered_map<std::string, uint8_t>;
+
 // Simple bindings (used with the above):
 template <typename T, int Adjust, typename... Args>
 py::class_<T> bind_local(Args && ...args) {


### PR DESCRIPTION
This is an attempt to address one of the lingering questions from #919. Even if it doesn't directly answer that, it's still a useful test to add. 

One module uses a generic vector caster from `<pybind11/stl.h>` while the other exports `std::vector<int>` with a local `py:bind_vector`. The vector caster from `<pybind11/stl.h>` accepts anything that looks like a sequence, so it will happily load the `py::module_local` opaque vector from a different module. Even if it can't see it's C++ type data, it still behaves like a sequence and can be converted generically.

Note: Type aliases and `PYBIND11_MAKE_OPAQUE` needed to be added for several types because of the inclusion of `<pybind11/stl.h>`.