### PR TITLE
Avoid duplicate C++ standard flags if CMAKE_CXX_STANDARD is set

### DIFF
--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -18,7 +18,7 @@ find_package(PythonLibsNew ${PYBIND11_PYTHON_VERSION} REQUIRED)
 include(CheckCXXCompilerFlag)
 include(CMakeParseArguments)
 
-if(NOT PYBIND11_CPP_STANDARD)
+if(NOT PYBIND11_CPP_STANDARD AND NOT CMAKE_CXX_STANDARD)
   if(NOT MSVC)
     check_cxx_compiler_flag("-std=c++14" HAS_CPP14_FLAG)
 


### PR DESCRIPTION
Fixes #998.

`CMAKE_CXX_STANDARD` is only available on CMake >= 3.1. If the flag is set, we avoid initializing `PYBIND11_CPP_STANDARD`.

I didn't add any tests because all the CI builds currently rely on `PYBIND11_CPP_STANDARD` (for older CMake support) and there's no need to complicate things there.