### PR TITLE
Move internal headers into `detail` subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,14 +36,15 @@ set(PYTHON_MODULE_EXTENSION ${PYTHON_MODULE_EXTENSION} CACHE INTERNAL "")
 
 # NB: when adding a header don't forget to also add it to setup.py
 set(PYBIND11_HEADERS
+  include/pybind11/detail/class.h
+  include/pybind11/detail/common.h
+  include/pybind11/detail/descr.h
+  include/pybind11/detail/typeid.h
   include/pybind11/attr.h
   include/pybind11/buffer_info.h
   include/pybind11/cast.h
   include/pybind11/chrono.h
-  include/pybind11/class_support.h
-  include/pybind11/common.h
   include/pybind11/complex.h
-  include/pybind11/descr.h
   include/pybind11/options.h
   include/pybind11/eigen.h
   include/pybind11/embed.h
@@ -55,7 +56,6 @@ set(PYBIND11_HEADERS
   include/pybind11/pytypes.h
   include/pybind11/stl.h
   include/pybind11/stl_bind.h
-  include/pybind11/typeid.h
 )
 string(REPLACE "include/" "${CMAKE_CURRENT_SOURCE_DIR}/include/"
        PYBIND11_HEADERS "${PYBIND11_HEADERS}")
@@ -68,7 +68,7 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 # extract project version from source
-file(STRINGS "${PYBIND11_INCLUDE_DIR}/pybind11/common.h" pybind11_version_defines
+file(STRINGS "${PYBIND11_INCLUDE_DIR}/pybind11/detail/common.h" pybind11_version_defines
      REGEX "#define PYBIND11_VERSION_(MAJOR|MINOR|PATCH) ")
 foreach(ver ${pybind11_version_defines})
   if (ver MATCHES "#define PYBIND11_VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
@@ -110,8 +110,7 @@ if(NOT (CMAKE_VERSION VERSION_LESS 3.0))  # CMake >= 3.0
 endif()
 
 if (PYBIND11_INSTALL)
-  install(FILES ${PYBIND11_HEADERS}
-          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pybind11)
+  install(DIRECTORY ${PYBIND11_INCLUDE_DIR}/pybind11 DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
   # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
   set(PYBIND11_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for pybind11Config.cmake")
 

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "common.h"
+#include "detail/common.h"
 
 NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -11,8 +11,8 @@
 #pragma once
 
 #include "pytypes.h"
-#include "typeid.h"
-#include "descr.h"
+#include "detail/typeid.h"
+#include "detail/descr.h"
 #include <array>
 #include <limits>
 #include <tuple>

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -1,5 +1,5 @@
 /*
-    pybind11/class_support.h: Python C API implementation details for py::class_
+    pybind11/detail/class.h: Python C API implementation details for py::class_
 
     Copyright (c) 2017 Wenzel Jakob <wenzel.jakob@epfl.ch>
 
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "attr.h"
+#include "../attr.h"
 
 NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -1,5 +1,5 @@
 /*
-    pybind11/common.h -- Basic macros
+    pybind11/detail/common.h -- Basic macros
 
     Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>
 

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -1,5 +1,5 @@
 /*
-    pybind11/descr.h: Helper type for concatenating type signatures
+    pybind11/detail/descr.h: Helper type for concatenating type signatures
     either at runtime (C++11) or compile time (C++14)
 
     Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>

--- a/include/pybind11/detail/typeid.h
+++ b/include/pybind11/detail/typeid.h
@@ -1,5 +1,5 @@
 /*
-    pybind11/typeid.h: Compiler-independent access to type identifiers
+    pybind11/detail/typeid.h: Compiler-independent access to type identifiers
 
     Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>
 

--- a/include/pybind11/options.h
+++ b/include/pybind11/options.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "common.h"
+#include "detail/common.h"
 
 NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -42,7 +42,7 @@
 
 #include "attr.h"
 #include "options.h"
-#include "class_support.h"
+#include "detail/class.h"
 
 NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1,5 +1,5 @@
 /*
-    pybind11/typeid.h: Convenience wrapper classes for basic Python types
+    pybind11/pytypes.h: Convenience wrapper classes for basic Python types
 
     Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>
 
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "common.h"
+#include "detail/common.h"
 #include "buffer_info.h"
 #include <utility>
 #include <type_traits>

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "common.h"
+#include "detail/common.h"
 #include "operators.h"
 
 #include <algorithm>

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,15 @@ if os.environ.get('PYBIND11_USE_CMAKE'):
     headers = []
 else:
     headers = [
+        'include/pybind11/detail/class.h',
+        'include/pybind11/detail/common.h',
+        'include/pybind11/detail/descr.h',
+        'include/pybind11/detail/typeid.h'
         'include/pybind11/attr.h',
         'include/pybind11/buffer_info.h',
         'include/pybind11/cast.h',
         'include/pybind11/chrono.h',
-        'include/pybind11/class_support.h',
-        'include/pybind11/common.h',
         'include/pybind11/complex.h',
-        'include/pybind11/descr.h',
         'include/pybind11/eigen.h',
         'include/pybind11/embed.h',
         'include/pybind11/eval.h',
@@ -31,7 +32,6 @@ else:
         'include/pybind11/pytypes.h',
         'include/pybind11/stl.h',
         'include/pybind11/stl_bind.h',
-        'include/pybind11/typeid.h'
     ]
 
 setup(


### PR DESCRIPTION
The header reorganization discussed in #708 can be broken up into 3 main parts:

1. Moving internal headers into a `detail` subdirectory.
2. Breaking up large detail-heavy headers into smaller ones (e.g. `detail/meta.h` for the metaprogramming bits).
3. Separate `cast` subdirectory for type casters.

Instead of tackling all this at the same time, it would be best to take it in different stages. This PR takes care of number 1 by simply moving the non-user-facing headers (everything fully intact and no user-side changes). This would allow new features like #805 to already make use of the `detail` subdirectory.

Number 2 can be done separately in smaller pieces. Number 3 would have some user-facing changes and it would be best to do in conjunction with the caster changes from #864.