### PR TITLE
Test and document binding protected member functions

### DIFF
--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -229,6 +229,57 @@ TEST_SUBMODULE(class_, m) {
     // This test is actually part of test_local_bindings (test_duplicate_local), but we need a
     // definition in a different compilation unit within the same module:
     bind_local<LocalExternal, 17>(m, "LocalExternal", py::module_local());
+
+    // test_bind_protected_functions
+    class ProtectedA {
+    protected:
+        int foo() const { return value; }
+
+    private:
+        int value = 42;
+    };
+
+    class PublicistA : public ProtectedA {
+    public:
+        using ProtectedA::foo;
+    };
+
+    py::class_<ProtectedA>(m, "ProtectedA")
+        .def(py::init<>())
+#if !defined(_MSC_VER) || _MSC_VER >= 1910
+        .def("foo", &PublicistA::foo);
+#else
+        .def("foo", static_cast<int (ProtectedA::*)() const>(&PublicistA::foo));
+#endif
+
+    class ProtectedB {
+    public:
+        virtual ~ProtectedB() = default;
+
+    protected:
+        virtual int foo() const { return value; }
+
+    private:
+        int value = 42;
+    };
+
+    class TrampolineB : public ProtectedB {
+    public:
+        int foo() const override { PYBIND11_OVERLOAD(int, ProtectedB, foo, ); }
+    };
+
+    class PublicistB : public ProtectedB {
+    public:
+        using ProtectedB::foo;
+    };
+
+    py::class_<ProtectedB, TrampolineB>(m, "ProtectedB")
+        .def(py::init<>())
+#if !defined(_MSC_VER) || _MSC_VER >= 1910
+        .def("foo", &PublicistB::foo);
+#else
+        .def("foo", static_cast<int (ProtectedB::*)() const>(&PublicistB::foo));
+#endif
 }
 
 template <int N> class BreaksBase { public: virtual ~BreaksBase() = default; };

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -176,3 +176,22 @@ def test_operator_new_delete(capture):
         "C delete " + sz_noalias + "\n" +
         "C delete " + sz_alias + "\n"
     )
+
+
+def test_bind_protected_functions():
+    """Expose protected member functions to Python using a helper class"""
+    a = m.ProtectedA()
+    assert a.foo() == 42
+
+    b = m.ProtectedB()
+    assert b.foo() == 42
+
+    class C(m.ProtectedB):
+        def __init__(self):
+            m.ProtectedB.__init__(self)
+
+        def foo(self):
+            return 0
+
+    c = C()
+    assert c.foo() == 0


### PR DESCRIPTION
Resolves #991.

This isn't a new feature, it just documents a pattern for exposing `protected` member functions as discussed in #991.

The test revealed a bug on MSVC 2015 (fixed already in 2017):
```c++
struct A {
    void foo() { return 42; }
};

struct B1 : A {};
struct B2 : A { using A::foo; };

static_assert(std::is_member_function_pointer<decltype(&B1::foo)>::value, "");
static_assert(std::is_member_function_pointer<decltype(&B2::foo)>::value, "");
```
The second `static_assert` fails only on MSVC 2015. I've noted a workaround in the docs.