### PR TITLE
Reduce binary size overhead of new-style constructors

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1389,12 +1389,12 @@ template <typename... Args> detail::initimpl::constructor<Args...> init() { retu
 template <typename... Args> detail::initimpl::alias_constructor<Args...> init_alias() { return {}; }
 
 /// Binds a factory function as a constructor
-template <typename Func, typename Ret = detail::initimpl::factory_t<Func>>
+template <typename Func, typename Ret = detail::initimpl::factory<Func>>
 Ret init(Func &&f) { return {std::forward<Func>(f)}; }
 
 /// Dual-argument factory function: the first function is called when no alias is needed, the second
 /// when an alias is needed (i.e. due to python-side inheritance).  Arguments must be identical.
-template <typename CFunc, typename AFunc, typename Ret = detail::initimpl::factory_t<CFunc, AFunc>>
+template <typename CFunc, typename AFunc, typename Ret = detail::initimpl::factory<CFunc, AFunc>>
 Ret init(CFunc &&c, AFunc &&a) {
     return {std::forward<CFunc>(c), std::forward<AFunc>(a)};
 }

--- a/tests/test_factory_constructors.py
+++ b/tests/test_factory_constructors.py
@@ -40,8 +40,7 @@ def test_init_factory_basic():
 
     with pytest.raises(TypeError) as excinfo:
         m.TestFactory3(tag.null_ptr)
-    assert (str(excinfo.value) ==
-            "pybind11::init(): factory function returned nullptr")
+    assert str(excinfo.value) == "pybind11::init(): factory function returned nullptr"
 
     assert [i.alive() for i in cstats] == [3, 3, 3]
     assert ConstructorStats.detail_reg_inst() == n_inst + 9
@@ -352,9 +351,9 @@ def test_reallocations(capture, msg):
         create_and_destroy(1.5)
     assert msg(capture) == strip_comments("""
         noisy new               # allocation required to attempt first overload
+        noisy delete            # have to dealloc before considering factory init overload
         noisy new               # pointer factory calling "new", part 1: allocation
         NoisyAlloc(double 1.5)  # ... part two, invoking constructor
-        noisy delete            # have to dealloc before stashing factory-generated pointer
         ---
         ~NoisyAlloc()  # Destructor
         noisy delete   # operator delete
@@ -396,9 +395,9 @@ def test_reallocations(capture, msg):
         create_and_destroy(4, 0.5)
     assert msg(capture) == strip_comments("""
         noisy new          # preallocation needed before invoking placement-new overload
+        noisy delete       # deallocation of preallocated storage
         noisy new          # Factory pointer allocation
         NoisyAlloc(int 4)  # factory pointer construction
-        noisy delete       # deallocation of preallocated storage
         ---
         ~NoisyAlloc()  # Destructor
         noisy delete   # operator delete
@@ -408,6 +407,8 @@ def test_reallocations(capture, msg):
         create_and_destroy(5, "hi")
     assert msg(capture) == strip_comments("""
         noisy new            # preallocation needed before invoking first placement new
+        noisy delete         # delete before considering new-style constructor
+        noisy new            # preallocation for second placement new
         noisy placement new  # Placement new in the second placement new overload
         NoisyAlloc(int 5)    # construction
         ---
@@ -450,11 +451,9 @@ def test_invalid_self():
     for arg in (1, 2):
         with pytest.raises(TypeError) as excinfo:
             BrokenTF1(arg)
-        assert (str(excinfo.value) ==
-                "__init__(self, ...) called with invalid `self` argument")
+        assert str(excinfo.value) == "__init__(self, ...) called with invalid `self` argument"
 
     for arg in (1, 2, 3, 4):
         with pytest.raises(TypeError) as excinfo:
             BrokenTF6(arg)
-        assert (str(excinfo.value) ==
-                "__init__(self, ...) called with invalid `self` argument")
+        assert str(excinfo.value) == "__init__(self, ...) called with invalid `self` argument"


### PR DESCRIPTION
This is a follow-up to #805. It removes the binary size increase of the new-style constructors (about ~1% binary size reduction).

The lookup of the `self` type and value pointer are moved out of template code and into `dispatcher`. This brings down the binary size of constructors back to the level of the old placement-new approach. (It also avoids a second lookup for `init_instance`.)

With this implementation, mixing old- and new-style constructors in the same overload set may result in some runtime overhead for temporary allocations/deallocations, but this should be fine as
old style constructors are phased out.