### PR TITLE
Brace initialization for simple POD classes

### DIFF
--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -492,6 +492,30 @@ you could equivalently write:
 
 which will invoke the constructor in-place at the pre-allocated memory.
 
+Brace initialization
+--------------------
+
+``pybind11::init<>`` internally uses C++11 brace initialization to call the
+constructor of the target class. This means that it can be used to bind
+*implicit* constructors as well:
+
+.. code-block:: cpp
+
+    struct Aggregate {
+        int a;
+        std::string b;
+    };
+
+    py::class_<Aggregate>(m, "Aggregate")
+        .def(py::init<int, const std::string &>());
+
+.. note::
+
+    Note that brace initialization preferentially invokes constructor overloads
+    taking a ``std::initializer_list``. In the rare event that this causes an
+    issue, you can work around it by using ``py::init(...)`` with a lambda
+    function that constructs the new object as desired.
+
 .. _classes_with_non_public_destructors:
 
 Non-public destructors

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -381,12 +381,12 @@ class like this:
         static Example create(int a) { return Example(a); }
     };
 
-While it is possible to expose the ``create`` method to Python, it is often
-preferrable to expose it on the Python side as a constructor rather than a
-named static method.  You can do this by calling ``.def(py::init(...))`` with
-the function reference returning the new instance passed as an argument.  It is
-also possible to use this approach to bind a function returning a new instance
-by raw pointer or by the holder (e.g. ``std::unique_ptr``).
+While it is possible to create a straightforward binding of the static
+``create`` method, it may sometimes be preferable to expose it as a constructor
+on the Python side. This can be accomplished by calling ``.def(py::init(...))``
+with the function reference returning the new instance passed as an argument.
+It is also possible to use this approach to bind a function returning a new
+instance by raw pointer or by the holder (e.g. ``std::unique_ptr``).
 
 The following example shows the different approaches:
 
@@ -421,18 +421,20 @@ The following example shows the different approaches:
 When the constructor is invoked from Python, pybind11 will call the factory
 function and store the resulting C++ instance in the Python instance.
 
-When combining factory functions constructors with :ref:`overriding_virtuals`
-there are two approaches.  The first is to add a constructor to the alias class
-that takes a base value by rvalue-reference.  If such a constructor is
-available, it will be used to construct an alias instance from the value
-returned by the factory function.  The second option is to provide two factory
-functions to ``py::init()``: the first will be invoked when no alias class is
-required (i.e. when the class is being used but not inherited from in Python),
-and the second will be invoked when an alias is required.
+When combining factory functions constructors with :ref:`virtual function
+trampolines <overriding_virtuals>` there are two approaches.  The first is to
+add a constructor to the alias class that takes a base value by
+rvalue-reference.  If such a constructor is available, it will be used to
+construct an alias instance from the value returned by the factory function.
+The second option is to provide two factory functions to ``py::init()``: the
+first will be invoked when no alias class is required (i.e. when the class is
+being used but not inherited from in Python), and the second will be invoked
+when an alias is required.
 
 You can also specify a single factory function that always returns an alias
 instance: this will result in behaviour similar to ``py::init_alias<...>()``,
-as described in :ref:`extended_aliases`.
+as described in the :ref:`extended trampoline class documentation
+<extended_aliases>`.
 
 The following example shows the different factory approaches for a class with
 an alias:

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -172,7 +172,7 @@ template <typename... Args> struct constructor {
             // we really can't support that in C++, so just ignore the second __init__.
             if (v_h.instance_registered()) return;
 
-            construct<Class>(v_h, new Cpp<Class>(std::forward<Args>(args)...), false);
+            construct<Class>(v_h, new Cpp<Class>{std::forward<Args>(args)...}, false);
         }, extra...);
     }
 
@@ -186,9 +186,9 @@ template <typename... Args> struct constructor {
             if (v_h.instance_registered()) return; // Ignore duplicate __init__ calls (see above)
 
             if (Py_TYPE(v_h.inst) == cl_type->type)
-                construct<Class>(v_h, new Cpp<Class>(std::forward<Args>(args)...), false);
+                construct<Class>(v_h, new Cpp<Class>{std::forward<Args>(args)...}, false);
             else
-                construct<Class>(v_h, new Alias<Class>(std::forward<Args>(args)...), true);
+                construct<Class>(v_h, new Alias<Class>{std::forward<Args>(args)...}, true);
         }, extra...);
     }
 
@@ -200,7 +200,7 @@ template <typename... Args> struct constructor {
         cl.def("__init__", [cl_type](handle self_, Args... args) {
             auto v_h = load_v_h(self_, cl_type);
             if (v_h.instance_registered()) return; // Ignore duplicate __init__ calls (see above)
-            construct<Class>(v_h, new Alias<Class>(std::forward<Args>(args)...), true);
+            construct<Class>(v_h, new Alias<Class>{std::forward<Args>(args)...}, true);
         }, extra...);
     }
 };
@@ -214,7 +214,7 @@ template <typename... Args> struct alias_constructor {
         cl.def("__init__", [cl_type](handle self_, Args... args) {
             auto v_h = load_v_h(self_, cl_type);
             if (v_h.instance_registered()) return; // Ignore duplicate __init__ calls (see above)
-            construct<Class>(v_h, new Alias<Class>(std::forward<Args>(args)...), true);
+            construct<Class>(v_h, new Alias<Class>{std::forward<Args>(args)...}, true);
         }, extra...);
     }
 };

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -280,6 +280,17 @@ TEST_SUBMODULE(class_, m) {
 #else
         .def("foo", static_cast<int (ProtectedB::*)() const>(&PublicistB::foo));
 #endif
+
+    // test_brace_initialization
+    struct BraceInitialization {
+        int field1;
+        std::string field2;
+    };
+
+    py::class_<BraceInitialization>(m, "BraceInitialization")
+        .def(py::init<int, const std::string &>())
+        .def_readwrite("field1", &BraceInitialization::field1)
+        .def_readwrite("field2", &BraceInitialization::field2);
 }
 
 template <int N> class BreaksBase { public: virtual ~BreaksBase() = default; };

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -195,3 +195,10 @@ def test_bind_protected_functions():
 
     c = C()
     assert c.foo() == 0
+
+
+def test_brace_initialization():
+    """ Tests that simple POD classes can be constructed using C++11 brace initialization """
+    a = m.BraceInitialization(123, "test")
+    assert a.field1 == 123
+    assert a.field2 == "test"


### PR DESCRIPTION
For simple POD classes storing just a few fields, I often don't bother writing constructors and use the generalized C++11 brace initialization syntax. pybind11 doesn't like that and currently requires one to add constructors to the POD class (the ``py::init`` details use the C++03 syntax). This commit switches the pybind11 implementation to use brace initialization as well.

^@jagerman
^@dean0x7d
Unrelated: I almost did a force push to the master branch instead of my personal repo but noticed in the last moment. I switched the master branch to protected status now (i.e. force pushes not allowed) to prevent accidents -- it's easily removed temporarily if we ever need to.