### PR TITLE
Clang5 travis-ci build & fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ matrix:
     services: docker
     env: PYTHON=3.6 CPP=17 GCC=7
   - os: linux
-    env: PYTHON=3.6 CPP=17 CLANG=4.0
+    env: PYTHON=3.6 CPP=17 CLANG=5.0
     addons:
       apt:
-        sources: [deadsnakes, llvm-toolchain-trusty-4.0]
-        packages: [python3.6-dev python3.6-venv clang-4.0 llvm-4.0-dev, lld-4.0]
+        sources: [deadsnakes, llvm-toolchain-trusty-5.0, ubuntu-toolchain-r-test]
+        packages: [python3.6-dev python3.6-venv clang-5.0 llvm-5.0-dev, lld-5.0]
   - os: osx
     osx_image: xcode7.3
     env: PYTHON=2.7 CPP=14 CLANG
@@ -153,13 +153,13 @@ install:
         libeigen3-dev libboost-dev cmake make ${COMPILER_PACKAGES} && break; done"
   else
 
-    if [ "$CLANG" = "4.0" ]; then
+    if [ "$CLANG" = "5.0" ]; then
       if ! [ -d ~/.local/include/c++/v1 ]; then
-        # Neither debian nor llvm provide a libc++ 4.0 deb; luckily it's fairly quick
+        # Neither debian nor llvm provide a libc++ 5.0 deb; luckily it's fairly quick
         # to build, install (and cache), so do it ourselves:
         git clone --depth=1 https://github.com/llvm-mirror/llvm.git llvm-source
-        git clone https://github.com/llvm-mirror/libcxx.git llvm-source/projects/libcxx -b release_40
-        git clone https://github.com/llvm-mirror/libcxxabi.git llvm-source/projects/libcxxabi -b release_40
+        git clone https://github.com/llvm-mirror/libcxx.git llvm-source/projects/libcxx -b release_50
+        git clone https://github.com/llvm-mirror/libcxxabi.git llvm-source/projects/libcxxabi -b release_50
         mkdir llvm-build && cd llvm-build
         # Building llvm requires a newer cmake than is provided by the trusty container:
         CMAKE=cmake-3.8.0-Linux-x86_64

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -342,7 +342,7 @@ public:
      * dimensionality, this is not checked (and so is up to the caller to use safely).
      */
     template <typename... Ix> const T &operator()(Ix... index) const {
-        static_assert(sizeof...(Ix) == Dims || Dynamic,
+        static_assert(ssize_t{sizeof...(Ix)} == Dims || Dynamic,
                 "Invalid number of indices for unchecked array reference");
         return *reinterpret_cast<const T *>(data_ + byte_offset_unsafe(strides_, ssize_t(index)...));
     }
@@ -391,7 +391,7 @@ class unchecked_mutable_reference : public unchecked_reference<T, Dims> {
 public:
     /// Mutable, unchecked access to data at the given indices.
     template <typename... Ix> T& operator()(Ix... index) {
-        static_assert(sizeof...(Ix) == Dims || Dynamic,
+        static_assert(ssize_t{sizeof...(Ix)} == Dims || Dynamic,
                 "Invalid number of indices for unchecked array reference");
         return const_cast<T &>(ConstBase::operator()(index...));
     }

--- a/tests/test_factory_constructors.cpp
+++ b/tests/test_factory_constructors.cpp
@@ -177,7 +177,7 @@ TEST_SUBMODULE(factory_constructors, m) {
 
     // Stateful & reused:
     int c = 1;
-    auto c4a = [c](pointer_tag, TF4_tag, int a) { return new TestFactory4(a);};
+    auto c4a = [c](pointer_tag, TF4_tag, int a) { (void) c; return new TestFactory4(a);};
 
     // test_init_factory_basic, test_init_factory_casting
     py::class_<TestFactory3, std::shared_ptr<TestFactory3>>(m, "TestFactory3")


### PR DESCRIPTION
This upgrades the travis-ci clang/libc++-4 build to clang/libc++-5, and fixes new warnings generated under clang-5.