### PR TITLE
Speed up AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,12 +10,15 @@ platform:
 - x86
 environment:
   matrix:
-  - CONDA: 36
+  - PYTHON: 36
     CPP: 14
-  - CONDA: 27
+    CONFIG: Debug
+  - PYTHON: 27
     CPP: 14
+    CONFIG: Debug
   - CONDA: 36
     CPP: latest
+    CONFIG: Release
 matrix:
   exclude:
     - image: Visual Studio 2015
@@ -38,7 +41,7 @@ install:
       if ($env:PLATFORM -eq "x64") { $env:PYTHON = "$env:PYTHON-x64" }
       $env:PATH = "C:\Python$env:PYTHON\;C:\Python$env:PYTHON\Scripts\;$env:PATH"
       pip install --disable-pip-version-check --user --upgrade pip wheel
-      pip install pytest numpy scipy
+      pip install pytest numpy
     } elseif ($env:CONDA) {
       if ($env:CONDA -eq "27") { $env:CONDA = "" }
       if ($env:PLATFORM -eq "x64") { $env:CONDA = "$env:CONDA-x64" }
@@ -57,7 +60,7 @@ build_script:
     -DDOWNLOAD_CATCH=ON
     -DCMAKE_SUPPRESS_REGENERATION=1
 - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-- cmake --build . --config Release --target pytest -- /v:m /logger:%MSBuildLogger%
-- cmake --build . --config Release --target cpptest -- /v:m /logger:%MSBuildLogger%
-- cmake --build . --config Release --target test_cmake_build -- /v:m /logger:%MSBuildLogger%
+- cmake --build . --config %CONFIG% --target pytest -- /m /v:m /logger:%MSBuildLogger%
+- cmake --build . --config %CONFIG% --target cpptest -- /m /v:m /logger:%MSBuildLogger%
+- if "%CPP%"=="latest" (cmake --build . --config %CONFIG% --target test_cmake_build -- /m /v:m /logger:%MSBuildLogger%)
 on_failure: if exist "tests\test_cmake_build" type tests\test_cmake_build\*.log*

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -8,6 +8,10 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
+#if defined(_MSC_VER) && _MSC_VER < 1910
+#  pragma warning(disable: 4702) // unreachable code in system header
+#endif
+
 #include "pybind11_tests.h"
 #include "object.h"
 


### PR DESCRIPTION
The AppVeyor builds have gotten ridiculously slow: 9-10 minutes per config and over an hour in total. This PR aims to bring them back to a more reasonable level: 3-4 minutes per config.

The `latest` build remains as is, but all others are modified to:

* Use regular Python instead of conda. `pip install` is much faster than conda, but scipy isn't available. Numpy is still tested.

* Compile in debug mode instead of release.

* Skip CMake build tests. For some reason, CMake configuration is very slow on AppVeyor and these tests are almost entirely CMake.

The `latest` config still covers scipy, release mode and the CMake build tests, so the others don't need to.