### PR TITLE
Add missing comma in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ else:
         'include/pybind11/detail/descr.h',
         'include/pybind11/detail/init.h',
         'include/pybind11/detail/internals.h',
-        'include/pybind11/detail/typeid.h'
+        'include/pybind11/detail/typeid.h',
         'include/pybind11/attr.h',
         'include/pybind11/buffer_info.h',
         'include/pybind11/cast.h',


### PR DESCRIPTION
Test framework must be missing a test for `setup.py`.