### PR TITLE
Fix setup.py detail headers and add pip install tests to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,8 @@ matrix:
   # Documentation build:
   - os: linux
     language: docs
-    env: DOCS STYLE LINT
+    env: DOCS STYLE LINT PIP
+    cache: false
     install:
     - export PATH="~/.local/bin:$PATH"
     - $PY_CMD -m pip install --user --upgrade sphinx sphinx_rtd_theme breathe flake8 pep8-naming
@@ -76,6 +77,12 @@ matrix:
     - $PY_CMD -m sphinx -W -b html docs docs/.build
     - tools/check-style.sh
     - flake8
+    - |
+      # Make sure setup.py distributes and installs all the headers
+      $PY_CMD setup.py sdist
+      $PY_CMD -m pip install --user -U ./dist/*
+      installed=$($PY_CMD -c "import pybind11; print(pybind11.get_include(True) + '/pybind11')")
+      diff -rq $installed ./include/pybind11
 cache:
   directories:
   - $HOME/.local/bin

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include include/pybind11/*.h
+recursive-include include/pybind11 *.h
 include LICENSE README.md CONTRIBUTING.md

--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -8,12 +8,18 @@ from . import get_include
 
 
 def print_includes():
-    dirs = [sysconfig.get_path('include')]
-    if sysconfig.get_path('platinclude') not in dirs:
-        dirs.append(sysconfig.get_path('platinclude'))
-    if get_include() not in dirs:
-        dirs.append(get_include())
-    print(' '.join('-I' + d for d in dirs))
+    dirs = [sysconfig.get_path('include'),
+            sysconfig.get_path('platinclude'),
+            get_include(),
+            get_include(True)]
+
+    # Make unique but preserve order
+    unique_dirs = []
+    for d in dirs:
+        if d not in unique_dirs:
+            unique_dirs.append(d)
+
+    print(' '.join('-I' + d for d in unique_dirs))
 
 
 def main():


### PR DESCRIPTION
The default `install_headers` from `distutils` flattens all the headers into a single directory -- the `detail` subdirectory was lost. This commit fixes this by overriding the setup with a custom header installer.

Tests are added to Travis to make sure `setup.py sdist` and `pip install` do not miss any headers and that the directory structure is preserved.