### PR TITLE
[setup.cfg] set zip_safe to False

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[global]
+zip_safe=False
+
 [bdist_wheel]
 universal=1
 


### PR DESCRIPTION
This avoids a bug, if pybind11 is dragged in with setuptools.setup_requires,
as without the flag a zip file (.egg) would be created, which can not be used
as include directory.

[ci skip] until a proper test