### PR TITLE
Accessing C++ hash functions from Python and vice versa

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -262,6 +262,11 @@ v2.2.0 (Not yet released)
   Use ``py::object::borrowed_t{}``/``py::object::stolen_t{}`` instead.
   `#771 <https://github.com/pybind/pybind11/pull/771>`_.
 
+* Added ``py::hash`` to fetch the hash value of Python objects, and
+  ``.def(hash(py::self))`` to provide the C++ ``std::hash`` as the Python
+  ``__hash__`` method.
+  `#1034 <https://github.com/pybind/pybind11/pull/1034>`_.
+
 * Additional compile-time and run-time error checking and more informative messages.
   `#786 <https://github.com/pybind/pybind11/pull/786>`_,
   `#794 <https://github.com/pybind/pybind11/pull/794>`_,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -238,6 +238,11 @@ v2.2.0 (Not yet released)
 * Fixed implicit conversion of `py::enum_` to integer types on Python 2.7.
   `#821 <https://github.com/pybind/pybind11/pull/821>`_.
 
+* Added ``py::hash`` to fetch the hash value of Python objects, and
+  ``.def(hash(py::self))`` to provide the C++ ``std::hash`` as the Python
+  ``__hash__`` method.
+  `#1034 <https://github.com/pybind/pybind11/pull/1034>`_.
+
 * Fixed ``__truediv__`` on Python 2 and ``__itruediv__`` on Python 3.
   `#867 <https://github.com/pybind/pybind11/pull/867>`_.
 
@@ -261,11 +266,6 @@ v2.2.0 (Not yet released)
 * Deprecated ``py::object::borrowed``/``py::object::stolen``.
   Use ``py::object::borrowed_t{}``/``py::object::stolen_t{}`` instead.
   `#771 <https://github.com/pybind/pybind11/pull/771>`_.
-
-* Added ``py::hash`` to fetch the hash value of Python objects, and
-  ``.def(hash(py::self))`` to provide the C++ ``std::hash`` as the Python
-  ``__hash__`` method.
-  `#1034 <https://github.com/pybind/pybind11/pull/1034>`_.
 
 * Additional compile-time and run-time error checking and more informative messages.
   `#786 <https://github.com/pybind/pybind11/pull/786>`_,

--- a/include/pybind11/operators.h
+++ b/include/pybind11/operators.h
@@ -28,7 +28,7 @@ enum op_id : int {
     op_int, op_long, op_float, op_str, op_cmp, op_gt, op_ge, op_lt, op_le,
     op_eq, op_ne, op_iadd, op_isub, op_imul, op_idiv, op_imod, op_ilshift,
     op_irshift, op_iand, op_ixor, op_ior, op_complex, op_bool, op_nonzero,
-    op_repr, op_truediv, op_itruediv
+    op_repr, op_truediv, op_itruediv, op_hash
 };
 
 enum op_type : int {
@@ -148,6 +148,7 @@ PYBIND11_INPLACE_OPERATOR(ior,      operator|=,   l |= r)
 PYBIND11_UNARY_OPERATOR(neg,        operator-,    -l)
 PYBIND11_UNARY_OPERATOR(pos,        operator+,    +l)
 PYBIND11_UNARY_OPERATOR(abs,        abs,          std::abs(l))
+PYBIND11_UNARY_OPERATOR(hash,       hash,         std::hash<L>()(l))
 PYBIND11_UNARY_OPERATOR(invert,     operator~,    (~l))
 PYBIND11_UNARY_OPERATOR(bool,       operator!,    !!l)
 PYBIND11_UNARY_OPERATOR(int,        int_,         (int) l)

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -391,10 +391,8 @@ inline void setattr(handle obj, const char *name, handle value) {
     if (PyObject_SetAttrString(obj.ptr(), name, value.ptr()) != 0) { throw error_already_set(); }
 }
 
-inline Py_ssize_t hash(handle obj) {
-    static_assert(sizeof(long) <= sizeof(Py_ssize_t),
-                  "long is wider than Py_ssize_t - return type needs to be adjusted");
-    Py_ssize_t h = PyObject_Hash(obj.ptr());
+inline ssize_t hash(handle obj) {
+    auto h = PyObject_Hash(obj.ptr());
     if (h == -1) { throw error_already_set(); }
     return h;
 }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -390,6 +390,13 @@ inline void setattr(handle obj, handle name, handle value) {
 inline void setattr(handle obj, const char *name, handle value) {
     if (PyObject_SetAttrString(obj.ptr(), name, value.ptr()) != 0) { throw error_already_set(); }
 }
+
+inline long hash(object obj) {
+    long h = PyObject_Hash(obj.ptr());
+    if (h == -1) { throw error_already_set(); }
+    return h;
+}
+
 /// @} python_builtins
 
 NAMESPACE_BEGIN(detail)

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -391,8 +391,10 @@ inline void setattr(handle obj, const char *name, handle value) {
     if (PyObject_SetAttrString(obj.ptr(), name, value.ptr()) != 0) { throw error_already_set(); }
 }
 
-inline auto hash(handle obj) -> decltype(PyObject_Hash(obj.ptr())) {
-    auto h = PyObject_Hash(obj.ptr());
+inline Py_ssize_t hash(handle obj) {
+    static_assert(sizeof(long) <= sizeof(Py_ssize_t),
+                  "long is wider than Py_ssize_t - return type needs to be adjusted");
+    Py_ssize_t h = PyObject_Hash(obj.ptr());
     if (h == -1) { throw error_already_set(); }
     return h;
 }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -391,8 +391,8 @@ inline void setattr(handle obj, const char *name, handle value) {
     if (PyObject_SetAttrString(obj.ptr(), name, value.ptr()) != 0) { throw error_already_set(); }
 }
 
-inline long hash(object obj) {
-    long h = PyObject_Hash(obj.ptr());
+inline auto hash(handle obj) -> decltype(PyObject_Hash(obj.ptr())) {
+    auto h = PyObject_Hash(obj.ptr());
     if (h == -1) { throw error_already_set(); }
     return h;
 }

--- a/tests/test_operator_overloading.cpp
+++ b/tests/test_operator_overloading.cpp
@@ -10,6 +10,7 @@
 #include "pybind11_tests.h"
 #include "constructor_stats.h"
 #include <pybind11/operators.h>
+#include <functional>
 
 class Vector2 {
 public:
@@ -53,6 +54,14 @@ int operator+(const C2 &, const C2 &) { return 22; }
 int operator+(const C2 &, const C1 &) { return 21; }
 int operator+(const C1 &, const C2 &) { return 12; }
 
+namespace std {
+    template<>
+    struct hash<Vector2> {
+        // Not a good hash function, but easy to test
+        size_t operator()(const Vector2 &) { return 4; }
+    };
+}
+
 TEST_SUBMODULE(operators, m) {
 
     // test_operator_overloading
@@ -77,6 +86,7 @@ TEST_SUBMODULE(operators, m) {
         .def(float() * py::self)
         .def(float() / py::self)
         .def("__str__", &Vector2::toString)
+        .def(hash(py::self))
         ;
 
     m.attr("Vector") = m.attr("Vector2");

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -35,6 +35,8 @@ def test_operator_overloading():
     v2 /= v1
     assert str(v2) == "[2.000000, 8.000000]"
 
+    assert hash(v1) == 4
+
     cstats = ConstructorStats.get(m.Vector2)
     assert cstats.alive() == 2
     del v1

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -261,4 +261,6 @@ TEST_SUBMODULE(pytypes, m) {
     });
 
     m.def("print_failure", []() { py::print(42, UnregisteredType()); });
+
+    m.def("hash_function", [](py::object obj) { return py::hash(obj); });
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -5,18 +5,6 @@ from pybind11_tests import pytypes as m
 from pybind11_tests import debug_enabled
 
 
-class Hashable(object):
-    def __init__(self, value):
-        self.value = value
-
-    def __hash__(self):
-        return self.value
-
-
-class Unhashable(object):
-    __hash__ = None
-
-
 def test_list(capture, doc):
     with capture:
         l = m.get_list()
@@ -235,6 +223,16 @@ def test_print(capture):
 
 
 def test_hash():
+    class Hashable(object):
+        def __init__(self, value):
+            self.value = value
+
+        def __hash__(self):
+            return self.value
+
+    class Unhashable(object):
+        __hash__ = None
+
     assert m.hash_function(Hashable(42)) == 42
     with pytest.raises(TypeError):
         m.hash_function(Unhashable())

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -5,6 +5,18 @@ from pybind11_tests import pytypes as m
 from pybind11_tests import debug_enabled
 
 
+class Hashable(object):
+    def __init__(self, value):
+        self.value = value
+
+    def __hash__(self):
+        return self.value
+
+
+class Unhashable(object):
+    __hash__ = None
+
+
 def test_list(capture, doc):
     with capture:
         l = m.get_list()
@@ -220,3 +232,9 @@ def test_print(capture):
         if debug_enabled else
         "arguments to Python object (compile in debug mode for details)"
     )
+
+
+def test_hash():
+    assert m.hash_function(Hashable(42)) == 42
+    with pytest.raises(TypeError):
+        m.hash_function(Unhashable())


### PR DESCRIPTION
There are two separate additions:

1. `py::hash(obj)` is equivalent to the Python `hash(obj)`.
2. `.def(hash(py::self))` registers the hash function defined by std::hash<T> as the Python hash function.