### PR TITLE
Added function for reloading module

### DIFF
--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -133,6 +133,11 @@ embedding the interpreter. This makes it easy to import local Python files:
     int n = result.cast<int>();
     assert(n == 3);
 
+Modules can be reloaded using `module::reload()` if the source is modified e.g.
+by an external process. This can be useful in scenarios where the application
+imports a user defined data processing script which needs to be updated after
+changes by the user. Note that this function does not reload modules recursively.
+
 .. _embedding_modules:
 
 Adding embedded modules

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -190,7 +190,7 @@ naturally:
     namespace py = pybind11;
 
     PYBIND11_EMBEDDED_MODULE(cpp_module, m) {
-        m.attr("a") = 1
+        m.attr("a") = 1;
     }
 
     int main() {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -835,6 +835,14 @@ public:
         return reinterpret_steal<module>(obj);
     }
 
+    /// Reload the module or throws `error_already_set`.
+    void reload() {
+        PyObject *obj = PyImport_ReloadModule(ptr());
+        if (!obj)
+            throw error_already_set();
+        *this = reinterpret_steal<module>(obj);
+    }
+
     // Adds an object to the module using the given name.  Throws if an object with the given name
     // already exists.
     //

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -3,6 +3,7 @@
 
 #include <thread>
 #include <fstream>
+#include <functional>
 
 namespace py = pybind11;
 using namespace py::literals;


### PR DESCRIPTION
I tried embedding the interpreter using pybind11 in an application where we want to do on-line processing using Python combined with C++. The processing runs iteratively, so I needed a way to reload the imported modules to allow the user to change the Python code between different runs. This PR simply adds a wrapper to PyImport_ReloadModule() and seems to solve the problem nicely.

If this seems relevant to merge in I can try and finalize it with tests and docs.

I'm not so familiar with the fancy C++ stuff so I'm not sure that the final `*this = reinterpret_steal<module>(obj);` is good.