### PR TITLE
Functional returning a pointer policy

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -891,7 +891,7 @@ T cast(const handle &handle) { return T(reinterpret_borrow<object>(handle)); }
 template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
 object cast(T &&value, return_value_policy policy = return_value_policy::automatic_reference,
             handle parent = handle()) {
-    return reinterpret_steal<object>(detail::make_caster<T>::cast(value, policy, parent));
+    return reinterpret_steal<object>(detail::make_caster<T>::cast(std::forward<T>(value), policy, parent));
 }
 
 template <typename T> T handle::cast() const { return pybind11::cast<T>(*this); }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -891,14 +891,7 @@ T cast(const handle &handle) { return T(reinterpret_borrow<object>(handle)); }
 template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
 object cast(T &&value, return_value_policy policy = return_value_policy::automatic_reference,
             handle parent = handle()) {
-    using no_ref_T = typename std::remove_reference<T>::type;
-    if (policy == return_value_policy::automatic)
-        policy = std::is_pointer<no_ref_T>::value ? return_value_policy::take_ownership :
-                 std::is_lvalue_reference<T>::value ? return_value_policy::copy : return_value_policy::move;
-    else if (policy == return_value_policy::automatic_reference)
-        policy = std::is_pointer<no_ref_T>::value ? return_value_policy::reference :
-                 std::is_lvalue_reference<T>::value ? return_value_policy::copy : return_value_policy::move;
-    return reinterpret_steal<object>(detail::make_caster<T>::cast(std::forward<T>(value), policy, parent));
+    return reinterpret_steal<object>(detail::make_caster<T>::cast(value, policy, parent));
 }
 
 template <typename T> T handle::cast() const { return pybind11::cast<T>(*this); }

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -12,6 +12,16 @@
 #include <pybind11/functional.h>
 #include <thread>
 
+struct TestNotCopyable{
+    TestNotCopyable() {};
+    TestNotCopyable(const TestNotCopyable &obj) = delete;
+};
+
+TestNotCopyable* full_func_return_ptr() {
+    return new TestNotCopyable();
+}
+
+std::function<TestNotCopyable*(void)> func_return_ptr = &full_func_return_ptr;
 
 int dummy_function(int i) { return i + 1; }
 
@@ -185,4 +195,9 @@ TEST_SUBMODULE(callbacks, m) {
             f();
         }
     });
+
+    // Testing returning pointers to non-copyable objects
+    m.attr("full_func_return_ptr") = py::cpp_function(full_func_return_ptr);
+    m.attr("func_return_ptr") = func_return_ptr;
+    py::class_<TestNotCopyable>(m, "TestNotCopyable");
 }

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -13,7 +13,7 @@
 #include <thread>
 
 struct TestNotCopyable{
-    TestNotCopyable() {};
+    TestNotCopyable() = default;
     TestNotCopyable(const TestNotCopyable &obj) = delete;
 };
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -193,3 +193,12 @@ def test_callback_num_times():
                 min(rates), sum(rates) / len(rates), max(rates)
             )
         )
+
+
+def test_full_func_return_ptr():
+    m.full_func_return_ptr()
+
+
+@pytest.mark.xfail(reason="Currently auto policy is not inherited")
+def test_full_func_return_ptr_inherit():
+    m.func_return_ptr()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -199,6 +199,5 @@ def test_full_func_return_ptr():
     m.full_func_return_ptr()
 
 
-@pytest.mark.xfail(reason="Currently auto policy is not inherited")
 def test_full_func_return_ptr_inherit():
     m.func_return_ptr()


### PR DESCRIPTION
This is a proposed fix for #1041. This auto-selects a return policy when a functional gets auto-wrapped, instead of inheriting the copy policy that is left over from the auto policy selection.  Added tests that fail without the patch, and succeed with the patch.