### PR TITLE
Fix style script and add comment to failing blocks

### DIFF
--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -75,7 +75,7 @@ NAMESPACE_END(detail)
 
         ...
 
-        {   // Block
+        {
             py::scoped_ostream_redirect output;
             std::cout << "Hello, World!"; // Python stdout
         } // <-- return std::cout to normal
@@ -85,7 +85,7 @@ NAMESPACE_END(detail)
 
     .. code-block:: cpp
 
-        {   // Block
+        {
             py::scoped_ostream_redirect output{std::cerr, py::module::import("sys").attr("stderr")};
             std::cerr << "Hello, World!";
         }

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -75,7 +75,7 @@ NAMESPACE_END(detail)
 
         ...
 
-        {
+        /* block */ {
             py::scoped_ostream_redirect output;
             std::cout << "Hello, World!"; // Python stdout
         } // <-- return std::cout to normal
@@ -85,7 +85,7 @@ NAMESPACE_END(detail)
 
     .. code-block:: cpp
 
-        {
+        /* block */ {
             py::scoped_ostream_redirect output{std::cerr, py::module::import("sys").attr("stderr")};
             std::cerr << "Hello, World!";
         }

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -75,7 +75,7 @@ NAMESPACE_END(detail)
 
         ...
 
-        /* block */ {
+        {   // Block
             py::scoped_ostream_redirect output;
             std::cout << "Hello, World!"; // Python stdout
         } // <-- return std::cout to normal
@@ -85,7 +85,7 @@ NAMESPACE_END(detail)
 
     .. code-block:: cpp
 
-        /* block */ {
+        {   // Block
             py::scoped_ostream_redirect output{std::cerr, py::module::import("sys").attr("stderr")};
             std::cerr << "Hello, World!";
         }

--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -37,7 +37,7 @@ fi
 found="$(GREP_COLORS='mt=41' GREP_COLOR='41' grep '[[:blank:]]\+$' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always )"
 if [ -n "$found" ]; then
     # The mt=41 sets a red background for matched trailing spaces
-    echo -e '\033[31,01mError: found trailing spaces in the following files:\033[0m'
+    echo -e '\033[31;01mError: found trailing spaces in the following files:\033[0m'
     check_style_errors=1
     echo "$found" | sed -e 's/^/    /'
 fi

--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -64,7 +64,7 @@ last && /^\s*{/ {
 if [ -n "$found" ]; then
     check_style_errors=1
     echo -e '\033[31;01mError: braces should occur on the same line as the if/while/.. statement. Found issues in the following files:\033[0m'
-    echo "$found" | sed -e 's/^/    /'
+    echo "$found"
 fi
 
 exit $check_style_errors

--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -21,50 +21,50 @@ IFS=$'\n'
 found="$( GREP_COLORS='mt=41' GREP_COLOR='41' grep $'\t' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always )"
 if [ -n "$found" ]; then
     # The mt=41 sets a red background for matched tabs:
-    echo -e '\033[31m\033[01mError: found CRLF characters in the following files:\033[0m'
+    echo -e '\033[31;01mError: found tab characters in the following files:\033[0m'
     check_style_errors=1
-    echo "$found" | while read line; do
-        echo -e '\033[31m\033[01mError: found tabs instead of spaces in the following files:\033[0m'
-    done
+    echo "$found" | sed -e 's/^/    /'
 fi
 
 
 found="$( grep -IUlr $'\r' include tests/*.{cpp,py,h} docs/*.rst --color=always )"
 if [ -n "$found" ]; then
-    echo -e '\033[31m\033[01mError: found CRLF characters in the following files:\033[0m'
+    echo -e '\033[31;01mError: found CRLF characters in the following files:\033[0m'
     check_style_errors=1
-    echo "$found" | while read line; do
-        echo "    $line"
-    done
+    echo "$found" | sed -e 's/^/    /'
 fi
 
 found="$(GREP_COLORS='mt=41' GREP_COLOR='41' grep '[[:blank:]]\+$' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always )"
 if [ -n "$found" ]; then
     # The mt=41 sets a red background for matched trailing spaces
-    echo -e '\033[31m\033[01mError: found trailing spaces in the following files:\033[0m'
+    echo -e '\033[31,01mError: found trailing spaces in the following files:\033[0m'
     check_style_errors=1
-    echo "$found" | while read line; do
-        echo "    $line"
-    done
+    echo "$found" | sed -e 's/^/    /'
 fi
 
-found="$(grep '\<\(if\|for\|while\|catch\)(\|){' include tests/*.{cpp,py,h} -rn --color=always)"
+found="$(grep '\<\(if\|for\|while\|catch\)(\|){' include tests/*.{cpp,h} -rn --color=always)"
 if [ -n "$found" ]; then
-    echo -e '\033[31m\033[01mError: found the following coding style problems:\033[0m'
+    echo -e '\033[31;01mError: found the following coding style problems:\033[0m'
     check_style_errors=1
-
-    echo "$found" | while read line; do
-        echo "    $line"
-    done
+    echo "$found" | sed -e 's/^/    /'
 fi
 
-found="$(GREP_COLORS='mt=41' GREP_COLOR='41' grep '^\s*{\s*$' include docs/*.rst -rn --color=always)"
-if [ -n "$found" ] ; then
+found="$(awk '
+function prefix(filename, lineno) {
+    return "    \033[35m" filename "\033[36m:\033[32m" lineno "\033[36m:\033[0m"
+}
+function mark(pattern, string) { sub(pattern, "\033[01;31m&\033[0m", string); return string }
+last && /^\s*{/ {
+    print prefix(FILENAME, FNR-1) mark("\\)\\s*$", last)
+    print prefix(FILENAME, FNR)   mark("^\\s*{", $0)
+    last=""
+}
+{ last = /(if|for|while|catch|switch)\s*\(.*\)\s*$/ ? $0 : "" }
+' $(find include -type f) tests/*.{cpp,h} docs/*.rst)"
+if [ -n "$found" ]; then
     check_style_errors=1
-    echo -e '\033[31m\033[01mError: braces should occur on the same line as the if/while/.. statement. Found issues in the following files: \033[0m'
-    echo "$found" | while read line; do
-        echo "    $line"
-    done
+    echo -e '\033[31;01mError: braces should occur on the same line as the if/while/.. statement. Found issues in the following files:\033[0m'
+    echo "$found" | sed -e 's/^/    /'
 fi
 
 exit $check_style_errors

--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -19,7 +19,7 @@ check_style_errors=0
 IFS=$'\n'
 
 found="$( GREP_COLORS='mt=41' GREP_COLOR='41' grep $'\t' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always )"
-if [ ! -z "$found" ]; then
+if [ -n "$found" ]; then
     # The mt=41 sets a red background for matched tabs:
     echo -e '\033[31m\033[01mError: found CRLF characters in the following files:\033[0m'
     check_style_errors=1
@@ -30,7 +30,7 @@ fi
 
 
 found="$( grep -IUlr $'\r' include tests/*.{cpp,py,h} docs/*.rst --color=always )"
-if [ ! -z "$found" ]; then
+if [ -n "$found" ]; then
     echo -e '\033[31m\033[01mError: found CRLF characters in the following files:\033[0m'
     check_style_errors=1
     echo "$found" | while read line; do
@@ -39,7 +39,7 @@ if [ ! -z "$found" ]; then
 fi
 
 found="$(GREP_COLORS='mt=41' GREP_COLOR='41' grep '[[:blank:]]\+$' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always )"
-if [ ! -z "$found" ]; then
+if [ -n "$found" ]; then
     # The mt=41 sets a red background for matched trailing spaces
     echo -e '\033[31m\033[01mError: found trailing spaces in the following files:\033[0m'
     check_style_errors=1
@@ -49,7 +49,7 @@ if [ ! -z "$found" ]; then
 fi
 
 found="$(grep '\<\(if\|for\|while\|catch\)(\|){' include tests/*.{cpp,py,h} -rn --color=always)"
-if [ ! -z "$found" ]; then
+if [ -n "$found" ]; then
     echo -e '\033[31m\033[01mError: found the following coding style problems:\033[0m'
     check_style_errors=1
 
@@ -59,7 +59,7 @@ if [ ! -z "$found" ]; then
 fi
 
 found="$(GREP_COLORS='mt=41' GREP_COLOR='41' grep '^\s*{\s*$' include docs/*.rst -rn --color=always)"
-if [ ! -z "$found" ] ; then
+if [ -n "$found" ] ; then
     check_style_errors=1
     echo -e '\033[31m\033[01mError: braces should occur on the same line as the if/while/.. statement. Found issues in the following files: \033[0m'
     echo "$found" | while read line; do

--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# 
+#
 # Script to check include/test code for common pybind11 code style errors.
-# 
+#
 # This script currently checks for
 #
 # 1. use of tabs instead of spaces
@@ -11,72 +11,60 @@
 # 5. Missing space between right parenthesis and brace, e.g. 'for (...){'
 # 6. opening brace on its own line. It should always be on the same line as the
 #    if/while/for/do statment.
-# 
+#
 # Invoke as: tools/check-style.sh
 #
 
-errors=0
+check_style_errors=0
 IFS=$'\n'
-found=
-# The mt=41 sets a red background for matched tabs:
-GREP_COLORS='mt=41' GREP_COLOR='41' grep $'\t' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always |
-        while read f; do
-    if [ -z "$found" ]; then
+
+found="$( GREP_COLORS='mt=41' GREP_COLOR='41' grep $'\t' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always )"
+if [ ! -z "$found" ]; then
+    # The mt=41 sets a red background for matched tabs:
+    echo -e '\033[31m\033[01mError: found CRLF characters in the following files:\033[0m'
+    check_style_errors=1
+    echo "$found" | while read line; do
         echo -e '\033[31m\033[01mError: found tabs instead of spaces in the following files:\033[0m'
-        found=1
-        errors=1
-    fi
+    done
+fi
 
-    echo "    $f"
-done
 
-found=
-grep -IUlr $'\r' include tests/*.{cpp,py,h} docs/*.rst --color=always |
-        while read f; do
-    if [ -z "$found" ]; then
-        echo -e '\033[31m\033[01mError: found CRLF characters in the following files:\033[0m'
-        found=1
-        errors=1
-    fi
+found="$( grep -IUlr $'\r' include tests/*.{cpp,py,h} docs/*.rst --color=always )"
+if [ ! -z "$found" ]; then
+    echo -e '\033[31m\033[01mError: found CRLF characters in the following files:\033[0m'
+    check_style_errors=1
+    echo "$found" | while read line; do
+        echo "    $line"
+    done
+fi
 
-    echo "    $f"
-done
+found="$(GREP_COLORS='mt=41' GREP_COLOR='41' grep '[[:blank:]]\+$' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always )"
+if [ ! -z "$found" ]; then
+    # The mt=41 sets a red background for matched trailing spaces
+    echo -e '\033[31m\033[01mError: found trailing spaces in the following files:\033[0m'
+    check_style_errors=1
+    echo "$found" | while read line; do
+        echo "    $line"
+    done
+fi
 
-found=
-# The mt=41 sets a red background for matched trailing spaces
-GREP_COLORS='mt=41' GREP_COLOR='41' grep '[[:blank:]]\+$' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always |
-        while read f; do
-    if [ -z "$found" ]; then
-        echo -e '\033[31m\033[01mError: found trailing spaces in the following files:\033[0m'
-        found=1
-        errors=1
-    fi
+found="$(grep '\<\(if\|for\|while\|catch\)(\|){' include tests/*.{cpp,py,h} -rn --color=always)"
+if [ ! -z "$found" ]; then
+    echo -e '\033[31m\033[01mError: found the following coding style problems:\033[0m'
+    check_style_errors=1
 
-    echo "    $f"
-done
+    echo "$found" | while read line; do
+        echo "    $line"
+    done
+fi
 
-found=
-grep '\<\(if\|for\|while\|catch\)(\|){' include tests/*.{cpp,py,h} -rn --color=always |
-        while read line; do
-    if [ -z "$found" ]; then
-        echo -e '\033[31m\033[01mError: found the following coding style problems:\033[0m'
-        found=1
-        errors=1
-    fi
+found="$(GREP_COLORS='mt=41' GREP_COLOR='41' grep '^\s*{\s*$' include docs/*.rst -rn --color=always)"
+if [ ! -z "$found" ] ; then
+    check_style_errors=1
+    echo -e '\033[31m\033[01mError: braces should occur on the same line as the if/while/.. statement. Found issues in the following files: \033[0m'
+    echo "$found" | while read line; do
+        echo "    $line"
+    done
+fi
 
-    echo "    $line"
-done
-
-found=
-GREP_COLORS='mt=41' GREP_COLOR='41' grep '^\s*{\s*$' include docs/*.rst -rn --color=always |
-        while read f; do
-    if [ -z "$found" ]; then
-        echo -e '\033[31m\033[01mError: braces should occur on the same line as the if/while/.. statement. Found issues in the following files: \033[0m'
-        found=1
-        errors=1
-    fi
-
-    echo "    $f"
-done
-
-exit $errors
+exit $check_style_errors


### PR DESCRIPTION
This fixes #1044. A bash while loop cannot modify the surrounding environment (runs in a sub-shell), so this was rewritten to be simpler and give the correct error code so travis will report errors correctly.

This also fixes the failing lines in iostream's `rst` file by adding `{ // block`.