### PR TITLE
Speed up Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
         packages: [python3.6-dev python3.6-venv, cmake=2.\*, cmake-data=2.\*]
   - sudo: true
     services: docker
-    env: PYTHON=2.7 CPP=14 GCC=6
+    env: PYTHON=2.7 CPP=14 GCC=6 CMAKE=1
   - sudo: true
     services: docker
     env: PYTHON=3.5 CPP=14 GCC=6 DEBUG=1
@@ -31,7 +31,7 @@ matrix:
         packages: [python3.6-dev python3.6-venv clang-5.0 llvm-5.0-dev, lld-5.0]
   - os: osx
     osx_image: xcode7.3
-    env: PYTHON=2.7 CPP=14 CLANG
+    env: PYTHON=2.7 CPP=14 CLANG CMAKE=1
   - os: osx
     osx_image: xcode8.3
     env: PYTHON=3.6 CPP=14 CLANG DEBUG=1
@@ -169,9 +169,9 @@ install:
         git clone https://github.com/llvm-mirror/libcxxabi.git llvm-source/projects/libcxxabi -b release_50
         mkdir llvm-build && cd llvm-build
         # Building llvm requires a newer cmake than is provided by the trusty container:
-        CMAKE=cmake-3.8.0-Linux-x86_64
-        curl https://cmake.org/files/v3.8/$CMAKE.tar.gz | tar xz
-        ./$CMAKE/bin/cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/.local ../llvm-source
+        CMAKE_VER=cmake-3.8.0-Linux-x86_64
+        curl https://cmake.org/files/v3.8/$CMAKE_VER.tar.gz | tar xz
+        ./$CMAKE_VER/bin/cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/.local ../llvm-source
         make -j2 install-cxxabi install-cxx
         cp -a include/c++/v1/*cxxabi*.h ~/.local/include/c++/v1
         cd ..
@@ -201,7 +201,7 @@ script:
     -DDOWNLOAD_CATCH=ON
 - $SCRIPT_RUN_PREFIX make pytest -j 2
 - $SCRIPT_RUN_PREFIX make cpptest -j 2
-- $SCRIPT_RUN_PREFIX make test_cmake_build
+- if [ -n "$CMAKE" ]; then $SCRIPT_RUN_PREFIX make test_cmake_build; fi
 after_failure: cat tests/test_cmake_build/*.log*
 after_script:
 - if [ -n "$DOCKER" ]; then docker stop "$containerid"; docker rm "$containerid"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,10 @@ matrix:
     addons:
       apt:
         packages: [libblas-dev, liblapack-dev, gfortran]
+  # Build in 32-bit mode and tests against the CMake-installed version
   - sudo: true
     services: docker
-    env: ARCH=i386 PYTHON=3.5 CPP=14 GCC=6
-  # This next one does a make install *before* testing, then builds the tests against the installed version:
-  - sudo: true
-    services: docker
-    env: PYTHON=3.5 CPP=14 CLANG=3.9 INSTALL=1
+    env: ARCH=i386 PYTHON=3.5 CPP=14 GCC=6 INSTALL=1
     script:
       - |
         $SCRIPT_RUN_PREFIX sh -c "set -e
@@ -106,7 +103,7 @@ before_install:
       fi
       export CXX=g++-$GCC CC=gcc-$GCC
     fi
-    if [ "$GCC" = "6" ] || [ "$CLANG" = "3.9" ]; then DOCKER=${ARCH:+$ARCH/}debian:stretch
+    if [ "$GCC" = "6" ]; then DOCKER=${ARCH:+$ARCH/}debian:stretch
     elif [ "$GCC" = "7" ]; then DOCKER=debian:buster
     fi
   elif [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,32 +57,36 @@ matrix:
         mkdir /build-tests && cd /build-tests
         cmake ../pybind11-tests ${CMAKE_EXTRA_ARGS} -DPYBIND11_WERROR=ON
         make pytest -j 2"
-  # A barebones build makes sure everything still works without optional deps (numpy/scipy/eigen)
-  # and also tests the automatic discovery functions in CMake (Python version, C++ standard).
+  # This config does a few things:
+  # - Checks C++ and Python code styles (check-style.sh and flake8).
+  # - Makes sure sphinx can build the docs without any errors or warnings.
+  # - Tests setup.py sdist and install (all header files should be present).
+  # - Makes sure that everything still works without optional deps (numpy/scipy/eigen) and
+  #   also tests the automatic discovery functions in CMake (Python version, C++ standard).
   - os: linux
-    env: BAREBONES PYTHON=3.5
-    install: $PY_CMD -m pip install --user --upgrade pytest
-  # Documentation build:
-  - os: linux
-    language: docs
-    env: DOCS STYLE LINT PIP
+    env: STYLE DOCS PIP PYTHON=3.5
     cache: false
     install:
     - export PATH="~/.local/bin:$PATH"
-    - $PY_CMD -m pip install --user --upgrade sphinx sphinx_rtd_theme breathe flake8 pep8-naming
+    - $PY_CMD -m pip install --user --upgrade sphinx sphinx_rtd_theme breathe flake8 pep8-naming pytest
     - |
       curl -fsSL ftp://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.12.linux.bin.tar.gz | tar xz
       export PATH="$PWD/doxygen-1.8.12/bin:$PATH"
     script:
-    - $PY_CMD -m sphinx -W -b html docs docs/.build
     - tools/check-style.sh
     - flake8
+    - $PY_CMD -m sphinx -W -b html docs docs/.build
     - |
       # Make sure setup.py distributes and installs all the headers
       $PY_CMD setup.py sdist
       $PY_CMD -m pip install --user -U ./dist/*
       installed=$($PY_CMD -c "import pybind11; print(pybind11.get_include(True) + '/pybind11')")
       diff -rq $installed ./include/pybind11
+    - |
+      # Barebones build
+      cmake -DCMAKE_BUILD_TYPE=Debug -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON
+      make pytest -j 2
+      make cpptest -j 2
 cache:
   directories:
   - $HOME/.local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     osx_image: xcode7.3
     env: PYTHON=2.7 CPP=14 CLANG
   - os: osx
-    osx_image: xcode7.3
+    osx_image: xcode8.3
     env: PYTHON=3.6 CPP=14 CLANG
   # Test a PyPy 2.7 build
   - os: linux
@@ -133,7 +133,7 @@ before_install:
       PY_CMD=python$PYTHON
       if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         if [ "$PY" = "3" ]; then
-          brew update; brew install python$PY;
+          brew install python$PY;
         else
           curl -fsSL https://bootstrap.pypa.io/get-pip.py | $PY_CMD - --user
         fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
     env: PYTHON=2.7 CPP=14 CLANG
   - os: osx
     osx_image: xcode8.3
-    env: PYTHON=3.6 CPP=14 CLANG
+    env: PYTHON=3.6 CPP=14 CLANG DEBUG=1
   # Test a PyPy 2.7 build
   - os: linux
     env: PYPY=5.8 PYTHON=2.7 CPP=11 GCC=4.8


### PR DESCRIPTION
Similarly to the recent AppVeyor changes, this removes the `test_cmake_build` target from all configurations except for two: one on Linux and one on macOS. This is pretty much all that's needed to cover those (they only depend on the platform, not on the compiler) and it saves ~30 seconds build time on the other configs.

The Python 3 on macOS build gets an updated image to speed up the homebrew Python installation (the Python 2.7 build is still using Travis's default osx image).

This also removes two configurations completely (down to 11 from 13):

- Style/docs/pip is merged with barebones.
- The 32-bit build is merged with CMake install/standalone tests (this removes clang 3.9 from testing, but there are already 3 other clang versions being tested on Travis and the new xcode8.3 image should be close to clang 3.9).

Each change is committed separately for easier review -- to be squashed before merging.