### PR TITLE
Fix compilation with Clang on host GCC < 5 (old libstdc++)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,9 @@ v2.3.0 (Not yet released)
 v2.2.1 (Not yet released)
 -----------------------------------------------------
 
+* Fixed compilation with Clang on host GCC < 5 (old libstdc++ which isn't fully
+  C++11 compliant). `#1062 <https://github.com/pybind/pybind11/pull/1062>`_.
+
 * Fixed a regression where the ``py::keep_alive`` policy could not be applied
   to constructors. `#1065 <https://github.com/pybind/pybind11/pull/1065>`_.
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -288,7 +288,9 @@ template <typename T> using remove_all_extents_t = typename array_info<T>::type;
 
 template <typename T> using is_pod_struct = all_of<
     std::is_standard_layout<T>,     // since we're accessing directly in memory we need a standard layout type
-#if !defined(__GNUG__) || defined(__clang__) || __GNUC__ >= 5
+#if !defined(__GNUG__) || defined(_LIBCPP_VERSION) || defined(_GLIBCXX_USE_CXX11_ABI)
+    // _GLIBCXX_USE_CXX11_ABI indicates that we're using libstdc++ from GCC 5 or newer, independent
+    // of the actual compiler (Clang can also use libstdc++, but it always defines __GNUC__ == 4).
     std::is_trivially_copyable<T>,
 #else
     // GCC 4 doesn't implement is_trivially_copyable, so approximate it


### PR DESCRIPTION
This issue comes from Gitter: https://gitter.im/pybind/Lobby?at=59ad8678162adb6d2e68311c

The libstdc++ which comes with GCC 4.x does not implement `std::is_trivially_copyable`, so there's a workaround in place. But it does not take into account that Clang can also be installed on a host GCC 4 with the same incomplete libstdc++.

The fix here uses `_GLIBCXX_USE_CXX11_ABI` which is defined in the libstdc++ from GCC 5 and not defined in older versions.