### PR TITLE
Add a dummy common.h header with a deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(PYBIND11_HEADERS
   include/pybind11/buffer_info.h
   include/pybind11/cast.h
   include/pybind11/chrono.h
+  include/pybind11/common.h
   include/pybind11/complex.h
   include/pybind11/options.h
   include/pybind11/eigen.h

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -1,0 +1,2 @@
+#include "detail/common.h"
+#warning "Including 'common.h' is deprecated. It will be removed in v3.0. Use 'pybind11.h'."

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ else:
         'include/pybind11/buffer_info.h',
         'include/pybind11/cast.h',
         'include/pybind11/chrono.h',
+        'include/pybind11/common.h',
         'include/pybind11/complex.h',
         'include/pybind11/eigen.h',
         'include/pybind11/embed.h',


### PR DESCRIPTION
`common.h` was never a public header (undocumented and it never did anything when included alongside `pybind11.h` or any other header), but it does look like it was being used: https://gitter.im/pybind/Lobby?at=59ad8483614889d475bd4d3a

This PR adds a dummy file with a deprecation warning. To be removed in v3.0.