### PR TITLE
Relax py::pickle() get/set type check

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,9 @@ v2.2.1 (Not yet released)
 * Fixed a regression where the ``py::keep_alive`` policy could not be applied
   to constructors. `#1065 <https://github.com/pybind/pybind11/pull/1065>`_.
 
+* Relax overly strict ``py::picke()`` check for matching get and set types.
+  `#1064 <https://github.com/pybind/pybind11/pull/1064>`_.
+
 v2.2.0 (August 31, 2017)
 -----------------------------------------------------
 

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -293,7 +293,7 @@ struct pickle_factory;
 template <typename Get, typename Set,
           typename RetState, typename Self, typename NewInstance, typename ArgState>
 struct pickle_factory<Get, Set, RetState(Self), NewInstance(ArgState)> {
-    static_assert(std::is_same<RetState, ArgState>::value,
+    static_assert(std::is_same<intrinsic_t<RetState>, intrinsic_t<ArgState>>::value,
                   "The type returned by `__getstate__` must be the same "
                   "as the argument accepted by `__setstate__`");
 

--- a/tests/test_pickling.cpp
+++ b/tests/test_pickling.cpp
@@ -115,7 +115,7 @@ TEST_SUBMODULE(pickling, m) {
             [](py::object self) {
                 return py::make_tuple(self.attr("value"), self.attr("extra"), self.attr("__dict__"));
             },
-            [](py::tuple t) {
+            [](const py::tuple &t) {
                 if (t.size() != 3)
                     throw std::runtime_error("Invalid state!");
 


### PR DESCRIPTION
Fixes #1061.

`T` and `const T &` are compatible types.