### PR TITLE
Fix application of keep_alive policy to constructors (regression)

### DIFF
--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -191,6 +191,17 @@ container:
     py::class_<List>(m, "List")
         .def("append", &List::append, py::keep_alive<1, 2>());
 
+For consistency, the argument indexing is identical for constructors. Index
+``1`` still refers to the implicit ``this`` pointer, i.e. the object which is
+being constructed. Index ``0`` refers to the return type which is presumed to
+be ``void`` when a constructor is viewed like a function. The following example
+ties the lifetime of the constructor element to the constructed object:
+
+.. code-block:: cpp
+
+    py::class_<Nurse>(m, "Nurse")
+        .def(py::init<Patient &>(), py::keep_alive<1, 2>());
+
 .. note::
 
     ``keep_alive`` is analogous to the ``with_custodian_and_ward`` (if Nurse,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,12 @@ v2.3.0 (Not yet released)
 
 * TBD
 
+v2.2.1 (Not yet released)
+-----------------------------------------------------
+
+* Fixed a regression where the ``py::keep_alive`` policy could not be applied
+  to constructors. `#1065 <https://github.com/pybind/pybind11/pull/1065>`_.
+
 v2.2.0 (August 31, 2017)
 -----------------------------------------------------
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1800,6 +1800,9 @@ struct function_call {
 
     /// The parent, if any
     handle parent;
+
+    /// If this is a call to an initializer, this argument contains `self`
+    handle init_self;
 };
 
 

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -32,7 +32,7 @@ bool DependentGuard::enabled = false;
 TEST_SUBMODULE(call_policies, m) {
     // Parent/Child are used in:
     // test_keep_alive_argument, test_keep_alive_return_value, test_alive_gc_derived,
-    // test_alive_gc_multi_derived, test_return_none
+    // test_alive_gc_multi_derived, test_return_none, test_keep_alive_constructor
     class Child {
     public:
         Child() { py::print("Allocating child."); }
@@ -51,6 +51,7 @@ TEST_SUBMODULE(call_policies, m) {
     };
     py::class_<Parent>(m, "Parent")
         .def(py::init<>())
+        .def(py::init([](Child *) { return new Parent(); }), py::keep_alive<1, 2>())
         .def("addChild", &Parent::addChild)
         .def("addChildKeepAlive", &Parent::addChild, py::keep_alive<1, 2>())
         .def("returnChild", &Parent::returnChild)

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -156,6 +156,25 @@ def test_return_none(capture):
     assert capture == "Releasing parent."
 
 
+def test_keep_alive_constructor(capture):
+    n_inst = ConstructorStats.detail_reg_inst()
+
+    with capture:
+        p = m.Parent(m.Child())
+        assert ConstructorStats.detail_reg_inst() == n_inst + 2
+    assert capture == """
+        Allocating child.
+        Allocating parent.
+    """
+    with capture:
+        del p
+        assert ConstructorStats.detail_reg_inst() == n_inst
+    assert capture == """
+        Releasing parent.
+        Releasing child.
+    """
+
+
 def test_call_guard():
     assert m.unguarded_call() == "unguarded"
     assert m.guarded_call() == "guarded"


### PR DESCRIPTION
The regression was introduced in #1014 where the constructor's `self` argument became `value_and_holder` instead of the instance itself, so the `keep_alive` policy stoped binding to the created instance. This PR fixes it by stashing the original `self` instance in `function_call` (only for constructor calls).

This also adds a quick paragraph to the docs to clear up argument indexing of constructors.