### PR TITLE
Fix a reference leak in the number converter

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,9 @@ v2.2.1 (Not yet released)
 * Fixed compilation with Clang on host GCC < 5 (old libstdc++ which isn't fully
   C++11 compliant). `#1062 <https://github.com/pybind/pybind11/pull/1062>`_.
 
+* Fixed a reference leak in the number converter.
+  `#1078 <https://github.com/pybind/pybind11/pull/1078>`_.
+
 * Fixed a regression where the automatic ``std::vector<bool>`` caster would
   fail to compile. The same fix also applies to any container which returns
   element proxies instead of references.

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -964,9 +964,9 @@ public:
             );
             PyErr_Clear();
             if (type_error && convert && PyNumber_Check(src.ptr())) {
-                auto tmp = reinterpret_borrow<object>(std::is_floating_point<T>::value
-                                                      ? PyNumber_Float(src.ptr())
-                                                      : PyNumber_Long(src.ptr()));
+                auto tmp = reinterpret_steal<object>(std::is_floating_point<T>::value
+                                                     ? PyNumber_Float(src.ptr())
+                                                     : PyNumber_Long(src.ptr()));
                 PyErr_Clear();
                 return load(tmp, false);
             }


### PR DESCRIPTION
Fixes #1075.

`PyNumber_Float()` and `PyNumber_Long()` return new references.