### PR TITLE
Make PYBIND11_MODULE name usable with define

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -205,6 +205,7 @@ extern "C" {
 #define PYBIND11_TRY_NEXT_OVERLOAD ((PyObject *) 1) // special failure return code
 #define PYBIND11_STRINGIFY(x) #x
 #define PYBIND11_TOSTRING(x) PYBIND11_STRINGIFY(x)
+#define PYBIND11_CONCAT(first, second) first##second
 
 /** \rst
     ***Deprecated in favor of PYBIND11_MODULE***
@@ -267,7 +268,7 @@ extern "C" {
         }
 \endrst */
 #define PYBIND11_MODULE(name, variable)                                        \
-    static void pybind11_init_##name(pybind11::module &);                      \
+    static void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &);     \
     PYBIND11_PLUGIN_IMPL(name) {                                               \
         int major, minor;                                                      \
         if (sscanf(Py_GetVersion(), "%i.%i", &major, &minor) != 2) {           \
@@ -281,9 +282,9 @@ extern "C" {
                          major, minor);                                        \
             return nullptr;                                                    \
         }                                                                      \
-        auto m = pybind11::module(#name);                                      \
+        auto m = pybind11::module(PYBIND11_TOSTRING(name));                    \
         try {                                                                  \
-            pybind11_init_##name(m);                                           \
+            PYBIND11_CONCAT(pybind11_init_, name)(m);                          \
             return m.ptr();                                                    \
         } catch (pybind11::error_already_set &e) {                             \
             PyErr_SetString(PyExc_ImportError, e.what());                      \
@@ -293,7 +294,7 @@ extern "C" {
             return nullptr;                                                    \
         }                                                                      \
     }                                                                          \
-    void pybind11_init_##name(pybind11::module &variable)
+    void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &variable)
 
 
 NAMESPACE_BEGIN(PYBIND11_NAMESPACE)

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -44,11 +44,11 @@
         }
  \endrst */
 #define PYBIND11_EMBEDDED_MODULE(name, variable)                              \
-    static void pybind11_init_##name(pybind11::module &);                     \
-    static PyObject *pybind11_init_wrapper_##name() {                         \
-        auto m = pybind11::module(#name);                                     \
+    static void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &);    \
+    static PyObject PYBIND11_CONCAT(*pybind11_init_wrapper_, name)() {        \
+        auto m = pybind11::module(PYBIND11_TOSTRING(name));                   \
         try {                                                                 \
-            pybind11_init_##name(m);                                          \
+            PYBIND11_CONCAT(pybind11_init_, name)(m);                         \
             return m.ptr();                                                   \
         } catch (pybind11::error_already_set &e) {                            \
             PyErr_SetString(PyExc_ImportError, e.what());                     \
@@ -59,8 +59,9 @@
         }                                                                     \
     }                                                                         \
     PYBIND11_EMBEDDED_MODULE_IMPL(name)                                       \
-    pybind11::detail::embedded_module name(#name, pybind11_init_impl_##name); \
-    void pybind11_init_##name(pybind11::module &variable)
+    pybind11::detail::embedded_module name(PYBIND11_TOSTRING(name),           \
+                               PYBIND11_CONCAT(pybind11_init_impl_, name));   \
+    void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &variable)
 
 
 NAMESPACE_BEGIN(PYBIND11_NAMESPACE)


### PR DESCRIPTION
The name in the `PYBIND11_MODULE(name, variable)`  #define can not be used with a preprocessor define.

Given a simple cpp file `define_module_name.cpp`, where `MODULENAME` is defined elsewhere, and **preprocess** it.
```
// define_module_name.cpp, preprocessor command (add your pybind11/python -I flags!):
// c++ -E -o define_module_name.ii -DMODULENAME=my_module_name define_module_name.cpp
#include <pybind11/pybind11.h>
#include <pybind11/embed.h>

PYBIND11_MODULE(MODULENAME, m) { }
PYBIND11_EMBEDDED_MODULE(MODULENAME, m) { }
```
The result in `define_module_name.ii` will contain both `my_module_name` and `MODULENAME`:
```
PyObject *PyInit_my_module_name()

static void pybind11_init_MODULENAME(pybind11::module &);
auto m = pybind11::module("MODULENAME");
pybind11_init_MODULENAME(m);
void pybind11_init_MODULENAME(pybind11::module &m) { }
```
This commit fixes this by adding one level of macro indirection.