### PR TITLE
Fix cmake cxx standard definition

### DIFF
--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -173,7 +173,12 @@ function(pybind11_add_module target_name)
   endif()
 
   # Make sure C++11/14 are enabled
-  target_compile_options(${target_name} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${PYBIND11_CPP_STANDARD}>)
+  if(CMAKE_VERSION VERSION_LESS 3.3.0)
+    target_compile_options(${target_name} PUBLIC ${PYBIND11_CPP_STANDARD})
+  else()
+    # use generator expression to make sure the flag only applies to CXX
+    target_compile_options(${target_name} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${PYBIND11_CPP_STANDARD}>)
+  endif()
 
   if(ARG_NO_EXTRAS)
     return()

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -173,7 +173,7 @@ function(pybind11_add_module target_name)
   endif()
 
   # Make sure C++11/14 are enabled
-  target_compile_options(${target_name} PUBLIC ${PYBIND11_CPP_STANDARD})
+  target_compile_options(${target_name} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${PYBIND11_CPP_STANDARD}>)
 
   if(ARG_NO_EXTRAS)
     return()


### PR DESCRIPTION
This compile option is only for cxx.
The current code will cause problem when compiling a c/cpp mix project. The -std=c++11 flag will be passed to c obj as well. This change fixes the issue.