### PR TITLE
Add support for CMake compiler features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,8 @@ if(NOT (CMAKE_VERSION VERSION_LESS 3.0))  # CMake >= 3.0
   target_include_directories(pybind11 INTERFACE $<BUILD_INTERFACE:${PYBIND11_INCLUDE_DIR}>
                                                 $<BUILD_INTERFACE:${PYTHON_INCLUDE_DIRS}>
                                                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-  target_compile_options(pybind11 INTERFACE $<BUILD_INTERFACE:${PYBIND11_CPP_STANDARD}>)
+
+  _pybind11_target_cxx_std(pybind11)
 
   add_library(module INTERFACE)
   add_library(pybind11::module ALIAS module)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -113,6 +113,10 @@ v2.2.3 (April 29, 2018)
 * Fixed an endianness-related fault in the test suite.
   `#1287 <https://github.com/pybind/pybind11/pull/1287>`_.
 
+* Improved CMake C++ standard discovery for CMake 3.8+, and allow compiler features
+  to be used on CMake 3.1+. Added C++17 standard check.
+  `#1098 <https://github.com/pybind/pybind11/pull/1098>`_.
+
 v2.2.2 (February 7, 2018)
 -----------------------------------------------------
 

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -100,12 +100,32 @@ regular LTO if ``-flto=thin`` is not available.
 Configuration variables
 -----------------------
 
-By default, pybind11 will compile modules with the C++14 standard, if available
-on the target compiler, falling back to C++11 if C++14 support is not
-available.  Note, however, that this default is subject to change: future
-pybind11 releases are expected to migrate to newer C++ standards as they become
-available.  To override this, the standard flag can be given explicitly in
-``PYBIND11_CPP_STANDARD``:
+By default, pybind11 will compile modules with the highest C++ standard available
+on the target compiler, from the set C++17, C++14, and C++11. With CMake 3.8+, this
+uses CMake's compile features mechinism and meta-features to detect your compiler's
+abilities. Older CMake versions fall back to manually trying to compile a mini-program
+with each flag.
+
+If you want to override this behavior, you have three options:
+
+CMake 3.1+: If you set ``CMAKE_CXX_STANDARD`` before including pybind11, it will be respected and no
+futher action will be taken by pybind11.
+
+CMake 3.1+: If you explicitly set a list of compile features in ``PYBIND11_CXX_FEATURES``, that will be used.
+See `CMAKE_CXX_KNOWN_FEATURES <https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html>`_
+for your CMake version.
+
+.. code-block:: cmake
+
+    # These meta-features were added in CMake 3.8:
+    set(PYBIND11_CXX_FEATURES cxx_std_11)
+    set(PYBIND11_CXX_FEATURES cxx_std_14)
+    set(PYBIND11_CXX_FEATURES cxx_std_17) # Experimental C++17 support
+
+    add_subdirectory(pybind11)  # or find_package(pybind11)
+
+CMake 2.8+: If neither of the above is set and you want to explicitly control the flag,
+the standard flag can be given as ``PYBIND11_CPP_STANDARD``:
 
 .. code-block:: cmake
 
@@ -120,9 +140,13 @@ available.  To override this, the standard flag can be given explicitly in
 
     add_subdirectory(pybind11)  # or find_package(pybind11)
 
-Note that this and all other configuration variables must be set **before** the
+Note that these and all other configuration variables must be set **before** the
 call to ``add_subdirectory`` or ``find_package``. The variables can also be set
 when calling CMake from the command line using the ``-D<variable>=<value>`` flag.
+
+Mixed C and C++ projects should use the ``PYBIND11_CXX_FEATURES`` mechanism to avoid
+adding flags to the C compiler. If you need the latest version of CMake, it is trivial
+to install; try ``pip install cmake`` or ``pip install --user cmake``.
 
 The target Python version can be selected by setting ``PYBIND11_PYTHON_VERSION``
 or an exact Python installation can be specified with ``PYTHON_EXECUTABLE``.

--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -28,8 +28,8 @@
 #
 # Python headers, libraries (as needed by platform), and the C++ standard
 # are attached to the target. Set PythonLibsNew variables to influence
-# python detection and PYBIND11_CPP_STANDARD (-std=c++11 or -std=c++14) to
-# influence standard setting. ::
+# python detection and PYBIND11_CPP_STANDARD or PYBIND11_CXX_FEATURES to
+# influence standard setting or CMake compiler features. ::
 #
 #   find_package(pybind11 CONFIG REQUIRED)
 #   message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
@@ -90,7 +90,7 @@ if(NOT TARGET ${PN}::pybind11)
       set_property(TARGET ${PN}::module APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${PYTHON_LIBRARIES})
     endif()
 
-    set_property(TARGET ${PN}::pybind11 APPEND PROPERTY INTERFACE_COMPILE_OPTIONS "${PYBIND11_CPP_STANDARD}")
+    _pybind11_target_cxx_std(${PN}::pybind11)
 
     get_property(_iid TARGET ${PN}::pybind11 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
     get_property(_ill TARGET ${PN}::module PROPERTY INTERFACE_LINK_LIBRARIES)


### PR DESCRIPTION
This is a suggested implementation for #1097.

This causes pybind11 to use CMake's built-in compiler features feature if no `PYBIND11_CPP_STANDARD` is set on CMake 3.8+. This integrates with the rest of the CMake infrastructure if the user wants to use `compiler_features`. It can also be added manually now. For example:

```cmake
cmake_minimum_required(VERSION 3.8)
project(scripting VERSION 1.0 LANGUAGES CXX)

set(PYBIND11_CXX_FEATURES cxx_std_11)
add_subdirectory(pybind11)

add_executable(scripting src/main.cpp)
target_compile_features(scripting PUBLIC cxx_std_14)
set_target_properties(scripting PROPERTIES CXX_EXTENSIONS OFF)

target_link_libraries(scripting pybind11::embed)

pybind11_add_module(fooapi src/foo.cpp)
```
In this example, scripting will be build with `-std=c++14`, and fooapi will be built with `-std=c++11`. No flags will be duplicated, only one std flag will be listed, etc. Before the patch, the standard gets listed twice, would be included on C only compilation, etc.

See below for a description of how the auto-discovery works.