### PR TITLE
WIP: Adding string constructor for enum

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -506,6 +506,21 @@ The ``name`` property returns the name of the enum value as a unicode string.
         >>> pet_type.name
         'Cat'
 
+You can also access the enumeration using a string using the enum's constructor,
+such as ``Pet('Cat')``. This makes it possible to automatically convert a string
+to an enumeration in an API if the enumeration is marked implicitly convertible
+from a string, with a line such as:
+
+.. code-block:: cpp
+
+    py::implicitly_convertible<std::string, Pet::Kind>();
+
+Now, in Python, the following code will also correctly construct a cat:
+
+.. code-block:: pycon
+
+    >>> p = Pet('Lucy', 'Cat')
+
 .. note::
 
     When the special tag ``py::arithmetic()`` is specified to the ``enum_``

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1411,6 +1411,14 @@ public:
             return m;
         }, return_value_policy::copy);
         def(init([](Scalar i) { return static_cast<Type>(i); }));
+        def(init([name, m_entries_ptr](std::string value) -> Type {
+            pybind11::dict values = reinterpret_borrow<pybind11::dict>(m_entries_ptr);
+            pybind11::str key = pybind11::str(value);
+            if (values.contains(key))
+                return pybind11::cast<Type>(values[key]);
+            else
+                throw value_error("\"" + value + "\" is not a valid value for enum type " + name);
+        }));
         def("__int__", [](Type value) { return (Scalar) value; });
         #if PY_MAJOR_VERSION < 3
             def("__long__", [](Type value) { return (Scalar) value; });

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -20,6 +20,22 @@ TEST_SUBMODULE(enums, m) {
         .value("ETwo", ETwo, "Docstring for ETwo")
         .export_values();
 
+    // test_conversion_enum
+    enum class ConversionEnum {
+        Convert1 = 1,
+        Convert2
+    };
+
+    py::enum_<ConversionEnum>(m, "ConversionEnum", py::arithmetic())
+        .value("Convert1", ConversionEnum::Convert1)
+        .value("Convert2", ConversionEnum::Convert2)
+        ;
+    py::implicitly_convertible<py::str, ConversionEnum>();
+
+    m.def("test_conversion_enum", [](ConversionEnum z) {
+        return "ConversionEnum::" + std::string(z == ConversionEnum::Convert1 ? "Convert1" : "Convert2");
+    });
+
     // test_scoped_enum
     enum class ScopedEnum {
         Two = 2,

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -54,6 +54,7 @@ Members:
 
     assert int(m.UnscopedEnum.ETwo) == 2
     assert str(m.UnscopedEnum(2)) == "UnscopedEnum.ETwo"
+    assert str(m.UnscopedEnum("ETwo")) == "UnscopedEnum.ETwo"
 
     # order
     assert m.UnscopedEnum.EOne < m.UnscopedEnum.ETwo
@@ -70,8 +71,28 @@ Members:
     assert not (2 < m.UnscopedEnum.EOne)
 
 
+def test_converstion_enum():
+    assert m.test_conversion_enum(m.ConversionEnum.Convert1) == "ConversionEnum::Convert1"
+    assert m.test_conversion_enum(m.ConversionEnum("Convert1")) == "ConversionEnum::Convert1"
+    assert m.test_conversion_enum("Convert1") == "ConversionEnum::Convert1"
+
+
+def test_conversion_enum_raises():
+    with pytest.raises(ValueError) as excinfo:
+        m.ConversionEnum("Convert0")
+    assert str(excinfo.value) == "\"Convert0\" is not a valid value for enum type ConversionEnum"
+
+
+def test_conversion_enum_raises_implicit():
+    with pytest.raises(ValueError) as excinfo:
+        m.test_conversion_enum("Convert0")
+    assert str(excinfo.value) == "\"Convert0\" is not a valid value for enum type ConversionEnum"
+
+
 def test_scoped_enum():
     assert m.test_scoped_enum(m.ScopedEnum.Three) == "ScopedEnum::Three"
+    with pytest.raises(TypeError):
+        m.test_scoped_enum("Three")
     z = m.ScopedEnum.Two
     assert m.test_scoped_enum(z) == "ScopedEnum::Two"
 


### PR DESCRIPTION
This adds the ability to access an enum using a string. So the following works now:

```python
from m import MyEnum
a = MyEnum.A
b = MyEnum("A")
a == b
```

Besides making it a bit easier to access enum values using a variable (vs. `getattr`), this also fixes #483 in a general way (and was based on comments there, combined with newer procedures). Assuming you have a C++ enum and function like this:

```cpp
enum class MyEnum {
    A = 1,
    B
};

int read_enum(MyEnum e) {
    return e==MyEnum::A ? 1 : 2;
}    
```

You can now add to the bindings:

```cpp
py::implicitly_convertible<std::string, MyEnum>();
```

And then this works:

```python
m.read_enum("A");
```

That reuses and elevates a nice feature (`implicitly_convertible`), rather than adding something new to `enum_`'s syntax. If this looks good, I'll add some docs and remove the WIP flag. The issue pointed out in the PR, which is that the error is swallowed up and converted to a less-useful one also needs to be addressed.