### PR TITLE
Added write only property functions for issue #1142

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,9 @@ v2.3.0 (Not yet released)
   for non-MSVC compilers).
   `#934 <https://github.com/pybind/pybind11/pull/934>`_.
 
+* Added support for write only properties.
+  `#1144 <https://github.com/pybind/pybind11/pull/1144>`_.
+
 v2.2.1 (September 14, 2017)
 -----------------------------------------------------
 

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -155,6 +155,9 @@ the setter and getter functions:
             .def_property("name", &Pet::getName, &Pet::setName)
             // ... remainder ...
 
+Write only properties can be defined by passing ``nullptr`` as the
+input for the read function.
+
 .. seealso::
 
     Similar functions :func:`class_::def_readwrite_static`,

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -959,8 +959,8 @@ protected:
     void def_property_static_impl(const char *name,
                                   handle fget, handle fset,
                                   detail::function_record *rec_func) {
-        const auto is_static = !(rec_func->is_method && rec_func->scope);
-        const auto has_doc = rec_func->doc && pybind11::options::show_user_defined_docstrings();
+        const auto is_static = rec_func && !(rec_func->is_method && rec_func->scope);
+        const auto has_doc = rec_func && rec_func->doc && pybind11::options::show_user_defined_docstrings();
         auto property = handle((PyObject *) (is_static ? get_internals().static_property_type
                                                        : &PyProperty_Type));
         attr(name) = property(fget.ptr() ? fget : none(),
@@ -1200,7 +1200,7 @@ public:
     /// Uses cpp_function's return_value_policy by default
     template <typename... Extra>
     class_ &def_property_readonly(const char *name, const cpp_function &fget, const Extra& ...extra) {
-        return def_property(name, fget, cpp_function(), extra...);
+        return def_property(name, fget, nullptr, extra...);
     }
 
     /// Uses return_value_policy::reference by default
@@ -1212,7 +1212,7 @@ public:
     /// Uses cpp_function's return_value_policy by default
     template <typename... Extra>
     class_ &def_property_readonly_static(const char *name, const cpp_function &fget, const Extra& ...extra) {
-        return def_property_static(name, fget, cpp_function(), extra...);
+        return def_property_static(name, fget, nullptr, extra...);
     }
 
     /// Uses return_value_policy::reference_internal by default
@@ -1242,7 +1242,7 @@ public:
     template <typename... Extra>
     class_ &def_property_static(const char *name, const cpp_function &fget, const cpp_function &fset, const Extra& ...extra) {
         auto rec_fget = get_function_record(fget), rec_fset = get_function_record(fset);
-        auto rec_active = rec_fget;
+        auto *rec_active = rec_fget;
         if (rec_fget) {
            char *doc_prev = rec_fget->doc; /* 'extra' field may include a property-specific documentation string */
            detail::process_attributes<Extra...>::init(extra..., rec_fget);

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -284,6 +284,7 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         .def_property("def_property_writeonly", nullptr, &TestProperties::set)
         .def_property_readonly("def_property_readonly", &TestProperties::get)
         .def_property("def_property", &TestProperties::get, &TestProperties::set)
+        .def_property("def_property_impossible", nullptr, nullptr)
         .def_readonly_static("def_readonly_static", &TestProperties::static_value)
         .def_readwrite_static("def_readwrite_static", &TestProperties::static_value)
         .def_property_static("def_writeonly_static", nullptr,

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -279,12 +279,19 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         .def(py::init<>())
         .def_readonly("def_readonly", &TestProperties::value)
         .def_readwrite("def_readwrite", &TestProperties::value)
+        .def_property("def_writeonly", nullptr,
+                      [](TestProperties& s,int v) { s.value = v; } )
+        .def_property("def_property_writeonly", nullptr, &TestProperties::set)
         .def_property_readonly("def_property_readonly", &TestProperties::get)
         .def_property("def_property", &TestProperties::get, &TestProperties::set)
         .def_readonly_static("def_readonly_static", &TestProperties::static_value)
         .def_readwrite_static("def_readwrite_static", &TestProperties::static_value)
+        .def_property_static("def_writeonly_static", nullptr,
+                             [](py::object, int v) { TestProperties::static_value = v; })
         .def_property_readonly_static("def_property_readonly_static",
                                       [](py::object) { return TestProperties::static_get(); })
+        .def_property_static("def_property_writeonly_static", nullptr,
+                             [](py::object, int v) { return TestProperties::static_set(v); })
         .def_property_static("def_property_static",
                              [](py::object) { return TestProperties::static_get(); },
                              [](py::object, int v) { TestProperties::static_set(v); })

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -98,6 +98,11 @@ def test_properties():
     instance.def_property = 3
     assert instance.def_property == 3
 
+    with pytest.raises(AttributeError):
+        dummy = instance.def_property_writeonly  # noqa: F841 unused var
+    instance.def_property_writeonly = 4
+    assert instance.def_property_readonly == 4
+
 
 def test_static_properties():
     assert m.TestProperties.def_readonly_static == 1
@@ -108,13 +113,27 @@ def test_static_properties():
     m.TestProperties.def_readwrite_static = 2
     assert m.TestProperties.def_readwrite_static == 2
 
-    assert m.TestProperties.def_property_readonly_static == 2
     with pytest.raises(AttributeError) as excinfo:
-        m.TestProperties.def_property_readonly_static = 3
+        dummy = m.TestProperties.def_writeonly_static  # noqa: F841 unused var
+    assert "unreadable attribute" in str(excinfo)
+
+    m.TestProperties.def_writeonly_static = 3
+    assert m.TestProperties.def_readonly_static == 3
+
+    assert m.TestProperties.def_property_readonly_static == 3
+    with pytest.raises(AttributeError) as excinfo:
+        m.TestProperties.def_property_readonly_static = 99
     assert "can't set attribute" in str(excinfo)
 
-    m.TestProperties.def_property_static = 3
-    assert m.TestProperties.def_property_static == 3
+    m.TestProperties.def_property_static = 4
+    assert m.TestProperties.def_property_static == 4
+
+    with pytest.raises(AttributeError) as excinfo:
+        dummy = m.TestProperties.def_property_writeonly_static
+    assert "unreadable attribute" in str(excinfo)
+
+    m.TestProperties.def_property_writeonly_static = 5
+    assert m.TestProperties.def_property_static == 5
 
     # Static property read and write via instance
     instance = m.TestProperties()
@@ -126,6 +145,13 @@ def test_static_properties():
     instance.def_readwrite_static = 2
     assert m.TestProperties.def_readwrite_static == 2
     assert instance.def_readwrite_static == 2
+
+    with pytest.raises(AttributeError) as excinfo:
+        dummy = instance.def_property_writeonly_static  # noqa: F841 unused var
+    assert "unreadable attribute" in str(excinfo)
+
+    instance.def_property_writeonly_static = 4
+    assert instance.def_property_static == 4
 
     # It should be possible to override properties in derived classes
     assert m.TestPropertiesOverride().def_readonly == 99

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -98,10 +98,20 @@ def test_properties():
     instance.def_property = 3
     assert instance.def_property == 3
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError) as excinfo:
         dummy = instance.def_property_writeonly  # noqa: F841 unused var
+    assert "unreadable attribute" in str(excinfo)
+
     instance.def_property_writeonly = 4
     assert instance.def_property_readonly == 4
+
+    with pytest.raises(AttributeError) as excinfo:
+        dummy = instance.def_property_impossible  # noqa: F841 unused var
+    assert "unreadable attribute" in str(excinfo)
+
+    with pytest.raises(AttributeError) as excinfo:
+        instance.def_property_impossible = 5
+    assert "can't set attribute" in str(excinfo)
 
 
 def test_static_properties():


### PR DESCRIPTION
Added support for write only properties using the def methods:

- def_writeonly
- def_writeonly_static
- def_property_writeonly
- def_property_writeonly_static

The lowest level property implementation in def_property_static() was updated to check to see if the fget pointer is null to allow for these cases.  Tests cases added and run.  Python handles the non-readable attribute the same way it does in regular Python so the error is identical to that in #1142.

```
>>> msr.ignore = "asdf"
>>> msr.ignore
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: unreadable attribute
```