### PR TITLE
Fix for CUDA (and Intel) compilers from #1121

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -835,7 +835,7 @@ public:
             nullptr, nullptr, holder);
     }
 
-    template <typename T> using cast_op_type = cast_op_type<T>;
+    template <typename T> using cast_op_type = detail::cast_op_type<T>;
 
     operator itype*() { return (type *) value; }
     operator itype&() { if (!value) throw reference_cast_error(); return *((itype *) value); }


### PR DESCRIPTION
This is needed to compile with NVCC to bind CUDA code again (worked in 2.1). Should also be applied to master, I believe.