### PR TITLE
support docstrings in enum:_:value()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,9 @@ v2.3.0 (Not yet released)
   for non-MSVC compilers).
   `#934 <https://github.com/pybind/pybind11/pull/934>`_.
 
+* The ``value()``  method of ``py::enum_`` now accepts an optional docstring
+  that will be shown in the documentation of the associated enumeration.
+
 v2.2.1 (September 14, 2017)
 -----------------------------------------------------
 

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -15,9 +15,9 @@ TEST_SUBMODULE(enums, m) {
         EOne = 1,
         ETwo
     };
-    py::enum_<UnscopedEnum>(m, "UnscopedEnum", py::arithmetic())
-        .value("EOne", EOne)
-        .value("ETwo", ETwo)
+    py::enum_<UnscopedEnum>(m, "UnscopedEnum", py::arithmetic(), "An unscoped enumeration")
+        .value("EOne", EOne, "Docstring for EOne")
+        .value("ETwo", ETwo, "Docstring for ETwo")
         .export_values();
 
     // test_scoped_enum

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -18,6 +18,22 @@ def test_unscoped_enum():
     assert m.UnscopedEnum.__members__ == \
         {"EOne": m.UnscopedEnum.EOne, "ETwo": m.UnscopedEnum.ETwo}
 
+    assert m.UnscopedEnum.__doc__ == \
+        '''An unscoped enumeration
+
+Members:
+
+  EOne : Docstring for EOne
+
+  ETwo : Docstring for ETwo''' or m.UnscopedEnum.__doc__ == \
+        '''An unscoped enumeration
+
+Members:
+
+  ETwo : Docstring for ETwo
+
+  EOne : Docstring for EOne'''
+
     # no TypeError exception for unscoped enum ==/!= int comparisons
     y = m.UnscopedEnum.ETwo
     assert y == 2


### PR DESCRIPTION
This PR fixes #1136 by adding an optional docstring for each value of an enumeration so that they can be documented in a way that is analogous to classes, methods, properties, etc.

I'm not 100% happy happy with the change because it ends up adding even more code that is instantiated for each enumeration. A longer-term change that would be nice to do is to refactor enumeration so that there is a top-level class ``enum_base`` class (analogous to ``pybind11_object``) which contains genereric versions of all methods and thin wrappers that are instantiated for each concrete enumeration.