### PR TITLE
Only build embedded tests with a shared libpython

### DIFF
--- a/tests/test_embed/CMakeLists.txt
+++ b/tests/test_embed/CMakeLists.txt
@@ -4,6 +4,12 @@ if(${PYTHON_MODULE_EXTENSION} MATCHES "pypy")
   return()
 endif()
 
+
+if(NOT PYTHON_LIBRARY_SHARED)
+  message(STATUS "Python shared library not found; skipping interpreter tests")
+  return()
+endif()
+
 find_package(Catch 1.9.3)
 if(CATCH_FOUND)
   message(STATUS "Building interpreter tests using Catch v${CATCH_VERSION}")

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -85,6 +85,7 @@ print(struct.calcsize('@P'));
 print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));
 print(s.get_config_var('LIBDIR') or '');
 print(s.get_config_var('MULTIARCH') or '');
+print(s.get_config_var('LDLIBRARY'));
 "
     RESULT_VARIABLE _PYTHON_SUCCESS
     OUTPUT_VARIABLE _PYTHON_VALUES
@@ -112,6 +113,7 @@ list(GET _PYTHON_VALUES 6 PYTHON_SIZEOF_VOID_P)
 list(GET _PYTHON_VALUES 7 PYTHON_LIBRARY_SUFFIX)
 list(GET _PYTHON_VALUES 8 PYTHON_LIBDIR)
 list(GET _PYTHON_VALUES 9 PYTHON_MULTIARCH)
+list(GET _PYTHON_VALUES 10 _PYTHON_LIBRARY_NAME)
 
 # Make sure the Python has the same pointer-size as the chosen compiler
 # Skip if CMAKE_SIZEOF_VOID_P is not defined
@@ -165,7 +167,7 @@ else()
     # Probably this needs to be more involved. It would be nice if the config
     # information the python interpreter itself gave us were more complete.
     find_library(PYTHON_LIBRARY
-        NAMES "python${PYTHON_LIBRARY_SUFFIX}"
+        NAMES ${_PYTHON_LIBRARY_NAME}
         PATHS ${_PYTHON_LIBS_SEARCH}
         NO_DEFAULT_PATH)
 

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -5,7 +5,8 @@
 #
 #  PYTHONLIBS_FOUND           - have the Python libs been found
 #  PYTHON_PREFIX              - path to the Python installation
-#  PYTHON_LIBRARIES           - path to the python library
+#  PYTHON_LIBRARIES           - path to the python library (could be static)
+#  PYTHON_SHARED_LIBRARY      - path to the python shared library, if found
 #  PYTHON_INCLUDE_DIRS        - path to where Python.h is found
 #  PYTHON_MODULE_EXTENSION    - lib extension, e.g. '.so' or '.pyd'
 #  PYTHON_MODULE_PREFIX       - lib name prefix: usually an empty string
@@ -85,7 +86,6 @@ print(struct.calcsize('@P'));
 print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));
 print(s.get_config_var('LIBDIR') or '');
 print(s.get_config_var('MULTIARCH') or '');
-print(s.get_config_var('LDLIBRARY'));
 "
     RESULT_VARIABLE _PYTHON_SUCCESS
     OUTPUT_VARIABLE _PYTHON_VALUES
@@ -113,7 +113,6 @@ list(GET _PYTHON_VALUES 6 PYTHON_SIZEOF_VOID_P)
 list(GET _PYTHON_VALUES 7 PYTHON_LIBRARY_SUFFIX)
 list(GET _PYTHON_VALUES 8 PYTHON_LIBDIR)
 list(GET _PYTHON_VALUES 9 PYTHON_MULTIARCH)
-list(GET _PYTHON_VALUES 10 _PYTHON_LIBRARY_NAME)
 
 # Make sure the Python has the same pointer-size as the chosen compiler
 # Skip if CMAKE_SIZEOF_VOID_P is not defined
@@ -163,13 +162,27 @@ else()
     else()
         set(_PYTHON_LIBS_SEARCH "${PYTHON_LIBDIR}")
     endif()
-    #message(STATUS "Searching for Python libs in ${_PYTHON_LIBS_SEARCH}")
+
+    # Override the library suffix to only look for shared libraries first:
+    set(_PYTHON_SAVE_CFLS "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX} ${CMAKE_SHARED_MODULE_SUFFIX})
     # Probably this needs to be more involved. It would be nice if the config
     # information the python interpreter itself gave us were more complete.
-    find_library(PYTHON_LIBRARY
-        NAMES ${_PYTHON_LIBRARY_NAME}
+    find_library(PYTHON_LIB_SHARED
+        NAMES "python${PYTHON_LIBRARY_SUFFIX}"
         PATHS ${_PYTHON_LIBS_SEARCH}
         NO_DEFAULT_PATH)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES "${_PYTHON_SAVE_CFLS}")  # Restore original
+
+    if (PYTHON_LIB_SHARED)
+        set(PYTHON_LIBRARY "${PYTHON_LIB_SHARED}")
+    else()
+        # If that didn't work, try again, this time allowing a static lib
+        find_library(PYTHON_LIBRARY
+            NAMES "python${PYTHON_LIBRARY_SUFFIX}"
+            PATHS ${_PYTHON_LIBS_SEARCH}
+            NO_DEFAULT_PATH)
+    endif()
 
     # If all else fails, just set the name/version and let the linker figure out the path.
     if(NOT PYTHON_LIBRARY)
@@ -179,6 +192,7 @@ endif()
 
 MARK_AS_ADVANCED(
   PYTHON_LIBRARY
+  PYTHON_LIB_SHARED
   PYTHON_INCLUDE_DIR
 )
 
@@ -188,6 +202,7 @@ MARK_AS_ADVANCED(
 # module.
 SET(PYTHON_INCLUDE_DIRS "${PYTHON_INCLUDE_DIR}")
 SET(PYTHON_LIBRARIES "${PYTHON_LIBRARY}")
+SET(PYTHON_LIBRARY_SHARED "${PYTHON_LIB_SHARED}")
 SET(PYTHON_DEBUG_LIBRARIES "${PYTHON_DEBUG_LIBRARY}")
 
 find_package_message(PYTHON


### PR DESCRIPTION
Edit: see below.

~~CMake's find_library can return a static library in some conditions
(certainly if the shared object isn't present; I'm not sure if there
are other conditions as well), which we don't support (and fails).~~

~~This improves the libpython detection by getting the shared library name
directly from Python rather than letting CMake guess (by prepending
`lib` and appending library suffixes).~~

~~This should, at least, prevent the embedded build from failing as in
issue #1159 -- instead it should either find the proper shared library,
or else result in a compilation failure from the missing library.~~

That didn't work on macOS.  It looks like Python just doesn't export enough to find the shared library.  Pushed a new approach that essentially goes back to the previous version, but does it in two steps: first looking only for a shared library, then, if that fails, widening the search to allow a static lib.  The shared library gets exported in a separate variable, which is then used to disable the embedding tests if a shared library wasn't found.