### PR TITLE
Trivial typos

### DIFF
--- a/docs/advanced/cast/eigen.rst
+++ b/docs/advanced/cast/eigen.rst
@@ -41,7 +41,7 @@ consideration: by default, numpy matrices and eigen matrices are *not* storage
 compatible.
 
 If the numpy matrix cannot be used as is (either because its types differ, e.g.
-passing an array of integers to an Eigen paramater requiring doubles, or
+passing an array of integers to an Eigen parameter requiring doubles, or
 because the storage is incompatible), pybind11 makes a temporary copy and
 passes the copy instead.
 
@@ -89,7 +89,7 @@ as dictated by the binding function's return value policy (see the
 documentation on :ref:`return_value_policies` for full details).  That means,
 without an explicit return value policy, lvalue references will be copied and
 pointers will be managed by pybind11.  In order to avoid copying, you should
-explictly specify an appropriate return value policy, as in the following
+explicitly specify an appropriate return value policy, as in the following
 example:
 
 .. code-block:: cpp
@@ -287,7 +287,7 @@ On the other hand, pybind11 allows you to pass 1-dimensional arrays of length N
 as Eigen parameters.  If the Eigen type can hold a column vector of length N it
 will be passed as such a column vector.  If not, but the Eigen type constraints
 will accept a row vector, it will be passed as a row vector.  (The column
-vector takes precendence when both are supported, for example, when passing a
+vector takes precedence when both are supported, for example, when passing a
 1D numpy array to a MatrixXd argument).  Note that the type need not be
 expicitly a vector: it is permitted to pass a 1D numpy array of size 5 to an
 Eigen ``Matrix<double, Dynamic, 5>``: you would end up with a 1x5 Eigen matrix.

--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -473,7 +473,7 @@ Overload resolution order
 When a function or method with multiple overloads is called from Python,
 pybind11 determines which overload to call in two passes.  The first pass
 attempts to call each overload without allowing argument conversion (as if
-every argument had been specified as ``py::arg().noconvert()`` as decribed
+every argument had been specified as ``py::arg().noconvert()`` as described
 above).
 
 If no overload succeeds in the no-conversion first pass, a second pass is

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -471,7 +471,7 @@ template <size_t... IPrev, size_t I, bool B, bool... Bs> struct select_indices_i
     : select_indices_impl<conditional_t<B, index_sequence<IPrev..., I>, index_sequence<IPrev...>>, I + 1, Bs...> {};
 template <bool... Bs> using select_indices = typename select_indices_impl<index_sequence<>, 0, Bs...>::type;
 
-/// Backports of std::bool_constant and std::negation to accomodate older compilers
+/// Backports of std::bool_constant and std::negation to accommodate older compilers
 template <bool B> using bool_constant = std::integral_constant<bool, B>;
 template <typename T> struct negation : bool_constant<!T::value> { };
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,5 +6,5 @@ max-line-length = 99
 show_source = True
 exclude = .git, __pycache__, build, dist, docs, tools, venv
 ignore =
-    # required for pretty matrix formating: multiple spaces after `,` and `[`
+    # required for pretty matrix formatting: multiple spaces after `,` and `[`
     E201, E241

--- a/tests/test_factory_constructors.cpp
+++ b/tests/test_factory_constructors.cpp
@@ -13,7 +13,7 @@
 #include <cmath>
 
 // Classes for testing python construction via C++ factory function:
-// Not publically constructible, copyable, or movable:
+// Not publicly constructible, copyable, or movable:
 class TestFactory1 {
     friend class TestFactoryHelper;
     TestFactory1() : value("(empty)") { print_default_created(this); }

--- a/tests/test_virtual_functions.cpp
+++ b/tests/test_virtual_functions.cpp
@@ -249,7 +249,7 @@ TEST_SUBMODULE(virtual_functions, m) {
     m.def("dispatch_issue_go", [](const Base * b) { return b->dispatch(); });
 
     // test_override_ref
-    // #392/397: overridding reference-returning functions
+    // #392/397: overriding reference-returning functions
     class OverrideTest {
     public:
         struct A { std::string value = "hi"; };

--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -227,7 +227,7 @@ def test_dispatch_issue(msg):
 
 
 def test_override_ref():
-    """#392/397: overridding reference-returning functions"""
+    """#392/397: overriding reference-returning functions"""
     o = m.OverrideTest("asdf")
 
     # Not allowed (see associated .cpp comment)

--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -10,7 +10,7 @@
 # 4. missing space between keyword and parenthesis, e.g.: for(, if(, while(
 # 5. Missing space between right parenthesis and brace, e.g. 'for (...){'
 # 6. opening brace on its own line. It should always be on the same line as the
-#    if/while/for/do statment.
+#    if/while/for/do statement.
 #
 # Invoke as: tools/check-style.sh
 #


### PR DESCRIPTION
Non-user facing. 
Found using `codespell -q 3`