### PR TITLE
Document using atexit for module destructors

### DIFF
--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -172,19 +172,9 @@ Module Destructors
 ==================
 
 pybind11 does not provide an explicit mechanism to invoke cleanup code at
-module destruction time. The Python :py:mod:`atexit` module [#f7]_ can be used
-to register functions to be called at shutdown.
-
-.. code-block:: cpp
-
-    auto atexit = py::module::import("atexit");
-    atexit.attr("register")(py::cpp_function([]() {
-        // perform cleanup here -- this function is called with the GIL held
-    }));
-
-In rare cases where such functionality is required and :py:mod:`atexit` is
-insufficient, it is possible to emulate it using Python capsules or weak
-references with a destruction callback.
+module destruction time. In rare cases where such functionality is required, it
+is possible to emulate it using Python capsules or weak references with a
+destruction callback.
 
 .. code-block:: cpp
 
@@ -228,10 +218,18 @@ avoids this issue involves weak reference with a cleanup callback:
 
 .. note::
 
-    Only the :py:mod:`atexit` approach works on PyPy. The other approaches rely
-    on implementation details of CPython's garbage collection.
+    PyPy (at least version 5.9) does not garbage collect objects when the
+    interpreter exits. An alternative approach (which also works on CPython) is to use
+    the :py:mod:`atexit` module [#f7]_, for example:
 
-.. [#f7] https://docs.python.org/3/library/atexit.html
+    .. code-block:: cpp
+
+        auto atexit = py::module::import("atexit");
+        atexit.attr("register")(py::cpp_function([]() {
+            // perform cleanup here -- this function is called with the GIL held
+        }));
+
+    .. [#f7] https://docs.python.org/3/library/atexit.html
 
 
 Generating documentation using Sphinx


### PR DESCRIPTION
None of the three currently recommended approaches works on PyPy, due to
it not garbage collecting things when you want it to. Added an example
showing how to get interpreter shutdown callbacks using the Python
atexit module, and added a note that the other approaches are not
portable.