### PR TITLE
Link to libpython with flat namespace on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if(NOT (CMAKE_VERSION VERSION_LESS 3.0))  # CMake >= 3.0
   if(WIN32 OR CYGWIN)
     target_link_libraries(module INTERFACE $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
   elseif(APPLE)
-    target_link_libraries(module INTERFACE "-undefined dynamic_lookup")
+    target_link_libraries(module INTERFACE "-flat_namespace" ${PYTHON_LIBRARIES})
   endif()
 
   add_library(embed INTERFACE)


### PR DESCRIPTION
On OSX, linking against `libpython` dynamically from the compiled python module will break at runtime if the python interpreter was statically linked with `libpython`. This problem has been avoided by not linking against `libpython` at all, and then disabling unresolved symbol errors with `-undefined dynamic`.

The downside of that solution is that it suppresses all unresolved symbol errors for that link, even those that are entirely unrelated to use of `pybind11`. This can hide other build setup issues and lead to less obvious runtime errors.

The reason things break on OSX is the two-level namespace: the symbols statically linked into the interpreter and the symbols obtained from `libpython` dynamically are distinct (unlike on Linux). If we disable the two-level namespace with `-flat_namespace`, the problem goes away and we can link to `libpython` and retain unresolved symbol errors.

This change was tested on Sierra with `make check` and seems to work fine; I confirmed that the new linker argument is being applied, and also that if I remove `libpython` from the link then I get unresolved symbol errors as expected.

I am using `pybind11` on another project in which we use our own CMake setup and link against Anaconda python packages, which (as of recently) statically link `libpython` - so I encountered the duplicate symbol problem, and found the `-flat_namespace` solution works perfectly.