### PR TITLE
Clarify docs for functions taking bytes and not str.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ MANIFEST
 *.py[co]
 *.egg-info
 *~
+.*.swp
 .DS_Store
 /dist
 /build

--- a/docs/advanced/cast/strings.rst
+++ b/docs/advanced/cast/strings.rst
@@ -58,7 +58,9 @@ Passing bytes to C++
 --------------------
 
 A Python ``bytes`` object will be passed to C++ functions that accept
-``std::string`` or ``char*`` *without* conversion.
+``std::string`` or ``char*`` *without* conversion.  On Python 3, in order to
+make a function *only* accept ``bytes`` (and not ``str``), declare it as taking
+a ``py::bytes`` argument.
 
 
 Returning C++ strings to Python


### PR DESCRIPTION
I don't think the point mentioned in the commit is explicitly mentioned anywhere; my reading of the current docs originally suggested (wrongly) to me that there was no way to declare a function as accepting bytes and not str.