### PR TITLE
Matching Python 2 int behavior on Python 2

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -981,18 +981,11 @@ public:
         if (std::is_floating_point<T>::value) {
             return PyFloat_FromDouble((double) src);
         } else if (sizeof(T) <= sizeof(ssize_t)) {
-#if PY_VERSION_HEX < 0x03000000
             // This returns a long automatically if needed
             if (std::is_signed<T>::value)
-                return PyInt_FromSsize_t((ssize_t) src);
+                return PYBIND11_LONG_FROM_SIGNED(src);
             else
-                return PyInt_FromSize_t((size_t) src);
-#else
-            if (std::is_signed<T>::value)
-                return PyLong_FromSsize_t((ssize_t) src);
-            else
-                return PyLong_FromSize_t((size_t) src);
-#endif
+                return PYBIND11_LONG_FROM_UNSIGNED(src);
         } else {
             if (std::is_signed<T>::value)
                 return PyLong_FromLongLong((long long) src);

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -980,11 +980,19 @@ public:
     static handle cast(T src, return_value_policy /* policy */, handle /* parent */) {
         if (std::is_floating_point<T>::value) {
             return PyFloat_FromDouble((double) src);
-        } else if (sizeof(T) <= sizeof(long)) {
+        } else if (sizeof(T) <= sizeof(ssize_t)) {
+#if PY_VERSION_HEX < 0x03000000
+            // This returns a long automatically if needed
             if (std::is_signed<T>::value)
-                return PyLong_FromLong((long) src);
+                return PyInt_FromSsize_t((ssize_t) src);
             else
-                return PyLong_FromUnsignedLong((unsigned long) src);
+                return PyInt_FromSize_t((size_t) src);
+#else
+            if (std::is_signed<T>::value)
+                return PyLong_FromSsize_t((ssize_t) src);
+            else
+                return PyLong_FromSize_t((size_t) src);
+#endif
         } else {
             if (std::is_signed<T>::value)
                 return PyLong_FromLongLong((long long) src);

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -158,6 +158,8 @@
 #define PYBIND11_BYTES_SIZE PyBytes_Size
 #define PYBIND11_LONG_CHECK(o) PyLong_Check(o)
 #define PYBIND11_LONG_AS_LONGLONG(o) PyLong_AsLongLong(o)
+#define PYBIND11_LONG_FROM_SIGNED(o) PyLong_FromSsize_t((ssize_t) o)
+#define PYBIND11_LONG_FROM_UNSIGNED(o) PyLong_FromSize_t((size_t) o)
 #define PYBIND11_BYTES_NAME "bytes"
 #define PYBIND11_STRING_NAME "str"
 #define PYBIND11_SLICE_OBJECT PyObject
@@ -180,6 +182,8 @@
 #define PYBIND11_BYTES_SIZE PyString_Size
 #define PYBIND11_LONG_CHECK(o) (PyInt_Check(o) || PyLong_Check(o))
 #define PYBIND11_LONG_AS_LONGLONG(o) (PyInt_Check(o) ? (long long) PyLong_AsLong(o) : PyLong_AsLongLong(o))
+#define PYBIND11_LONG_FROM_SIGNED(o) PyInt_FromSsize_t((ssize_t) o) // Returns long if needed.
+#define PYBIND11_LONG_FROM_UNSIGNED(o) PyInt_FromSize_t((size_t) o) // Returns long if needed.
 #define PYBIND11_BYTES_NAME "str"
 #define PYBIND11_STRING_NAME "unicode"
 #define PYBIND11_SLICE_OBJECT PySliceObject

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -159,5 +159,5 @@ TEST_SUBMODULE(builtin_casters, m) {
     // test int vs. long (Python 2)
     m.def("int_cast", []() {return (int) 42;});
     m.def("long_cast", []() {return (long) 42;});
-    m.def("longlong_cast", []() {return (long long) 42;});
+    m.def("longlong_cast", []() {return  ULLONG_MAX;});
 }

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -155,4 +155,9 @@ TEST_SUBMODULE(builtin_casters, m) {
     // test_complex
     m.def("complex_cast", [](float x) { return "{}"_s.format(x); });
     m.def("complex_cast", [](std::complex<float> x) { return "({}, {})"_s.format(x.real(), x.imag()); });
+
+    // test int vs. long (Python 2)
+    m.def("int_cast", []() {return (int) 42;});
+    m.def("long_cast", []() {return (long) 42;});
+    m.def("longlong_cast", []() {return (long long) 42;});
 }

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -323,3 +323,12 @@ def test_numpy_bool():
     assert convert(np.bool_(False)) is False
     assert noconvert(np.bool_(True)) is True
     assert noconvert(np.bool_(False)) is False
+
+
+def test_int_long():
+    """In Python 2, a C++ int should return a Python int if possible, not long."""
+    import sys
+    must_be_long = type(getattr(sys, 'maxint', 1) + 1)
+    isinstance(m.int_cast(), int)
+    isinstance(m.long_cast(), int)
+    isinstance(m.longlong_cast(), must_be_long)

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -326,9 +326,13 @@ def test_numpy_bool():
 
 
 def test_int_long():
-    """In Python 2, a C++ int should return a Python int if possible, not long."""
+    """In Python 2, a C++ int should return a Python int rather than long
+    if possible: longs are not always accepted where ints are used (such
+    as the argument to sys.exit()). A C++ long long is always a Python
+    long."""
+
     import sys
     must_be_long = type(getattr(sys, 'maxint', 1) + 1)
-    isinstance(m.int_cast(), int)
-    isinstance(m.long_cast(), int)
-    isinstance(m.longlong_cast(), must_be_long)
+    assert isinstance(m.int_cast(), int)
+    assert isinstance(m.long_cast(), int)
+    assert isinstance(m.longlong_cast(), must_be_long)


### PR DESCRIPTION
This is from a Gitter discussion. Pybind11's default conversion to `int` always produces a `long` on Python 2 (`int`s and `long`s were unified in Python 3). This patch fixes `int` handling to match Python 2 on Python 2; for short types (`size_t` or smaller), the number will be returned as an `int` if possible, otherwise `long`. Requires Python 2.5+.

An example of where this matters: The `sys.exit` function must have an int. So if you have this:

```cpp
.def("__int__", &Thing::operator int)
```

You currently need this to work;

```python
sys.exit(int(int(thing)))
```

My Python 2 numpy is having issues, so can't test locally yet.