### PR TITLE
Detect pybind11 header path without depending on pip internals (fixes #1174)

### DIFF
--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -1,11 +1,28 @@
 from ._version import version_info, __version__  # noqa: F401 imported but unused
 
 
-def get_include(*args, **kwargs):
+def get_include(user=False):
+    from distutils.dist import Distribution
     import os
-    try:
-        from pip import locations
-        return os.path.dirname(
-            locations.distutils_scheme('pybind11', *args, **kwargs)['headers'])
-    except ImportError:
-        return 'include'
+    import sys
+
+    # Are we running in a virtual environment?
+    virtualenv = hasattr(sys, 'real_prefix') or \
+        sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+
+    if virtualenv:
+        return os.path.join(sys.prefix, 'include', 'site',
+                            'python' + sys.version[:3])
+    else:
+        dist = Distribution({'name': 'pybind11'})
+        dist.parse_config_files()
+
+        dist_cobj = dist.get_command_obj('install', create=True)
+
+        # Search for packages in user's home directory?
+        if user:
+            dist_cobj.user = user
+            dist_cobj.prefix = ""
+        dist_cobj.finalize_options()
+
+        return os.path.dirname(dist_cobj.install_headers)


### PR DESCRIPTION
The upcoming version of pip will disable all access to internals including the ``pip.locations.distutils_scheme('pybind11')['headers']`` function that we currently rely on. This commit reimplements a basic subset of this function within pybind11. I'm also open to other approaches if anybody has a better idea :)

We should probably backport a similar patch to previous releases.