### PR TITLE
Fix warning in C++17 mode.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -193,9 +193,9 @@ install:
         ${PYPY:+--extra-index-url https://imaginary.ca/trusty-pypi}
     echo "done."
 
-    wget -q -O eigen.tar.gz https://bitbucket.org/eigen/eigen/get/3.3.3.tar.gz
-    tar xzf eigen.tar.gz
-    export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH:+$CMAKE_INCLUDE_PATH:}$PWD/eigen-eigen-67e894c6cd8f"
+    curl -fsSL https://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2 | \
+        tar --extract -j --one-top-level=eigen --strip-components=1
+    export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH:+$CMAKE_INCLUDE_PATH:}$PWD/eigen"
   fi
   set +e
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,8 +193,9 @@ install:
         ${PYPY:+--extra-index-url https://imaginary.ca/trusty-pypi}
     echo "done."
 
+    mkdir eigen
     curl -fsSL https://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2 | \
-        tar --extract -j --one-top-level=eigen --strip-components=1
+        tar --extract -j --directory=eigen --strip-components=1
     export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH:+$CMAKE_INCLUDE_PATH:}$PWD/eigen"
   fi
   set +e

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -25,8 +25,12 @@ template <typename T> struct format_descriptor<std::complex<T>, detail::enable_i
     static std::string format() { return std::string(value); }
 };
 
+#ifndef PYBIND11_CPP17
+
 template <typename T> constexpr const char format_descriptor<
     std::complex<T>, detail::enable_if_t<std::is_floating_point<T>::value>>::value[3];
+
+#endif
 
 NAMESPACE_BEGIN(detail)
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -704,8 +704,12 @@ template <typename T> struct format_descriptor<T, detail::enable_if_t<std::is_ar
     static std::string format() { return std::string(1, c); }
 };
 
+#if !defined(PYBIND11_CPP17)
+
 template <typename T> constexpr const char format_descriptor<
     T, detail::enable_if_t<std::is_arithmetic<T>::value>>::value[2];
+
+#endif
 
 /// RAII wrapper that temporarily clears any Python error state
 struct error_scope {

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -17,6 +17,11 @@
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wconversion"
 #  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#  if defined(PYBIND11_CPP17) && defined(__clang__)
+//   Eigen generates a bunch of implicit-copy-constructor-is-deprecated warnings with -Wdeprecated
+//   under Clang in C++17 mode, so disable that warning here:
+#    pragma GCC diagnostic ignored "-Wdeprecated"
+#  endif
 #  if __GNUC__ >= 7
 #    pragma GCC diagnostic ignored "-Wint-in-bool-context"
 #  endif

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -17,9 +17,9 @@
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wconversion"
 #  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#  if defined(PYBIND11_CPP17) && defined(__clang__)
+#  ifdef __clang__
 //   Eigen generates a bunch of implicit-copy-constructor-is-deprecated warnings with -Wdeprecated
-//   under Clang in C++17 mode, so disable that warning here:
+//   under Clang, so disable that warning here:
 #    pragma GCC diagnostic ignored "-Wdeprecated"
 #  endif
 #  if __GNUC__ >= 7

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -295,6 +295,9 @@ public:
         PyErr_Fetch(&type.ptr(), &value.ptr(), &trace.ptr());
     }
 
+    error_already_set(const error_already_set &) = default;
+    error_already_set(error_already_set &&) = default;
+
     inline ~error_already_set();
 
     /// Give the currently-held error back to Python, if any.  If there is currently a Python error

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,7 +124,7 @@ function(pybind11_enable_warnings target_name)
   if(MSVC)
     target_compile_options(${target_name} PRIVATE /W4)
   else()
-      target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wconversion -Wcast-qual)
+      target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wconversion -Wcast-qual -Wdeprecated)
   endif()
 
   if(PYBIND11_WERROR)

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -36,6 +36,8 @@ TEST_SUBMODULE(call_policies, m) {
     class Child {
     public:
         Child() { py::print("Allocating child."); }
+        Child(const Child &) = default;
+        Child(Child &&) = default;
         ~Child() { py::print("Releasing child."); }
     };
     py::class_<Child>(m, "Child")

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -14,6 +14,9 @@
 TEST_SUBMODULE(class_, m) {
     // test_instance
     struct NoConstructor {
+        NoConstructor() = default;
+        NoConstructor(const NoConstructor &) = default;
+        NoConstructor(NoConstructor &&) = default;
         static NoConstructor *new_instance() {
             auto *ptr = new NoConstructor();
             print_created(ptr, "via new_instance");
@@ -82,7 +85,12 @@ TEST_SUBMODULE(class_, m) {
     m.def("dog_bark", [](const Dog &dog) { return dog.bark(); });
 
     // test_automatic_upcasting
-    struct BaseClass { virtual ~BaseClass() {} };
+    struct BaseClass {
+        BaseClass() = default;
+        BaseClass(const BaseClass &) = default;
+        BaseClass(BaseClass &&) = default;
+        virtual ~BaseClass() {}
+    };
     struct DerivedClass1 : BaseClass { };
     struct DerivedClass2 : BaseClass { };
 

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -49,7 +49,14 @@ namespace test_exc_sp {
 int f1(int x) noexcept { return x+1; }
 int f2(int x) noexcept(true) { return x+2; }
 int f3(int x) noexcept(false) { return x+3; }
+#if defined(__GNUG__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
 int f4(int x) throw() { return x+4; } // Deprecated equivalent to noexcept(true)
+#if defined(__GNUG__)
+#  pragma GCC diagnostic pop
+#endif
 struct C {
     int m1(int x) noexcept { return x-1; }
     int m2(int x) const noexcept { return x-2; }
@@ -57,8 +64,15 @@ struct C {
     int m4(int x) const noexcept(true) { return x-4; }
     int m5(int x) noexcept(false) { return x-5; }
     int m6(int x) const noexcept(false) { return x-6; }
+#if defined(__GNUG__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
     int m7(int x) throw() { return x-7; }
     int m8(int x) const throw() { return x-8; }
+#if defined(__GNUG__)
+#  pragma GCC diagnostic pop
+#endif
 };
 }
 

--- a/tests/test_factory_constructors.cpp
+++ b/tests/test_factory_constructors.cpp
@@ -285,6 +285,7 @@ TEST_SUBMODULE(factory_constructors, m) {
     // test_reallocations
     // Class that has verbose operator_new/operator_delete calls
     struct NoisyAlloc {
+        NoisyAlloc(const NoisyAlloc &) = default;
         NoisyAlloc(int i) { py::print(py::str("NoisyAlloc(int {})").format(i)); }
         NoisyAlloc(double d) { py::print(py::str("NoisyAlloc(double {})").format(d)); }
         ~NoisyAlloc() { py::print("~NoisyAlloc()"); }

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -130,8 +130,8 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     // test_mi_unaligned_base
     // test_mi_base_return
     // Issue #801: invalid casting to derived type with MI bases
-    struct I801B1 { int a = 1; virtual ~I801B1() = default; };
-    struct I801B2 { int b = 2; virtual ~I801B2() = default; };
+    struct I801B1 { int a = 1; I801B1() = default; I801B1(const I801B1 &) = default; virtual ~I801B1() = default; };
+    struct I801B2 { int b = 2; I801B2() = default; I801B2(const I801B2 &) = default; virtual ~I801B2() = default; };
     struct I801C : I801B1, I801B2 {};
     struct I801D : I801C {}; // Indirect MI
     // Unregistered classes:
@@ -205,7 +205,7 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     // test_diamond_inheritance
     // Issue #959: segfault when constructing diamond inheritance instance
     // All of these have int members so that there will be various unequal pointers involved.
-    struct B { int b; virtual ~B() = default; };
+    struct B { int b; B() = default; B(const B&) = default; virtual ~B() = default; };
     struct C0 : public virtual B { int c0; };
     struct C1 : public virtual B { int c1; };
     struct D : public C0, public C1 { int d; };

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -98,6 +98,7 @@ TEST_SUBMODULE(smart_ptr, m) {
     // Object managed by a std::shared_ptr<>
     class MyObject2 {
     public:
+        MyObject2(const MyObject2 &) = default;
         MyObject2(int value) : value(value) { print_created(this, toString()); }
         std::string toString() const { return "MyObject2[" + std::to_string(value) + "]"; }
         virtual ~MyObject2() { print_destroyed(this); }
@@ -116,6 +117,7 @@ TEST_SUBMODULE(smart_ptr, m) {
     // Object managed by a std::shared_ptr<>, additionally derives from std::enable_shared_from_this<>
     class MyObject3 : public std::enable_shared_from_this<MyObject3> {
     public:
+        MyObject3(const MyObject3 &) = default;
         MyObject3(int value) : value(value) { print_created(this, toString()); }
         std::string toString() const { return "MyObject3[" + std::to_string(value) + "]"; }
         virtual ~MyObject3() { print_destroyed(this); }
@@ -219,6 +221,8 @@ TEST_SUBMODULE(smart_ptr, m) {
 
     // Issue #865: shared_from_this doesn't work with virtual inheritance
     struct SharedFromThisVBase : std::enable_shared_from_this<SharedFromThisVBase> {
+        SharedFromThisVBase() = default;
+        SharedFromThisVBase(const SharedFromThisVBase &) = default;
         virtual ~SharedFromThisVBase() = default;
     };
     struct SharedFromThisVirt : virtual SharedFromThisVBase {};


### PR DESCRIPTION
In C++17, static constexpr members are implicitly inline and it's deprecated to re-declare them outside the class. This fixes a GCC 7.2 ``-Wdeprecated`` warning in C++17 mode.