### PR TITLE
Enable `enable_shared_from_this` support for casts

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -774,6 +774,9 @@ template <typename T1, typename T2> struct is_copy_constructible<std::pair<T1, T
     : all_of<is_copy_constructible<T1>, is_copy_constructible<T2>> {};
 #endif
 
+template <typename> handle cast_shared_from_this(const void *) { return {}; }
+template <typename itype, typename T> handle cast_shared_from_this(const std::enable_shared_from_this<T> *src);
+
 /// Generic type caster for objects stored on the heap
 template <typename type> class type_caster_base : public type_caster_generic {
     using itype = intrinsic_t<type>;
@@ -784,8 +787,13 @@ public:
     explicit type_caster_base(const std::type_info &info) : type_caster_generic(info) { }
 
     static handle cast(const itype &src, return_value_policy policy, handle parent) {
-        if (policy == return_value_policy::automatic || policy == return_value_policy::automatic_reference)
+        if (policy == return_value_policy::automatic || policy == return_value_policy::automatic_reference) {
+            // In automatic mode, check for shared_from_this before falling back to `::copy` (the
+            // pointer-accepting cast() doesn't try cast_shared_from_this for a copy policy).
+            if (handle h = cast_shared_from_this<itype>(&src))
+                return h;
             policy = return_value_policy::copy;
+        }
         return cast(&src, policy, parent);
     }
 
@@ -822,6 +830,10 @@ public:
     }
 
     static handle cast(const itype *src, return_value_policy policy, handle parent) {
+        if (policy != return_value_policy::copy)
+            if (handle h = cast_shared_from_this<itype>(src))
+                return h;
+
         auto st = src_and_type(src);
         return type_caster_generic::cast(
             st.first, policy, parent, st.second,
@@ -1681,6 +1693,16 @@ template <typename T> enable_if_t<!cast_is_temporary_value_reference<T>::value, 
 template <typename T> enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&) {
     pybind11_fail("Internal error: cast_safe fallback invoked"); }
 template <> inline void cast_safe<void>(object &&) {}
+
+// Pre-declared above
+template <typename itype, typename T> handle cast_shared_from_this(const std::enable_shared_from_this<T> *src) {
+    try {
+        auto sh = std::dynamic_pointer_cast<const itype>(src->shared_from_this());
+        if (sh)
+            return cast(sh).release();
+    } catch (const std::bad_weak_ptr &) {}
+    return {};
+};
 
 NAMESPACE_END(detail)
 

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -215,7 +215,28 @@ TEST_SUBMODULE(smart_ptr, m) {
         .def_property_readonly("holder_copy", [](const SharedFromThisRef &s) { return s.shared; },
                                py::return_value_policy::copy)
         .def("set_ref", [](SharedFromThisRef &, const B &) { return true; })
-        .def("set_holder", [](SharedFromThisRef &, std::shared_ptr<B>) { return true; });
+        .def("set_holder", [](SharedFromThisRef &, std::shared_ptr<B>) { return true; })
+        .def("get_unshared_ref", [](const SharedFromThisRef &s) -> const B & { return s.value; }) // should copy
+        .def("get_shared_ref", [](const SharedFromThisRef &s) -> const B & { return *s.shared; }) // should find shared_from_this
+        .def("get_copy_ref", [](const SharedFromThisRef &s) -> const B & { return *s.shared; },
+                py::return_value_policy::copy) // should copy (even with the `shared_from_this`)
+        ;
+    struct UnregisteredSharedFromThisBase : std::enable_shared_from_this<UnregisteredSharedFromThisBase> {
+        virtual ~UnregisteredSharedFromThisBase() = default;
+    };
+    struct SFTSubclass : UnregisteredSharedFromThisBase {
+        SFTSubclass() { print_created(this); }
+        SFTSubclass(const SFTSubclass &) { print_copy_created(this); }
+        SFTSubclass(SFTSubclass &&) { print_move_created(this); }
+        ~SFTSubclass() override { print_destroyed(this); }
+        int test = 123;
+    };
+    py::class_<SFTSubclass, std::shared_ptr<SFTSubclass>>(m, "SFTSubclass")
+        .def_readonly("test", &SFTSubclass::test);
+    m.def("call_with_sft_subclass", [](py::function f) {
+        auto s = std::make_shared<SFTSubclass>();
+        return f(*s);
+    });
 
     // Issue #865: shared_from_this doesn't work with virtual inheritance
     struct SharedFromThisVBase : std::enable_shared_from_this<SharedFromThisVBase> {

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -194,6 +194,38 @@ def test_shared_ptr_from_this_and_references():
     y = m.SharedFromThisVirt.get()
     assert y is z
 
+    cc_init, mc_init = stats.copy_constructions, stats.move_constructions
+    s2 = m.SharedFromThisRef()
+    a1 = s2.get_unshared_ref()  # Inherits from enable_shared_from_this, but isn't active
+    assert stats.copy_constructions == cc_init + 1 and stats.move_constructions == mc_init
+    a2 = s2.get_unshared_ref()  # Likewise: should make another copy
+    assert stats.copy_constructions == cc_init + 2 and stats.move_constructions == mc_init
+    assert a1 is not a2
+    cc_init = cc_init + 2
+
+    b1 = s2.get_shared_ref()  # Has a shared_from_this, should use it rather than copying
+    assert stats.copy_constructions == cc_init and stats.move_constructions == mc_init
+    b2 = s2.get_shared_ref()  # Likewise: but also should be `is` b1
+    assert b2 is b1
+    assert stats.copy_constructions == cc_init and stats.move_constructions == mc_init
+
+    s3 = m.SharedFromThisRef()  # New instance so `get_copy_ref` doesn't return a known reference
+    cc_init, mc_init = stats.copy_constructions, stats.move_constructions
+    c1 = s3.get_copy_ref()  # Explicit copy rvp: should ignore shared_from_this
+    assert stats.copy_constructions == cc_init + 1 and stats.move_constructions == mc_init
+    c2 = s3.get_copy_ref()  # Explicit copy rvp: should ignore shared_from_this
+    assert stats.copy_constructions == cc_init + 2 and stats.move_constructions == mc_init
+    assert c1 is not c2
+
+    def func(s):
+        assert isinstance(s, m.SFTSubclass)
+        assert s.test == 123
+
+    m.call_with_sft_subclass(func)
+    sfts_stats = ConstructorStats.get(m.SFTSubclass)
+    assert sfts_stats.alive() == 0
+    assert sfts_stats.copy_constructions == 0 and sfts_stats.move_constructions == 0
+
 
 def test_move_only_holder():
     a = m.TypeWithMoveOnlyHolder.make()


### PR DESCRIPTION
Currently we support `enable_shared_from_this` only if we end up taking over an existing reference or pointer; this extends the support by looking for `std::enable_shared_shared_from_this` inheritance for any type of cast except for an explicit `return_value_policy::copy`.

This lets pybind avoid a copy when doing something like:

```C++
    m.def("f", []() {
        auto b = std::make_shared<B>();
        foo(*b);
    }
```

where `foo` is some function that takes the `B` by lvalue reference, but ends up requiring casting it to Python.  (In the motivating example for this PR the specific case was a trampoline overload).

The .so impact is minimal (+8192 bytes *including* the added test code) as the compiler should be able to optimize away the check entirely for non-shared-from-this classes.

Cc: @florianwechsung for input.