### PR TITLE
Add spaces around "=" in signature repr.

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -238,7 +238,7 @@ protected:
             } else if (c == '}') {
                 // Write default value if available.
                 if (arg_index < rec->args.size() && rec->args[arg_index].descr) {
-                    signature += "=";
+                    signature += " = ";
                     signature += rec->args[arg_index].descr;
                 }
                 arg_index++;

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -5,11 +5,11 @@ from pybind11_tests import kwargs_and_defaults as m
 def test_function_signatures(doc):
     assert doc(m.kw_func0) == "kw_func0(arg0: int, arg1: int) -> str"
     assert doc(m.kw_func1) == "kw_func1(x: int, y: int) -> str"
-    assert doc(m.kw_func2) == "kw_func2(x: int=100, y: int=200) -> str"
-    assert doc(m.kw_func3) == "kw_func3(data: str='Hello world!') -> None"
-    assert doc(m.kw_func4) == "kw_func4(myList: List[int]=[13, 17]) -> str"
-    assert doc(m.kw_func_udl) == "kw_func_udl(x: int, y: int=300) -> str"
-    assert doc(m.kw_func_udl_z) == "kw_func_udl_z(x: int, y: int=0) -> str"
+    assert doc(m.kw_func2) == "kw_func2(x: int = 100, y: int = 200) -> str"
+    assert doc(m.kw_func3) == "kw_func3(data: str = 'Hello world!') -> None"
+    assert doc(m.kw_func4) == "kw_func4(myList: List[int] = [13, 17]) -> str"
+    assert doc(m.kw_func_udl) == "kw_func_udl(x: int, y: int = 300) -> str"
+    assert doc(m.kw_func_udl_z) == "kw_func_udl_z(x: int, y: int = 0) -> str"
     assert doc(m.args_function) == "args_function(*args) -> tuple"
     assert doc(m.args_kwargs_function) == "args_kwargs_function(*args, **kwargs) -> tuple"
     assert doc(m.KWClass.foo0) == \
@@ -93,7 +93,7 @@ def test_mixed_args_and_kwargs(msg):
         assert mpakd(1, i=1)
     assert msg(excinfo.value) == """
         mixed_plus_args_kwargs_defaults(): incompatible function arguments. The following argument types are supported:
-            1. (i: int=1, j: float=3.14159, *args, **kwargs) -> tuple
+            1. (i: int = 1, j: float = 3.14159, *args, **kwargs) -> tuple
 
         Invoked with: 1; kwargs: i=1
     """  # noqa: E501 line too long
@@ -101,7 +101,7 @@ def test_mixed_args_and_kwargs(msg):
         assert mpakd(1, 2, j=1)
     assert msg(excinfo.value) == """
         mixed_plus_args_kwargs_defaults(): incompatible function arguments. The following argument types are supported:
-            1. (i: int=1, j: float=3.14159, *args, **kwargs) -> tuple
+            1. (i: int = 1, j: float = 3.14159, *args, **kwargs) -> tuple
 
         Invoked with: 1, 2; kwargs: j=1
     """  # noqa: E501 line too long

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -164,7 +164,7 @@ def test_stl_pass_by_pointer(msg):
         m.stl_pass_by_pointer()  # default value is `nullptr`
     assert msg(excinfo.value) == """
         stl_pass_by_pointer(): incompatible function arguments. The following argument types are supported:
-            1. (v: List[int]=None) -> List[int]
+            1. (v: List[int] = None) -> List[int]
 
         Invoked with:
     """  # noqa: E501 line too long
@@ -173,7 +173,7 @@ def test_stl_pass_by_pointer(msg):
         m.stl_pass_by_pointer(None)
     assert msg(excinfo.value) == """
         stl_pass_by_pointer(): incompatible function arguments. The following argument types are supported:
-            1. (v: List[int]=None) -> List[int]
+            1. (v: List[int] = None) -> List[int]
 
         Invoked with: None
     """  # noqa: E501 line too long


### PR DESCRIPTION
PEP8 indicates (correctly, IMO) that when an annotation is present, the
signature should include spaces around the equal sign, i.e.

    def f(x: int = 1): ...

instead of

    def f(x: int=1): ...

(in the latter case the equal appears to bind to the type, not to the
argument).

pybind11 signatures always includes a type annotation so we can always
add the spaces.