### PR TITLE
Require cmake version 3 in pybind11Config.cmake

### DIFF
--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -59,7 +59,7 @@
 #     find_package(pybind11) when not REQUIRED, perhaps to force internal build
 
 @PACKAGE_INIT@
-
+cmake_minimum_required( VERSION 3.0 )
 set(PN pybind11)
 
 # location of pybind11/pybind11.h


### PR DESCRIPTION
It seems that the `pybind11Config.cmake` file has a hard requirement on cmake version greater than 3.0; this PR will just make that explicit.

If there is interest in merging this PR I would be happy to update the PR with documentation fixes, raising the minimum cmake version from 2.8.12 to 3.0.