### PR TITLE
Segfault fix in cpp_function::dispatcher of an overloaded function with *args/**kwargs

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -452,6 +452,7 @@ protected:
             // py::arg().noconvert()).  This lets us prefer calls without conversion, with
             // conversion as a fallback.
             std::vector<function_call> second_pass;
+            std::vector<object> args_kwargs_keepalive;
 
             // However, if there are no overloads, we can just skip the no-convert pass entirely
             const bool overloaded = it != nullptr && it->next != nullptr;
@@ -586,6 +587,7 @@ protected:
                     }
                     call.args.push_back(extra_args);
                     call.args_convert.push_back(false);
+                    args_kwargs_keepalive.push_back(extra_args);
                 }
 
                 // 4b. If we have a py::kwargs, pass on any remaining kwargs
@@ -594,6 +596,7 @@ protected:
                         kwargs = dict(); // If we didn't get one, send an empty one
                     call.args.push_back(kwargs);
                     call.args_convert.push_back(false);
+                    args_kwargs_keepalive.push_back(kwargs);
                 }
 
                 // 5. Put everything in a vector.  Not technically step 5, we've been building it


### PR DESCRIPTION
Fixing a segfault in the cpp_function::dispatcher of an overloaded function with args/kwargs, during the second pass over the overloads (with conversions).

Inside the overload loop, new `py::object`s are created for the *args and **kwargs arguments (`extra_args` and `kwargs`), but these go out of scope by the time a second pass with conversions over the different overloads is executed.
At the destruction of the `argument_loader`, its nested casters, and the `py::args` object, if Python already garbage collected, things go wrong.

A quick, 3-line solution is to keep a `std::vector<py::object>` and add the `extra_args` and `kwargs` instances to keep them alive for long enough.

Attached is a trace of the segfault in GDB (running `python3-gdb`; `python3` just gets corrupted instead of segfaulting and shouts `Fatal Python error: GC object already tracked` somewhere later):
[args-crash-gdb-bt.txt](https://github.com/pybind/pybind11/files/1583437/args-crash-gdb-bt.txt)


I don't know if there might be a better/cleaner/... solution than this 'keepalive' vector, but this at least seems to be solving the segfaults/corruption and does not change the flow of the dispatcher.