### PR TITLE
WIP Add arg().disown() (superseding the consume call_policy)

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -124,10 +124,11 @@ struct argument_record {
     const char *descr; ///< Human-readable version of the argument value
     handle value;      ///< Associated Python object
     bool convert : 1;  ///< True if the argument is allowed to convert when loading
+    bool disown : 1;   ///< TODO docs
     bool none : 1;     ///< True if None is allowed when loading
 
-    argument_record(const char *name, const char *descr, handle value, bool convert, bool none)
-        : name(name), descr(descr), value(value), convert(convert), none(none) { }
+    argument_record(const char *name, const char *descr, handle value, bool convert, bool disown, bool none)
+        : name(name), descr(descr), value(value), convert(convert), disown(disown), none(none) { }
 };
 
 /// Internal data structure which holds metadata about a bound function (signature, overloads, etc.)
@@ -353,8 +354,8 @@ template <> struct process_attribute<is_new_style_constructor> : process_attribu
 template <> struct process_attribute<arg> : process_attribute_default<arg> {
     static void init(const arg &a, function_record *r) {
         if (r->is_method && r->args.empty())
-            r->args.emplace_back("self", nullptr, handle(), true /*convert*/, false /*none not allowed*/);
-        r->args.emplace_back(a.name, nullptr, handle(), !a.flag_noconvert, a.flag_none);
+            r->args.emplace_back("self", nullptr, handle(), true /*convert*/, false /*disown*/, false /*none not allowed*/);
+        r->args.emplace_back(a.name, nullptr, handle(), !a.flag_noconvert, a.flag_disown, a.flag_none);
     }
 };
 
@@ -362,7 +363,7 @@ template <> struct process_attribute<arg> : process_attribute_default<arg> {
 template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
     static void init(const arg_v &a, function_record *r) {
         if (r->is_method && r->args.empty())
-            r->args.emplace_back("self", nullptr /*descr*/, handle() /*parent*/, true /*convert*/, false /*none not allowed*/);
+            r->args.emplace_back("self", nullptr /*descr*/, handle() /*parent*/, true /*convert*/, false /*disown*/, false /*none not allowed*/);
 
         if (!a.value) {
 #if !defined(NDEBUG)
@@ -385,7 +386,7 @@ template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
                           "Compile in debug mode for more information.");
 #endif
         }
-        r->args.emplace_back(a.name, a.descr, a.value.inc_ref(), !a.flag_noconvert, a.flag_none);
+        r->args.emplace_back(a.name, a.descr, a.value.inc_ref(), !a.flag_noconvert, a.flag_disown, a.flag_none);
     }
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ set(PYBIND11_TEST_FILES
   test_enum.cpp
   test_eval.cpp
   test_exceptions.cpp
+  test_disown.cpp
   test_factory_constructors.cpp
   test_iostream.cpp
   test_kwargs_and_defaults.cpp

--- a/tests/test_disown.cpp
+++ b/tests/test_disown.cpp
@@ -1,0 +1,50 @@
+/*
+    tests/test_disown.cpp -- disown
+
+    Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>
+    Copyright (c) 2017 Attila Török <torokati44@gmail.com>
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#include "pybind11_tests.h"
+
+class Box {
+    int size;
+    static int num_boxes;
+
+public:
+    Box(int size): size(size) { py::print("Box created."); ++num_boxes; }
+    ~Box() { py::print("Box destroyed."); --num_boxes; }
+
+    int get_size() { return size; }
+    static int get_num_boxes() { return num_boxes; }
+};
+
+int Box::num_boxes = 0;
+
+class Filter {
+    int threshold;
+
+public:
+    Filter(int threshold): threshold(threshold) { py::print("Filter created."); }
+    ~Filter() { py::print("Filter destroyed."); }
+
+    void process(Box *box) { // ownership of box is taken
+        py::print("Box is processed by Filter.");
+        if (box->get_size() > threshold)
+            delete box;
+        // otherwise the box is leaked
+    };
+};
+
+test_initializer disown([](py::module &m) {
+    py::class_<Box>(m, "Box")
+        .def(py::init<int>())
+        .def_static("get_num_boxes", &Box::get_num_boxes);
+
+    py::class_<Filter>(m, "Filter")
+        .def(py::init<int>())
+        .def("process", &Filter::process, py::arg("box").disown());
+});

--- a/tests/test_disown.py
+++ b/tests/test_disown.py
@@ -1,0 +1,42 @@
+import pytest
+
+
+def test_disown_argument(capture):
+    from pybind11_tests import Box, Filter
+
+    with capture:
+        filt = Filter(4)
+    assert capture == "Filter created."
+    with capture:
+        box_1 = Box(1)
+        box_8 = Box(8)
+    assert capture == """
+        Box created.
+        Box created.
+    """
+
+    assert Box.get_num_boxes() == 2
+
+    with capture:
+        filt.process(box_1)  # box_1 is not big enough, but process() leaks it
+    assert capture == "Box is processed by Filter."
+
+    assert Box.get_num_boxes() == 2
+
+    with capture:
+        filt.process(box_8)  # box_8 is destroyed by process() of filt
+    assert capture == """
+        Box is processed by Filter.
+        Box destroyed.
+    """
+
+    assert Box.get_num_boxes() == 1  # box_1 still exists somehow, but we can't access it
+
+    with capture:
+        del filt
+        del box_1
+        del box_8
+        pytest.gc_collect()
+    assert capture == "Filter destroyed."
+
+    assert Box.get_num_boxes() == 1  # 1 box is leaked, and we can't do anything


### PR DESCRIPTION
I finally found some time to work a little bit on #971. This PR supersedes it. _(Should I close it?)_ I reworked it, taking some of @jagerman's advice. However, it is still not nearly complete.

- [x] It is now done with `py::arg`, instead of as a call policy.
- [x] The holder is now destructed, and the reference is set to be not owning.
- [x] Releasing is done via a `holder_helper` static method.
- [ ] Moving `owned` to `value_and_holder` is not yet done.
- [ ] The default `holder_helper::release` does not give a meaningful error when there is no `holder_type::release()`
- [ ] `holder_type` is still assumed to be `std::unique_ptr<void*>`

For the last one: I have no idea how to get the proper `holder_type` for the args. I tried to look in the direction of `class_<arg>::holder_type`, but that would have to be forward declared, and I'm no even sure what to supply as the `type` template parameter.

Is this in the right place in `dispatcher()`?
Also, I saw that #1146 referenced #971, is this PR still relevant despite that one?

Any comments are still much appreciated.