### PR TITLE
fix return from std::map bindings to __delitem__

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -587,7 +587,7 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args&&.
                auto it = m.find(k);
                if (it == m.end())
                    throw key_error();
-               return m.erase(it);
+               m.erase(it);
            }
     );
 

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -182,6 +182,7 @@ def test_noncopyable_containers():
 
     assert vsum == 150
 
+
 def test_map_delitem():
     mm = m.MapStringDouble()
     mm['a'] = 1

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -181,3 +181,24 @@ def test_noncopyable_containers():
         vsum += v.value
 
     assert vsum == 150
+
+def test_map_delitem():
+    mm = m.MapStringDouble()
+    mm['a'] = 1
+    mm['b'] = 2.5
+
+    assert list(mm) == ['a', 'b']
+    assert list(mm.items()) == [('a', 1), ('b', 2.5)]
+    del mm['a']
+    assert list(mm) == ['b']
+    assert list(mm.items()) == [('b', 2.5)]
+
+    um = m.UnorderedMapStringDouble()
+    um['ua'] = 1.1
+    um['ub'] = 2.6
+
+    assert sorted(list(um)) == ['ua', 'ub']
+    assert sorted(list(um.items())) == [('ua', 1.1), ('ub', 2.6)]
+    del um['ua']
+    assert sorted(list(um)) == ['ub']
+    assert sorted(list(um.items())) == [('ub', 2.6)]


### PR DESCRIPTION
tests and fixes #1228 