### PR TITLE
Feature/unique ptr arg pr1

### DIFF
--- a/docs/advanced/smart_ptrs.rst
+++ b/docs/advanced/smart_ptrs.rst
@@ -1,5 +1,19 @@
-Smart pointers
-##############
+.. _holders:
+
+Smart pointers and holders
+##########################
+
+Holders
+=======
+
+The binding generator for classes, :class:`class_`, can be passed a template
+type that denotes a special *holder* type that is used to manage references to
+the object.  If no such holder type template argument is given, the default for
+a type named ``Type`` is ``std::unique_ptr<Type>``, which means that the object
+is deallocated when Python's reference count goes to zero. It is possible to
+switch to other types of reference counting wrappers or smart pointers, which
+is useful in codebases that rely on them, such as ``std::shared_ptr<Type>``, or
+even a custom type.
 
 std::unique_ptr
 ===============
@@ -31,15 +45,10 @@ instance, the object might be referenced elsewhere).
 std::shared_ptr
 ===============
 
-The binding generator for classes, :class:`class_`, can be passed a template
-type that denotes a special *holder* type that is used to manage references to
-the object.  If no such holder type template argument is given, the default for
-a type named ``Type`` is ``std::unique_ptr<Type>``, which means that the object
-is deallocated when Python's reference count goes to zero.
+If you have an existing code base with ``std::shared_ptr``, or you wish to enable
+reference counting in C++ as well, then you may use this type as a holder.
 
-It is possible to switch to other types of reference counting wrappers or smart
-pointers, which is useful in codebases that rely on them. For instance, the
-following snippet causes ``std::shared_ptr`` to be used instead.
+As an example, the following snippet causes ``std::shared_ptr`` to be used instead.
 
 .. code-block:: cpp
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1463,6 +1463,15 @@ struct move_only_holder_caster {
         auto *ptr = holder_helper<holder_type>::get(src);
         return type_caster_base<type>::cast_holder(ptr, &src);
     }
+
+    // Force rvalue.
+    template <typename T>
+    using cast_op_type = holder_type&&;
+
+    operator holder_type&&() {
+        throw std::runtime_error("Currently unsupported");
+    }
+
     static constexpr auto name = type_caster_base<type>::name;
 };
 
@@ -1533,21 +1542,25 @@ class type_caster<T, enable_if_t<is_pyobject<T>::value>> : public pyobject_caste
 template <typename T> using move_is_plain_type = satisfies_none_of<T,
     std::is_void, std::is_pointer, std::is_reference, std::is_const
 >;
+template <typename T, typename SFINAE = void> struct move_common : std::false_type {};
+template <typename T> struct move_common<T, enable_if_t<all_of<
+    move_is_plain_type<T>,
+    std::is_move_constructible<T>,
+    std::is_same<
+        intrinsic_t<typename make_caster<T>::template cast_op_type<T&>>,
+        T>
+>::value>> : std::true_type {};
 template <typename T, typename SFINAE = void> struct move_always : std::false_type {};
 template <typename T> struct move_always<T, enable_if_t<all_of<
-    move_is_plain_type<T>,
-    negation<is_copy_constructible<T>>,
-    std::is_move_constructible<T>,
-    std::is_same<decltype(std::declval<make_caster<T>>().operator T&()), T&>
+    move_common<T>,
+    negation<is_copy_constructible<T>>
 >::value>> : std::true_type {};
 template <typename T, typename SFINAE = void> struct move_if_unreferenced : std::false_type {};
 template <typename T> struct move_if_unreferenced<T, enable_if_t<all_of<
-    move_is_plain_type<T>,
-    negation<move_always<T>>,
-    std::is_move_constructible<T>,
-    std::is_same<decltype(std::declval<make_caster<T>>().operator T&()), T&>
+    move_common<T>,
+    is_copy_constructible<T>
 >::value>> : std::true_type {};
-template <typename T> using move_never = none_of<move_always<T>, move_if_unreferenced<T>>;
+template <typename T> using move_never = negation<move_common<T>>;
 
 // Detect whether returning a `type` from a cast on type's type_caster is going to result in a
 // reference or pointer to a local variable of the type_caster.  Basically, only

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -70,14 +70,14 @@ public:
     /// Construct a cpp_function from a class method (non-const)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     cpp_function(Return (Class::*f)(Arg...), const Extra&... extra) {
-        initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(args...); },
+        initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
                    (Return (*) (Class *, Arg...)) nullptr, extra...);
     }
 
     /// Construct a cpp_function from a class method (const)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     cpp_function(Return (Class::*f)(Arg...) const, const Extra&... extra) {
-        initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(args...); },
+        initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
                    (Return (*)(const Class *, Arg ...)) nullptr, extra...);
     }
 

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -4,10 +4,10 @@ from pybind11_tests import ConstructorStats
 
 
 def test_methods_and_attributes():
-    instance1 = m.ExampleMandA()
-    instance2 = m.ExampleMandA(32)
+    instance1 = m.ExampleMandA()  # 1 ctor
+    instance2 = m.ExampleMandA(32)  # 1 ctor
 
-    instance1.add1(instance2)
+    instance1.add1(instance2)  # 1 copy ctor + 1 move
     instance1.add2(instance2)
     instance1.add3(instance2)
     instance1.add4(instance2)
@@ -20,7 +20,7 @@ def test_methods_and_attributes():
 
     assert str(instance1) == "ExampleMandA[value=320]"
     assert str(instance2) == "ExampleMandA[value=32]"
-    assert str(instance1.self1()) == "ExampleMandA[value=320]"
+    assert str(instance1.self1()) == "ExampleMandA[value=320]"  # 1 copy ctor + 1 move
     assert str(instance1.self2()) == "ExampleMandA[value=320]"
     assert str(instance1.self3()) == "ExampleMandA[value=320]"
     assert str(instance1.self4()) == "ExampleMandA[value=320]"
@@ -58,8 +58,8 @@ def test_methods_and_attributes():
     assert cstats.alive() == 0
     assert cstats.values() == ["32"]
     assert cstats.default_constructions == 1
-    assert cstats.copy_constructions == 3
-    assert cstats.move_constructions >= 1
+    assert cstats.copy_constructions == 2
+    assert cstats.move_constructions == 2
     assert cstats.copy_assignments == 0
     assert cstats.move_assignments == 0
 

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -271,4 +271,18 @@ TEST_SUBMODULE(smart_ptr, m) {
                 list.append(py::cast(e));
             return list;
         });
+
+    // At present, only used for trait checks below. In the future, will be exposed to pybind.
+    struct UniquePtrHeld {};
+
+    // Check traits in a concise manner.
+    static_assert(
+        py::detail::move_common<std::unique_ptr<UniquePtrHeld>>::value,
+        "This trait must be true.");
+    static_assert(
+        py::detail::move_always<std::unique_ptr<UniquePtrHeld>>::value,
+        "This trait must be true.");
+    static_assert(
+        !py::detail::move_if_unreferenced<std::unique_ptr<UniquePtrHeld>>::value,
+        "This trait must be false.");
 }


### PR DESCRIPTION
This is the first PR in order to enable passing `unique_ptr` back and forth between C++.
This is a more manageable bite-size chunk of #1146 (supporting #11

This relates #971, #1226.

I'm moving forward with this because we have found this feature useful in Drake, and have a potential mechanism to even allow this to be REPL-friendly. (This change does require minimal changes in existing code, which is preferable to switching to `shared_ptr` and never being able to release a pointer from its clutches.)
https://github.com/RobotLocomotion/drake/blob/f6f23c5/bindings/pydrake/systems/framework_py.cc#L148
https://github.com/EricCousineau-TRI/pybind11/blob/25b08a4/tests/test_smart_ptr.py#L319
