### PR TITLE
 Use `return_value_policy::reference` for mutable lvalues (#1200).

### DIFF
--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -92,15 +92,17 @@ The following table provides an overview of available policies:
 +--------------------------------------------------+----------------------------------------------------------------------------+
 | :enum:`return_value_policy::automatic`           | **Default policy.** This policy falls back to the policy                   |
 |                                                  | :enum:`return_value_policy::take_ownership` when the return value is a     |
-|                                                  | pointer. Otherwise, it uses :enum:`return_value_policy::move` or           |
-|                                                  | :enum:`return_value_policy::copy` for rvalue and lvalue references,        |
-|                                                  | respectively. See above for a description of what all of these different   |
-|                                                  | policies do.                                                               |
+|                                                  | pointer or :enum:`return_value_policy:reference` when the return value is  |
+|                                                  | a mutable lvalue reference. Otherwise, it uses                             |
+|                                                  | :enum:`return_value_policy::move` or :enum:`return_value_policy::copy` for |
+|                                                  | rvalue and const lvalue references, respectively. See above for a          |
+|                                                  | description of what all of these different policies do.                    |
 +--------------------------------------------------+----------------------------------------------------------------------------+
 | :enum:`return_value_policy::automatic_reference` | As above, but use policy :enum:`return_value_policy::reference` when the   |
-|                                                  | return value is a pointer. This is the default conversion policy for       |
-|                                                  | function arguments when calling Python functions manually from C++ code    |
-|                                                  | (i.e. via handle::operator()). You probably won't need to use this.        |
+|                                                  | return value is a pointer or mutable lvalue reference. This is the default |
+|                                                  | conversion policy for function arguments when calling Python functions     |
+|                                                  | manually from C++ code (i.e. via handle::operator()). You probably won't   |
+|                                                  | need to use this.                                                          |
 +--------------------------------------------------+----------------------------------------------------------------------------+
 
 Return value policies can also be applied to properties:

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -789,6 +789,12 @@ public:
         return cast(&src, policy, parent);
     }
 
+    static handle cast(itype &src, return_value_policy policy, handle parent) {
+        if (policy == return_value_policy::automatic || policy == return_value_policy::automatic_reference)
+            policy = return_value_policy::reference;
+        return cast(&src, policy, parent);
+    }
+
     static handle cast(itype &&src, return_value_policy, handle parent) {
         return cast(&src, return_value_policy::move, parent);
     }

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -146,4 +146,34 @@ TEST_SUBMODULE(callbacks, m) {
     py::class_<CppBoundMethodTest>(m, "CppBoundMethodTest")
         .def(py::init<>())
         .def("triple", [](CppBoundMethodTest &, int val) { return 3 * val; });
+
+    struct CppCopyable {
+        int value{};
+    };
+    py::class_<CppCopyable>(m, "CppCopyable")
+        .def(py::init<>())
+        .def_readwrite("value", &CppCopyable::value);
+    // Works fine, as pybind is aware of the existing instance.
+    m.def(
+        "callback_mutate_copyable_py",
+        [](std::function<void(CppCopyable&)> f, CppCopyable& obj) {
+            f(obj);
+        });
+    // Does not work as expected, because pybind will copy the instance when
+    // binding.
+    m.def(
+        "callback_mutate_copyable_cpp_ref",
+        [](std::function<void(CppCopyable&)> f, int value) {
+            CppCopyable obj{value};
+            f(obj);
+            return obj;
+        });
+    // Works as expected, because pybind will not copy the instance.
+    m.def(
+        "callback_mutate_copyable_cpp_ptr",
+        [](std::function<void(CppCopyable*)> f, int value) {
+            CppCopyable obj{value};
+            f(&obj);
+            return obj;
+        });
 }

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -159,8 +159,7 @@ TEST_SUBMODULE(callbacks, m) {
         [](std::function<void(CppCopyable&)> f, CppCopyable& obj) {
             f(obj);
         });
-    // Does not work as expected, because pybind will copy the instance when
-    // binding.
+    // Works as expected, because pybind will not copy the instance.
     m.def(
         "callback_mutate_copyable_cpp_ref",
         [](std::function<void(CppCopyable&)> f, int value) {

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -118,8 +118,6 @@ def test_object_mutation():
     assert obj.value == 1
 
     obj = m.callback_mutate_copyable_cpp_ref(incr, 10)
-    # WARNING: This this creates a COPY when passing to callback.
-    assert obj.value == 10
-
+    assert obj.value == 11
     obj = m.callback_mutate_copyable_cpp_ptr(incr, 10)
     assert obj.value == 11


### PR DESCRIPTION
This addresses #1200 (and #1231) by ensuring that argument casting is more C++-ish: Do not default to copying for mutable lvalue references.

The problem in the above issues is that in casting a Python function to a C++ function and calling it directly on a C++ object, there's a possibility that the C++ object will have not been seen by `pybind`. Because of this, the prior policy was to copy the previously unseen object.

This PR *only* changes function argument casting to alleviate this. It keeps the behavior of `cast<>()` the same, for reasons stated in `test_methods_and_attributes.py` unittest.

\cc @uentity @benEnsta  