### PR TITLE
Fixes for numpy 1.14.0 compatibility

### DIFF
--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -181,8 +181,7 @@ def test_negative_stride_from_python(msg):
         double_threer(): incompatible function arguments. The following argument types are supported:
             1. (arg0: numpy.ndarray[float32[1, 3], flags.writeable]) -> None
 
-        Invoked with: array([ 5.,  4.,  3.], dtype=float32)
-    """  # noqa: E501 line too long
+        Invoked with: """ + repr(np.array([ 5.,  4.,  3.], dtype='float32'))  # noqa: E501 line too long
 
     with pytest.raises(TypeError) as excinfo:
         m.double_threec(second_col)
@@ -190,8 +189,7 @@ def test_negative_stride_from_python(msg):
         double_threec(): incompatible function arguments. The following argument types are supported:
             1. (arg0: numpy.ndarray[float32[3, 1], flags.writeable]) -> None
 
-        Invoked with: array([ 7.,  4.,  1.], dtype=float32)
-    """  # noqa: E501 line too long
+        Invoked with: """ + repr(np.array([ 7.,  4.,  1.], dtype='float32'))  # noqa: E501 line too long
 
 
 def test_nonunit_stride_to_python():

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -137,6 +137,7 @@ def test_make_c_f_array():
 
 def test_wrap():
     def assert_references(a, b, base=None):
+        from distutils.version import LooseVersion
         if base is None:
             base = a
         assert a is not b
@@ -147,7 +148,10 @@ def test_wrap():
         assert a.flags.f_contiguous == b.flags.f_contiguous
         assert a.flags.writeable == b.flags.writeable
         assert a.flags.aligned == b.flags.aligned
-        assert a.flags.updateifcopy == b.flags.updateifcopy
+        if LooseVersion(np.__version__) >= LooseVersion("1.14.0"):
+            assert a.flags.writebackifcopy == b.flags.writebackifcopy
+        else:
+            assert a.flags.updateifcopy == b.flags.updateifcopy
         assert np.all(a == b)
         assert not b.flags.owndata
         assert b.base is base
@@ -282,17 +286,17 @@ def test_overload_resolution(msg):
             1. (arg0: numpy.ndarray[int32]) -> str
             2. (arg0: numpy.ndarray[float64]) -> str
 
-        Invoked with:"""
+        Invoked with: """
 
     with pytest.raises(TypeError) as excinfo:
         m.overloaded3(np.array([1], dtype='uintc'))
-    assert msg(excinfo.value) == expected_exc + " array([1], dtype=uint32)"
+    assert msg(excinfo.value) == expected_exc + repr(np.array([1], dtype='uint32'))
     with pytest.raises(TypeError) as excinfo:
         m.overloaded3(np.array([1], dtype='float32'))
-    assert msg(excinfo.value) == expected_exc + " array([ 1.], dtype=float32)"
+    assert msg(excinfo.value) == expected_exc + repr(np.array([1.], dtype='float32'))
     with pytest.raises(TypeError) as excinfo:
         m.overloaded3(np.array([1], dtype='complex'))
-    assert msg(excinfo.value) == expected_exc + " array([ 1.+0.j])"
+    assert msg(excinfo.value) == expected_exc + repr(np.array([1. + 0.j]))
 
     # Exact matches:
     assert m.overloaded4(np.array([1], dtype='double')) == 'double'


### PR DESCRIPTION
- UPDATEIFCOPY is deprecated, replaced with similar (but not identical)
  WRITEBACKIFCOPY; trying to access the flag causes a deprecation
  warning under numpy 1.14, so just check the new flag there.
- Numpy `repr` formatting of floats changed in 1.14.0 to `[1., 2., 3.]`
  instead of the pre-1.14 `[ 1.,  2.,  3.]`.  Updated the tests to
  check for equality with the `repr(...)` value rather than the
  hard-coded (and now version-dependent) string representation.