### PR TITLE
Track patients with unordered_set rather than vector

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -290,8 +290,8 @@ inline void add_patient(PyObject *nurse, PyObject *patient) {
     auto &internals = get_internals();
     auto instance = reinterpret_cast<detail::instance *>(nurse);
     instance->has_patients = true;
-    Py_INCREF(patient);
-    internals.patients[nurse].push_back(patient);
+    auto it = internals.patients[nurse].insert(patient);
+    if (it.second) Py_INCREF(patient);
 }
 
 inline void clear_patients(PyObject *self) {
@@ -300,12 +300,12 @@ inline void clear_patients(PyObject *self) {
     auto pos = internals.patients.find(self);
     assert(pos != internals.patients.end());
     // Clearing the patients can cause more Python code to run, which
-    // can invalidate the iterator. Extract the vector of patients
+    // can invalidate the iterator. Extract the set of patients
     // from the unordered_map first.
     auto patients = std::move(pos->second);
     internals.patients.erase(pos);
     instance->has_patients = false;
-    for (PyObject *&patient : patients)
+    for (PyObject *patient : patients)
         Py_CLEAR(patient);
 }
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -70,7 +70,7 @@ struct internals {
     std::unordered_multimap<const void *, instance*> registered_instances; // void * -> instance*
     std::unordered_set<std::pair<const PyObject *, const char *>, overload_hash> inactive_overload_cache;
     type_map<std::vector<bool (*)(PyObject *, void *&)>> direct_conversions;
-    std::unordered_map<const PyObject *, std::vector<PyObject *>> patients;
+    std::unordered_map<const PyObject *, std::unordered_set<PyObject *>> patients;
     std::forward_list<void (*) (std::exception_ptr)> registered_exception_translators;
     std::unordered_map<std::string, void *> shared_data; // Custom data to be shared across extensions
     std::vector<PyObject *> loader_patient_stack; // Used by `loader_life_support`
@@ -111,7 +111,7 @@ struct type_info {
 };
 
 /// Tracks the `internals` and `type_info` ABI version independent of the main library version
-#define PYBIND11_INTERNALS_VERSION 1
+#define PYBIND11_INTERNALS_VERSION 2
 
 #if defined(WITH_THREAD)
 #  define PYBIND11_INTERNALS_KIND ""

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -1,6 +1,6 @@
 import pytest
 from pybind11_tests import call_policies as m
-from pybind11_tests import ConstructorStats
+from pybind11_tests import ConstructorStats, UserType
 
 
 def test_keep_alive_argument(capture):
@@ -67,6 +67,35 @@ def test_keep_alive_return_value(capture):
         Releasing parent.
         Releasing child.
     """
+
+
+def test_keep_alive_single():
+    """Issue #1251 - patients are stored multiple times when given to the same nurse"""
+
+    nurse, p1, p2 = UserType(), UserType(), UserType()
+    b = m.refcount(nurse)
+    assert [m.refcount(nurse), m.refcount(p1), m.refcount(p2)] == [b, b, b]
+    m.add_patient(nurse, p1)
+    assert m.get_patients(nurse) == {p1, }
+    assert [m.refcount(nurse), m.refcount(p1), m.refcount(p2)] == [b, b + 1, b]
+    m.add_patient(nurse, p1)
+    assert m.get_patients(nurse) == {p1, }
+    assert [m.refcount(nurse), m.refcount(p1), m.refcount(p2)] == [b, b + 1, b]
+    m.add_patient(nurse, p1)
+    assert m.get_patients(nurse) == {p1, }
+    assert [m.refcount(nurse), m.refcount(p1), m.refcount(p2)] == [b, b + 1, b]
+    m.add_patient(nurse, p2)
+    assert m.get_patients(nurse) == {p1, p2}
+    assert [m.refcount(nurse), m.refcount(p1), m.refcount(p2)] == [b, b + 1, b + 1]
+    m.add_patient(nurse, p2)
+    assert m.get_patients(nurse) == {p1, p2}
+    assert [m.refcount(nurse), m.refcount(p1), m.refcount(p2)] == [b, b + 1, b + 1]
+    m.add_patient(nurse, p2)
+    m.add_patient(nurse, p1)
+    assert m.get_patients(nurse) == {p1, p2}
+    assert [m.refcount(nurse), m.refcount(p1), m.refcount(p2)] == [b, b + 1, b + 1]
+    del nurse
+    assert [m.refcount(p1), m.refcount(p2)] == [b, b]
 
 
 # https://bitbucket.org/pypy/pypy/issues/2447


### PR DESCRIPTION
The stored vector of pybind-registered-type patients can grow without
bound if a function is called with the same patient multiple times.

This commit changes the pybind internal patient storage to an
`unordered_set` to avoid the issue.

Fixes #1251 

I've also pushed a separate fix for 2.2.2 (in #1250) that solves this by walking through the vector to avoid storing a duplicate.  (It's not as nice a fix, but it doesn't require changing the `internals` structure for 2.2.2).