### PR TITLE
Adding pybind11::cast overload for rvalue references

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1667,19 +1667,13 @@ T cast(const handle &handle) { return T(reinterpret_borrow<object>(handle)); }
 
 // C++ type -> py::object
 template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
-object cast(const T &value, return_value_policy policy = return_value_policy::automatic_reference,
+object cast(T &&value, return_value_policy policy = return_value_policy::automatic_reference,
             handle parent = handle()) {
     if (policy == return_value_policy::automatic)
         policy = std::is_pointer<T>::value ? return_value_policy::take_ownership : return_value_policy::copy;
     else if (policy == return_value_policy::automatic_reference)
         policy = std::is_pointer<T>::value ? return_value_policy::reference : return_value_policy::copy;
-    return reinterpret_steal<object>(detail::make_caster<T>::cast(value, policy, parent));
-}
-
-// C++ type -> py::object (move)
-template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0, detail::enable_if_t<!std::is_reference<T>::value, int> = 0>
-object cast(T &&value, return_value_policy policy = return_value_policy::move, handle parent = handle()) {
-    return reinterpret_steal<object>(detail::make_caster<T>::cast(std::move(value), policy, parent));
+    return reinterpret_steal<object>(detail::make_caster<T>::cast(std::forward<T>(value), policy, parent));
 }
 
 template <typename T> T handle::cast() const { return pybind11::cast<T>(*this); }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1670,9 +1670,11 @@ template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> =
 object cast(T &&value, return_value_policy policy = return_value_policy::automatic_reference,
             handle parent = handle()) {
     if (policy == return_value_policy::automatic)
-        policy = std::is_pointer<T>::value ? return_value_policy::take_ownership : return_value_policy::copy;
+        policy = std::is_pointer<T>::value ? return_value_policy::take_ownership :
+                 std::is_lvalue_reference<T>::value ? return_value_policy::copy : return_value_policy::move;
     else if (policy == return_value_policy::automatic_reference)
-        policy = std::is_pointer<T>::value ? return_value_policy::reference : return_value_policy::copy;
+        policy = std::is_pointer<T>::value ? return_value_policy::reference :
+                 std::is_lvalue_reference<T>::value ? return_value_policy::copy : return_value_policy::move;
     return reinterpret_steal<object>(detail::make_caster<T>::cast(std::forward<T>(value), policy, parent));
 }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1676,6 +1676,12 @@ object cast(const T &value, return_value_policy policy = return_value_policy::au
     return reinterpret_steal<object>(detail::make_caster<T>::cast(value, policy, parent));
 }
 
+// C++ type -> py::object (move)
+template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0, detail::enable_if_t<!std::is_reference<T>::value, int> = 0>
+object cast(T &&value, return_value_policy policy = return_value_policy::move, handle parent = handle()) {
+    return reinterpret_steal<object>(detail::make_caster<T>::cast(std::move(value), policy, parent));
+}
+
 template <typename T> T handle::cast() const { return pybind11::cast<T>(*this); }
 template <> inline void handle::cast() const { return; }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1669,11 +1669,12 @@ T cast(const handle &handle) { return T(reinterpret_borrow<object>(handle)); }
 template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
 object cast(T &&value, return_value_policy policy = return_value_policy::automatic_reference,
             handle parent = handle()) {
+    using no_ref_T = typename std::remove_reference<T>::type;
     if (policy == return_value_policy::automatic)
-        policy = std::is_pointer<T>::value ? return_value_policy::take_ownership :
+        policy = std::is_pointer<no_ref_T>::value ? return_value_policy::take_ownership :
                  std::is_lvalue_reference<T>::value ? return_value_policy::copy : return_value_policy::move;
     else if (policy == return_value_policy::automatic_reference)
-        policy = std::is_pointer<T>::value ? return_value_policy::reference :
+        policy = std::is_pointer<no_ref_T>::value ? return_value_policy::reference :
                  std::is_lvalue_reference<T>::value ? return_value_policy::copy : return_value_policy::move;
     return reinterpret_steal<object>(detail::make_caster<T>::cast(std::forward<T>(value), policy, parent));
 }

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -291,7 +291,8 @@ TEST_SUBMODULE(smart_ptr, m) {
         ~C() { print_destroyed(this); }
     };
     py::class_<C, custom_unique_ptr<C>>(m, "TypeWithMoveOnlyHolder")
-        .def_static("make", []() { return custom_unique_ptr<C>(new C); });
+        .def_static("make", []() { return custom_unique_ptr<C>(new C); })
+        .def_static("make_as_object", []() { return py::cast(custom_unique_ptr<C>(new C)); });
 
     // test_holder_with_addressof_operator
     struct TypeForHolderWithAddressOf {

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -218,7 +218,10 @@ def test_shared_ptr_from_this_and_references():
 
 def test_move_only_holder():
     a = m.TypeWithMoveOnlyHolder.make()
+    b = m.TypeWithMoveOnlyHolder.make_as_object()
     stats = ConstructorStats.get(m.TypeWithMoveOnlyHolder)
+    assert stats.alive() == 2
+    del b
     assert stats.alive() == 1
     del a
     assert stats.alive() == 0


### PR DESCRIPTION
`py::cast(std::move(move_only_holder));`does not seem to work in the current version of pybind11. This PR adds a function template to support this.

I have not figured out where to add tests, but the current test suite seems to pass with this addition.