### PR TITLE
Fix pybind11 interoperability with Clang trunk

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1685,6 +1685,9 @@ template <> inline void cast_safe<void>(object &&) {}
 
 NAMESPACE_END(detail)
 
+template <return_value_policy policy = return_value_policy::automatic_reference>
+tuple make_tuple() { return tuple(0); }
+
 template <return_value_policy policy = return_value_policy::automatic_reference,
           typename... Args> tuple make_tuple(Args&&... args_) {
     constexpr size_t size = sizeof...(Args);

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -30,7 +30,8 @@
 #    define PYBIND11_HAS_OPTIONAL 1
 #  endif
 // std::experimental::optional (but not allowed in c++11 mode)
-#  if defined(PYBIND11_CPP14) && __has_include(<experimental/optional>)
+#  if defined(PYBIND11_CPP14) && (__has_include(<experimental/optional>) && \
+                                 !__has_include(<optional>))
 #    include <experimental/optional>
 #    define PYBIND11_HAS_EXP_OPTIONAL 1
 #  endif


### PR DESCRIPTION
pybind11 fails to compile on the latest Clang. There are two issues:

1. ``#include <experimental/optional>`` now fails with a preprocessor error stating that  ``#include <optional>`` should be used instead. The solution is to never include  ``experimental/optional`` if ``optional`` is available.

2. There are places in the pybind11 codebase that (indirectly) call ``make_tuple()`` without any arguments, e.g. the ``str_attr`` accessor. This causes am obscure compiler failure (excerpt below).

The underlying problem is that ``std::array<...>::operator[]`` can no longer be instantiated for arrays with zero elements. The solution is to provide a ``make_tuple()`` overload that takes no arguments.

```
In file included from ext/pybind11/include/pybind11/cast.h:17:
/usr/local/bin/../include/c++/v1/array:244:61: error: non-const lvalue reference to type 'std::__1::array<pybind11::object, 0>::value_type' (aka 'pybind11::object') cannot bind to a value of unrelated type 'std::__1::aligned_storage<8, 8>::type'                                             ake
    reference operator[](size_type __n)             {return __elems_[__n];}
                                                            ^~~~~~~~~~~~~
ext/pybind11/include/pybind11/cast.h:1696:14: note: in instantiation of member function 'std::__1::array<pybind11::object, 0>::operator[]' requested here
        if (!args[i]) {
             ^
ext/pybind11/include/pybind11/cast.h:1879:28: note: in instantiation of function template specialization 'pybind11::make_tuple<pybind11::return_value_policy::automatic_reference>' requested here
        : m_args(pybind11::make_tuple<policy>(std::forward<Ts>(values)...)) { }                                 ba/python/python.h:8:
                           ^
ext/pybind11/include/pybind11/cast.h:2023:12: note: in instantiation of function template specialization 'pybind11::detail::simple_collector<pybind11::return_value_policy::automatic_reference>::simple_collector<>' requested here
    return simple_collector<policy>(std::forward<Args>(args)...);
           ^
ext/pybind11/include/pybind11/cast.h:2043:20: note: in instantiation of function template specialization 'pybind11::detail::collect_arguments<pybind11::return_value_policy::automatic_reference, void>' requested here
    return detail::collect_arguments<policy>(std::forward<Args>(args)...).call(derived().ptr());
                   ^
ext/pybind11/include/pybind11/pybind11.h:200:58: note: in instantiation of function template specialization 'pybind11::detail::object_api<pybind11::detail::accessor<pybind11::detail::accessor_policies::str_attr> >::operator()<pybind11::return_value_policy::automatic_reference>' requested here
                a.descr = strdup(a.value.attr("__repr__")().cast<std::string>().c_str());     
```