### PR TITLE
Fix for Issue #1258

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,6 +47,9 @@ v2.3.0 (Not yet released)
 * ``pybind11_add_module()``: allow including Python as a ``SYSTEM`` include path.
   `#1416 <https://github.com/pybind/pybind11/pull/1416>`_.
 
+* ``pybind11/stl.h`` does not convert strings to ``vector<string>`` anymore.
+  `#1258 <https://github.com/pybind/pybind11/issues/1258>`_.
+
 v2.2.4 (September 11, 2018)
 -----------------------------------------------------
 

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -138,7 +138,7 @@ template <typename Type, typename Value> struct list_caster {
     using value_conv = make_caster<Value>;
 
     bool load(handle src, bool convert) {
-        if (!isinstance<sequence>(src))
+        if (!isinstance<sequence>(src) || isinstance<str>(src))
             return false;
         auto s = reinterpret_borrow<sequence>(src);
         value.clear();

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -11,6 +11,9 @@
 #include "constructor_stats.h"
 #include <pybind11/stl.h>
 
+#include <vector>
+#include <string>
+
 // Test with `std::variant` in C++17 mode, or with `boost::variant` in C++11/14
 #if PYBIND11_HAS_VARIANT
 using std::variant;
@@ -32,6 +35,8 @@ struct visit_helper<boost::variant> {
 };
 }} // namespace pybind11::detail
 #endif
+
+PYBIND11_MAKE_OPAQUE(std::vector<std::string, std::allocator<std::string>>);
 
 /// Issue #528: templated constructor
 struct TplCtorClass {
@@ -236,6 +241,11 @@ TEST_SUBMODULE(stl, m) {
 
     // test_stl_pass_by_pointer
     m.def("stl_pass_by_pointer", [](std::vector<int>* v) { return *v; }, "v"_a=nullptr);
+
+    // #1258: pybind11/stl.h converts string to vector<string>
+    m.def("func_with_string_or_vector_string_arg_overload", [](std::vector<std::string>) { return 1; });
+    m.def("func_with_string_or_vector_string_arg_overload", [](std::list<std::string>) { return 2; });
+    m.def("func_with_string_or_vector_string_arg_overload", [](std::string) { return 3; });
 
     class Placeholder {
     public:

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -201,6 +201,14 @@ def test_missing_header_message():
     assert expected_message in str(excinfo.value)
 
 
+def test_function_with_string_and_vector_string_arg():
+    """Check if a string is NOT implicitly converted to a list, which was the
+    behavior before fix of issue #1258"""
+    assert m.func_with_string_or_vector_string_arg_overload(('A', 'B', )) == 2
+    assert m.func_with_string_or_vector_string_arg_overload(['A', 'B']) == 2
+    assert m.func_with_string_or_vector_string_arg_overload('A') == 3
+
+
 def test_stl_ownership():
     cstats = ConstructorStats.get(m.Placeholder)
     assert cstats.alive() == 0


### PR DESCRIPTION
list_caster::load method will now check for a Python string and prevent its automatic conversion to a list.
This should fix the issue "pybind11/stl.h converts string to vector<string> #1258" (https://github.com/pybind/pybind11/issues/1258)