### PR TITLE
[WIP] numpy_ufunc: Allow custom ufuncs to be defined 

### DIFF
--- a/include/pybind11/detail/inference.h
+++ b/include/pybind11/detail/inference.h
@@ -1,0 +1,141 @@
+/*
+    pybind11/detail/inference.h -- Simple inference for generic functions
+
+    Copyright (c) 2018 Eric Cousineau <eric.cousineau@tri.global>
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include "common.h"
+
+NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+// SFINAE for functors.
+// N.B. This *only* distinguished between function / method pointers and
+// lambda objects. It does *not* distinguish among other types.
+template <typename Func, typename T = void>
+using enable_if_lambda_t = enable_if_t<!std::is_function<intrinsic_t<Func>>::value, T>;
+
+template <size_t N, size_t K, typename T, typename ... Ts>
+struct type_at_impl {
+  using type = typename type_at_impl<N, K + 1, Ts...>::type;
+};
+
+template <size_t N, typename T, typename ... Ts>
+struct type_at_impl<N, N, T, Ts...> {
+  using type = T;
+};
+
+// Convenient mechanism for passing sets of arguments.
+template <typename ... Ts>
+struct type_pack {
+    static constexpr int size = sizeof...(Ts);
+
+    template <template <typename...> class Tpl>
+    using bind = Tpl<Ts...>;
+
+    template <size_t N>
+    struct type_at_internal {
+      static_assert(N < size, "Invalid type index");
+      using type = typename type_at_impl<N, 0, Ts...>::type;
+    };
+
+    template <size_t N>
+    using type_at = typename type_at_internal<N>::type;
+};
+
+template <typename... A, typename... B>
+auto type_pack_concat(type_pack<A...> = {}, type_pack<B...> = {}) {
+  return type_pack<A..., B...>{};
+}
+
+template <template <typename> class Apply, typename... T>
+auto type_pack_apply(type_pack<T...> = {}) {
+  return type_pack<Apply<T>...>{};
+}
+
+struct function_inference {
+    // Collects both a functor object and its signature for ease of inference.
+    template <typename Func, typename ReturnT, typename ... ArgsT>
+    struct inferred_info {
+      // TODO(eric.cousineau): Ensure that this permits copy elision when combined
+      // with `std::forward<Func>(func)`, while still behaving well with primitive
+      // types.
+      std::decay_t<Func> func;
+
+      using Return = ReturnT;
+      using Args = type_pack<ArgsT...>;
+    };
+
+    // Factory method for `inferred_info<>`, to be used by `run`.
+    template <typename Return, typename ... Args, typename Func>
+    static auto make_inferred_info(Func&& func, Return (*infer)(Args...) = nullptr) {
+      (void)infer;
+      return inferred_info<Func, Return, Args...>{std::forward<Func>(func)};
+    }
+
+    // Infers `inferred_info<>` from a function pointer.
+    template <typename Return, typename ... Args>
+    static auto run(Return (*func)(Args...)) {
+      return make_inferred_info<Return, Args...>(func);
+    }
+
+    // Infers `inferred_info<>` from a mutable method pointer.
+    template <typename Return, typename Class, typename ... Args>
+    static auto run(Return (Class::*method)(Args...)) {
+      auto func = [method](Class& self, Args... args) {
+        return (self.*method)(std::forward<Args>(args)...);
+      };
+      return make_inferred_info<Return, Class&, Args...>(func);
+    }
+
+    // Infers `inferred_info<>` from a const method pointer.
+    template <typename Return, typename Class, typename ... Args>
+    static auto run(Return (Class::*method)(Args...) const) {
+      auto func = [method](const Class& self, Args... args) {
+        return (self.*method)(std::forward<Args>(args)...);
+      };
+      return make_inferred_info<Return, const Class&, Args...>(func);
+    }
+
+    // Helpers for general functor objects.
+    struct infer_helper {
+      // Removes class from mutable method pointer for inferring signature
+      // of functor.
+      template <typename Class, typename Return, typename ... Args>
+      static auto remove_class_from_ptr(Return (Class::*)(Args...)) {
+        using Ptr = Return (*)(Args...);
+        return Ptr{};
+      }
+
+      // Removes class from const method pointer for inferring signature of functor.
+      template <typename Class, typename Return, typename ... Args>
+      static auto remove_class_from_ptr(Return (Class::*)(Args...) const) {
+        using Ptr = Return (*)(Args...);
+        return Ptr{};
+      }
+
+      // Infers funtion pointer from functor.
+      // @pre `Func` must have only *one* overload of `operator()`.
+      template <typename Func>
+      static auto infer_function_ptr() {
+        return remove_class_from_ptr(&Func::operator());
+      }
+    };
+
+    // Infers `inferred_info<>` from a generic functor.
+    template <typename Func, typename = detail::enable_if_lambda_t<Func>>
+    static auto run(Func&& func) {
+      return make_inferred_info(
+          std::forward<Func>(func),
+          infer_helper::infer_function_ptr<std::decay_t<Func>>());
+    }
+};
+
+NAMESPACE_END(detail)
+
+NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -75,6 +75,105 @@ struct PyVoidScalarObject_Proxy {
     PyObject *base;
 };
 
+// UFuncs.
+using npy_intp = Py_intptr_t;
+
+typedef void (*PyUFuncGenericFunction)(
+    char **args, npy_intp *dimensions, npy_intp *strides, void *innerloopdata);
+
+typedef void (PyArray_VectorUnaryFunc)(
+    void* from_, void* to_, npy_intp n, void* fromarr, void* toarr);
+
+typedef struct {
+      PyObject_HEAD
+      int nin;
+      int nout;
+      int nargs;
+      int identity;
+      PyUFuncGenericFunction *functions;
+      void **data;
+      int ntypes;
+      int reserved1;
+      const char *name;
+      char *types;
+      const char *doc;
+      void *ptr;
+      PyObject *obj;
+      PyObject *userloops;
+      uint32_t *op_flags;
+      uint32_t *iter_flags;
+} PyUFuncObject;
+
+// Manually defined :(
+constexpr int NPY_NTYPES_ABI_COMPATIBLE = 21;
+constexpr int NPY_NSORTS = 3;
+
+// TODO(eric.cousineau): Fill this out as needed for type safety.
+// TODO(eric.cousineau): Do not define these if NPY headers are present (for debugging).
+using PyArray_GetItemFunc = void;
+using PyArray_SetItemFunc = void;
+using PyArray_CopySwapNFunc = void;
+using PyArray_CopySwapFunc = void;
+using PyArray_CompareFunc = void;
+using PyArray_ArgFunc = void;
+using PyArray_DotFunc = void;
+using PyArray_ScanFunc = void;
+using PyArray_FromStrFunc = void;
+using PyArray_NonzeroFunc = void;
+using PyArray_FillFunc = void;
+using PyArray_FillWithScalarFunc = void;
+using PyArray_SortFunc = void;
+using PyArray_ArgSortFunc = void;
+using PyArray_ScalarKindFunc = void;
+using PyArray_FastClipFunc = void;
+using PyArray_FastPutmaskFunc = void;
+using PyArray_FastTakeFunc = void;
+using PyArray_ArgFunc = void;
+
+typedef struct {
+    PyArray_VectorUnaryFunc *cast[NPY_NTYPES_ABI_COMPATIBLE];
+    PyArray_GetItemFunc *getitem;
+    PyArray_SetItemFunc *setitem;
+    PyArray_CopySwapNFunc *copyswapn;
+    PyArray_CopySwapFunc *copyswap;
+    PyArray_CompareFunc *compare;
+    PyArray_ArgFunc *argmax;
+    PyArray_DotFunc *dotfunc;
+    PyArray_ScanFunc *scanfunc;
+    PyArray_FromStrFunc *fromstr;
+    PyArray_NonzeroFunc *nonzero;
+    PyArray_FillFunc *fill;
+    PyArray_FillWithScalarFunc *fillwithscalar;
+    PyArray_SortFunc *sort[NPY_NSORTS];
+    PyArray_ArgSortFunc *argsort[NPY_NSORTS];
+    PyObject *castdict;
+    PyArray_ScalarKindFunc *scalarkind;
+    int **cancastscalarkindto;
+    int *cancastto;
+    PyArray_FastClipFunc *fastclip;
+    PyArray_FastPutmaskFunc *fastputmask;
+    PyArray_FastTakeFunc *fasttake;
+    PyArray_ArgFunc *argmin;
+} PyArray_ArrFuncs;
+
+using PyArray_ArrayDescr = void;
+
+typedef struct {
+    PyObject_HEAD
+    PyTypeObject *typeobj;
+    char kind;
+    char type;
+    char byteorder;
+    char unused;
+    int flags;
+    int type_num;
+    int elsize;
+    int alignment;
+    PyArray_ArrayDescr *subarray;
+    PyObject *fields;
+    PyArray_ArrFuncs *f;
+} PyArray_Descr;
+
 struct numpy_type_info {
     PyObject* dtype_ptr;
     std::string format_str;
@@ -109,7 +208,8 @@ inline numpy_internals& get_numpy_internals() {
 }
 
 struct npy_api {
-    enum constants {
+    enum constants : int {
+        // Array properties
         NPY_ARRAY_C_CONTIGUOUS_ = 0x0001,
         NPY_ARRAY_F_CONTIGUOUS_ = 0x0002,
         NPY_ARRAY_OWNDATA_ = 0x0004,
@@ -117,6 +217,7 @@ struct npy_api {
         NPY_ARRAY_ENSUREARRAY_ = 0x0040,
         NPY_ARRAY_ALIGNED_ = 0x0100,
         NPY_ARRAY_WRITEABLE_ = 0x0400,
+        // Dtypes
         NPY_BOOL_ = 0,
         NPY_BYTE_, NPY_UBYTE_,
         NPY_SHORT_, NPY_USHORT_,
@@ -126,8 +227,26 @@ struct npy_api {
         NPY_FLOAT_, NPY_DOUBLE_, NPY_LONGDOUBLE_,
         NPY_CFLOAT_, NPY_CDOUBLE_, NPY_CLONGDOUBLE_,
         NPY_OBJECT_ = 17,
-        NPY_STRING_, NPY_UNICODE_, NPY_VOID_
+        NPY_STRING_, NPY_UNICODE_, NPY_VOID_,
+        NPY_USERDEF_ = 256,
+        // Descriptor flags
+        NPY_NEEDS_INIT_ = 0x08,
+        NPY_NEEDS_PYAPI_ = 0x10,
+        NPY_USE_GETITEM_ = 0x20,
+        NPY_USE_SETITEM_ = 0x40,
+        // UFunc
+        PyUFunc_None_ = -1,
     };
+
+    typedef enum {
+            NPY_NOSCALAR_ = -1,
+            NPY_BOOL_SCALAR_,
+            NPY_INTPOS_SCALAR_,
+            NPY_INTNEG_SCALAR_,
+            NPY_FLOAT_SCALAR_,
+            NPY_COMPLEX_SCALAR_,
+            NPY_OBJECT_SCALAR_
+    } NPY_SCALARKIND;
 
     typedef struct {
         Py_intptr_t *ptr;
@@ -146,6 +265,7 @@ struct npy_api {
         return (bool) PyObject_TypeCheck(obj, PyArrayDescr_Type_);
     }
 
+    // Multiarray.
     unsigned int (*PyArray_GetNDArrayCFeatureVersion_)();
     PyObject *(*PyArray_DescrFromType_)(int);
     PyObject *(*PyArray_NewFromDescr_)
@@ -166,8 +286,29 @@ struct npy_api {
     PyObject *(*PyArray_Squeeze_)(PyObject *);
     int (*PyArray_SetBaseObject_)(PyObject *, PyObject *);
     PyObject* (*PyArray_Resize_)(PyObject*, PyArray_Dims*, int, int);
+
+    // - Dtypes
+    PyTypeObject* PyGenericArrType_Type_;
+    int (*PyArray_RegisterDataType_)(PyArray_Descr* dtype);
+    int (*PyArray_RegisterCastFunc_)(PyArray_Descr* descr, int totype, PyArray_VectorUnaryFunc* castfunc);
+    int (*PyArray_RegisterCanCast_)(PyArray_Descr* descr, int totype, NPY_SCALARKIND scalar);
+    void (*PyArray_InitArrFuncs_)(PyArray_ArrFuncs *f);
+
+    // UFuncs.
+    PyObject* (*PyUFunc_FromFuncAndData_)(
+        PyUFuncGenericFunction* func, void** data, char* types, int ntypes,
+        int nin, int nout, int identity, char* name, char* doc, int unused);
+
+    int (*PyUFunc_RegisterLoopForType_)(
+        PyUFuncObject* ufunc, int usertype, PyUFuncGenericFunction function, int* arg_types, void* data);
+
+    int (*PyUFunc_ReplaceLoopBySignature_)(
+        PyUFuncObject *func, PyUFuncGenericFunction newfunc,
+        int *signature, PyUFuncGenericFunction *oldfunc);
 private:
+    // TODO(eric.cousineau): Rename to `items` or something, since this now applies to types.
     enum functions {
+        // multiarray
         API_PyArray_GetNDArrayCFeatureVersion = 211,
         API_PyArray_Type = 2,
         API_PyArrayDescr_Type = 3,
@@ -184,38 +325,68 @@ private:
         API_PyArray_EquivTypes = 182,
         API_PyArray_GetArrayParamsFromObject = 278,
         API_PyArray_Squeeze = 136,
-        API_PyArray_SetBaseObject = 282
+        API_PyArray_SetBaseObject = 282,
+        // - DTypes
+        API_PyGenericArrType_Type = 10,
+        API_PyArray_RegisterDataType = 192,
+        API_PyArray_RegisterCastFunc = 193,
+        API_PyArray_RegisterCanCast = 194,
+        API_PyArray_InitArrFuncs = 195,
+        // umath
+        API_PyUFunc_FromFuncAndData = 1,
+        API_PyUFunc_RegisterLoopForType = 2,
+        API_PyUFunc_ReplaceLoopBySignature = 30,
     };
 
-    static npy_api lookup() {
-        module m = module::import("numpy.core.multiarray");
-        auto c = m.attr("_ARRAY_API");
+    static void** get_api_ptr(object c) {
 #if PY_MAJOR_VERSION >= 3
-        void **api_ptr = (void **) PyCapsule_GetPointer(c.ptr(), NULL);
+        return (void **) PyCapsule_GetPointer(c.ptr(), NULL);
 #else
-        void **api_ptr = (void **) PyCObject_AsVoidPtr(c.ptr());
+        return (void **) PyCObject_AsVoidPtr(c.ptr());
 #endif
+    }
+
+    static npy_api lookup() {
         npy_api api;
 #define DECL_NPY_API(Func) api.Func##_ = (decltype(api.Func##_)) api_ptr[API_##Func];
-        DECL_NPY_API(PyArray_GetNDArrayCFeatureVersion);
-        if (api.PyArray_GetNDArrayCFeatureVersion_() < 0x7)
-            pybind11_fail("pybind11 numpy support requires numpy >= 1.7.0");
-        DECL_NPY_API(PyArray_Type);
-        DECL_NPY_API(PyVoidArrType_Type);
-        DECL_NPY_API(PyArrayDescr_Type);
-        DECL_NPY_API(PyArray_DescrFromType);
-        DECL_NPY_API(PyArray_DescrFromScalar);
-        DECL_NPY_API(PyArray_FromAny);
-        DECL_NPY_API(PyArray_Resize);
-        DECL_NPY_API(PyArray_CopyInto);
-        DECL_NPY_API(PyArray_NewCopy);
-        DECL_NPY_API(PyArray_NewFromDescr);
-        DECL_NPY_API(PyArray_DescrNewFromType);
-        DECL_NPY_API(PyArray_DescrConverter);
-        DECL_NPY_API(PyArray_EquivTypes);
-        DECL_NPY_API(PyArray_GetArrayParamsFromObject);
-        DECL_NPY_API(PyArray_Squeeze);
-        DECL_NPY_API(PyArray_SetBaseObject);
+        // multiarray -> _ARRAY_API
+        {
+            module multiarray = module::import("numpy.core.multiarray");
+            auto api_ptr = get_api_ptr(multiarray.attr("_ARRAY_API"));
+            DECL_NPY_API(PyArray_GetNDArrayCFeatureVersion);
+            if (api.PyArray_GetNDArrayCFeatureVersion_() < 0x7)
+                pybind11_fail("pybind11 numpy support requires numpy >= 1.7.0");
+            DECL_NPY_API(PyArray_Type);
+            DECL_NPY_API(PyVoidArrType_Type);
+            DECL_NPY_API(PyArrayDescr_Type);
+            DECL_NPY_API(PyArray_DescrFromType);
+            DECL_NPY_API(PyArray_DescrFromScalar);
+            DECL_NPY_API(PyArray_FromAny);
+            DECL_NPY_API(PyArray_Resize);
+            DECL_NPY_API(PyArray_CopyInto);
+            DECL_NPY_API(PyArray_NewCopy);
+            DECL_NPY_API(PyArray_NewFromDescr);
+            DECL_NPY_API(PyArray_DescrNewFromType);
+            DECL_NPY_API(PyArray_DescrConverter);
+            DECL_NPY_API(PyArray_EquivTypes);
+            DECL_NPY_API(PyArray_GetArrayParamsFromObject);
+            DECL_NPY_API(PyArray_Squeeze);
+            DECL_NPY_API(PyArray_SetBaseObject);
+            // - Dtypes
+            DECL_NPY_API(PyGenericArrType_Type);
+            DECL_NPY_API(PyArray_RegisterDataType);
+            DECL_NPY_API(PyArray_InitArrFuncs);
+            DECL_NPY_API(PyArray_RegisterCastFunc);
+            DECL_NPY_API(PyArray_RegisterCanCast);
+        }
+        // umath -> _UFUNC_API
+        {
+            module umath = module::import("numpy.core.umath");
+            auto api_ptr = get_api_ptr(umath.attr("_UFUNC_API"));
+            DECL_NPY_API(PyUFunc_FromFuncAndData);
+            DECL_NPY_API(PyUFunc_RegisterLoopForType);
+            DECL_NPY_API(PyUFunc_ReplaceLoopBySignature);
+        }
 #undef DECL_NPY_API
         return api;
     }
@@ -1046,6 +1217,26 @@ private:
 public:
     static constexpr auto name = base_descr::name;
     static pybind11::dtype dtype() { return base_descr::dtype(); }
+};
+
+template <>
+struct npy_format_descriptor<object> {
+    static pybind11::dtype dtype() {
+        if (auto ptr = npy_api::get().PyArray_DescrFromType_(npy_api::NPY_OBJECT_))
+            return reinterpret_borrow<pybind11::dtype>(ptr);
+        pybind11_fail("Unsupported buffer format!");
+    }
+};
+
+template <>
+struct npy_format_descriptor<void> {
+    static constexpr auto name = detail::_<void>();
+    static pybind11::dtype dtype() {
+        if (auto ptr = detail::npy_api::get().PyArray_DescrFromType_(
+              detail::npy_api::constants::NPY_VOID_))
+            return reinterpret_borrow<pybind11::dtype>(ptr);
+        pybind11_fail("Unsupported buffer format!");
+    }
 };
 
 struct field_descriptor {

--- a/include/pybind11/numpy_ufunc.h
+++ b/include/pybind11/numpy_ufunc.h
@@ -1,0 +1,216 @@
+/*
+    pybind11/detail/numpy_ufunc.h: Simple glue for Python UFuncs
+
+    Copyright (c) 2018 Eric Cousineau <eric.cousineau@tri.global>
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include "numpy.h"
+#include "detail/inference.h"
+
+NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+// Utilities
+
+// Builtins registered using numpy/build/{...}/numpy/core/include/numpy/__umath_generated.c
+
+template <typename... Args>
+struct ufunc_ptr {
+  PyUFuncGenericFunction func{};
+  void* data{};
+};
+
+// Unary ufunc.
+template <typename Arg0, typename Out, typename Func>
+auto ufunc_to_ptr(Func func, type_pack<Arg0, Out>) {
+    auto ufunc = [](
+            char** args, npy_intp* dimensions, npy_intp* steps, void* data) {
+        Func& func = *(Func*)data;
+        int step_0 = steps[0];
+        int step_out = steps[1];
+        int n = *dimensions;
+        char *in_0 = args[0], *out = args[1];
+        for (int k = 0; k < n; k++) {
+            // TODO(eric.cousineau): Support pointers being changed.
+            *(Out*)out = func(*(Arg0*)in_0);
+            in_0 += step_0;
+            out += step_out;
+        }
+    };
+    // N.B. `new Func(...)` will never be destroyed.
+    return ufunc_ptr<Arg0, Out>{ufunc, new Func(func)};
+}
+
+// Binary ufunc.
+template <typename Arg0, typename Arg1, typename Out, typename Func = void>
+auto ufunc_to_ptr(Func func, type_pack<Arg0, Arg1, Out>) {
+    auto ufunc = [](char** args, npy_intp* dimensions, npy_intp* steps, void* data) {
+        Func& func = *(Func*)data;
+        int step_0 = steps[0];
+        int step_1 = steps[1];
+        int step_out = steps[2];
+        int n = *dimensions;
+        char *in_0 = args[0], *in_1 = args[1], *out = args[2];
+        for (int k = 0; k < n; k++) {
+            // TODO(eric.cousineau): Support pointers being fed in.
+            *(Out*)out = func(*(Arg0*)in_0, *(Arg1*)in_1);
+            in_0 += step_0;
+            in_1 += step_1;
+            out += step_out;
+        }
+    };
+    // N.B. `new Func(...)` will never be destroyed.
+    return ufunc_ptr<Arg0, Arg1, Out>{ufunc, new Func(func)};
+}
+
+// Generic dispatch.
+template <typename Func>
+auto ufunc_to_ptr(Func func) {
+    auto info = detail::function_inference::run(func);
+    using Info = decltype(info);
+    auto type_args = type_pack_apply<std::decay_t>(
+        type_pack_concat(
+            typename Info::Args{},
+            type_pack<typename Info::Return>{}));
+    return ufunc_to_ptr(func, type_args);
+}
+
+template <typename From, typename To, typename Func>
+void ufunc_register_cast(
+    Func&& func, bool allow_coercion, type_pack<From, To> = {}) {
+  static auto cast_lambda = detail::function_inference::run(func).func;
+  auto cast_func = +[](
+        void* from_, void* to_, npy_intp n,
+        void* fromarr, void* toarr) {
+      const From* from = (From*)from_;
+      To* to = (To*)to_;
+      for (npy_intp i = 0; i < n; i++)
+          to[i] = cast_lambda(from[i]);
+  };
+  auto& api = npy_api::get();
+  auto from = npy_format_descriptor<From>::dtype();
+  int to_num = npy_format_descriptor<To>::dtype().num();
+  auto from_raw = (PyArray_Descr*)from.ptr();
+  if (api.PyArray_RegisterCastFunc_(from_raw, to_num, cast_func) < 0)
+      pybind11_fail("ufunc: Cannot register cast");
+  if (allow_coercion) {
+    if (api.PyArray_RegisterCanCast_(
+            from_raw, to_num, npy_api::NPY_NOSCALAR_) < 0)
+        pybind11_fail(
+            "ufunc: Cannot register implicit / coercion cast capability");
+  }
+}
+
+NAMESPACE_END(detail)
+
+class ufunc : public object {
+public:
+    ufunc(object ptr) : object(ptr) {
+        // TODO(eric.cousineau): Check type.
+    }
+
+    ufunc(detail::PyUFuncObject* ptr)
+        : object(reinterpret_borrow<object>((PyObject*)ptr))
+    {}
+
+    ufunc(handle scope, const char* name) : scope_{scope}, name_{name} {}
+
+    // Gets a NumPy UFunc by name.
+    static ufunc get_builtin(const char* name) {
+        module numpy = module::import("numpy");
+        return ufunc(numpy.attr(name));
+    }
+
+    template <typename Type, typename Func>
+    ufunc& def_loop(Func func) {
+        do_register<Type>(detail::ufunc_to_ptr(func));
+        return *this;
+    }
+
+    detail::PyUFuncObject* ptr() const {
+        return (detail::PyUFuncObject*)self().ptr();
+    }
+
+private:
+    object& self() { return *this; }
+    const object& self() const { return *this; }
+
+    // Registers a function pointer as a UFunc, mapping types to dtype nums.
+    template <typename Type, typename ... Args>
+    void do_register(detail::ufunc_ptr<Args...> user) {
+        constexpr int N = sizeof...(Args);
+        constexpr int nin = N - 1;
+        constexpr int nout = 1;
+        int dtype = dtype::of<Type>().num();
+        int dtype_args[] = {dtype::of<Args>().num()...};
+        // Determine if we need to make a new ufunc.
+        using constants = detail::npy_api::constants;
+        auto& api = detail::npy_api::get();
+        if (!self()) {
+            if (!name_)
+                pybind11_fail("dtype: unspecified name");
+            // TODO(eric.cousineau): Fix unfreed memory with `name`.
+            auto leak = new std::string(name_);
+            // The following dummy stuff is to allow monkey-patching existing ufuncs.
+            // This is a bit sketchy, as calling the wrong thing may cause a segfault.
+            // TODO(eric.cousineau): Figure out how to more elegantly specify preallocation...
+            // Preallocate to allow replacement?
+            constexpr int ntypes = 4;
+            static char tinker_types[ntypes] = {
+                constants::NPY_BOOL_,
+                constants::NPY_INT_,
+                constants::NPY_FLOAT_,
+                constants::NPY_DOUBLE_,
+            };
+            auto dummy_funcs = new detail::PyUFuncGenericFunction[ntypes];
+            auto dummy_data = new void*[ntypes];
+            constexpr int ntotal = (nin + nout) * ntypes;
+            auto dummy_types = new char[ntotal];
+            for (int it = 0; it < ntypes; ++it) {
+                for (int iarg = 0; iarg < nin + nout; ++iarg) {
+                    int i = it * (nin + nout) + iarg;
+                    dummy_types[i] = tinker_types[it];
+                }
+            }
+            auto h = api.PyUFunc_FromFuncAndData_(
+                dummy_funcs, dummy_data, dummy_types, ntypes,
+                nin, nout, constants::PyUFunc_None_, &(*leak)[0], "", 0);
+            self() = reinterpret_borrow<object>((PyObject*)h);
+            scope_.attr(name_) = self();
+        }
+        if (N != ptr()->nargs)
+            pybind11_fail("ufunc: Argument count mismatch");
+        if (dtype >= constants::NPY_USERDEF_) {
+            if (api.PyUFunc_RegisterLoopForType_(
+                    ptr(), dtype, user.func, dtype_args, user.data) < 0)
+                pybind11_fail("ufunc: Failed to register custom ufunc");
+        } else {
+            // Hack because NumPy API doesn't allow us convenience for builtin types :(
+            if (api.PyUFunc_ReplaceLoopBySignature_(
+                    ptr(), user.func, dtype_args, nullptr) < 0)
+                pybind11_fail("ufunc: Failed ot register builtin ufunc");
+            // Now that we've registered, ensure that we replace the data.
+            bool found{};
+            for (int i = 0; i < ptr()->ntypes; ++i) {
+                if (ptr()->functions[i] == user.func) {
+                    found = true;
+                    ptr()->data[i] = user.data;
+                    break;
+                }
+            }
+            if (!found)
+                pybind11_fail("Can't hack and slash");
+        }
+    }
+
+    // These are only used if we have something new.
+    const char* name_{};
+    handle scope_{}; 
+};
+
+NAMESPACE_END(PYBIND11_NAMESPACE)


### PR DESCRIPTION
I ended up implementing this for the following feature:
https://github.com/RobotLocomotion/pybind11/pull/12

This is a very minor adjustment for a WIP submission; things left to do:
- [ ] Simplify logic for defining builtin dtype loops; at present, it's nasty because I originally only focused on user-defined dtypes
- [ ] Add unittests - there are some in the above fork's PR for operator overloading, but nothing explicitly focused on ufuncs really
- [ ] See if structured dtypes are supported
- [ ] Either fix `detail/inteference.h` to be C++11-friendly, or ditch it and inline the function signature inference - I've seen this mechanism more or less copied+pasted in several locations in the code, and had pulled this from my implementation [here](https://github.com/RobotLocomotion/drake/blob/b9eb279cdbe2095d660fb8ad0be14c643967ced2/bindings/pydrake/util/wrap_function.h#L85) in preparation for wrapping things like `def` without having to repeating myself too much

May relate https://github.com/pybind/pybind11/issues/1294?