### PR TITLE
Fix enum value's __int__ returning non-int when underlying type is bool or of char type

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1574,9 +1574,9 @@ public:
     using Base::def_property_readonly_static;
     using Underlying = typename std::underlying_type<Type>::type;
     // Scalar is the integer representation of underlying type
-    using Scalar = detail::conditional_t<
-        detail::is_std_char_type<Underlying>::value,
-        detail::equivalent_integer_t<Underlying>, Underlying>;
+    using Scalar = detail::conditional_t<detail::any_of<
+        detail::is_std_char_type<Underlying>, std::is_same<Underlying, bool>
+    >::value, detail::equivalent_integer_t<Underlying>, Underlying>;
 
     template <typename... Extra>
     enum_(const handle &scope, const char *name, const Extra&... extra)

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -135,4 +135,14 @@ TEST_SUBMODULE(enums, m) {
     py::enum_<ScopedChar16Enum>(m, "ScopedChar16Enum")
         .value("Zero", ScopedChar16Enum::Zero)
         .value("Positive", ScopedChar16Enum::Positive);
+
+    // test_bool_underlying_enum
+    enum class ScopedBoolEnum : bool { FALSE, TRUE };
+
+    // bool is unsigned (std::is_signed returns false) and 1-bit long, so represented with u8
+    static_assert(std::is_same<py::enum_<ScopedBoolEnum>::Scalar, std::uint8_t>::value, "");
+
+    py::enum_<ScopedBoolEnum>(m, "ScopedBoolEnum")
+        .value("FALSE", ScopedBoolEnum::FALSE)
+        .value("TRUE", ScopedBoolEnum::TRUE);
 }

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -84,4 +84,55 @@ TEST_SUBMODULE(enums, m) {
             .value("ONE", SimpleEnum::THREE)
             .export_values();
     });
+
+    // test_enum_scalar
+    enum UnscopedUCharEnum : unsigned char {};
+    enum class ScopedShortEnum : short {};
+    enum class ScopedLongEnum : long {};
+    enum UnscopedUInt64Enum : std::uint64_t {};
+    static_assert(py::detail::all_of<
+        std::is_same<py::enum_<UnscopedUCharEnum>::Scalar, unsigned char>,
+        std::is_same<py::enum_<ScopedShortEnum>::Scalar, short>,
+        std::is_same<py::enum_<ScopedLongEnum>::Scalar, long>,
+        std::is_same<py::enum_<UnscopedUInt64Enum>::Scalar, std::uint64_t>
+    >::value, "Error during the deduction of enum's scalar type with normal integer underlying");
+
+    // test_enum_scalar_with_char_underlying
+    enum class ScopedCharEnum   : char     { Zero, Positive };
+    enum class ScopedWCharEnum  : wchar_t  { Zero, Positive };
+    enum class ScopedChar32Enum : char32_t { Zero, Positive };
+    enum class ScopedChar16Enum : char16_t { Zero, Positive };
+
+    // test the scalar of char type enums according to chapter 'Character types'
+    // from https://en.cppreference.com/w/cpp/language/types
+    static_assert(py::detail::any_of<
+        std::is_same<py::enum_<ScopedCharEnum>::Scalar, signed char>, // e.g.
+        std::is_same<py::enum_<ScopedCharEnum>::Scalar, unsigned char>  // e.g. arm linux
+    >::value, "char should be cast to either signed char or unsigned char");
+    static_assert(
+        sizeof(py::enum_<ScopedWCharEnum>::Scalar) == 2 ||
+        sizeof(py::enum_<ScopedWCharEnum>::Scalar) == 4
+    , "wchar_t should be either 16 bits (Windows) or 32 (everywhere else)");
+    static_assert(py::detail::all_of<
+        std::is_same<py::enum_<ScopedChar32Enum>::Scalar, std::uint_least32_t>,
+        std::is_same<py::enum_<ScopedChar16Enum>::Scalar, std::uint_least16_t>
+    >::value, "char32_t, char16_t (and char8_t)'s size, signedness, and alignment is determined");
+#if defined(PYBIND11_CPP20)
+    enum class ScopedChar8Enum : char8_t { Zero, Positive };
+    static_assert(std::is_same<py::enum_<ScopedChar8Enum>::Scalar, unsigned char>::value);
+#endif
+
+    // test_char_underlying_enum
+    py::enum_<ScopedCharEnum>(m, "ScopedCharEnum")
+        .value("Zero", ScopedCharEnum::Zero)
+        .value("Positive", ScopedCharEnum::Positive);
+    py::enum_<ScopedWCharEnum>(m, "ScopedWCharEnum")
+        .value("Zero", ScopedWCharEnum::Zero)
+        .value("Positive", ScopedWCharEnum::Positive);
+    py::enum_<ScopedChar32Enum>(m, "ScopedChar32Enum")
+        .value("Zero", ScopedChar32Enum::Zero)
+        .value("Positive", ScopedChar32Enum::Positive);
+    py::enum_<ScopedChar16Enum>(m, "ScopedChar16Enum")
+        .value("Zero", ScopedChar16Enum::Zero)
+        .value("Positive", ScopedChar16Enum::Positive);
 }

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -194,13 +194,37 @@ def test_binary_operators():
 def test_enum_to_int():
     m.test_enum_to_int(m.Flags.Read)
     m.test_enum_to_int(m.ClassWithUnscopedEnum.EMode.EFirstMode)
+    m.test_enum_to_int(m.ScopedCharEnum.Positive)
     m.test_enum_to_uint(m.Flags.Read)
     m.test_enum_to_uint(m.ClassWithUnscopedEnum.EMode.EFirstMode)
+    m.test_enum_to_uint(m.ScopedCharEnum.Positive)
     m.test_enum_to_long_long(m.Flags.Read)
     m.test_enum_to_long_long(m.ClassWithUnscopedEnum.EMode.EFirstMode)
+    m.test_enum_to_long_long(m.ScopedCharEnum.Positive)
 
 
 def test_duplicate_enum_name():
     with pytest.raises(ValueError) as excinfo:
         m.register_bad_enum()
     assert str(excinfo.value) == 'SimpleEnum: element "ONE" already exists!'
+
+
+def test_char_underlying_enum():
+    assert type(m.ScopedCharEnum.Positive.__int__()) == int
+    assert m.ScopedCharEnum.Zero.__int__() == 0
+    assert m.ScopedChar32Enum.Positive.__getstate__() == 1
+    assert m.ScopedChar32Enum.Zero.__hash__() == 0
+    try:
+        int(m.ScopedChar16Enum.Positive)
+        hash(m.ScopedChar16Enum.Zero)
+    except TypeError:
+        assert False
+    try:
+        m.ScopedWCharEnum(1)
+    except TypeError:
+        assert False
+    try:
+        m.ScopedWCharEnum("0")
+        assert False
+    except TypeError:
+        assert True

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -195,12 +195,15 @@ def test_enum_to_int():
     m.test_enum_to_int(m.Flags.Read)
     m.test_enum_to_int(m.ClassWithUnscopedEnum.EMode.EFirstMode)
     m.test_enum_to_int(m.ScopedCharEnum.Positive)
+    m.test_enum_to_int(m.ScopedBoolEnum.TRUE)
     m.test_enum_to_uint(m.Flags.Read)
     m.test_enum_to_uint(m.ClassWithUnscopedEnum.EMode.EFirstMode)
     m.test_enum_to_uint(m.ScopedCharEnum.Positive)
+    m.test_enum_to_uint(m.ScopedBoolEnum.TRUE)
     m.test_enum_to_long_long(m.Flags.Read)
     m.test_enum_to_long_long(m.ClassWithUnscopedEnum.EMode.EFirstMode)
     m.test_enum_to_long_long(m.ScopedCharEnum.Positive)
+    m.test_enum_to_long_long(m.ScopedBoolEnum.TRUE)
 
 
 def test_duplicate_enum_name():
@@ -228,3 +231,12 @@ def test_char_underlying_enum():
         assert False
     except TypeError:
         assert True
+
+
+def test_bool_underlying_enum():
+    assert type(m.ScopedBoolEnum.TRUE.__int__()) == int
+    assert m.ScopedBoolEnum.FALSE.__hash__() == 0
+    try:
+        m.ScopedBoolEnum(1)
+    except TypeError:
+        assert False


### PR DESCRIPTION
### Introduction

This PR solves the problem of enum value's `__int__` returning a non-int value when its underlying type is bool or of char type.

### Detail

This PR extends the `enum_` class with following type alias:

* `Underlying` type: the actual underlying type of enum (The original `Scalar` type);
* `Scalar` type: the integer type with **length** and **signedness** equivalent to the underlying type.

The enum should always use `Scalar` as the inner integer type when dealing with python side.

So,
* Scalar for underlying type of normal integer would stay the same; 
* Scalar for underlying type of bool or char type would use the int type of same length and signedness, specified through the `equivalent_integer` struct.

### Applicable issues
Fix #1331
Fix #1820
Fix https://github.com/osmcode/pyosmium/issues/114
