### PR TITLE
[READY] Implement an enum_ property "name"

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -488,6 +488,24 @@ The entries defined by the enumeration type are exposed in the ``__members__`` p
     >>> Pet.Kind.__members__
     {'Dog': Kind.Dog, 'Cat': Kind.Cat}
 
+The ``name`` property returns the name of the enum value as a unicode string.
+
+.. note::
+
+    It is also possible to use ``str(enum)``, however these accomplish different
+    goals. The following shows how these two approaches differ.
+
+    .. code-block:: pycon
+
+        >>> p = Pet( "Lucy", Pet.Cat )
+        >>> pet_type = p.type
+        >>> pet_type
+        Pet.Cat
+        >>> str(pet_type)
+        'Pet.Cat'
+        >>> pet_type.name
+        'Cat'
+
 .. note::
 
     When the special tag ``py::arithmetic()`` is specified to the ``enum_``

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1364,6 +1364,7 @@ detail::initimpl::pickle_factory<GetState, SetState> pickle(GetState &&g, SetSta
 template <typename Type> class enum_ : public class_<Type> {
 public:
     using class_<Type>::def;
+    using class_<Type>::def_property_readonly;
     using class_<Type>::def_property_readonly_static;
     using Scalar = typename std::underlying_type<Type>::type;
 
@@ -1380,6 +1381,13 @@ public:
                     return pybind11::str("{}.{}").format(name, kv.first);
             }
             return pybind11::str("{}.???").format(name);
+        });
+        def_property_readonly("name", [m_entries_ptr](Type value) -> pybind11::str {
+            for (const auto &kv : reinterpret_borrow<dict>(m_entries_ptr)) {
+                if (pybind11::cast<Type>(kv.second[int_(0)]) == value)
+                    return pybind11::str(kv.first);
+            }
+            return pybind11::str("???");
         });
         def_property_readonly_static("__doc__", [m_entries_ptr](handle self) {
             std::string docstring;

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -6,6 +6,19 @@ def test_unscoped_enum():
     assert str(m.UnscopedEnum.EOne) == "UnscopedEnum.EOne"
     assert str(m.UnscopedEnum.ETwo) == "UnscopedEnum.ETwo"
     assert str(m.EOne) == "UnscopedEnum.EOne"
+
+    # name property
+    assert m.UnscopedEnum.EOne.name == "EOne"
+    assert m.UnscopedEnum.ETwo.name == "ETwo"
+    assert m.EOne.name == "EOne"
+    # name readonly
+    with pytest.raises(AttributeError):
+        m.UnscopedEnum.EOne.name = ""
+    # name returns a copy
+    foo = m.UnscopedEnum.EOne.name
+    foo = "bar"
+    assert m.UnscopedEnum.EOne.name == "EOne"
+
     # __members__ property
     assert m.UnscopedEnum.__members__ == \
         {"EOne": m.UnscopedEnum.EOne, "ETwo": m.UnscopedEnum.ETwo}


### PR DESCRIPTION
The property returns the enum_ value as a string.
For example:

```
>>> import module
>>> module.enum.VALUE
enum.VALUE
>>> str(module.enum.VALUE)
'enum.VALUE'
>>> module.enum.VALUE.name
'VALUE'
```

This is actually the equivalent of Boost.Python "name" property.

@jagerman Pointed out #1122 as it is somewhat related. The reason I didn't propose this change there is because I believe that smaller changes are easier to both reason about and review.