### PR TITLE
strdup is deprecated on Windows platforms, replaced with posix compliant _strdup

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #if defined(_MSC_VER)
+#  define strdup _strdup
 #  pragma warning(push)
 #  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
 #  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant


### PR DESCRIPTION

https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/strdup-wcsdup-mbsdup

I was getting a linker error when building the example code using Clang for Windows using the standard library and linker shipped with the latest version of Visual Studio Community edition 2017.

(clang was installed via conda using the conda-forge package)