### PR TITLE
strdup is deprecated in MSVC. Use the ISO C++ conformant _strdup instead

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #if defined(_MSC_VER)
-#  define strdup _strdup
+#  define strdup _strdup         //The POSIX strdup is deprecated. Use the ISO C++ conformant _strdup instead
 #  pragma warning(push)
 #  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
 #  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #if defined(_MSC_VER)
+#  define strdup _strdup
 #  pragma warning(push)
 #  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
 #  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/ms235454.aspx

strdup is deprecated in Visual Studio 2015 and 2017. _strdup is the ISO C++ conformant replacement provided by Microsoft.

I was trying to compile the Pet class example from the documentation using Clang for Windows and was getting a linker error for an undefined symbol "strdup". Adding this define fixed it.

Was using Clang version 5.0 installed via conda using the conda-forge package. I was using the standard library and linker that was packaged with Visual Studio 2017 community edition.