### PR TITLE
Update numpy.rst

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -261,7 +261,7 @@ simply using ``vectorize``).
     namespace py = pybind11;
 
     py::array_t<double> add_arrays(py::array_t<double> input1, py::array_t<double> input2) {
-        auto buf1 = input1.request(), buf2 = input2.request();
+        py::buffer_info buf1 = input1.request(), buf2 = input2.request();
 
         if (buf1.ndim != 1 || buf2.ndim != 1)
             throw std::runtime_error("Number of dimensions must be one");
@@ -272,7 +272,7 @@ simply using ``vectorize``).
         /* No pointer is passed, so NumPy will allocate the buffer */
         auto result = py::array_t<double>(buf1.size);
 
-        auto buf3 = result.request();
+        py::buffer_info buf3 = result.request();
 
         double *ptr1 = (double *) buf1.ptr,
                *ptr2 = (double *) buf2.ptr,


### PR DESCRIPTION
Changing from auto to py::buffer_info is more intuitive. It took me few hours to understand the missing type was what I was looking for... Maybe replacing all auto typing with their real type is better for the tutorial code.