### PR TITLE
Properly report exceptions thrown during module initialization.

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1894,6 +1894,7 @@ class gil_scoped_release { };
 
 error_already_set::~error_already_set() {
     if (type) {
+        error_scope scope;
         gil_scoped_acquire gil;
         type.release().dec_ref();
         value.release().dec_ref();


### PR DESCRIPTION
If an exception is thrown during module initialization, the
error_already_set destructor will try to call `get_internals()` *after*
setting Python's error indicator, resulting in a `SystemError: ...
returned with an error set`.

Fix that by temporarily stashing away the error indicator when
initializing the internals.

(I *think* any proper unit test would require creating a new module just for that purpose, and I'm not particularly familiar with the testing machinery used by pybind, so guidance would be welcome here.  But "it works for me"...)

xref #1113.