### PR TITLE
Enforces intel icpc >= 2017, fixes #1121

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In addition to the core functionality, pybind11 provides some extra goodies:
 1. Clang/LLVM 3.3 or newer (for Apple Xcode's clang, this is 5.0.0 or newer)
 2. GCC 4.8 or newer
 3. Microsoft Visual Studio 2015 Update 3 or newer
-4. Intel C++ compiler 16 or newer (15 with a [workaround](https://github.com/pybind/pybind11/issues/276))
+4. Intel C++ compiler 17 or newer (16 with pybind11 v2.0 and 15 with pybind11 v2.0 and a [workaround](https://github.com/pybind/pybind11/issues/276))
 5. Cygwin/GCC (tested on 2.5.1)
 
 ## About

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,10 @@ v2.3.0 (Not yet released)
 * The ``value()``  method of ``py::enum_`` now accepts an optional docstring
   that will be shown in the documentation of the associated enumeration.
 
+* Intel compilers have needed to be >= 17.0 since v2.1. Now the check
+  is explicit and a compile-time error is raised if the compiler does
+  not meet the requirements.
+
 v2.2.2 (February 7, 2018)
 -----------------------------------------------------
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -91,4 +91,4 @@ Supported compilers
 1. Clang/LLVM (any non-ancient version with C++11 support)
 2. GCC 4.8 or newer
 3. Microsoft Visual Studio 2015 or newer
-4. Intel C++ compiler v15 or newer
+4. Intel C++ compiler v17 or newer (v16 with pybind11 v2.0 and v15 with pybind11 v2.0 and a `workaround <https://github.com/pybind/pybind11/issues/276>`_ )

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -46,8 +46,8 @@
 
 // Compiler version assertions
 #if defined(__INTEL_COMPILER)
-#  if __INTEL_COMPILER < 1500
-#    error pybind11 requires Intel C++ compiler v15 or newer
+#  if __INTEL_COMPILER < 1700
+#    error pybind11 requires Intel C++ compiler v17 or newer
 #  endif
 #elif defined(__clang__) && !defined(__apple_build_version__)
 #  if __clang_major__ < 3 || (__clang_major__ == 3 && __clang_minor__ < 3)


### PR DESCRIPTION
* @wjakob, your assessment [here](https://github.com/pybind/pybind11/issues/1121#issuecomment-381917924) is correct.
* I tried 2017.0.4 and it returns plain `1700` for `__INTEL_COMPILER`. Certainly as far back as 2017.0.2 _does_ work and as far forward as 2016.0.3 _doesn't_ work, so the 2017 boundary seems a good approximation.
* I edited all the docs references I could find, but [this file](https://github.com/pybind/pybind11/blob/master/docs/upgrade.rst) may still need attention. I wasn't sure how to handle it with respect to 2.2.3 vs 2.2.2+cherrypick.

Thanks for everyone's help in trying to solve #1121 for 2016.