### PR TITLE
pybind11Tools: Use interface target library when able

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -189,6 +189,11 @@ to an independently constructed (through ``add_library``, not
     Studio (``/bigobj``).  The :ref:`FAQ <faq:symhidden>` contains an
     explanation on why these are needed.
 
+.. note::
+
+    ``pybind11_add_module`` will use this interface library target in addition
+    to the above compiler flags if using a version of CMake greater than 3.0.
+
 Embedding the Python interpreter
 --------------------------------
 


### PR DESCRIPTION
It'd be nice if the interface target libraries were used via `pybind11_add_module`.

\cc @jamiesnape