### PR TITLE
WIP: Fix iostream when used with nogil

### DIFF
--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -42,8 +42,11 @@ private:
             // This subtraction cannot be negative, so dropping the sign
             str line(pbase(), static_cast<size_t>(pptr() - pbase()));
 
-            pywrite(line);
-            pyflush();
+            {
+                gil_scoped_acquire tmp;
+                pywrite(line);
+                pyflush();
+            }
 
             setp(pbase(), epptr());
         }


### PR DESCRIPTION
When using the iostream wrappers, if you release the gil, you get a segfault. This small patch ensures that mixing them is safe.

Edit: Waiting on #1286, or #1211, or #1556 (probably more)