### PR TITLE
Fix pip10 buggy behavoir

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,8 +41,8 @@ install:
     if ($env:PYTHON) {
       if ($env:PLATFORM -eq "x64") { $env:PYTHON = "$env:PYTHON-x64" }
       $env:PATH = "C:\Python$env:PYTHON\;C:\Python$env:PYTHON\Scripts\;$env:PATH"
-      pip install --disable-pip-version-check --user --upgrade pip wheel
-      pip install pytest numpy
+      python -m pip install --upgrade pip wheel
+      python -m pip install pytest numpy --no-warn-script-location
     } elseif ($env:CONDA) {
       if ($env:CONDA -eq "27") { $env:CONDA = "" }
       if ($env:PLATFORM -eq "x64") { $env:CONDA = "$env:CONDA-x64" }


### PR DESCRIPTION
`pip` in Pip10 is broken. You can't use `pip` on windows, but have to do `python -m pip`. (Also true with Ubuntu and probably others). Pip officially is forcing `python -m pip` to do a pip upgrade on Windows (since it replaces the running executable - I assume it has to replace it because of the `import main` disaster...).

There's a not in PATH warning that turns into an error... (The warning is not a bad idea, the fact that it errors out on Appveyor is not so great). Added a flag to stop the error (we use `python -m pytest` so the warning is not needed anyway).