### PR TITLE
Fix SEGV to create empty shaped numpy array

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -758,8 +758,9 @@ protected:
     static std::vector<ssize_t> c_strides(const std::vector<ssize_t> &shape, ssize_t itemsize) {
         auto ndim = shape.size();
         std::vector<ssize_t> strides(ndim, itemsize);
-        for (size_t i = ndim - 1; i > 0; --i)
-            strides[i - 1] = strides[i] * shape[i];
+        if (ndim > 0)
+            for (size_t i = ndim - 1; i > 0; --i)
+                strides[i - 1] = strides[i] * shape[i];
         return strides;
     }
 

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -102,6 +102,9 @@ TEST_SUBMODULE(numpy_array, sm) {
     sm.def("make_f_array", [] { return py::array_t<float>({ 2, 2 }, { 4, 8 }); });
     sm.def("make_c_array", [] { return py::array_t<float>({ 2, 2 }, { 8, 4 }); });
 
+    // test_empty_shaped_array
+    sm.def("make_empty_shaped_array", [] { return py::array(py::dtype("f"), {}, {}); });
+
     // test_wrap
     sm.def("wrap", [](py::array a) {
         return py::array(

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -135,6 +135,10 @@ def test_make_c_f_array():
     assert not m.make_f_array().flags.c_contiguous
 
 
+def test_make_empty_shaped_array():
+    assert m.make_empty_shaped_array()
+
+
 def test_wrap():
     def assert_references(a, b, base=None):
         from distutils.version import LooseVersion


### PR DESCRIPTION
Fix https://github.com/pybind/pybind11/issues/1370