### PR TITLE
Minor fix for MSVC warning CS4459

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1389,9 +1389,9 @@ public:
             }
             return pybind11::str("???");
         });
-        def_property_readonly_static("__doc__", [m_entries_ptr](handle self) {
+        def_property_readonly_static("__doc__", [m_entries_ptr](handle self_) {
             std::string docstring;
-            const char *tp_doc = ((PyTypeObject *) self.ptr())->tp_doc;
+            const char *tp_doc = ((PyTypeObject *) self_.ptr())->tp_doc;
             if (tp_doc)
                 docstring += std::string(tp_doc) + "\n\n";
             docstring += "Members:";
@@ -1404,7 +1404,7 @@ public:
             }
             return docstring;
         });
-        def_property_readonly_static("__members__", [m_entries_ptr](handle /* self */) {
+        def_property_readonly_static("__members__", [m_entries_ptr](handle /* self_ */) {
             dict m;
             for (const auto &kv : reinterpret_borrow<dict>(m_entries_ptr))
                 m[kv.first] = kv.second[int_(0)];


### PR DESCRIPTION
When using pybind11 to bind enums on MSVC and warnings (/W4) enabled,
the following warning pollutes builds. This fix renames one of the
occurrences.

```
pybind11\include\pybind11\pybind11.h(1398): warning C4459: declaration of 'self' hides global declaration
pybind11\include\pybind11\operators.h(41): note: see declaration of 'pybind11::detail::self'
```