### PR TITLE
Container: ipython completions

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -593,6 +593,16 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args&&.
 
     cl.def("__len__", &Map::size);
 
+    // interactive ipython key completions, currently works with string keys
+    cl.def("_ipython_key_completions_",
+        [](Map &m) {
+            auto l = py::list();
+            for (const auto &p : m)
+                l.append(p.first);
+            return l;
+        }
+    );
+
     return cl;
 }
 

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -116,6 +116,7 @@ def test_map_string_double():
     assert list(mm) == ['a', 'b']
     assert list(mm.items()) == [('a', 1), ('b', 2.5)]
     assert str(mm) == "MapStringDouble{a: 1, b: 2.5}"
+    assert sorted(list(mm)) == sorted(mm._ipython_key_completions_())
 
     um = m.UnorderedMapStringDouble()
     um['ua'] = 1.1
@@ -124,6 +125,7 @@ def test_map_string_double():
     assert sorted(list(um)) == ['ua', 'ub']
     assert sorted(list(um.items())) == [('ua', 1.1), ('ub', 2.6)]
     assert "UnorderedMapStringDouble" in str(um)
+    assert sorted(list(um)) == sorted(um._ipython_key_completions_())
 
 
 def test_map_string_double_const():


### PR DESCRIPTION
Add ipython 5+ completions for the `__getitem__` method in `dict` / C++ maps.

This adds interactive completion in ipython (and related kernels, e.g. in Notebooks).
From my tests, this currently works only for dictionaries with string keys and is ignored for all others.

### Example

https://github.com/openPMD/openPMD-api/pull/191

### Reference

https://ipython.readthedocs.io/en/5.x/config/integrating.html