### PR TITLE
Fix auto type deduction failures when var name is an existing type name

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -814,7 +814,7 @@ template <typename type> class type_caster_base : public type_caster_generic {
     using itype = intrinsic_t<type>;
 
 public:
-    static constexpr auto name = _<type>();
+    static constexpr auto name_ = _<type>();
 
     type_caster_base() : type_caster_base(typeid(type)) { }
     explicit type_caster_base(const std::type_info &info) : type_caster_generic(info) { }
@@ -917,7 +917,7 @@ private:
             "std::reference_wrapper<T> caster requires T to have a caster with an `T &` operator");
 public:
     bool load(handle src, bool convert) { return subcaster.load(src, convert); }
-    static constexpr auto name = caster_t::name;
+    static constexpr auto name_ = caster_t::name_;
     static handle cast(const std::reference_wrapper<type> &src, return_value_policy policy, handle parent) {
         // It is definitely wrong to take ownership of this pointer, so mask that rvp
         if (policy == return_value_policy::take_ownership || policy == return_value_policy::automatic)
@@ -932,7 +932,7 @@ public:
     protected: \
         type value; \
     public: \
-        static constexpr auto name = py_name; \
+        static constexpr auto name_ = py_name; \
         template <typename T_, enable_if_t<std::is_same<type, remove_cv_t<T_>>::value, int> = 0> \
         static handle cast(T_ *src, return_value_policy policy, handle parent) { \
             if (!src) return none().release(); \
@@ -1350,7 +1350,7 @@ public:
         return cast_impl(std::forward<T>(src), policy, parent, indices{});
     }
 
-    static constexpr auto name = _("Tuple[") + concat(make_caster<Ts>::name...) + _("]");
+    static constexpr auto name_ = _("Tuple[") + concat(make_caster<Ts>::name_...) + _("]");
 
     template <typename T> using cast_op_type = type;
 
@@ -1526,10 +1526,10 @@ template <typename base, typename holder> struct is_holder_type :
 template <typename base, typename deleter> struct is_holder_type<base, std::unique_ptr<base, deleter>> :
     std::true_type {};
 
-template <typename T> struct handle_type_name { static constexpr auto name = _<T>(); };
-template <> struct handle_type_name<bytes> { static constexpr auto name = _(PYBIND11_BYTES_NAME); };
-template <> struct handle_type_name<args> { static constexpr auto name = _("*args"); };
-template <> struct handle_type_name<kwargs> { static constexpr auto name = _("**kwargs"); };
+template <typename T> struct handle_type_name { static constexpr auto name_ = _<T>(); };
+template <> struct handle_type_name<bytes> { static constexpr auto name_ = _(PYBIND11_BYTES_NAME); };
+template <> struct handle_type_name<args> { static constexpr auto name_ = _("*args"); };
+template <> struct handle_type_name<kwargs> { static constexpr auto name_ = _("**kwargs"); };
 
 template <typename type>
 struct pyobject_caster {
@@ -1547,7 +1547,7 @@ struct pyobject_caster {
     static handle cast(const handle &src, return_value_policy /* policy */, handle /* parent */) {
         return src.inc_ref();
     }
-    PYBIND11_TYPE_CASTER(type, handle_type_name<type>::name);
+    PYBIND11_TYPE_CASTER(type, handle_type_name<type>::name_);
 };
 
 template <typename T>
@@ -1867,7 +1867,7 @@ public:
     static constexpr bool has_kwargs = kwargs_pos < 0;
     static constexpr bool has_args = args_pos < 0;
 
-    static constexpr auto arg_names = concat(type_descr(make_caster<Args>::name)...);
+    static constexpr auto arg_names = concat(type_descr(make_caster<Args>::name_)...);
 
     bool load_args(function_call &call) {
         return load_impl_sequence(call, indices{});

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -24,7 +24,7 @@ public:
 
     template <typename> using cast_op_type = value_and_holder &;
     operator value_and_holder &() { return *value; }
-    static constexpr auto name = _<value_and_holder>();
+    static constexpr auto name_ = _<value_and_holder>();
 
 private:
     value_and_holder *value = nullptr;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -164,7 +164,7 @@ protected:
         process_attributes<Extra...>::init(extra..., rec);
 
         /* Generate a readable signature describing the function's arguments and return value types */
-        static constexpr auto signature = _("(") + cast_in::arg_names + _(") -> ") + cast_out::name;
+        static constexpr auto signature = _("(") + cast_in::arg_names + _(") -> ") + cast_out::name_;
         PYBIND11_DESCR_CONSTEXPR auto types = decltype(signature)::types();
 
         /* Register the function with Python from generic (non-templated) code */
@@ -738,15 +738,15 @@ protected:
                 msg += pybind11::repr(args_[ti]);
             }
             if (kwargs_in) {
-                auto kwargs = reinterpret_borrow<dict>(kwargs_in);
-                if (kwargs.size() > 0) {
+                auto kwargs_ = reinterpret_borrow<dict>(kwargs_in);
+                if (kwargs_.size() > 0) {
                     if (some_args) msg += "; ";
                     msg += "kwargs: ";
                     bool first = true;
-                    for (auto kwarg : kwargs) {
+                    for (auto kwarg_ : kwargs_) {
                         if (first) first = false;
                         else msg += ", ";
-                        msg += pybind11::str("{}={!r}").format(kwarg.first, kwarg.second);
+                        msg += pybind11::str("{}={!r}").format(kwarg_.first, kwarg_.second);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #1381 

`name` is certainly the messiest and most pervasive of the bunch here.  I'm happy to change any of the variable names as needed.

While this does address the PGI type deduction issues, pybind11 still won't correctly build with PGI without #1428.