### PR TITLE
Fix Travis GCC 7 Python 3.6.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ matrix:
   - sudo: true
     services: docker
     env: PYTHON=3.6 CPP=17 GCC=7
+    # fails
   - os: linux
     env: PYTHON=3.6 CPP=17 CLANG=5.0
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ matrix:
   - sudo: true
     services: docker
     env: PYTHON=3.6 CPP=17 GCC=7
-    # fails
   - os: linux
     env: PYTHON=3.6 CPP=17 CLANG=5.0
     addons:
@@ -109,7 +108,7 @@ before_install:
       export CXX=g++-$GCC CC=gcc-$GCC
     fi
     if [ "$GCC" = "6" ]; then DOCKER=${ARCH:+$ARCH/}debian:stretch
-    elif [ "$GCC" = "7" ]; then DOCKER=debian:buster EXTRA_PACKAGES+=" catch" DOWNLOAD_CATCH=OFF
+    elif [ "$GCC" = "7" ]; then DOCKER=debian:buster EXTRA_PACKAGES+=" catch python3-distutils" DOWNLOAD_CATCH=OFF
     fi
   elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     export CXX=clang++ CC=clang;


### PR DESCRIPTION
Travis is broken in `master`.

Trying to add the [missing `distutils`](https://travis-ci.org/pybind/pybind11/jobs/394630866) for Python 3.6.6 on Debian "buster".