### PR TITLE
Fix CMake scripts so projects using CUDA .cu files build correctly.

### DIFF
--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -145,6 +145,7 @@ function(pybind11_add_module target_name)
   # namespace; also turning it on for a pybind module compilation here avoids
   # potential warnings or issues from having mixed hidden/non-hidden types.
   set_target_properties(${target_name} PROPERTIES CXX_VISIBILITY_PRESET "hidden")
+  set_target_properties(${target_name} PROPERTIES CUDA_VISIBILITY_PRESET "hidden")
 
   if(WIN32 OR CYGWIN)
     # Link against the Python shared library on Windows
@@ -197,6 +198,15 @@ function(pybind11_add_module target_name)
   if(MSVC)
     # /MP enables multithreaded builds (relevant when there are many files), /bigobj is
     # needed for bigger binding projects due to the limit to 64k addressable sections
-    target_compile_options(${target_name} PRIVATE /MP /bigobj)
+    set(msvc_extra_options /MP /bigobj)
+    if(CMAKE_VERSION VERSION_LESS 3.11)
+      target_compile_options(${target_name} PRIVATE ${msvc_extra_options})
+    else()
+      # Only set these options for C++ files.  This is important so that, for
+      # instance, projects that include other types of source files like CUDA
+      # .cu files don't get these options propagated to nvcc since that would
+      # cause the build to fail.
+      target_compile_options(${target_name} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${msvc_extra_options}>)
+    endif()
   endif()
 endfunction()


### PR DESCRIPTION
This PR makes a few minor changes to the CMake scripts so projects using CUDA .cu files build correctly.  For example, CMake allows you to use CUDA files in a python extension module with a CMakeLists.txt such as:

```
CMAKE_MINIMUM_REQUIRED(VERSION 3.11)
project(pystuff LANGUAGES CXX CUDA)

add_subdirectory(pybind11)

pybind11_add_module(pystuff 
   cpp_stuff.cpp 
   cuda_stuff.cu
   )
```

That works fine on Linux with the current pybind11 cmake scripts.  However, it fails on OS X and windows with Visual Studio.  On OS X it fails because of incorrect link visibility settings for the CUDA code.  In Visual Studio it fails because the current CMake scripts end up passing /MP and /bigobj to nvcc, but nvcc doesn't understand those options and so it errors out.  

This PR fixes those issues.  Allowing CMake projects such as the one shown above to compile on all three platforms.

And as an aside, pybind11 is great.  I switched dlib to it from boost python and my life is much improved :)