### PR TITLE
Untangle cast logic to not implicitly require castability

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1028,6 +1028,12 @@ public:
     }
 
     template<typename U = T>
+    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, short>::value, handle>::type
+    cast(U src, return_value_policy /* policy */, handle /* parent */) {
+        return PyLong_FromLong((long) src);
+    }
+
+    template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, int>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
         return PyLong_FromLong((long) src);
@@ -1041,6 +1047,12 @@ public:
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned char>::value, handle>::type
+    cast(U src, return_value_policy /* policy */, handle /* parent */) {
+        return PyLong_FromUnsignedLong((unsigned long) src);
+    }
+
+    template<typename U = T>
+    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned short>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
         return PyLong_FromUnsignedLong((unsigned long) src);
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1020,6 +1020,13 @@ public:
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
         return PyFloat_FromDouble((double) src);
     }
+
+    template<typename U = T>
+    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, char>::value, handle>::type
+    cast(U src, return_value_policy /* policy */, handle /* parent */) {
+        return PyLong_FromLong((long) src);
+    }
+
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, int>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
@@ -1030,6 +1037,12 @@ public:
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, long>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
         return PyLong_FromLong((long) src);
+    }
+
+    template<typename U = T>
+    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned char>::value, handle>::type
+    cast(U src, return_value_policy /* policy */, handle /* parent */) {
+        return PyLong_FromUnsignedLong((unsigned long) src);
     }
 
     template<typename U = T>

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1024,19 +1024,19 @@ public:
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, char>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromLong((long) src);
+        return PyLong_FromLong((char) src);
     }
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, short>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromLong((long) src);
+        return PyLong_FromLong((short) src);
     }
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, int>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromLong((long) src);
+        return PyLong_FromLong((int) src);
     }
 
     template<typename U = T>
@@ -1048,19 +1048,19 @@ public:
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned char>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromUnsignedLong((unsigned long) src);
+        return PyLong_FromUnsignedLong((unsigned char) src);
     }
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned short>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromUnsignedLong((unsigned long) src);
+        return PyLong_FromUnsignedLong((unsigned short) src);
     }
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned int>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromUnsignedLong((unsigned long) src);
+        return PyLong_FromUnsignedLong((unsigned int) src);
     }
 
     template<typename U = T>

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1024,43 +1024,43 @@ public:
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, char>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromLong((char) src);
+        return PYBIND11_LONG_FROM_SIGNED((char) src);
     }
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, short>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromLong((short) src);
+        return PYBIND11_LONG_FROM_SIGNED((short) src);
     }
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, int>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromLong((int) src);
+        return PYBIND11_LONG_FROM_SIGNED((int) src);
     }
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, long>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromLong((long) src);
+        return PYBIND11_LONG_FROM_SIGNED((long) src);
     }
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned char>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromUnsignedLong((unsigned char) src);
+        return PYBIND11_LONG_FROM_UNSIGNED((unsigned char) src);
     }
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned short>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromUnsignedLong((unsigned short) src);
+        return PYBIND11_LONG_FROM_UNSIGNED((unsigned short) src);
     }
 
     template<typename U = T>
     static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned int>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromUnsignedLong((unsigned int) src);
+        return PYBIND11_LONG_FROM_UNSIGNED((unsigned int) src);
     }
 
     template<typename U = T>

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -17,6 +17,7 @@
 #include <array>
 #include <limits>
 #include <tuple>
+#include <type_traits>
 
 #if defined(PYBIND11_CPP17)
 #  if defined(__has_include)
@@ -1010,10 +1011,8 @@ public:
     }
 
     template <class A, class B>
-    struct is_explicitly_convertible
-    {
-        enum {value = std::is_same<A, B>::value || (std::is_constructible<B, A>::value && !std::is_convertible<A, B>::value)};
-    };
+    using is_explicitly_convertible = std::integral_constant<bool,
+        std::is_same<A, B>::value || (std::is_constructible<B, A>::value && !std::is_convertible<A, B>::value)>;
 
     template<typename U = T>
     static typename std::enable_if<std::is_floating_point<U>::value, handle>::type

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1010,10 +1010,6 @@ public:
         return true;
     }
 
-    template <class A, class B>
-    using is_explicitly_convertible = std::integral_constant<bool,
-        std::is_same<A, B>::value || (std::is_constructible<B, A>::value && !std::is_convertible<A, B>::value)>;
-
     template<typename U = T>
     static typename std::enable_if<std::is_floating_point<U>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
@@ -1021,61 +1017,25 @@ public:
     }
 
     template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, char>::value, handle>::type
-    cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PYBIND11_LONG_FROM_SIGNED((char) src);
-    }
-
-    template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, short>::value, handle>::type
-    cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PYBIND11_LONG_FROM_SIGNED((short) src);
-    }
-
-    template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, int>::value, handle>::type
-    cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PYBIND11_LONG_FROM_SIGNED((int) src);
-    }
-
-    template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, long>::value, handle>::type
+    static typename std::enable_if<!std::is_floating_point<U>::value && std::is_signed<U>::value && (sizeof(U) <= sizeof(long)), handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
         return PYBIND11_LONG_FROM_SIGNED((long) src);
     }
 
     template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned char>::value, handle>::type
+    static typename std::enable_if<!std::is_floating_point<U>::value && std::is_unsigned<U>::value && (sizeof(U) <= sizeof(unsigned long)), handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PYBIND11_LONG_FROM_UNSIGNED((unsigned char) src);
+        return PYBIND11_LONG_FROM_UNSIGNED((unsigned long) src);
     }
 
     template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned short>::value, handle>::type
-    cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PYBIND11_LONG_FROM_UNSIGNED((unsigned short) src);
-    }
-
-    template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned int>::value, handle>::type
-    cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PYBIND11_LONG_FROM_UNSIGNED((unsigned int) src);
-    }
-
-    template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned long>::value, handle>::type
-    cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromUnsignedLong((unsigned long) src);
-    }
-
-    template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, long long>::value, handle>::type
+    static typename std::enable_if<!std::is_floating_point<U>::value && std::is_signed<U>::value && (sizeof(U) > sizeof(long)), handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
         return PyLong_FromLongLong((long long) src);
     }
 
     template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && is_explicitly_convertible<U, unsigned long long>::value, handle>::type
+    static typename std::enable_if<!std::is_floating_point<U>::value && std::is_unsigned<U>::value && (sizeof(U) > sizeof(unsigned long)), handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
         return PyLong_FromUnsignedLongLong((unsigned long long) src);
     }


### PR DESCRIPTION
The current code requires implicitly that integral types are cast-able to floating point. In case of strongly-typed integrals (e.g. [as explained here](http://www.ilikebigbits.com/blog/2014/5/6/type-safe-identifiers-in-c)) this is not always the case.

The patch at hand uses compile-time magic to make sure that cast-ability is only requested if the type supports it. 