### PR TITLE
Fix typo in doc: build-in -> built-in

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -80,7 +80,7 @@ Redirecting C++ streams
 
 .. doxygenfunction:: add_ostream_redirect
 
-Python build-in functions
+Python built-in functions
 =========================
 
 .. doxygengroup:: python_builtins


### PR DESCRIPTION
Hi Wenzel and other maintainers, I just noticed this small typo in the doc :)

Thanks again for your work on pybind11, it is so incredibly useful! I'm using it for https://github.com/vgc/vgc, although I'm quite new to writing Python bindings (or even Python semantics for that matter), so I'm sure there is plenty of room for improvements in how I use pybind11.

Cheers (and maybe see you at Siggraph),
Boris