### PR TITLE
check for already existing enum value added; added test

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1465,7 +1465,7 @@ public:
         this->attr(name) = v;
         auto name_converted = pybind11::str(name);
         if (m_entries.contains(name_converted))
-            throw value_error("Enum error - element with provided name already exist");
+            throw value_error("Enum error - element with name: " + std::string(name) + " already exists");
         m_entries[name_converted] = std::make_pair(v, doc);
         return *this;
     }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1463,7 +1463,10 @@ public:
     enum_& value(char const* name, Type value, const char *doc = nullptr) {
         auto v = pybind11::cast(value, return_value_policy::copy);
         this->attr(name) = v;
-        m_entries[pybind11::str(name)] = std::make_pair(v, doc);
+		auto name_converted = pybind11::str(name);
+		if (m_entries.contains(name_converted))
+			throw value_error("Enum error - element with provided name already exist");
+        m_entries[name_converted] = std::make_pair(v, doc);
         return *this;
     }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1463,9 +1463,9 @@ public:
     enum_& value(char const* name, Type value, const char *doc = nullptr) {
         auto v = pybind11::cast(value, return_value_policy::copy);
         this->attr(name) = v;
-		auto name_converted = pybind11::str(name);
-		if (m_entries.contains(name_converted))
-			throw value_error("Enum error - element with provided name already exist");
+        auto name_converted = pybind11::str(name);
+        if (m_entries.contains(name_converted))
+            throw value_error("Enum error - element with provided name already exist");
         m_entries[name_converted] = std::make_pair(v, doc);
         return *this;
     }

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -298,5 +298,5 @@ void exportBadEnum(pybind11::module &m)
 TEST_CASE("Defining enum with mutiple identical values should cause an error")
 {
     pybind11::module m("tempModule");
-    REQUIRE_THROWS_WITH(exportBadEnum(m), "Enum error - element with provided name already exist");
+    REQUIRE_THROWS_WITH(exportBadEnum(m), "Enum error - element with name: ONE already exists");
 }

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -282,21 +282,3 @@ TEST_CASE("Reload module from file") {
     result = module.attr("test")().cast<int>();
     REQUIRE(result == 2);
 }
-
-void exportBadEnum(pybind11::module &m)
-{
-    enum SimpleEnum
-    {
-        ONE, TWO, THREE
-    };
-    py::enum_<SimpleEnum>(m, "SimpleEnum")
-        .value("ONE", SimpleEnum::ONE)          //NOTE: all value function calls are called with the same first parameter value
-        .value("ONE", SimpleEnum::TWO)
-        .value("ONE", SimpleEnum::THREE)
-        .export_values();
-}
-TEST_CASE("Defining enum with mutiple identical values should cause an error")
-{
-    pybind11::module m("tempModule");
-    REQUIRE_THROWS_WITH(exportBadEnum(m), "Enum error - element with name: ONE already exists");
-}

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -282,3 +282,21 @@ TEST_CASE("Reload module from file") {
     result = module.attr("test")().cast<int>();
     REQUIRE(result == 2);
 }
+
+void exportBadEnum(pybind11::module &m)
+{
+	enum SimpleEnum
+	{
+		ONE, TWO, THREE
+	};
+	py::enum_<SimpleEnum>(m, "SimpleEnum")
+		.value("ONE", SimpleEnum::ONE)          //NOTE: all value function calls are called with the same first parameter value
+		.value("ONE", SimpleEnum::TWO)
+		.value("ONE", SimpleEnum::THREE)
+		.export_values();
+}
+TEST_CASE("Defining enum with mutiple identical values should cause an error")
+{
+	pybind11::module m("tempModule");
+	REQUIRE_THROWS_WITH(exportBadEnum(m), "Enum error - element with provided name already exist");
+}

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -285,18 +285,18 @@ TEST_CASE("Reload module from file") {
 
 void exportBadEnum(pybind11::module &m)
 {
-	enum SimpleEnum
-	{
-		ONE, TWO, THREE
-	};
-	py::enum_<SimpleEnum>(m, "SimpleEnum")
-		.value("ONE", SimpleEnum::ONE)          //NOTE: all value function calls are called with the same first parameter value
-		.value("ONE", SimpleEnum::TWO)
-		.value("ONE", SimpleEnum::THREE)
-		.export_values();
+    enum SimpleEnum
+    {
+        ONE, TWO, THREE
+    };
+    py::enum_<SimpleEnum>(m, "SimpleEnum")
+        .value("ONE", SimpleEnum::ONE)          //NOTE: all value function calls are called with the same first parameter value
+        .value("ONE", SimpleEnum::TWO)
+        .value("ONE", SimpleEnum::THREE)
+        .export_values();
 }
 TEST_CASE("Defining enum with mutiple identical values should cause an error")
 {
-	pybind11::module m("tempModule");
-	REQUIRE_THROWS_WITH(exportBadEnum(m), "Enum error - element with provided name already exist");
+    pybind11::module m("tempModule");
+    REQUIRE_THROWS_WITH(exportBadEnum(m), "Enum error - element with provided name already exist");
 }

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -68,4 +68,18 @@ TEST_SUBMODULE(enums, m) {
     m.def("test_enum_to_int", [](int) { });
     m.def("test_enum_to_uint", [](uint32_t) { });
     m.def("test_enum_to_long_long", [](long long) { });
+
+    // test_duplicate_enum_name
+    enum SimpleEnum
+    {
+        ONE, TWO, THREE
+    };
+
+    m.def("register_bad_enum", [m]() {
+        py::enum_<SimpleEnum>(m, "SimpleEnum")
+            .value("ONE", SimpleEnum::ONE)          //NOTE: all value function calls are called with the same first parameter value
+            .value("ONE", SimpleEnum::TWO)
+            .value("ONE", SimpleEnum::THREE)
+            .export_values();
+    });
 }

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -148,3 +148,9 @@ def test_enum_to_int():
     m.test_enum_to_uint(m.ClassWithUnscopedEnum.EMode.EFirstMode)
     m.test_enum_to_long_long(m.Flags.Read)
     m.test_enum_to_long_long(m.ClassWithUnscopedEnum.EMode.EFirstMode)
+
+
+def test_duplicate_enum_name():
+    with pytest.raises(ValueError) as excinfo:
+        m.register_bad_enum()
+    assert str(excinfo.value) == "Enum error - element with name: ONE already exists"


### PR DESCRIPTION
Fix for https://github.com/pybind/pybind11/issues/1451 (Defining enum with mutiple identical values should cause an error)
Now trying to add already existing value throws an exception.