### PR TITLE
Switching deprecated Thread Local Storage (TLS) usage in Python 3.7 to Thread Specific Storage (TSS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
     env: PYTHON=2.7 CPP=14 CLANG CMAKE=1
   - os: osx
     osx_image: xcode9
-    env: PYTHON=3.6 CPP=14 CLANG DEBUG=1
+    env: PYTHON=3.7 CPP=14 CLANG DEBUG=1
   # Test a PyPy 2.7 build
   - os: linux
     env: PYPY=5.8 PYTHON=2.7 CPP=11 GCC=4.8

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -21,15 +21,13 @@ inline PyObject *make_object_base_type(PyTypeObject *metaclass);
 // The old Python Thread Local Storage (TLS) API is deprecated in Python 3.7 in favor of the new
 // Thread Specific Storage (TSS) API.
 #if PY_VERSION_HEX >= 0x03070000
-    #define PYBIND11_TLS_KEY_TYPE Py_tss_t *
-    #define PYBIND11_TLS_KEY_NULL_VALUE nullptr
+    #define PYBIND11_TLS_KEY_INIT(var) Py_tss_t *var = nullptr
     #define PYBIND11_TLS_GET_VALUE(key) PyThread_tss_get((key))
     #define PYBIND11_TLS_REPLACE_VALUE(key, value) PyThread_tss_set((key), (tstate))
     #define PYBIND11_TLS_DELETE_VALUE(key) PyThread_tss_set((key), nullptr)
 #else
     // Usually an int but a long on Cygwin64 with Python 3.x
-    #define PYBIND11_TLS_KEY_TYPE decltype(PyThread_create_key())
-    #define PYBIND11_TLS_KEY_NULL_VALUE 0
+    #define PYBIND11_TLS_KEY_INIT(var) decltype(PyThread_create_key()) var = 0
     #define PYBIND11_TLS_GET_VALUE(key) PyThread_get_key_value((key))
     #if PY_MAJOR_VERSION < 3
         #define PYBIND11_TLS_REPLACE_VALUE(key, value) do { PyThread_delete_key_value((key)); PyThread_set_key_value((key), (value)); } while (false)
@@ -100,7 +98,7 @@ struct internals {
     PyTypeObject *default_metaclass;
     PyObject *instance_base;
 #if defined(WITH_THREAD)
-    PYBIND11_TLS_KEY_TYPE tstate = PYBIND11_TLS_KEY_NULL_VALUE;
+    PYBIND11_TLS_KEY_INIT(tstate);
     PyInterpreterState *istate = nullptr;
 #endif
 };


### PR DESCRIPTION
Python 3.7 deprecated the use of the 'Thread Local Storage (TLS) API', resulting in a bunch of warnings when compiling (see #1444). This PR switches between using the old TLS API and new TSS API, based on the Python version number.

See https://python.readthedocs.io/en/latest/c-api/init.html#thread-specific-storage-tss-api and https://www.python.org/dev/peps/pep-0539/ for details on the new API.

Potential issues:
- Parts of the code where TLS was used were already subject to conditional compilation, macros and `#if`s. But now a few more are added to switch between the old and new API (though only at a handful of places). Is it worth adding a wrapper API, to get rid of some of the preprocessor directives within the code?
- The new `Py_tss_t *` key type of `internals::tstate` needs to be allocated (`PyThread_tss_alloc()`), but since the internals struct gets statically allocated once (and there is no destructor or other cleanup), it never gets `PyThread_tss_free`d (neither is the entry removed with `PyThread_tss_delete`). But then the old version never called `PyThread_delete_key`, either, and the struct has a static lifetime. Should there be a way of cleaning this up (e.g., through a `Py_AtExit` callback)?