### PR TITLE
Fix compatibility with catch v2

### DIFF
--- a/tests/test_embed/catch.cpp
+++ b/tests/test_embed/catch.cpp
@@ -14,7 +14,7 @@
 
 namespace py = pybind11;
 
-int main(int argc, const char *argv[]) {
+int main(int argc, char *argv[]) {
     py::scoped_interpreter guard{};
     auto result = Catch::Session().run(argc, argv);
 


### PR DESCRIPTION
Catch v2 changed the `run(...)` signature to take a `char *argv[]`,
arguing partly that technically a `char *argv[]` type is the correct
`main()` signature rather than `const char *argv[]`.

Dropping the `const` here doesn't appear to cause any problems with
catch v1 (tested against both the cmake-downloaded 1.9.3 and Debian's
1.12.1 package) so we can follow suit.

Fixes #1459 