### PR TITLE
Allow ostream-redirection of more than 1024 characters

### DIFF
--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -34,7 +34,7 @@ private:
             *pptr() = traits_type::to_char_type(c);
             pbump(1);
         }
-        return sync() ? traits_type::not_eof(c) : traits_type::eof();
+        return sync() == 0 ? traits_type::not_eof(c) : traits_type::eof();
     }
 
     int sync() {

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -53,6 +53,16 @@ def test_captured(capsys):
     assert stdout == ''
     assert stderr == msg
 
+def test_captured_large_string(capsys):
+    # Make this bigger than the buffer used on the C++ side: 1024 chars
+    msg = "I've been redirected to Python, I hope!"
+    msg = msg * (1024 // len(msg) + 1)
+
+    m.captured_output_default(msg)
+    stdout, stderr = capsys.readouterr()
+    assert stdout == msg
+    assert stderr == ''
+
 
 def test_guard_capture(capsys):
     msg = "I've been redirected to Python, I hope!"


### PR DESCRIPTION
Fixes #1478 

In short, `detail::pythonbuf::overflow()` had its branch for the return statement backwards, since `bool(sync())` is `true` if and only if `sync()` fails; `sync()` returns `0` on success. This fixes it by using `sync() == 0` as the condition.