### PR TITLE
Enable dynamic attribute support for Pypy >= 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,15 @@ matrix:
   - os: osx
     osx_image: xcode9
     env: PYTHON=3.7 CPP=14 CLANG DEBUG=1
-  # Test a PyPy 2.7 build
+  # Test a PyPy 2.7 v5.8 build
   - os: linux
     env: PYPY=5.8 PYTHON=2.7 CPP=11 GCC=4.8
+    addons:
+      apt:
+        packages: [libblas-dev, liblapack-dev, gfortran]
+  # Test a PyPy 2.7 v6.0 build
+  - os: linux
+    env: PYPY=6.0 PYTHON=2.7 CPP=11 GCC=4.8
     addons:
       apt:
         packages: [libblas-dev, liblapack-dev, gfortran]
@@ -133,6 +139,10 @@ before_install:
     if [ "$PYPY" = "5.8" ]; then
       curl -fSL https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-linux64.tar.bz2 | tar xj
       PY_CMD=$(echo `pwd`/pypy2-v5.8.0-linux64/bin/pypy)
+      CMAKE_EXTRA_ARGS+=" -DPYTHON_EXECUTABLE:FILEPATH=$PY_CMD"
+    elif [ "$PYPY" = "6.0" ]; then
+      curl -fSL https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux64.tar.bz2 | tar xj
+      PY_CMD=$(echo `pwd`/pypy2-v6.0.0-linux64/bin/pypy)
       CMAKE_EXTRA_ARGS+=" -DPYTHON_EXECUTABLE:FILEPATH=$PY_CMD"
     else
       PY_CMD=python$PYTHON

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -441,10 +441,10 @@ extern "C" inline int pybind11_clear(PyObject *self) {
 /// Give instances of this type a `__dict__` and opt into garbage collection.
 inline void enable_dynamic_attributes(PyHeapTypeObject *heap_type) {
     auto type = &heap_type->ht_type;
-#if defined(PYPY_VERSION)
+#if defined(PYPY_VERSION) && (PYPY_VERSION_NUM < 0x06000000)
     pybind11_fail(std::string(type->tp_name) + ": dynamic attributes are "
                                                "currently not supported in "
-                                               "conjunction with PyPy!");
+                                               "conjunction with PyPy before 6.0!");
 #endif
     type->tp_flags |= Py_TPFLAGS_HAVE_GC;
     type->tp_dictoffset = type->tp_basicsize; // place dict at the end


### PR DESCRIPTION
According to my experiments, the code that's disabled by the conditional on Pypy appears to work just fine on (at least) Pypy 6.0.