### PR TITLE
add wrapper for callable builtin function

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -378,6 +378,12 @@ inline bool isinstance(handle obj, handle type) {
     return result != 0;
 }
 
+/// \ingroup python_builtins
+/// Return true if ``obj`` is callable, i.e. a ``function`` or ``class``.
+inline bool callable(handle obj) {
+    return PyCallable_Check(obj.ptr()) != 0;
+}
+
 /// \addtogroup python_builtins
 /// @{
 inline bool hasattr(handle obj, handle name) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 # Full set of test files (you can override these; see below)
 set(PYBIND11_TEST_FILES
   test_buffers.cpp
+  test_builtins.cpp
   test_builtin_casters.cpp
   test_call_policies.cpp
   test_callbacks.cpp

--- a/tests/test_builtins.cpp
+++ b/tests/test_builtins.cpp
@@ -1,0 +1,19 @@
+/*
+    tests/test_builtins.cpp -- python builtin functions
+
+    Copyright (c) 2018 Wenzel Jakob <wenzel.jakob@epfl.ch>
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#include "pybind11_tests.h"
+
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
+#endif
+
+TEST_SUBMODULE(builtins, m) {
+    m.def("is_callable", [](py::object o) { return py::callable(o); });
+}

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1,0 +1,35 @@
+from pybind11_tests import builtins as m
+
+
+def test_function_callable():
+    def func():
+        pass
+    assert m.is_callable(func)
+
+
+def test_class_callable():
+    class C:
+        pass
+    assert m.is_callable(C)
+
+
+def test_str_not_callable():
+    s = "test"
+    assert not m.is_callable(s)
+
+
+def test_obj_not_callable():
+    class C:
+        pass
+
+    c = C()
+    assert not m.is_callable(c)
+
+
+def test_obj_callable():
+    class C:
+        def __call__():
+            pass
+
+    c = C()
+    assert m.is_callable(c)


### PR DESCRIPTION
Wraps builtin function [callable](https://docs.python.org/3.7/library/functions.html#callable).

Same behavior as `py::isinstance<py::function>(obj)` bit a bit more clear, especially concerning class types.

Tests could be moved to an existing file.