### PR TITLE
Redesigned enum_<> to reduce object code bloat

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,11 @@ v2.3.0 (Not yet released)
 * Added support for write only properties.
   `#1144 <https://github.com/pybind/pybind11/pull/1144>`_.
 
+* Python type wrappers (``py::handle``, ``py::object``, etc.)
+  now support map Python's number protocol onto C++ arithmetic
+  operators such as ``operator+``, ``operator/=``, etc.
+  `#1511 <https://github.com/pybind/pybind11/pull/1511>`_.
+
 * A number of improvements related to enumerations:
 
    1. The ``enum_`` implementation was rewritten from scratch to reduce

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1183,6 +1183,7 @@ public:
     }
     size_t size() const { return (size_t) PyTuple_Size(m_ptr); }
     detail::tuple_accessor operator[](size_t index) const { return {*this, index}; }
+    detail::item_accessor operator[](handle h) const { return object::operator[](h); }
     detail::tuple_iterator begin() const { return {*this, 0}; }
     detail::tuple_iterator end() const { return {*this, PyTuple_GET_SIZE(m_ptr)}; }
 };
@@ -1220,6 +1221,7 @@ public:
     PYBIND11_OBJECT_DEFAULT(sequence, object, PySequence_Check)
     size_t size() const { return (size_t) PySequence_Size(m_ptr); }
     detail::sequence_accessor operator[](size_t index) const { return {*this, index}; }
+    detail::item_accessor operator[](handle h) const { return object::operator[](h); }
     detail::sequence_iterator begin() const { return {*this, 0}; }
     detail::sequence_iterator end() const { return {*this, PySequence_Size(m_ptr)}; }
 };
@@ -1232,6 +1234,7 @@ public:
     }
     size_t size() const { return (size_t) PyList_Size(m_ptr); }
     detail::list_accessor operator[](size_t index) const { return {*this, index}; }
+    detail::item_accessor operator[](handle h) const { return object::operator[](h); }
     detail::list_iterator begin() const { return {*this, 0}; }
     detail::list_iterator end() const { return {*this, PyList_GET_SIZE(m_ptr)}; }
     template <typename T> void append(T &&val) const {

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -153,4 +153,4 @@ def test_enum_to_int():
 def test_duplicate_enum_name():
     with pytest.raises(ValueError) as excinfo:
         m.register_bad_enum()
-    assert str(excinfo.value) == "Enum error - element with name: ONE already exists"
+    assert str(excinfo.value) == 'SimpleEnum: element "ONE" already exists!'

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -34,3 +34,9 @@ def test_roundtrip_with_dict(cls_name):
     assert p2.value == p.value
     assert p2.extra == p.extra
     assert p2.dynamic == p.dynamic
+
+
+def test_enum_pickle():
+    from pybind11_tests import enums as e
+    data = pickle.dumps(e.EOne, 2)
+    assert e.EOne == pickle.loads(data)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -289,4 +289,8 @@ TEST_SUBMODULE(pytypes, m) {
         l.append(a << b);
         return l;
     });
+
+    m.def("test_list_slicing", [](py::list a) {
+        return a[py::slice(0, -1, 2)];
+    });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -269,4 +269,24 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("print_failure", []() { py::print(42, UnregisteredType()); });
 
     m.def("hash_function", [](py::object obj) { return py::hash(obj); });
+
+    m.def("test_number_protocol", [](py::object a, py::object b) {
+        py::list l;
+        l.append(a.equal(b));
+        l.append(a.not_equal(b));
+        l.append(a < b);
+        l.append(a <= b);
+        l.append(a > b);
+        l.append(a >= b);
+        l.append(a + b);
+        l.append(a - b);
+        l.append(a * b);
+        l.append(a / b);
+        l.append(a | b);
+        l.append(a & b);
+        l.append(a ^ b);
+        l.append(a >> b);
+        l.append(a << b);
+        return l;
+    });
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -246,3 +246,8 @@ def test_number_protocol():
         li = [a == b, a != b, a < b, a <= b, a > b, a >= b, a + b,
               a - b, a * b, a / b, a | b, a & b, a ^ b, a >> b, a << b]
         assert m.test_number_protocol(a, b) == li
+
+
+def test_list_slicing():
+    li = list(range(100))
+    assert li[::2] == m.test_list_slicing(li)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import pytest
 import sys
 
@@ -238,3 +239,10 @@ def test_hash():
     assert m.hash_function(Hashable(42)) == 42
     with pytest.raises(TypeError):
         m.hash_function(Unhashable())
+
+
+def test_number_protocol():
+    for a, b in [(1, 1), (3, 5)]:
+        li = [a == b, a != b, a < b, a <= b, a > b, a >= b, a + b,
+              a - b, a * b, a / b, a | b, a & b, a ^ b, a >> b, a << b]
+        assert m.test_number_protocol(a, b) == li


### PR DESCRIPTION
This PR addresses an inefficiency in how enums are created in pybind11. Most of the ``enum_<>`` implementation is completely generic -- however, being a template class, it ended up instantiating vast amounts of essentially identical code in larger projects with many enums.
    
This commit introduces a generic non-templated helper class that is compatible with any kind of enumeration. ``enum_`` then becomes a thin wrapper around this new class. The API is compatible with the previous one.

The PR consists of two portions: the first considerably extends the ``object_api`` class by adding overloads for most C++ operators that map to their Python counterparts. The second part adds the ``enum_``-related changes, building on these operators.

With this change, the example shared library binary size goes down by 103 KiB (3.2%). It is worth noting that the examples only contain 6 enums. In larger projects with many enum data structures, savings can be substantial.