### PR TITLE
Add get method to py::dict

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1173,6 +1173,14 @@ public:
     void clear() const { PyDict_Clear(ptr()); }
     bool contains(handle key) const { return PyDict_Contains(ptr(), key.ptr()) == 1; }
     bool contains(const char *key) const { return PyDict_Contains(ptr(), pybind11::str(key).ptr()) == 1; }
+    template <typename T> object get(handle key, T &&defaultv) const {
+        PyObject* ret = PyDict_GetItem(ptr(), key.ptr());
+        return reinterpret_borrow<object>(ret ? handle(ret) : detail::object_or_cast(std::forward<T>(defaultv)));
+    }
+    template <typename T> object get(const char *key, T &&defaultv) const {
+        PyObject* ret = PyDict_GetItemString(ptr(), key);
+        return reinterpret_borrow<object>(ret ? handle(ret) : detail::object_or_cast(std::forward<T>(defaultv)));
+    }
 
 private:
     /// Call the `dict` Python type -- always returns a new reference

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -49,6 +49,10 @@ TEST_SUBMODULE(pytypes, m) {
         auto d2 = py::dict("z"_a=3, **d1);
         return d2;
     });
+    m.def("dict_get_test", []() {
+        py::dict d("key"_a=1);
+        return py::make_tuple(d.get("key", 2), d.get("key2", 3));
+    });
 
     // test_str
     m.def("str_from_string", []() { return py::str(std::string("baz")); });

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -57,6 +57,7 @@ def test_dict(capture, doc):
 
     assert m.dict_keyword_constructor() == {"x": 1, "y": 2, "z": 3}
 
+    assert m.dict_get_test() == (1, 3)
 
 def test_str(doc):
     assert m.str_from_string().encode().decode() == "baz"


### PR DESCRIPTION
It works just like Python except that the default argument is not optional