### PR TITLE
fix regression discussed by @cyfdecyf in #1454

### DIFF
--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -369,3 +369,9 @@ def test_inherited_virtuals():
     assert obj.unlucky_number() == -7
     assert obj.lucky_number() == -1.375
     assert obj.say_everything() == "BT -7"
+
+
+def test_issue_1454():
+    # Fix issue #1454 (crash when acquiring/releasing GIL on another thread in Python 2.7)
+    m.test_gil()
+    m.test_gil_from_thread()


### PR DESCRIPTION
The PYBIND11_TLS_DELETE_VALUE in PR #1454 changed behavior wrt. Python 2.x. This commit restores the old behavior.