### PR TITLE
compile time check that there are no argument annotations for properties

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1257,6 +1257,8 @@ public:
     /// Uses cpp_function's return_value_policy by default
     template <typename... Extra>
     class_ &def_property_static(const char *name, const cpp_function &fget, const cpp_function &fset, const Extra& ...extra) {
+        static_assert( 0 == detail::constexpr_sum(std::is_base_of<arg, Extra>::value...),
+                      "Argument annotations are not allowed for properties");
         auto rec_fget = get_function_record(fget), rec_fset = get_function_record(fset);
         auto *rec_active = rec_fget;
         if (rec_fget) {


### PR DESCRIPTION
fixes #1519 

When a property is made, all attributes are processed. However for properties, these attributes are processed outside of the `cpp_function` constructor. The `cpp_function` class duplicates and frees strings for attributes like `doc` and `arg`. When these attributes are processed and added to the `function_record` outside `cpp_function` the strings are not duplicated, but then are still `free`d by the `cpp_function` destruction, causing the error.

The `def_property_static` correctly `free`s and `strdup`s the doc attribute, but does not check if an `arg` attribute as processed. Since adding an argument annotation to either the setter or getter would never be displayed to the user, it makes more sense to check that there aren't any at compile time than to `free` and `strdup` all new `arg`s.