### PR TITLE
fix catch-by-value warnings in tests

### DIFF
--- a/tests/constructor_stats.h
+++ b/tests/constructor_stats.h
@@ -180,7 +180,7 @@ public:
                 }
             }
         }
-        catch (std::out_of_range) {}
+        catch (const std::out_of_range&) {}
         if (!t1) throw std::runtime_error("Unknown class passed to ConstructorStats::get()");
         auto &cs1 = get(*t1);
         // If we have both a t1 and t2 match, one is probably the trampoline class; return whichever


### PR DESCRIPTION
GCC8 shows the following warning which is fixed by this patch:

`warning: catching polymorphic type ‘class std::out_of_range’ by value [-Wcatch-value=]`