### PR TITLE
Issue #1532: Incompatible config options, /MP vs /Gm for MSVC in DEBUG

### DIFF
--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -211,13 +211,13 @@ function(pybind11_add_module target_name)
     # needed for bigger binding projects due to the limit to 64k addressable sections
     target_compile_options(${target_name} PRIVATE /bigobj)
     if(CMAKE_VERSION VERSION_LESS 3.11)
-      target_compile_options(${target_name} PRIVATE $<$<CONFIG:RELEASE>:/MP>)
+      target_compile_options(${target_name} PRIVATE $<$<NOT:$<CONFIG:Debug>>:/MP>)
     else()
       # Only set these options for C++ files.  This is important so that, for
       # instance, projects that include other types of source files like CUDA
       # .cu files don't get these options propagated to nvcc since that would
       # cause the build to fail.
-      target_compile_options(${target_name} PRIVATE $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:/MP>>)
+      target_compile_options(${target_name} PRIVATE $<$<NOT:$<CONFIG:Debug>>:$<$<COMPILE_LANGUAGE:CXX>:/MP>>)
     endif()
   endif()
 endfunction()

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -209,15 +209,15 @@ function(pybind11_add_module target_name)
   if(MSVC)
     # /MP enables multithreaded builds (relevant when there are many files), /bigobj is
     # needed for bigger binding projects due to the limit to 64k addressable sections
-    set(msvc_extra_options /MP /bigobj)
+    target_compile_options(${target_name} PRIVATE /bigobj)
     if(CMAKE_VERSION VERSION_LESS 3.11)
-      target_compile_options(${target_name} PRIVATE ${msvc_extra_options})
+      target_compile_options(${target_name} PRIVATE $<$<CONFIG:RELEASE>:/MP>)
     else()
       # Only set these options for C++ files.  This is important so that, for
       # instance, projects that include other types of source files like CUDA
       # .cu files don't get these options propagated to nvcc since that would
       # cause the build to fail.
-      target_compile_options(${target_name} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${msvc_extra_options}>)
+      target_compile_options(${target_name} PRIVATE $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:/MP>>)
     endif()
   endif()
 endfunction()


### PR DESCRIPTION
Added a cmake generator expression for /MP flag to only be set in RELEASE.