### PR TITLE
Update iostream.h: Changed a local varname 'self' to 'self_'

### DIFF
--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -194,7 +194,7 @@ inline class_<detail::OstreamRedirect> add_ostream_redirect(module m, std::strin
     return class_<detail::OstreamRedirect>(m, name.c_str(), module_local())
         .def(init<bool,bool>(), arg("stdout")=true, arg("stderr")=true)
         .def("__enter__", &detail::OstreamRedirect::enter)
-        .def("__exit__", [](detail::OstreamRedirect &self, args) { self.exit(); });
+        .def("__exit__", [](detail::OstreamRedirect &self_, args) { self_.exit(); }); //self_ to avoid conflicts with exposed pybind11::self (operators.h)
 }
 
 NAMESPACE_END(PYBIND11_NAMESPACE)


### PR DESCRIPTION
Avoiding conflicts in namespace pybind11::self.
https://github.com/pybind/pybind11/issues/1531