### PR TITLE
Numpy Scalar Array Overloads?

### DIFF
--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -259,6 +259,15 @@ def test_overload_resolution(msg):
     assert m.overloaded(np.array([1], dtype='complex')) == 'double complex'
     assert m.overloaded(np.array([1], dtype='csingle')) == 'float complex'
 
+    # Scalar arrays:
+    assert m.overloaded(np.float64(1)) == 'double'
+    assert m.overloaded(np.float32(1)) == 'float'
+    assert m.overloaded(np.ushort(1)) == 'unsigned short'
+    assert m.overloaded(np.intc(1)) == 'int'
+    assert m.overloaded(np.longlong(1)) == 'long long'
+    assert m.overloaded(np.complex(1)) == 'double complex'
+    assert m.overloaded(np.csingle(1)) == 'float complex'
+
     # No exact match, should call first convertible version:
     assert m.overloaded(np.array([1], dtype='uint8')) == 'double'
 


### PR DESCRIPTION
Numpy scalar arrays (ndim==0, shape=()) should match the same `array_t`, `array` and `buffer` overloads as their nD counterparts.

Yet, for some reason they do not.

Also, a `np.uint64(42)` matches a `py::buffer` interface for me in Python 3.6.6 yet not in Python 2.7.13

All tested with Numpy 1.15.1 (due to issues with proper scalar handling prior to 1.15.0).

Any idea what is wrong here?
(This PR is just opened for demonstration so we all see the same behavior.)