### PR TITLE
normalizes all possible output directories for "external_module"

### DIFF
--- a/tests/test_embed/CMakeLists.txt
+++ b/tests/test_embed/CMakeLists.txt
@@ -36,6 +36,11 @@ add_custom_target(cpptest COMMAND $<TARGET_FILE:test_embed>
 
 pybind11_add_module(external_module THIN_LTO external_module.cpp)
 set_target_properties(external_module PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+foreach(config ${CMAKE_CONFIGURATION_TYPES})
+    string(TOUPPER ${config} config)
+    set_target_properties(external_module PROPERTIES LIBRARY_OUTPUT_DIRECTORY_${config} ${CMAKE_CURRENT_SOURCE_DIR})
+endforeach()
+
 add_dependencies(cpptest external_module)
 
 add_dependencies(check cpptest)


### PR DESCRIPTION
Hi,
MSVC outputs targets into an additional directory depending on the
selected build type inside the IDE i.e. 
on a Release build, the target "external_module" goes to: "<output_dir>\\**Release**\\external_module<etc>.pyd".**

This will remove the extra directory for every possible build type in the target "external_module", so that the test target "cpptest"  can import "external_module" with the in cmake configured working directory.

Settting the property `LIBRARY_OUTPUT_DIRECTORY ` is not enough for MSVC (and, i guess, XCode does the same).