### PR TITLE
WIP: Numpy scalars overload to arrays

### DIFF
--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -186,6 +186,30 @@ TEST_SUBMODULE(numpy_array, sm) {
     sm.def("overloaded5", [](py::array_t<unsigned int>) { return "unsigned int"; });
     sm.def("overloaded5", [](py::array_t<double>) { return "double"; });
 
+    // Test numpy scalar matching with different order
+    sm.def("overloaded6", [](py::array_t<int>) { return "int"; });
+    sm.def("overloaded6", [](py::array_t<float>) { return "float"; });
+    sm.def("overloaded6", [](py::array_t<double>) { return "double"; });
+    sm.def("overloaded6", [](float) { return "float POD"; });
+    sm.def("overloaded6", [](double) { return "double POD"; });
+    sm.def("overloaded6", [](py::array) { return "array"; });
+    sm.def("overloaded6", [](py::buffer) { return "buffer"; });
+
+    sm.def("overloaded7", [](double) { return "double POD"; });
+    sm.def("overloaded7", [](py::array_t<double>) { return "double"; });
+    sm.def("overloaded7", [](py::buffer) { return "buffer"; });
+    sm.def("overloaded7", [](py::array) { return "array"; });
+
+    sm.def("overloaded8", [](py::buffer) { return "buffer"; });
+    sm.def("overloaded8", [](py::array_t<double>) { return "double"; });
+    sm.def("overloaded8", [](double) { return "double POD"; });
+    sm.def("overloaded8", [](py::array) { return "array"; });
+    
+    sm.def("overloaded9", [](py::array) { return "array"; });
+    sm.def("overloaded9", [](py::array_t<double>) { return "double"; });
+    sm.def("overloaded9", [](py::buffer) { return "buffer"; });
+    sm.def("overloaded9", [](double) { return "double POD"; });
+
     // test_greedy_string_overload
     // Issue 685: ndarray shouldn't go to std::string overload
     sm.def("issue685", [](std::string) { return "string"; });

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -259,15 +259,6 @@ def test_overload_resolution(msg):
     assert m.overloaded(np.array([1], dtype='complex')) == 'double complex'
     assert m.overloaded(np.array([1], dtype='csingle')) == 'float complex'
 
-    # Scalar arrays:
-    assert m.overloaded(np.float64(1)) == 'double'
-    assert m.overloaded(np.float32(1)) == 'float'
-    assert m.overloaded(np.ushort(1)) == 'unsigned short'
-    assert m.overloaded(np.intc(1)) == 'int'
-    assert m.overloaded(np.longlong(1)) == 'long long'
-    assert m.overloaded(np.complex(1)) == 'double complex'
-    assert m.overloaded(np.csingle(1)) == 'float complex'
-
     # No exact match, should call first convertible version:
     assert m.overloaded(np.array([1], dtype='uint8')) == 'double'
 
@@ -324,6 +315,31 @@ def test_overload_resolution(msg):
     assert m.overloaded5(np.array([1], dtype='uintc')) == 'unsigned int'
     assert m.overloaded5(np.array([1], dtype='float32')) == 'unsigned int'
 
+def test_scalar_overload_resolution():
+    # Exact overload matches:
+    assert m.overloaded(np.float64(1)) == 'double'
+    assert m.overloaded(np.float32(1)) == 'float'
+    assert m.overloaded(np.ushort(1)) == 'unsigned short'
+    assert m.overloaded(np.intc(1)) == 'int'
+    assert m.overloaded(np.longlong(1)) == 'long long'
+    assert m.overloaded(np.complex(1)) == 'double complex'
+    assert m.overloaded(np.csingle(1)) == 'float complex'
+
+    # binding order changes overload match
+    assert m.overloaded6(np.float64(1)) == 'double'
+    assert m.overloaded7(np.float64(1)) == 'double POD'
+    assert m.overloaded8(np.float64(1)) == 'buffer'
+    assert m.overloaded9(np.float64(1)) == 'array'
+
+    # scalars without array_t match fall through to array
+    assert m.overloaded6(np.int16(1)) == 'array'
+
+    # generic pep 3118 scalar overload not currently supported, falls through to py::buffer
+    from ctypes import c_double
+    assert m.overloaded6(c_double(1)) == 'buffer'
+
+    # python POD fall though to C++ POD
+    assert m.overloaded9(1.0) == 'double POD'
 
 def test_greedy_string_overload():
     """Tests fix for #685 - ndarray shouldn't go to std::string overload"""


### PR DESCRIPTION
Allows numpy scalar objects (ex `np.int16`, `np.float32`) to match a `py::array` and `py::array_t` arguments in bound functions.

Note that only numpy scalars will match, NOT any PEP 3118 scalar (ex `ctypes.c_int16`)

Includes tests from @ax3l  in PR #1537 

Numpy scalars will call the first overloaded binding that they can be converted into: POD, array_t, array, or buffer. If an existing user has bindings like 
```c++
sm.def("overloaded8", [](py::array_t<double>) { return "double"; });
sm.def("overloaded8", [](double) { return "double POD"; });
```

This patch would change behaviour. If maintaining backwards comparability for this case is important.  `array` could have a variodic template for a flag type `py::allow_scalar_conversion`
