### PR TITLE
Fix for C++ standard macros

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -45,6 +45,10 @@
 #  endif
 #endif
 
+#if defined(PYBIND11_CPP17) && !defined(PYBIND11_CPP14)
+#  define PYBIND11_CPP14
+#endif
+
 // Compiler version assertions
 #if defined(__INTEL_COMPILER)
 #  if __INTEL_COMPILER < 1700


### PR DESCRIPTION
This is a possible fix for #1554.

First commit is all about missing macro `PYBIND11_CPP17` where `PYBIND11_CPP14` are.