### PR TITLE
Resolve threading issue with gil_scoped_acquire

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,6 +47,13 @@ v2.3.0 (Not yet released)
 * ``pybind11_add_module()``: allow including Python as a ``SYSTEM`` include path.
   `#1416 <https://github.com/pybind/pybind11/pull/1416>`_.
 
+* Resolved an issue where std::function arguments to functions could create a deadlock
+  when called from threads other than the main thread.
+
+* py::gil_scoped_release no longer takes a boolean flag disassoc on construction,
+  a new method .detach() will provide this behaviour. The detach method can optionally
+  create a new thread context.
+
 v2.2.4 (September 11, 2018)
 -----------------------------------------------------
 

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -146,4 +146,7 @@ TEST_SUBMODULE(callbacks, m) {
     py::class_<CppBoundMethodTest>(m, "CppBoundMethodTest")
         .def(py::init<>())
         .def("triple", [](CppBoundMethodTest &, int val) { return 3 * val; });
+
+    // test_deadlock one-callback function
+    m.def("callback_void_std_function", [](std::function<void()> f) { f(); });
 }

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -105,3 +105,21 @@ def test_function_signatures(doc):
 
 def test_movable_object():
     assert m.callback_with_movable(lambda _: None) is True
+
+
+def test_no_deadlock():
+    # This code would deadlock - see issue 1525
+
+    def f():
+        pass
+
+    import threading
+
+    thread1 = threading.Thread(target=m.callback_void_std_function, args=(f,))
+    thread1.start()
+
+    thread2 = threading.Thread(target=m.callback_void_std_function, args=(f,))
+    thread2.start()
+
+    thread1.join()
+    thread2.join()


### PR DESCRIPTION
It was possible for python threads to execute c++ code which would subsequently call gil_scoped_acquire, incorrectly conclude that the gil was not held, and then deadlock.

The most basic example I can build of the failing code is:

```c++
#include <pybind11/pybind11.h>
#include <pybind11/functional.h>

PYBIND11_MODULE(pybind11test, m)
{
  m.def("deadlock", [] (std::function<void ()> f) { f(); });
}
```
and then invoked in python as so:

```python
import pybind11test

import threading

thread1 = threading.Thread(target=pybind11test.deadlock, args=(lambda: None,))
thread1.start()

thread2 = threading.Thread(target=pybind11test.deadlock, args=(lambda: None,))
thread2.start() 

thread1.join()
thread2.join()
```

I believe that this patch will resolve both #1525 and #1308.

To me this is a critical problem, as I often work with python threads. I would be very grateful if this can be reviewed and merged in time for the pybind11 2.3 release.

I am happy to make any changes you feel necessary, including writing a different solution altogether if you have a better one in mind.

Thanks in advance,
David