### PR TITLE
common: Prevent module re-import duplication in Python3 

### DIFF
--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -95,4 +95,9 @@ TEST_SUBMODULE(modules, m) {
 
         return failures;
     });
+
+    // Try re-import.
+    // If this fails, then it will fail at duplicate registration.
+    py::str name = m.attr("__name__");
+    m.attr("self_import_at_construction_time") = py::module::import(std::string(name).c_str());
 }

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -70,3 +70,8 @@ def test_duplicate_registration():
     """Registering two things with the same name"""
 
     assert m.duplicate_registration() == []
+
+
+def test_self_import_at_construction_time():
+    """Ensures that a pybind11 module can import itself at construction time."""
+    assert m.self_import_at_construction_time is m


### PR DESCRIPTION
Resolves #1559

With my system's version of Python3 (Ubuntu 16.04, Python 3.5.2), if I import a given module while that module is being constructed, it will duplicate the module object.

This captures this behavior in a test, and provides a potential workaround.
