### PR TITLE
Allow recursive checkout without https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tools/clang"]
 	path = tools/clang
-	url = https://github.com/wjakob/clang-cindex-python3
+	url = ../../wjakob/clang-cindex-python3


### PR DESCRIPTION
Pybind11 breaks a master project recursively cloning when it is added as a submodule via ssh and https is not available, because it has a submodule that does not respect the method it was checked out as (https vs. ssh). This makes the submodule relative, so that it will respect the checkout method of the master project.