### PR TITLE
Fix Python object lifetimes associated with shared_ptrs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,6 +50,9 @@ v2.3.0 (Not yet released)
 * ``pybind11/stl.h`` does not convert strings to ``vector<string>`` anymore.
   `#1258 <https://github.com/pybind/pybind11/issues/1258>`_.
 
+* fixed shared_ptrs to Python-derived instances outliving the associated Python object
+  `#1546 <https://github.com/pybind/pybind11/issues/1546>`_.
+
 v2.2.4 (September 11, 2018)
 -----------------------------------------------------
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1503,37 +1503,36 @@ protected:
 template <typename T>
 class type_caster<std::shared_ptr<T>>
 {
-    PYBIND11_TYPE_CASTER (std::shared_ptr<T>, _(PYBIND11_STRING_NAME));
+    PYBIND11_TYPE_CASTER(std::shared_ptr<T>, _(PYBIND11_STRING_NAME));
 
     // Re-use copyable_holder_caster
     using BaseCaster = copyable_holder_caster<T, std::shared_ptr<T>>;
 
-    bool load (pybind11::handle src, bool b)
+    bool load(pybind11::handle src, bool b)
     {
         BaseCaster bc;
-        bool success = bc.load (src, b);
-        if (!success)
-        {
+        bool success = bc.load(src, b);
+        if (!success) {
             return false;
         }
 
         // * Get src as a py::object
         // * Construct a shared_ptr to the py::object
-        auto py_obj = reinterpret_borrow<object> (src);
-        auto py_obj_ptr = std::make_shared<object> (py_obj);
+        auto py_obj = reinterpret_borrow<object>(src);
+        auto py_obj_ptr = std::make_shared<object>(py_obj);
 
         // * Use BaseCaster to get it as the shared_ptr<T>
         // * Use this to make an aliased shared_ptr<T> that keeps the py::object alive
-        auto base_ptr = static_cast<std::shared_ptr<T>> (bc);
-        value = std::shared_ptr<T> (py_obj_ptr, base_ptr.get ());
+        auto base_ptr = static_cast<std::shared_ptr<T>>(bc);
+        value = std::shared_ptr<T>(py_obj_ptr, base_ptr.get());
         return true;
     }
 
-    static handle cast (std::shared_ptr<T> sp,
-                        return_value_policy rvp,
-                        handle h)
+    static handle cast(std::shared_ptr<T> sp,
+                       return_value_policy rvp,
+                       handle h)
     {
-        return BaseCaster::cast (sp, rvp, h);
+        return BaseCaster::cast(sp, rvp, h);
     }
 };
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -20,6 +20,8 @@ NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 class handle; class object;
 class str; class iterator;
 struct arg; struct arg_v;
+class gil_scoped_acquire;
+class gil_scoped_release;
 
 NAMESPACE_BEGIN(detail)
 class args_proxy;

--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -375,3 +375,18 @@ def test_issue_1454():
     # Fix issue #1454 (crash when acquiring/releasing GIL on another thread in Python 2.7)
     m.test_gil()
     m.test_gil_from_thread()
+
+def test_issue_1546():
+    # Fix issue #1546 (Python object not kept alive by shared_ptr)
+    somelist = []
+    class Derived(m.SharedPtrBase):
+        def __init__(self):
+            super(Derived, self).__init__()
+
+        def f(self, value):
+            somelist.append (value)
+            print("Right one", 42)
+
+    holder = m.SharedPtrHolder(Derived())
+    holder.run(42);
+    assert somelist == [42]

--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -388,5 +388,7 @@ def test_issue_1546():
             print("Right one", 42)
 
     holder = m.SharedPtrHolder(Derived())
+    # At this point, our 'Derived' instance has gone out of scope in Python but
+    # is being kept alive by a shared_ptr inside 'holder'.
     holder.run(42);
     assert somelist == [42]

--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -376,19 +376,21 @@ def test_issue_1454():
     m.test_gil()
     m.test_gil_from_thread()
 
+
 def test_issue_1546():
     # Fix issue #1546 (Python object not kept alive by shared_ptr)
     somelist = []
+
     class Derived(m.SharedPtrBase):
         def __init__(self):
             super(Derived, self).__init__()
 
         def f(self, value):
-            somelist.append (value)
+            somelist.append(value)
             print("Right one", 42)
 
     holder = m.SharedPtrHolder(Derived())
     # At this point, our 'Derived' instance has gone out of scope in Python but
     # is being kept alive by a shared_ptr inside 'holder'.
-    holder.run(42);
+    holder.run(42)
     assert somelist == [42]


### PR DESCRIPTION
This is a straw man solution to #1546, based on the patch included in the report. It also fixes  #1333 and #1389 (note that "I was deleted" doesn't appear unless you conduct the test inside function scope).

Probably a pre-requisite for #1552 but does not fix it (I have to be careful wording this or github gets the wrong idea).

Questions:
* This means that every py::object->std::shared_ptr<T> cast keeps the py::object alive. This appears to be sufficient to solve the problem, but it might not be entirely necessary. For instance, some shared_ptr<T> casts might be associated with the original base class, and not require the py::object to be kept around. Suggestions for limiting the scope of the fix welcome.
* Does the test look okay? I'm happy to rename, move or change it in whatever way people think best.