### PR TITLE
Add PYBIND11_ prefix to the THROW macro to prevent name collisions.

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1464,12 +1464,12 @@ struct enum_base {
             PYBIND11_ENUM_OP_STRICT("__ne__", !int_(a).equal(int_(b)), return true);
 
             if (is_arithmetic) {
-                #define THROW throw type_error("Expected an enumeration of matching type!");
-                PYBIND11_ENUM_OP_STRICT("__lt__", int_(a) <  int_(b), THROW);
-                PYBIND11_ENUM_OP_STRICT("__gt__", int_(a) >  int_(b), THROW);
-                PYBIND11_ENUM_OP_STRICT("__le__", int_(a) <= int_(b), THROW);
-                PYBIND11_ENUM_OP_STRICT("__ge__", int_(a) >= int_(b), THROW);
-                #undef THROW
+                #define PYBIND11_THROW throw type_error("Expected an enumeration of matching type!");
+                PYBIND11_ENUM_OP_STRICT("__lt__", int_(a) <  int_(b), PYBIND11_THROW);
+                PYBIND11_ENUM_OP_STRICT("__gt__", int_(a) >  int_(b), PYBIND11_THROW);
+                PYBIND11_ENUM_OP_STRICT("__le__", int_(a) <= int_(b), PYBIND11_THROW);
+                PYBIND11_ENUM_OP_STRICT("__ge__", int_(a) >= int_(b), PYBIND11_THROW);
+                #undef PYBIND11_THROW
             }
         }
 


### PR DESCRIPTION
The https://github.com/pybind/pybind11/commit/54eb8193e512f35edca99753155c3a804ed5c176 commit introduced a `THROW` macro. Unfortunately, some of my projects use macro by that name as well, causing compilation errors (pybind's one is recognized as redefinition) with current pybind11.

This PR fixes the issue by prefixing the macro with proper prefix, so user code won't break it that easily.