### PR TITLE
std::array<> caster: support arbitrary sequences

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -199,9 +199,9 @@ private:
 
 public:
     bool load(handle src, bool convert) {
-        if (!isinstance<list>(src))
+        if (!isinstance<sequence>(src))
             return false;
-        auto l = reinterpret_borrow<list>(src);
+        auto l = reinterpret_borrow<sequence>(src);
         if (!require_size(l.size()))
             return false;
         size_t ctr = 0;

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -263,4 +263,6 @@ TEST_SUBMODULE(stl, m) {
               return result;
           },
           py::return_value_policy::take_ownership);
+
+    m.def("array_cast_sequence", [](std::array<int, 3> x) { return x; });
 }

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -216,3 +216,7 @@ def test_stl_ownership():
     assert len(r) == 1
     del r
     assert cstats.alive() == 0
+
+
+def test_array_cast_sequence():
+    assert m.array_cast_sequence((1, 2, 3)) == [1, 2, 3]


### PR DESCRIPTION
This PR brings the std::array<> caster in sync with the other STL type
casters: to accept an arbitrary sequence as input (rather than a list,
which is too restrictive).