### PR TITLE
Support <experimental/optional> even when <optional> found

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -31,8 +31,7 @@
 #    define PYBIND11_HAS_OPTIONAL 1
 #  endif
 // std::experimental::optional (but not allowed in c++11 mode)
-#  if defined(PYBIND11_CPP14) && (__has_include(<experimental/optional>) && \
-                                 !__has_include(<optional>))
+#  if defined(PYBIND11_CPP14) && (__has_include(<experimental/optional>))
 #    include <experimental/optional>
 #    define PYBIND11_HAS_EXP_OPTIONAL 1
 #  endif


### PR DESCRIPTION
Previously if the compiler had an <optional> header, support for
<experimental/optional> was disabled, even if the compiler also
supported <experimental/optional>. This meant that simply upgrading
one's compiler (e.g. from GCC 5.4 to GCC 7.3 in my case) made code using
std::experimental::optional stop working. This occurs even if passing
--std=c++14 to GCC, because it doesn't hide headers for C++17 features,
it just prevents them defining C++17 features.

I'm assuming that if a compiler supports C++14 AND has
<experimental/optional>, it's a pretty good indication that it supports
std::experimental::optional.