### PR TITLE
Implementation of Python's 'with' statement as py::with

### DIFF
--- a/docs/advanced/pycpp/utilities.rst
+++ b/docs/advanced/pycpp/utilities.rst
@@ -25,11 +25,11 @@ Executing code in a Python `with` statement
 ===========================================
 
 Where in C++, the scope of local variables and their destructor is used to manage
-resources in the RAII idiom, Python has a `with` statement and context managers
-for such situations. At the start and end of the `with` statement, the context
-manager's `__enter__` and `__exit__` methods are called, respectively. To more
+resources in the RAII idiom, Python has a ``with`` statement and context managers
+for such situations. At the start and end of the ``with`` statement, the context
+manager's ``__enter__`` and ``__exit__`` methods are called, respectively. To more
 easily use context managers in a C++ context, pybind11 provides a utility function
-``py::with``, that matches the semantics of a Python `with`-statement (see
+`py::with <with>`, that matches the semantics of a Python ``with``-statement (see
 `PEP 343 <https://www.python.org/dev/peps/pep-0343/>`_):
 
 .. code-block:: cpp
@@ -53,13 +53,13 @@ This code snippet corresponds to the following in Python:
             f.write("\n")
 
 The `py::object` parameter of the lambda function can be omitted if the object resulting
-from the context manager (i.e., the `as VAR` part in the `with` statement) is not of use.
+from the context manager (i.e., the ``as VAR`` part in the ``with`` statement) is not of use.
 
-Optionally, an extra `py::with_exception_policy` argument can be passed to `py::with`.
-If the value `py::with_exception_policy::translate` is selected, pybind11 will try to
-translate any C++ exception inside the `with` statement and pass the Python exception
-as argument into the `__exit__` method of the context manager (cfr. PEP 343). If
-`py::with_exception_policy::translate` is passed and an exception gets thrown, pybind11
+Optionally, an extra `py::with_exception_policy <with_exception_policy>` argument can be
+passed to `py::with <with>`. If the value ``py::with_exception_policy::translate`` is selected,
+pybind11 will try to translate any C++ exception inside the ``with`` statement and pass the
+Python exception as argument into the ``__exit__`` method of the context manager (cfr. PEP 343).
+If ``py::with_exception_policy::translate`` is passed and an exception gets thrown, pybind11
 will not try to translate it, `__exit__` will be called as if no exception was thrown,
 and the original exception will be cascaded down to the caller.
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1912,9 +1912,9 @@ void with(const object &mgr, Block &&block, with_exception_policy policy = with_
     }
     catch (const error_already_set &e) {
         // A Python error
-        auto exit_result = exit(e.get_type() ? e.get_type() : none(),
-                                e.get_value() ? e.get_value() : none(),
-                                e.get_trace() ? e.get_trace() : none());
+        auto exit_result = exit(e.type() ? e.type() : none(),
+                                e.value() ? e.value() : none(),
+                                e.trace() ? e.trace() : none());
         if (!bool_(std::move(exit_result)))
             std::rethrow_exception(original_exception);
     }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1829,7 +1829,7 @@ struct dependent_false { static constexpr bool value = false; };
 
 template <typename Block, typename Signature = remove_cv_t<function_signature_t<Block>>, typename SFINAE = void>
 struct with_block_call_traits {
-    static void call(Block &&block, object &&) {
+    static void call(Block &&, object &&) {
         static_assert(dependent_false<Block>::value,
                       "The inner block function passed to pybind11::with should either take no arguments, "
                       "or a single argument convertible from a pybind11::object& or pybind11::object&&, "

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ set(PYBIND11_TEST_FILES
   test_stl_binders.cpp
   test_tagbased_polymorphic.cpp
   test_virtual_functions.cpp
+  test_with.cpp
 )
 
 # Invoking cmake with something like:

--- a/tests/test_with.cpp
+++ b/tests/test_with.cpp
@@ -1,0 +1,136 @@
+/*
+    tests/test_with.cpp -- Usage of pybind11 with statement
+
+    Copyright (c) 2018 Yannick Jadoul
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#include "pybind11_tests.h"
+
+#include <pybind11/eval.h>
+
+class CppContextManager {
+public:
+    CppContextManager(std::string value, bool swallow_exceptions=false)
+        : m_value(std::move(value)), m_swallow_exceptions(swallow_exceptions) {}
+
+    std::string enter() {
+        ++m_entered;
+        return m_value;
+    }
+
+    bool exit(py::args args) {
+        ++m_exited;
+        m_exit_args = args;
+        return m_swallow_exceptions;
+    }
+
+    std::string m_value;
+    bool m_swallow_exceptions;
+    unsigned int m_entered = 0;
+    unsigned int m_exited = 0;
+    py::object m_exit_args = py::none();
+};
+
+class NewCppException {};
+
+
+TEST_SUBMODULE(with_, m) {
+    py::class_<CppContextManager>(m, "CppContextManager")
+        .def(py::init<std::string, bool>(), py::arg("value"), py::arg("swallow_exceptions") = false)
+        .def("__enter__", &CppContextManager::enter)
+        .def("__exit__", &CppContextManager::exit)
+        .def_readonly("value", &CppContextManager::m_value)
+        .def_readonly("entered", &CppContextManager::m_entered)
+        .def_readonly("exited", &CppContextManager::m_exited)
+        .def_readonly("exit_args", &CppContextManager::m_exit_args);
+
+    py::enum_<py::with_exception_policy>(m, "WithExceptionPolicy")
+        .value("Translate", py::with_exception_policy::translate)
+        .value("Cascade", py::with_exception_policy::cascade);
+
+    m.def("no_args", [](const py::object &mgr) {
+        py::object value;
+        py::with(mgr, [&value]() {
+            value = py::none();
+        });
+        return value;
+    });
+
+    m.def("lvalue_arg", [](const py::object &mgr) {
+        py::object value;
+        py::with(mgr, [&value](py::object v) {
+            value = v;
+        });
+        return value;
+    });
+
+    m.def("lvalue_ref_arg", [](const py::object &mgr) {
+        py::object value;
+        py::with(mgr, [&value](py::object &v) {
+            value = v;
+        });
+        return value;
+    });
+
+    m.def("lvalue_const_ref_arg", [](const py::object &mgr) {
+        py::object value;
+        py::with(mgr, [&value](const py::object &v) {
+            value = v;
+        });
+        return value;
+    });
+
+    m.def("rvalue_ref_arg", [](const py::object &mgr) {
+        py::object value;
+        py::with(mgr, [&value](py::object &&v) {
+            value = v;
+        });
+        return value;
+    });
+
+    m.def("python_exception", [](const py::object &mgr, py::with_exception_policy exception_policy) {
+        py::object value;
+        py::with(mgr, [&value](py::object v) {
+            value = v;
+            py::exec("raise RuntimeError('This is a test. Please stay calm.')");
+        }, exception_policy);
+        return value;
+    });
+
+    m.def("cpp_exception", [](const py::object &mgr, py::with_exception_policy exception_policy) {
+        py::object value;
+        py::with(mgr, [&value](py::object v) {
+            value = v;
+            throw std::runtime_error("This is a test. Please stay calm.");
+        }, exception_policy);
+        return value;
+    });
+
+    m.def("catch_cpp_exception", [](const py::object &mgr) {
+        try {
+            py::with(mgr, []() {
+                throw NewCppException();
+            });
+        }
+        catch (const py::error_already_set &) {
+            return "error_already_set";
+        }
+        catch (const NewCppException &) {
+            return "original_exception";
+        }
+        catch (...) {
+            return "another_exception";
+        }
+        return "no_exception";
+    });
+
+    m.def("SHOULD_NOT_COMPILE_UNCOMMENTED", [](const py::object &mgr) {
+        // py::with(mgr, [](int) {});
+        // py::with(mgr, [](py::object, int) {});
+        // py::with(mgr, [](py::object) { return "something"; });
+        (void) mgr;
+    });
+}

--- a/tests/test_with.py
+++ b/tests/test_with.py
@@ -131,14 +131,15 @@ def test_catch_cpp_exception(context_manager_cls, swallow_exceptions):
 
 
 def test_bad_context_managers():
-    with pytest.raises(AttributeError, match="object has no attribute '__exit__'"):
+    with pytest.raises(AttributeError, match="has no attribute '__exit__'"):
         m.lvalue_arg(NotAContextManager())
 
-    with pytest.raises(AttributeError, match="object has no attribute '__enter__'"):
+    with pytest.raises(AttributeError, match="has no attribute '__enter__'"):
         m.lvalue_arg(AlsoNotAContextManager())
 
     with pytest.raises(TypeError,
-                       match="__exit__\\(\\) takes 1 positional argument but 4 were given"):
+                       match="(:?__exit__\\(\\) takes 1 positional argument but 4 were given)|" +
+                       "(?:__exit__\\(\\) takes exactly 1 argument \\(4 given\\))"):  # Python 2
         m.lvalue_arg(AContextManagerWithAWrongExitSignature())
 
 

--- a/tests/test_with.py
+++ b/tests/test_with.py
@@ -1,0 +1,157 @@
+import pytest
+
+from pybind11_tests import with_ as m
+
+
+class PythonContextManager:
+
+    def __init__(self, value, swallow_exceptions=False):
+        self.value = value
+        self.swallow_exceptions = swallow_exceptions
+        self.entered = 0
+        self.exited = 0
+        self.exit_args = None
+
+    def __enter__(self):
+        self.entered += 1
+        # Return a new instance of a custom class, such that we can check
+        # the object's refcount and see if the py::object is moved when possible
+        return self.value
+
+    def __exit__(self, *args):
+        self.exited += 1
+        self.exit_args = args
+        return self.swallow_exceptions
+
+
+class NotAContextManager:
+    pass
+
+
+class AlsoNotAContextManager:
+
+    def __exit__(self, *args):
+        return False
+
+
+class AContextManagerWithAWrongExitSignature:
+
+    def __enter__(self):
+        return None
+
+    def __exit__(self):
+        return False
+
+
+class ContextManagerRaisingAtEnter:
+
+    def __init__(self):
+        self.entered = 0
+        self.exited = 0
+        self.exit_args = None
+
+    def __enter__(self):
+        self.entered += 1
+        raise RuntimeError('This is a test. Please stay calm.')
+
+    def __exit__(self, *args):
+        self.exited += 1
+        self.exit_args = args
+        return False
+
+
+class ContextManagerRaisingAtExit:
+
+    def __init__(self):
+        self.entered = 0
+        self.exited = 0
+        self.exit_args = None
+
+    def __enter__(self):
+        self.entered += 1
+        return None
+
+    def __exit__(self, *args):
+        self.exited += 1
+        self.exit_args = args
+        raise RuntimeError('This is a test. Please stay calm.')
+
+
+@pytest.mark.parametrize("context_manager_cls", [PythonContextManager, m.CppContextManager])
+@pytest.mark.parametrize("arg_type", ["no_args", "lvalue_arg", "lvalue_ref_arg",
+                                      "lvalue_const_ref_arg", "rvalue_ref_arg"])
+def test_arg_types(context_manager_cls, arg_type):
+    context_manager = context_manager_cls(arg_type)
+    test_func = getattr(m, arg_type)
+    expected_value = (None if arg_type == "no_args" else context_manager.value)
+
+    assert test_func(context_manager) == expected_value
+    assert context_manager.entered == 1
+    assert context_manager.exited == 1
+    assert context_manager.exit_args == (None, None, None)
+
+
+@pytest.mark.parametrize("context_manager_cls", [PythonContextManager, m.CppContextManager])
+@pytest.mark.parametrize("exception_type", ["python_exception", "cpp_exception"])
+@pytest.mark.parametrize("exception_policy", [m.WithExceptionPolicy.Translate,
+                                              m.WithExceptionPolicy.Cascade])
+@pytest.mark.parametrize("swallow_exceptions", [True, False])
+def test_exceptions(context_manager_cls, exception_type, exception_policy, swallow_exceptions):
+    value = '_'.join((exception_type, str(exception_policy), str(swallow_exceptions)))
+    context_manager = context_manager_cls(value, swallow_exceptions)
+    test_func = getattr(m, exception_type)
+    expected_value = value
+    should_ignore_exception_at_exit = exception_type == "cpp_exception" and \
+        exception_policy == m.WithExceptionPolicy.Cascade
+    should_raise = should_ignore_exception_at_exit or not swallow_exceptions
+
+    if should_raise:
+        with pytest.raises(RuntimeError, match="test"):
+            test_func(context_manager, exception_policy)
+    else:
+        assert test_func(context_manager, exception_policy) == expected_value
+    assert context_manager.entered == 1
+    assert context_manager.exited == 1
+    if should_ignore_exception_at_exit:
+        assert context_manager.exit_args == (None, None, None)
+    else:
+        assert context_manager.exit_args != (None, None, None)
+
+
+@pytest.mark.parametrize("context_manager_cls", [PythonContextManager, m.CppContextManager])
+@pytest.mark.parametrize("swallow_exceptions", [True, False])
+def test_catch_cpp_exception(context_manager_cls, swallow_exceptions):
+    context_manager = context_manager_cls("", swallow_exceptions=swallow_exceptions)
+    expected_value = "no_exception" if swallow_exceptions else "original_exception"
+
+    assert m.catch_cpp_exception(context_manager) == expected_value
+    assert context_manager.entered == 1
+    assert context_manager.exited == 1
+    assert context_manager.exit_args != (None, None, None)
+
+
+def test_bad_context_managers():
+    with pytest.raises(AttributeError, match="object has no attribute '__exit__'"):
+        m.lvalue_arg(NotAContextManager())
+
+    with pytest.raises(AttributeError, match="object has no attribute '__enter__'"):
+        m.lvalue_arg(AlsoNotAContextManager())
+
+    with pytest.raises(TypeError,
+                       match="__exit__\\(\\) takes 1 positional argument but 4 were given"):
+        m.lvalue_arg(AContextManagerWithAWrongExitSignature())
+
+
+def test_raising_context_managers():
+    context_manager = ContextManagerRaisingAtEnter()
+    with pytest.raises(RuntimeError, match="test"):
+        m.lvalue_arg(context_manager)
+    assert context_manager.entered == 1
+    assert context_manager.exited == 0
+
+    context_manager = ContextManagerRaisingAtExit()
+    with pytest.raises(RuntimeError, match="test"):
+        m.lvalue_arg(context_manager)
+    assert context_manager.entered == 1
+    assert context_manager.exited == 1
+    assert context_manager.exit_args == (None, None, None)


### PR DESCRIPTION
As discussed with @martinRenou and @bstaletic on Gitter, a `with` statement complying with the [semantics of PEP 343](https://www.python.org/dev/peps/pep-0343/#specification-the-with-statement) might be a useful utility to add to the pybind11 toolbox.

Since C++ will crash if an exception gets thrown while another one is already active, it seems impossible to have a safe RAII implementation of this. But for almost all purposes, this version, taking a function or lambda, should be sufficient.

This PR depends on @martinRenou's PR #1641 adding getters to `py::error_already_set`.