### PR TITLE
Increasing timeout in test_gil_scoped.py to get AppVeyor to succeed

### DIFF
--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -4,13 +4,13 @@ from pybind11_tests import gil_scoped as m
 
 
 def _run_in_process(target, *args, **kwargs):
-    """Runs target in process and returns its exitcode after 1s (None if still alive)."""
+    """Runs target in process and returns its exitcode after 10s (None if still alive)."""
     process = multiprocessing.Process(target=target, args=args, kwargs=kwargs)
     process.daemon = True
     try:
         process.start()
-        # Do not need to wait much, 1s should be more than enough.
-        process.join(timeout=1)
+        # Do not need to wait much, 10s should be more than enough.
+        process.join(timeout=10)
         return process.exitcode
     finally:
         if process.is_alive():


### PR DESCRIPTION
This PR should fix the occasional failures of AppVeyor jobs on `test_gil_scoped`, noticed after #1642 was merged.

@bstaletic, @wjakob