### PR TITLE
function_record: fix uninit member

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -182,7 +182,7 @@ struct function_record {
     bool is_method : 1;
 
     /// Number of arguments (including py::args and/or py::kwargs, if present)
-    std::uint16_t nargs;
+    std::uint16_t nargs = 0u;
 
     /// Python method object
     PyMethodDef *def = nullptr;


### PR DESCRIPTION
fix an uninitialized public member.

found with [coverity](https://scan.coverity.com/dashboard) in a [downstream project](https://github.com/openPMD/openPMD-api).