### PR TITLE
Overload Signature: Potential Nullptr Deref

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -763,7 +763,10 @@ protected:
         } else if (!result) {
             std::string msg = "Unable to convert function return value to a "
                               "Python type! The signature was\n\t";
-            msg += it->signature;
+            if (it == nullptr)
+                msg += "not found (nullptr).";
+            else
+                msg += it->signature;
             append_note_if_missing_header_is_suspected(msg);
             PyErr_SetString(PyExc_TypeError, msg.c_str());
             return nullptr;


### PR DESCRIPTION
Fix a potential nullptr in error handling. The `it` variable is already checked in the `try` block for non-nullptr and might therefore be `nullptr` in this branch as well.

Found with [coverity](https://scan.coverity.com/dashboard) in a [downstream project](https://github.com/openPMD/openPMD-api).