### PR TITLE
dict_readonly: member init

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -697,7 +697,7 @@ protected:
 
 private:
     handle obj;
-    PyObject *key, *value;
+    PyObject *key = nullptr, *value = nullptr;
     ssize_t pos = -1;
 };
 NAMESPACE_END(iterator_policies)


### PR DESCRIPTION
fix missing member initialization in pytypes: read-only dict.

`dict_readonly` has a `dereference` method that would return uninit data.

Found with [coverity](https://scan.coverity.com/dashboard) in a [downstream project](https://github.com/openPMD/openPMD-api).