### PR TITLE
pybind11_getbuffer: useless safe nullptr check

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -468,7 +468,7 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
         if (tinfo && tinfo->get_buffer)
             break;
     }
-    if (view == nullptr || obj == nullptr || !tinfo || !tinfo->get_buffer) {
+    if (view == nullptr || !tinfo || !tinfo->get_buffer) {
         if (view)
             view->obj = nullptr;
         PyErr_SetString(PyExc_BufferError, "pybind11_getbuffer(): Internal error");


### PR DESCRIPTION
Alternative implementation for #1657: if we know that `obj` is never a `nullptr` [1], we should not `nullptr`-check it *after* already de-referencing it five lines earlier.

[1] https://github.com/pybind/pybind11/pull/1657#issuecomment-452090058