### PR TITLE
compatibility with pytest 4.0, fix #1670

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,7 +185,7 @@ def gc_collect():
     gc.collect()
 
 
-def pytest_namespace():
+def pytest_configure():
     """Add import suppression and test requirements to `pytest` namespace"""
     try:
         import numpy as np
@@ -202,19 +202,17 @@ def pytest_namespace():
     pypy = platform.python_implementation() == "PyPy"
 
     skipif = pytest.mark.skipif
-    return {
-        'suppress': suppress,
-        'requires_numpy': skipif(not np, reason="numpy is not installed"),
-        'requires_scipy': skipif(not np, reason="scipy is not installed"),
-        'requires_eigen_and_numpy': skipif(not have_eigen or not np,
-                                           reason="eigen and/or numpy are not installed"),
-        'requires_eigen_and_scipy': skipif(not have_eigen or not scipy,
-                                           reason="eigen and/or scipy are not installed"),
-        'unsupported_on_pypy': skipif(pypy, reason="unsupported on PyPy"),
-        'unsupported_on_py2': skipif(sys.version_info.major < 3,
-                                     reason="unsupported on Python 2.x"),
-        'gc_collect': gc_collect
-    }
+    pytest.suppress = suppress
+    pytest.requires_numpy = skipif(not np, reason="numpy is not installed")
+    pytest.requires_scipy = skipif(not np, reason="scipy is not installed")
+    pytest.requires_eigen_and_numpy = skipif(not have_eigen or not np,
+                                             reason="eigen and/or numpy are not installed")
+    pytest.requires_eigen_and_scipy = skipif(
+        not have_eigen or not scipy, reason="eigen and/or scipy are not installed")
+    pytest.unsupported_on_pypy = skipif(pypy, reason="unsupported on PyPy")
+    pytest.unsupported_on_py2 = skipif(sys.version_info.major < 3,
+                                       reason="unsupported on Python 2.x")
+    pytest.gc_collect = gc_collect
 
 
 def _test_import_pybind11():


### PR DESCRIPTION
Cf. https://docs.pytest.org/en/latest/deprecations.html#pytest-namespace

