### PR TITLE
PYBIND11_TLS_REPLACE_VALUE should use macro argument value in Python …

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -23,7 +23,7 @@ inline PyObject *make_object_base_type(PyTypeObject *metaclass);
 #if PY_VERSION_HEX >= 0x03070000
 #    define PYBIND11_TLS_KEY_INIT(var) Py_tss_t *var = nullptr
 #    define PYBIND11_TLS_GET_VALUE(key) PyThread_tss_get((key))
-#    define PYBIND11_TLS_REPLACE_VALUE(key, value) PyThread_tss_set((key), (tstate))
+#    define PYBIND11_TLS_REPLACE_VALUE(key, value) PyThread_tss_set((key), (value))
 #    define PYBIND11_TLS_DELETE_VALUE(key) PyThread_tss_set((key), nullptr)
 #else
     // Usually an int but a long on Cygwin64 with Python 3.x


### PR DESCRIPTION
The `PYBIND11_TLS_REPLACE_VALUE` macro doesn't actually use the `value` argument when using the new Python TLS API (3.7+). Instead, it always uses `tstate` as the argument. This works because the two places `PYBIND11_TLS_REPLACE_VALUE` is used in the code the argument *is* `tstate`.

1. https://github.com/pybind/pybind11/blob/e2b884c33bcde70b2ea562ffa52dd7ebee276d50/include/pybind11/pybind11.h#L1890
2. https://github.com/pybind/pybind11/blob/e2b884c33bcde70b2ea562ffa52dd7ebee276d50/include/pybind11/pybind11.h#L1963

However, for correctness, and for anyone piggybacking on pybind's cross-version TLS support (like me!) it should use the `value` argument