### PR TITLE
Add optional buffer size to pythonbuf::d_buffer constructor

### DIFF
--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -25,7 +25,8 @@ class pythonbuf : public std::streambuf {
 private:
     using traits_type = std::streambuf::traits_type;
 
-    char d_buffer[1024];
+    const size_t buf_size;
+    std::unique_ptr<char[]> d_buffer;
     object pywrite;
     object pyflush;
 
@@ -51,10 +52,13 @@ private:
     }
 
 public:
-    pythonbuf(object pyostream)
-        : pywrite(pyostream.attr("write")),
+
+    pythonbuf(object pyostream, size_t buffer_size = 1024)
+        : buf_size(buffer_size),
+          d_buffer(new char[buf_size]),
+          pywrite(pyostream.attr("write")),
           pyflush(pyostream.attr("flush")) {
-        setp(d_buffer, d_buffer + sizeof(d_buffer) - 1);
+        setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
     }
 
     /// Sync before destroy


### PR DESCRIPTION
In some cases the user of pythonbuf needs to allocate the internal buffer to a specific size e.g. for performance or to enable synchronous writes to the buffer. By changing `pythonbuf::d_buffer` to be dynamically allocated, we can now enable these use-cases while still providing the default behavior of allocating a 1024 byte internal buffer (through a default parameter).

In my case, I am binding a C++ class that writes short strings to a stringstream that is attached on the python side to an io.TextIOWrapper. With the current implementation I was not able to read these strings before either flushing on the C++ side, or destroying the object altogether. In this case setting the internal buffer size to 1, rendering the stream synchronous, I'm able to read out the strings in python at any time (without modifying the C++ class itself).