### PR TITLE
[BUGFIX] Fixing pybind11::error_already_set.matches to also work with exception subclasses

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -344,7 +344,7 @@ public:
     /// Check if the currently trapped error type matches the given Python exception class (or a
     /// subclass thereof).  May also be passed a tuple to search for any exception class matches in
     /// the given tuple.
-    bool matches(handle ex) const { return PyErr_GivenExceptionMatches(ex.ptr(), m_type.ptr()); }
+    bool matches(handle exc) const { return PyErr_GivenExceptionMatches(m_type.ptr(), exc.ptr()); }
 
     const object& type() const { return m_type; }
     const object& value() const { return m_value; }

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -48,7 +48,9 @@ def test_python_call_in_catch():
 
 
 def test_exception_matches():
-    m.exception_matches()
+    assert m.exception_matches()
+    assert m.exception_matches_base()
+    assert m.modulenotfound_exception_matches_base()
 
 
 def test_custom(msg):


### PR DESCRIPTION
The `error_already_set.matches` implementation (introduced in #772) forwards the two exception types in the wrong order as arguments to [`PyErr_GivenExceptionMatches`](https://docs.python.org/3.7/c-api/exceptions.html#c.PyErr_GivenExceptionMatches). This PR fixes that (and renames the parameter/argument from `ex` to `exc` to explicitly match the Python documentation).

The reason this bug didn't cause a lot of harm and wasn't notice before is that the problem is only noticeable when matching to an exception base class (otherwise, the order of the arguments [does not end up mattering](https://github.com/python/cpython/blob/master/Python/errors.c#L184)).

This demonstrates the error, as `ModuleNotFound` error is a subclass of `ImportError` in Python >= 3.6:
```
try {
    return py::module::import("nonexistent");
}
catch (py::error_already_set &e) {
    py::print(e.matches(PyExc_ModuleNotFoundError)); // == True
    py::print(e.matches(PyExc_ImportError)); // == False
}
```