### PR TITLE
doc: Add "Getting Help" section

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,12 +1,6 @@
-Make sure you've completed the following steps before submitting your issue -- thank you!
-
-1. Check if your question has already been answered in the [FAQ](http://pybind11.readthedocs.io/en/latest/faq.html) section.
-2. Make sure you've read the [documentation](http://pybind11.readthedocs.io/en/latest/). Your issue may be addressed there.
-3. If those resources didn't help and you only have a short question (not a bug report), consider asking in the [Gitter chat room](https://gitter.im/pybind/Lobby).
-4. If you have a genuine bug report or a more complex question which is not answered in the previous items (or not suitable for chat), please fill in the details below.
-5. Include a self-contained and minimal piece of code that reproduces the problem. If that's not possible, try to make the description as clear as possible.
-
-*After reading, remove this checklist and the template text in parentheses below.*
+(Please review the
+[Getting Help](http://pybind11.readthedocs.io/en/latest/faq.html)
+section of the documentation before posting. If you still need to post an issue, update the template text in parentheses with the relevant information.)
 
 ## Issue description
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,3 +1,5 @@
+.. _faq:
+
 Frequently asked questions
 ##########################
 

--- a/docs/help.rst
+++ b/docs/help.rst
@@ -1,0 +1,36 @@
+Getting Help
+============
+
+Review Existing Questions
+*************************
+
+Please search for existing questions in the following sources:
+
+*   :ref:`This documentation <index>`
+
+    * The Sphinx search works really well!
+
+*   :ref:`FAQ <faq>`
+*   `GitHub Issues (Open + Closed) <https://github.com/pybind/pybind11/issues?q=is%3Aissue>`_
+*   `Gitter <https://gitter.im/pybind>`_
+
+    * Be sure that you search for scoped symbols using quotes, e.g.
+      ``"py::module"``.
+
+*   `StackOverflow <https://stackoverflow.com/questions/tagged/pybind11>`_
+
+Asking Your Question
+********************
+
+If you are asking for help in your specific application, debugging build
+errors, or general usage, please ask a
+`StackOverflow question <https://stackoverflow.com/questions/tagged/pybind11>`_
+or ask on `Gitter <https://gitter.im/pybind>`_.
+
+If you are confident your question is either a bug report, feature request, or
+a much more complex question, please post a
+`GitHub issue <https://github.com/pybind/pybind11/issues/new>`_.
+
+When you post your issue, *please* give the relevant context as possible (most
+importantly: what you are trying to do), and provide minimal and self-contained
+reproduction code.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,8 @@
 
     .. image:: pybind11-logo.png
 
+.. _index:
+
 pybind11 --- Seamless operability between C++11 and Python
 ==========================================================
 
@@ -13,6 +15,7 @@ pybind11 --- Seamless operability between C++11 and Python
    :maxdepth: 1
 
    intro
+   help
    changelog
    upgrade
 


### PR DESCRIPTION
Resolves #1724 (if it helps)

Modeling this after what we did on Drake: https://drake.mit.edu/getting_help.html

Meta:
~Is there an easy way to search Gitter chatrooms? I've struggled to figure this out, and it seems like a *really* rich source of info if it were easily searchable...~ See response below.