### PR TITLE
Make static member functions, added with `def_static`, `staticmethod` descriptor instances

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1112,7 +1112,7 @@ public:
                 "def_static(...) called with a non-static member function pointer");
         cpp_function cf(std::forward<Func>(f), name(name_), scope(*this),
                         sibling(getattr(*this, name_, none())), extra...);
-        attr(cf.name()) = cf;
+        attr(cf.name()) = staticmethod(cf);
         return *this;
     }
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -742,6 +742,8 @@ inline bool PyEllipsis_Check(PyObject *o) { return o == Py_Ellipsis; }
 
 inline bool PyUnicode_Check_Permissive(PyObject *o) { return PyUnicode_Check(o) || PYBIND11_BYTES_CHECK(o); }
 
+inline bool PyStaticMethod_Check(PyObject *o) { return o->ob_type == &PyStaticMethod_Type; }
+
 class kwargs_proxy : public handle {
 public:
     explicit kwargs_proxy(handle h) : handle(h) { }
@@ -1279,6 +1281,11 @@ public:
         return handle();
     }
     bool is_cpp_function() const { return (bool) cpp_function(); }
+};
+
+class staticmethod : public object {
+public:
+    PYBIND11_OBJECT_CVT(staticmethod, object, detail::PyStaticMethod_Check, PyStaticMethod_New)
 };
 
 class buffer : public object {


### PR DESCRIPTION
This PR makes sure Sphinx sees and documents static member functions as such (i.e., with an extra "*static*" annotation, cfr. [the Python docs](https://docs.python.org/3/library/stdtypes.html#str.maketrans)).

This also corresponds directly to what `@staticmethod` does in Python and [how Boost.Python does this](https://github.com/boostorg/python/blob/4b01139720128d45e6887b78271baf4eb201e24d/src/object/class.cpp#L709). One caveat, just like in pure Python, is that the `staticmethod` wrapper disappears when accessing the attribute, because of the [descriptor protocol implementation in `staticmethod`](https://docs.python.org/3.7/howto/descriptor.html#static-methods-and-class-methods).

If this is considered useful, we could also still add `@classmethod`?