### PR TITLE
Correctly report Python exceptions set but not thrown during import.

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -258,7 +258,8 @@ extern "C" {
     PYBIND11_PLUGIN_IMPL(name) {                                               \
         PYBIND11_CHECK_PYTHON_VERSION                                          \
         try {                                                                  \
-            return pybind11_init();                                            \
+            auto m = pybind11_init();                                          \
+            return PyErr_Occurred() ? nullptr : m;                             \
         } PYBIND11_CATCH_INIT_EXCEPTIONS                                       \
     }                                                                          \
     PyObject *pybind11_init()
@@ -287,7 +288,7 @@ extern "C" {
         auto m = pybind11::module(PYBIND11_TOSTRING(name));                    \
         try {                                                                  \
             PYBIND11_CONCAT(pybind11_init_, name)(m);                          \
-            return m.ptr();                                                    \
+            return PyErr_Occurred() ? nullptr : m.ptr();                       \
         } PYBIND11_CATCH_INIT_EXCEPTIONS                                       \
     }                                                                          \
     void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &variable)


### PR DESCRIPTION
Consider the following example:

    #include <pybind11/pybind11.h>
    PYBIND11_MODULE(python_example, m) {
        PyErr_SetString(PyExc_ImportError, "oops");
    }

Currently, importing this module will result in

    SystemError: initialization of python_example raised unreported exception

because the Python exception is not converted to a C++ one
(py::error_already_set).  Fix that by checking the error flag, so that
one instead gets

    ImportError: oops

Real use cases include numpy's `import_array()` or pycairo's
`import_cairo()`, which can set the exception flag (and return -1) on
failure.  Currently the correct way to handle them with pycairo is

    if (import_foo() < 0) { m.ptr() = nullptr; return; }

and this patch removes the need for `m.ptr() = nullptr;`.

No tests for now for the same reason as in https://github.com/pybind/pybind11/pull/1362 (I *think* any proper unit test would require creating a new module just for that purpose, and I'm not particularly familiar with the testing machinery used by pybind, so guidance would be welcome here. But "it works for me"...).