### PR TITLE
Added convenient attribute getters

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -146,8 +146,17 @@ public:
     PYBIND11_DEPRECATED("Use py::str(obj) instead")
     pybind11::str str() const;
 
+    /// Get or set the object's author, i.e. ``obj.__author__``.
+    str_attr_accessor author() const;
+    
     /// Get or set the object's docstring, i.e. ``obj.__doc__``.
     str_attr_accessor doc() const;
+    
+    /// Get or set the object's license, i.e. ``obj.__license__``.
+    str_attr_accessor license() const;
+    
+    /// Get or set the object's version, i.e. ``obj.__version__``.
+    str_attr_accessor version() const;
 
     /// Return the object's current reference count
     int ref_count() const { return static_cast<int>(Py_REFCNT(derived().ptr())); }
@@ -1379,7 +1388,16 @@ template <typename D>
 pybind11::str object_api<D>::str() const { return pybind11::str(derived()); }
 
 template <typename D>
+str_attr_accessor object_api<D>::author() const { return attr("__author__"); }
+
+template <typename D>
 str_attr_accessor object_api<D>::doc() const { return attr("__doc__"); }
+
+template <typename D>
+str_attr_accessor object_api<D>::license() const { return attr("__license__"); }
+
+template <typename D>
+str_attr_accessor object_api<D>::version() const { return attr("__version__"); }
 
 template <typename D>
 handle object_api<D>::get_type() const { return (PyObject *) Py_TYPE(derived().ptr()); }


### PR DESCRIPTION
#1745 
Like function `str_attr_accessor object_api<D>::doc()` is a convenient attribute getter for Python property `__doc__`, the corresponding function for `__version__`, `__author__` and `__license__` are added.

