### PR TITLE
Fix casting of time points with non-system-clock duration with VS

### DIFF
--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -128,7 +128,7 @@ public:
         // Lazy initialise the PyDateTime import
         if (!PyDateTimeAPI) { PyDateTime_IMPORT; }
 
-        std::time_t tt = system_clock::to_time_t(src);
+        std::time_t tt = system_clock::to_time_t(time_point_cast<system_clock::duration>(src));
         // this function uses static memory so it's best to copy it out asap just in case
         // otherwise other code that is using localtime may break this (not just python code)
         std::tm localtime = *std::localtime(&tt);

--- a/tests/test_chrono.cpp
+++ b/tests/test_chrono.cpp
@@ -14,6 +14,10 @@
 TEST_SUBMODULE(chrono, m) {
     using system_time = std::chrono::system_clock::time_point;
     using steady_time = std::chrono::steady_clock::time_point;
+
+    using timespan = std::chrono::duration<int64_t, std::nano>;
+    using timestamp = std::chrono::time_point<std::chrono::system_clock, timespan>;
+
     // test_chrono_system_clock
     // Return the current time off the wall clock
     m.def("test_chrono1", []() { return std::chrono::system_clock::now(); });
@@ -44,4 +48,8 @@ TEST_SUBMODULE(chrono, m) {
     // Float durations (issue #719)
     m.def("test_chrono_float_diff", [](std::chrono::duration<float> a, std::chrono::duration<float> b) {
         return a - b; });
+
+    m.def("test_nano_timepoint", [](timestamp start, timespan delta) -> timestamp {
+        return start + delta;
+    });
 }

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -99,3 +99,9 @@ def test_floating_point_duration():
     diff = m.test_chrono_float_diff(43.789012, 1.123456)
     assert diff.seconds == 42
     assert 665556 <= diff.microseconds <= 665557
+
+
+def test_nano_timepoint():
+    time = datetime.datetime.now()
+    time1 = m.test_nano_timepoint(time, datetime.timedelta(seconds=60))
+    assert(time1 == time + datetime.timedelta(seconds=60))


### PR DESCRIPTION
Add explicit `time_point_cast` to time point with duration of system
clock. Fixes Visual Studio compile error.