### PR TITLE
Fix for issue in latest conda

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,7 @@ install:
       if ($env:PLATFORM -eq "x64") { $env:CONDA = "$env:CONDA-x64" }
       $env:PATH = "C:\Miniconda$env:CONDA\;C:\Miniconda$env:CONDA\Scripts\;$env:PATH"
       $env:PYTHONHOME = "C:\Miniconda$env:CONDA"
-      conda update -y -n base conda
+      conda --version
       conda install -y -q pytest numpy scipy
     }
 - ps: |


### PR DESCRIPTION
Attempt to fix AppVeyor issue. There's a bug in Conda 4.6.11; this avoids the bug by allowing the transaction to happen in the preinstalled conda instead (4.5.4). Note that conda still updates conda.