### PR TITLE
doc: Add note about casting from `None` to `T*`

### DIFF
--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -470,10 +470,11 @@ The default behaviour when the tag is unspecified is to allow ``None``.
 .. note::
 
     Even when ``.none(true)`` is specified for an argument, ``None`` will be converted to a
-    ``nullptr`` *only* for custom types. Pointers to built-in types (``double *``, ``int *``, ...) and
-    STL types (``std::vector<T> *``, ...; if ``pybind11/stl.h`` is included) are copied when converted
-    to C++ (see :doc:`/advanced/cast/overview`) and will not allow ``None`` as argument.
-    To pass optional argument of these copied types consider using ``std::optional<T>``
+    ``nullptr`` *only* for custom and :ref:`opaque <opaque>` types. Pointers to built-in types
+    (``double *``, ``int *``, ...) and STL types (``std::vector<T> *``, ...; if ``pybind11/stl.h``
+    is included) are copied when converted to C++ (see :doc:`/advanced/cast/overview`) and will
+    not allow ``None`` as argument.  To pass optional argument of these copied types consider
+    using ``std::optional<T>``
 
 Overload resolution order
 =========================

--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -469,11 +469,11 @@ The default behaviour when the tag is unspecified is to allow ``None``.
 
 .. note::
 
-    Built-in types are not automatically casted from ``None`` to ``T *`` as well as stl
-    containers (such as ``std::vector<T>``) with ``pybind11/stl.h`` include.
-
-    To pass optional argument of such type consider using ``std::optional<T>``, or in case of stl containers
-    ``pybind11/stl_bind.h``
+    Even when ``.none(true)`` is specified for an argument, ``None`` will be converted to a
+    ``nullptr`` *only* for custom types. Pointers to built-in types (``double *``, ``int *``, ...) and
+    STL types (``std::vector<T> *``, ...; if ``pybind11/stl.h`` is included) are copied when converted
+    to C++ (see :doc:`/advanced/cast/overview`) and will not allow ``None`` as argument.
+    To pass optional argument of these copied types consider using ``std::optional<T>``
 
 Overload resolution order
 =========================

--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -467,6 +467,14 @@ dog)"``, while attempting to call ``meow(None)`` will raise a ``TypeError``:
 
 The default behaviour when the tag is unspecified is to allow ``None``.
 
+.. note::
+
+    Built-in types are not automatically casted from ``None`` to ``T *`` as well as stl
+    containers (such as ``std::vector<T>``) with ``pybind11/stl.h`` include.
+
+    To pass optional argument of such type consider using ``std::optional<T>``, or in case of stl containers
+    ``pybind11/stl_bind.h``
+
 Overload resolution order
 =========================
 


### PR DESCRIPTION
I get confused with default cast rules for types:

**Use case:**
I want to pass optional argument of type without natural sentinel value. Type `T*` has additional sentinel value compared to `T`. So minimal function interface would look like `void func(T* t)`.

**Problem:** 
`None` passed to T* argument treated differently for different `T`, namely:

`nullptr` passed to `double*` argument results to `TypeError`
`nullptr` passed to `Foo*` is OK
`nullptr` passed to `py::object*` is OK
`nullptr` passed to `std::vector<Foo>*` argument results to `TypeError` with `#include <pybind11/stl.h>`
`nullptr` passed to `std::vector<Foo>*` argument is OK with `#include <pybind11/stl_bind.h>` and `py::bind_vector<...>`
nullptr passed to const char* argument is OK

**Solution:**
Explicitly mention this behavior in documentation. 