### PR TITLE
Added __contains__ to stl bindings for maps

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -578,6 +578,15 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args&&.
         },
         return_value_policy::reference_internal // ref + keepalive
     );
+    
+    cl.def("__contains__",
+        [](Map &m, const KeyType &k) -> bool {
+            auto it = m.find(k);
+            if (it == m.end())
+              return false;
+           return true;
+        }
+    );
 
     // Assignment provided only if the type is copyable
     detail::map_assignment<Map, Class_>(cl);

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -578,7 +578,7 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args&&.
         },
         return_value_policy::reference_internal // ref + keepalive
     );
-    
+
     cl.def("__contains__",
         [](Map &m, const KeyType &k) -> bool {
             auto it = m.find(k);

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -56,7 +56,9 @@ def test_map(doc):
     """std::map <-> dict"""
     d = m.cast_map()
     assert d == {"key": "value"}
+    assert "key" in d
     d["key2"] = "value2"
+    assert "key2" in d
     assert m.load_map(d)
 
     assert doc(m.cast_map) == "cast_map() -> Dict[str, str]"


### PR DESCRIPTION
Currently there is no `__contains__` method defined for STL container bindings. If you do not define a `__contains__` it will by default fall back to `__iter__` for checking if the key exists as described [here](https://docs.python.org/3/reference/expressions.html#membership-test-operations). For many C++ map containers types this can be very expensive. 