### PR TITLE
Mark exceptions with export to fix exceptions in shared libraries

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -654,7 +654,7 @@ using expand_side_effects = bool[];
 NAMESPACE_END(detail)
 
 /// C++ bindings of builtin Python exceptions
-class builtin_exception : public std::runtime_error {
+class PYBIND11_EXPORT builtin_exception : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
     /// Set the error using the Python C API
@@ -662,7 +662,7 @@ public:
 };
 
 #define PYBIND11_RUNTIME_EXCEPTION(name, type) \
-    class name : public builtin_exception { public: \
+    class PYBIND11_EXPORT name : public builtin_exception { public: \
         using builtin_exception::builtin_exception; \
         name() : name("") { } \
         void set_error() const override { PyErr_SetString(type, what()); } \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -654,12 +654,20 @@ using expand_side_effects = bool[];
 NAMESPACE_END(detail)
 
 /// C++ bindings of builtin Python exceptions
+//
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable: 4275) // warning C4275: An exported class was derived from a class that wasn't exported
+#endif
 class PYBIND11_EXPORT builtin_exception : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
     /// Set the error using the Python C API
     virtual void set_error() const = 0;
 };
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 
 #define PYBIND11_RUNTIME_EXCEPTION(name, type) \
     class PYBIND11_EXPORT name : public builtin_exception { public: \

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -43,7 +43,7 @@ using list_accessor = accessor<accessor_policies::list_item>;
 using tuple_accessor = accessor<accessor_policies::tuple_item>;
 
 /// Tag and check to identify a class which implements the Python object API
-class pyobject_tag { };
+class PYBIND11_EXPORT pyobject_tag { };
 template <typename T> using is_pyobject = std::is_base_of<pyobject_tag, remove_reference_t<T>>;
 
 /** \rst
@@ -51,7 +51,7 @@ template <typename T> using is_pyobject = std::is_base_of<pyobject_tag, remove_r
     The only requirement for `Derived` is to implement ``PyObject *Derived::ptr() const``.
 \endrst */
 template <typename Derived>
-class object_api : public pyobject_tag {
+class PYBIND11_EXPORT object_api : public pyobject_tag {
     const Derived &derived() const { return static_cast<const Derived &>(*this); }
 
 public:
@@ -171,7 +171,7 @@ NAMESPACE_END(detail)
         The `object` class inherits from `handle` and adds automatic reference
         counting features.
 \endrst */
-class handle : public detail::object_api<handle> {
+class PYBIND11_EXPORT handle : public detail::object_api<handle> {
 public:
     /// The default constructor creates a handle with a ``nullptr``-valued pointer
     handle() = default;
@@ -227,7 +227,7 @@ protected:
     scope and is destructed. When using `object` instances consistently, it is much
     easier to get reference counting right at the first attempt.
 \endrst */
-class object : public handle {
+class PYBIND11_EXPORT object : public handle {
 public:
     object() = default;
     PYBIND11_DEPRECATED("Use reinterpret_borrow<object>() or reinterpret_steal<object>()")

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -319,7 +319,7 @@ NAMESPACE_END(detail)
 /// thrown to propagate python-side errors back through C++ which can either be caught manually or
 /// else falls back to the function dispatcher (which then raises the captured error back to
 /// python).
-class error_already_set : public std::runtime_error {
+class PYBIND11_EXPORT error_already_set : public std::runtime_error {
 public:
     /// Constructs a new exception from the current Python error indicator, if any.  The current
     /// Python error indicator will be cleared.

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -319,6 +319,10 @@ NAMESPACE_END(detail)
 /// thrown to propagate python-side errors back through C++ which can either be caught manually or
 /// else falls back to the function dispatcher (which then raises the captured error back to
 /// python).
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable: 4275) // warning C4275: An exported class was derived from a class that wasn't exported
+#endif
 class PYBIND11_EXPORT error_already_set : public std::runtime_error {
 public:
     /// Constructs a new exception from the current Python error indicator, if any.  The current
@@ -349,7 +353,9 @@ public:
 private:
     object type, value, trace;
 };
-
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 /** \defgroup python_builtins _
     Unless stated otherwise, the following C++ functions behave the same
     as their Python counterparts.


### PR DESCRIPTION
In a setup with two shared libraries, A and B, if A throws an exception, B should be able to catch it. To do this, the exception must have external linkage, otherwise A and B will both have their own separate copies of the type.  See https://gcc.gnu.org/wiki/Visibility for more information, but the short version is that all exceptions defined in libraries should be declared with `__attribute__ ((visibility("default")))`
