### PR TITLE
Use FindPython3.cmake rather than the deprecated FindPythonInterp.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.12.4)
 
 if (POLICY CMP0048)
   # cmake warns if loaded from a min-3.0-required parent dir, so silence the warning:

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -57,12 +57,12 @@ endif()
 
 # Use the Python interpreter to find the libs.
 if(PythonLibsNew_FIND_REQUIRED)
-    find_package(PythonInterp ${PythonLibsNew_FIND_VERSION} REQUIRED)
+    find_package(Python3 ${PythonLibsNew_FIND_VERSION} REQUIRED)
 else()
-    find_package(PythonInterp ${PythonLibsNew_FIND_VERSION})
+    find_package(Python3 ${PythonLibsNew_FIND_VERSION})
 endif()
 
-if(NOT PYTHONINTERP_FOUND)
+if(NOT Python3_FOUND)
     set(PYTHONLIBS_FOUND FALSE)
     return()
 endif()
@@ -73,7 +73,7 @@ endif()
 #
 # The library suffix is from the config var LDVERSION sometimes, otherwise
 # VERSION. VERSION will typically be like "2.7" on unix, and "27" on windows.
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+execute_process(COMMAND "${Python3_EXECUTABLE}" "-c"
     "from distutils import sysconfig as s;import sys;import struct;
 print('.'.join(str(v) for v in sys.version_info));
 print(sys.prefix);
@@ -191,8 +191,8 @@ SET(PYTHON_INCLUDE_DIRS "${PYTHON_INCLUDE_DIR}")
 SET(PYTHON_LIBRARIES "${PYTHON_LIBRARY}")
 SET(PYTHON_DEBUG_LIBRARIES "${PYTHON_DEBUG_LIBRARY}")
 
-find_package_message(PYTHON
+find_package_message(Python3
     "Found PythonLibs: ${PYTHON_LIBRARY}"
-    "${PYTHON_EXECUTABLE}${PYTHON_VERSION}")
+    "${Python3_EXECUTABLE}${PYTHON_VERSION}")
 
 set(PYTHONLIBS_FOUND TRUE)

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -57,12 +57,12 @@ endif()
 
 # Use the Python interpreter to find the libs.
 if(PythonLibsNew_FIND_REQUIRED)
-    find_package(Python3 ${PythonLibsNew_FIND_VERSION} REQUIRED)
+    find_package(Python ${PythonLibsNew_FIND_VERSION} REQUIRED)
 else()
-    find_package(Python3 ${PythonLibsNew_FIND_VERSION})
+    find_package(Python ${PythonLibsNew_FIND_VERSION})
 endif()
 
-if(NOT Python3_FOUND)
+if(NOT Python_FOUND)
     set(PYTHONLIBS_FOUND FALSE)
     return()
 endif()
@@ -73,7 +73,7 @@ endif()
 #
 # The library suffix is from the config var LDVERSION sometimes, otherwise
 # VERSION. VERSION will typically be like "2.7" on unix, and "27" on windows.
-execute_process(COMMAND "${Python3_EXECUTABLE}" "-c"
+execute_process(COMMAND "${Python_EXECUTABLE}" "-c"
     "from distutils import sysconfig as s;import sys;import struct;
 print('.'.join(str(v) for v in sys.version_info));
 print(sys.prefix);
@@ -191,8 +191,8 @@ SET(PYTHON_INCLUDE_DIRS "${PYTHON_INCLUDE_DIR}")
 SET(PYTHON_LIBRARIES "${PYTHON_LIBRARY}")
 SET(PYTHON_DEBUG_LIBRARIES "${PYTHON_DEBUG_LIBRARY}")
 
-find_package_message(Python3
+find_package_message(PYTHON
     "Found PythonLibs: ${PYTHON_LIBRARY}"
-    "${Python3_EXECUTABLE}${PYTHON_VERSION}")
+    "${Python_EXECUTABLE}${PYTHON_VERSION}")
 
 set(PYTHONLIBS_FOUND TRUE)


### PR DESCRIPTION
FindPythonInterp is deprecated and doesn't always find the Python executable (most notably the default installation in Fedora 30), so pybind11 should use FindPython3 or FindPython (if supporting Python2 is still desired; FindPython is version agnostic).