### PR TITLE
Minor tweaks to tools/mkdoc.py

### DIFF
--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -342,8 +342,17 @@ if __name__ == '__main__':
             break
     try:
         if out_path:
-            with open(out_path, 'w') as out_file:
-                mkdoc(args, out_file)
+            try:
+                with open(out_path, 'w') as out_file:
+                    mkdoc(args, out_file)
+            except:
+                # In the event of an error, don't leave a partially-written
+                # output file.
+                try:
+                    os.unlink(out_path)
+                except:
+                    pass
+                raise
         else:
             mkdoc(args)
     except NoFilenamesError:

--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -232,7 +232,7 @@ class ExtractionThread(Thread):
             job_semaphore.release()
 
 
-def extract_all(args):
+def read_args(args):
     parameters = []
     filenames = []
     if "-x" not in args:
@@ -277,6 +277,11 @@ def extract_all(args):
     if len(filenames) == 0:
         raise NoFilenamesError("args parameter did not contain any filenames")
 
+    return parameters, filenames
+
+
+def extract_all(args):
+    parameters, filenames = read_args(args)
     output = []
     for filename in filenames:
         thr = ExtractionThread(filename, parameters, output)

--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -225,8 +225,12 @@ class ExtractionThread(Thread):
             job_semaphore.release()
 
 if __name__ == '__main__':
-    parameters = ['-x', 'c++', '-std=c++11']
+    parameters = []
     filenames = []
+    if "-x" not in args:
+        parameters.extend(['-x', 'c++'])
+    if not any(it.startswith("-std=") for it in args):
+        parameters.append('-std=c++11')
 
     if platform.system() == 'Darwin':
         dev_path = '/Applications/Xcode.app/Contents/Developer/'

--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -59,7 +59,7 @@ job_semaphore = Semaphore(job_count)
 output = []
 
 def d(s):
-    return s.decode('utf8')
+    return s if isinstance(s, str) else s.decode('utf8')
 
 
 def sanitize_name(name):

--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -59,6 +59,11 @@ job_semaphore = Semaphore(job_count)
 
 output = []
 
+
+class NoFilenamesError(ValueError):
+    pass
+
+
 def d(s):
     return s if isinstance(s, str) else s.decode('utf8')
 
@@ -224,7 +229,8 @@ class ExtractionThread(Thread):
         finally:
             job_semaphore.release()
 
-if __name__ == '__main__':
+
+def mkdoc(args):
     parameters = []
     filenames = []
     if "-x" not in args:
@@ -260,15 +266,14 @@ if __name__ == '__main__':
         if clang_include_dir:
             parameters.extend(['-isystem', clang_include_dir])
 
-    for item in sys.argv[1:]:
+    for item in args:
         if item.startswith('-'):
             parameters.append(item)
         else:
             filenames.append(item)
 
     if len(filenames) == 0:
-        print('Syntax: %s [.. a list of header files ..]' % sys.argv[0])
-        exit(-1)
+        raise NoFilenamesError("args parameter did not contain any filenames")
 
     print('''/*
   This file contains docstrings for the Python bindings.
@@ -321,3 +326,11 @@ if __name__ == '__main__':
 #pragma GCC diagnostic pop
 #endif
 ''')
+
+
+if __name__ == '__main__':
+    try:
+        mkdoc(sys.argv[1:])
+    except NoFilenamesError:
+        print('Syntax: %s [.. a list of header files ..]' % sys.argv[0])
+        exit(-1)

--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -41,6 +41,10 @@ PRINT_LIST = [
     CursorKind.FIELD_DECL
 ]
 
+PREFIX_BLACKLIST = [
+    CursorKind.TRANSLATION_UNIT
+]
+
 CPP_OPERATORS = {
     '<=': 'le', '>=': 'ge', '==': 'eq', '!=': 'ne', '[]': 'array',
     '+=': 'iadd', '-=': 'isub', '*=': 'imul', '/=': 'idiv', '%=':
@@ -192,7 +196,7 @@ def extract(filename, node, prefix, output):
         return 0
     if node.kind in RECURSE_LIST:
         sub_prefix = prefix
-        if node.kind != CursorKind.TRANSLATION_UNIT:
+        if node.kind not in PREFIX_BLACKLIST:
             if len(sub_prefix) > 0:
                 sub_prefix += '_'
             sub_prefix += d(node.spelling)


### PR DESCRIPTION
This PR contains an assortment of minor changes to `tools/mkdoc.py` intended to make it easier to integrate into automated build workflows:

* Adds compatibility with Clang 8.x
* Accepts the `-o` option, so the output can be written to a file instead of stderr
* Detects and loads the clang system include dir (e.g. `/usr/lib/clang/8.0.0/include`) on Linux
* Tries to get as much of the functionality as possible out of `if __name__ == '__main__'` and into functions that can be called by other python scripts.

Because this is a grab bag of minor tweaks, I've tried to organize the commits so that it's easy to pick and choose -- if there's something I've done here that you don't like, I'm happy to rebase that commit out of the branch.

