### PR TITLE
Added note in documentation regarding make install

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "restructuredtext.preview.sphinx.disabled": true,
+    "restructuredtext.linter.disabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "restructuredtext.preview.sphinx.disabled": true,
-    "restructuredtext.linter.disabled": true
-}

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -149,18 +149,18 @@ See the `Config file`_ docstring for details of relevant CMake variables.
     find_package(pybind11 REQUIRED)
     pybind11_add_module(example example.cpp)
 
-Note that ``find_package(pybind11)`` will only work correctly if pybind11 
-has been correctly installed on the system, e. g. after downloading or cloning 
+Note that ``find_package(pybind11)`` will only work correctly if pybind11
+has been correctly installed on the system, e. g. after downloading or cloning
 the pybind11 repository  :
 
 .. code-block:: bash
 
     cd pybind11
     mkdir build
-    cd build 
+    cd build
     cmake ..
     make install
-    
+
 Once detected, the aforementioned ``pybind11_add_module`` can be employed as
 before. The function usage and configuration variables are identical no matter
 if pybind11 is added as a subdirectory or found as an installed package. You

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -149,6 +149,18 @@ See the `Config file`_ docstring for details of relevant CMake variables.
     find_package(pybind11 REQUIRED)
     pybind11_add_module(example example.cpp)
 
+Note that ``find_package(pybind11)`` will only work correctly if pybind11 
+has been correctly installed on the system, e. g. after downloading or cloning 
+the pybind11 repository  :
+
+.. code-block:: bash
+
+    cd pybind11
+    mkdir build
+    cd build 
+    cmake ..
+    make install
+    
 Once detected, the aforementioned ``pybind11_add_module`` can be employed as
 before. The function usage and configuration variables are identical no matter
 if pybind11 is added as a subdirectory or found as an installed package. You


### PR DESCRIPTION
Hello, 
For my application I was not able to use the typical cmake `add_subfolder` approach, and needed to use a external location for pybind11. 
Perhaps it is very obvious to some, but in order for `find_package` to work correctly one needs to run a `make install`. I spent an embarrassingly long amount of time figuring this out, so I added a little note in the documentation to help other noobs like me.

In case you are curious, my application uses a Docker development environment which contains all of the external libraries and dependencies. The source code folder is mounted as a volume in docker, and the compilation is done in the container. An external library on the container can not be a subfolder of the mounted volume, which is why the `add_subfolder` approach doesn't work in this case.

Thanks a lot for a great project, I was very happy to find it!