### PR TITLE
Fix malformed reST

### DIFF
--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -325,7 +325,7 @@ can now create a python class that inherits from ``Dog``:
 Extended trampoline class functionality
 =======================================
 
-.. _extended_class_functionality_forced_trampoline
+.. _extended_class_functionality_forced_trampoline:
 
 Forced trampoline class initialisation
 --------------------------------------


### PR DESCRIPTION
Commit 2b045757b560 ("Improve documentation related to inheritance. (#1676)") left off
a ':' from a hyperlink, which breaks the Travis CI build.