### PR TITLE
quiet clang warning by adding default move ctor

### DIFF
--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -64,6 +64,8 @@ public:
         setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
     }
 
+    pythonbuf(pythonbuf&&) = default;
+
     /// Sync before destroy
     ~pythonbuf() {
         sync();


### PR DESCRIPTION
clang-8 warns:

```
../ThirdParty/build/install/include/pybind11/iostream.h:124:5: warning: explicitly defaulted move constructor is implicitly deleted [-Wdefaulted-function-deleted]
    scoped_ostream_redirect(scoped_ostream_redirect&& other) = default;
    ^
../ThirdParty/build/install/include/pybind11/iostream.h:110:23: note: move constructor of 'scoped_ostream_redirect' is implicitly deleted because field 'buffer' has a deleted move constructor
    detail::pythonbuf buffer;
                      ^
../ThirdParty/build/install/include/pybind11/iostream.h:30:29: note: copy constructor of 'pythonbuf' is implicitly deleted because field 'd_buffer' has a deleted copy constructor
    std::unique_ptr<char[]> d_buffer;
                            ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:685:7: note: 'unique_ptr' has been explicitly marked deleted here
      unique_ptr(const unique_ptr&) = delete;
      ^
1 warning generated.
```
`pythonbuf` holds a unique_ptr (hence has no copy ctor), and defines a destructor, and hence should have a deleted move ctor (https://en.cppreference.com/w/cpp/language/move_constructor)