### PR TITLE
bind_vector to work properly with boost::container::small_vector

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -431,10 +431,9 @@ class_<Vector, holder_type> bind_vector(handle scope, std::string const &name, A
         "Check whether the list is nonempty"
     );
 
-    cl.def("__len__", &Vector::size);
-
-
-
+    cl.def("__len__", [](const Vector &v) -> typename Vector::size_type {
+      return v.size();
+    });
 
 #if 0
     // C++ style functions deprecated, leaving it here as an example

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -15,6 +15,11 @@
 #include <deque>
 #include <unordered_map>
 
+#ifdef PYBIND11_TEST_BOOST
+#include <boost/container/small_vector.hpp>
+PYBIND11_MAKE_OPAQUE(boost::container::small_vector<int, 4>)
+#endif
+
 class El {
 public:
     El() = delete;
@@ -63,6 +68,15 @@ TEST_SUBMODULE(stl_binders, m) {
         .def(py::init<int>());
     py::bind_vector<std::vector<El>>(m, "VectorEl");
     py::bind_vector<std::vector<std::vector<El>>>(m, "VectorVectorEl");
+
+#ifdef PYBIND11_TEST_BOOST
+    // test_vector_boost
+    // boost::container::small_vector defines certain methods in a base class,
+    // leading to a TypeError about incompatible function arguments since
+    // bind_vector does not support a base class argument. This is circumvented
+    // using a lambda instead of a pointer to the method.
+    py::bind_vector<boost::container::small_vector<int, 4>>(m, "VectorBoost");
+#endif
 
     // test_map_string_double
     py::bind_map<std::map<std::string, double>>(m, "MapStringDouble");

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -128,6 +128,13 @@ def test_vector_custom():
     assert str(vv_b) == "VectorEl[El{1}, El{2}]"
 
 
+@pytest.mark.skipif(not hasattr(m, "VectorBoost"), reason='no <boost>')
+def test_vector_boost():
+    v = m.VectorBoost([0, 0])
+    assert bool(v) is True
+    assert len(v) == 2
+
+
 def test_map_string_double():
     mm = m.MapStringDouble()
     mm['a'] = 1


### PR DESCRIPTION
`boost::container::small_vector` defines certain methods such as `size` in a base class. This leads to errors such as

```
    def test_vector_boost():
        v = m.VectorBoost([0, 0])
        assert bool(v) is True
>       assert len(v) == 2
E       TypeError: __len__(): incompatible function arguments. The following argument types are supported:
E           1. (self: boost::container::vector<int, boost::container::small_vector_allocator<boost::container::new_allocator<int> > >) -> int
E       
E       Invoked with: VectorBoost[0, 0]
```

My interpretation is that pybind11 does not know that `boost::container::vector` is a base class (since as far as I can tell we cannot pass a base to `bind_vector`?). For some reason this works when compiled with c++14 standard, but not with c++17 (gcc7 on Ubuntu 18.04).

This pull request fixes/circumvents the issue by wrapping the call to `size` in a lambda. I am not sure this is the best solution though?