### PR TITLE
a workaround to avoid a c++14 feature

### DIFF
--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -65,12 +65,19 @@ public:
             }
         };
 
-        value = [hfunc = func_handle(std::move(func))](Args... args) -> Return {
-            gil_scoped_acquire acq;
-            object retval(hfunc.f(std::forward<Args>(args)...));
-            /* Visual studio 2015 parser issue: need parentheses around this expression */
-            return (retval.template cast<Return>());
+        // to emulate 'move initialization capture' in C++11
+        struct func_wrapper {
+            func_handle hfunc;
+            func_wrapper(func_handle&& hf): hfunc(std::move(hf)) {}
+            Return operator()(Args... args) const {
+                gil_scoped_acquire acq;
+                object retval(hfunc.f(std::forward<Args>(args)...));
+                /* Visual studio 2015 parser issue: need parentheses around this expression */
+                return (retval.template cast<Return>());
+            }
         };
+
+        value = func_wrapper(func_handle(std::move(func)));
         return true;
     }
 


### PR DESCRIPTION
Hi,

Thank you for the amazing work. I'm one of the users of this great library.

Today I found that the latest version of this library includes a c++14 feature, lambda capture initializer. You can see it by the following minimum code.

```cpp
// sample.cpp
#include <pybind11/pybind11.h>
#include <pybind11/functional.h>

PYBIND11_MODULE(example, /*m*/) {
}
```

and 

```console
$ g++-9 -std=c++11 -c -Wall -Wpedantic -Wextra sample.cpp
In file included from sample.cpp:2:
./include/pybind11/functional.h: In member function 'bool pybind11::detail::type_caster<std::function<_Res(_ArgTypes ...)> >::load(pybind11::handle, bool)':
./include/pybind11/functional.h:68:18: warning: lambda capture initializers only available with '-std=c++14' or '-std=gnu++14'
   68 |         value = [hfunc = func_handle(std::move(func))](Args... args) -> Return {
      |                  ^~~~~
```

As the name suggests, pybind11 requires only C++11 (at least now). Although most of the existing compilers can compile this c++14 extension, I think it is good to have a workaround to make it c++11 conformant.

So here I added a temporary function-object that behaves equivalently to the lambda expression.