### PR TITLE
Dtype field ordering for NumPy 1.14

### DIFF
--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -29,6 +29,13 @@ std::ostream& operator<<(std::ostream& os, const SimpleStruct& v) {
     return os << "s:" << v.bool_ << "," << v.uint_ << "," << v.float_ << "," << v.ldbl_;
 }
 
+struct SimpleStructReordered {
+    bool bool_;
+    float float_;
+    uint32_t uint_;
+    long double ldbl_;
+};
+
 PYBIND11_PACKED(struct PackedStruct {
     bool bool_;
     uint32_t uint_;
@@ -255,6 +262,7 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     py::class_<SimpleStruct>(m, "SimpleStruct");
 
     PYBIND11_NUMPY_DTYPE(SimpleStruct, bool_, uint_, float_, ldbl_);
+    PYBIND11_NUMPY_DTYPE(SimpleStructReordered, bool_, uint_, float_, ldbl_);
     PYBIND11_NUMPY_DTYPE(PackedStruct, bool_, uint_, float_, ldbl_);
     PYBIND11_NUMPY_DTYPE(NestedStruct, a, b);
     PYBIND11_NUMPY_DTYPE(PartialStruct, bool_, uint_, float_, ldbl_);


### PR DESCRIPTION
As reported in #1274, the fields are ordered "by position" instead of "by field name" as of NumPy 1.14. This PR sorts the fields by position before registering the dtype.

Perhaps it's worth debating if this goes against what the user wanted. An alternative approach would be to throw a more meaningful exception for Numpy >= 1.14, since we know the expected field order (e.g. "NumPy: Invalid field order while registering dtype, expecting: ..."). This would force the user to correctly order the fields without pybind doing it in the background. But the user would also have to be aware of that change in NumPy 1.14. IMHO the user mostly wants to just register the dtype and the proposed solution will do it across current versions.