### PR TITLE
Allow Windows.h min/max to coexist with pybind11

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -995,8 +995,10 @@ public:
         }
 
         bool py_err = py_value == (py_type) -1 && PyErr_Occurred();
+
+		// Protect std::numeric_limits::min/max with parentheses
         if (py_err || (std::is_integral<T>::value && sizeof(py_type) != sizeof(T) &&
-                       (py_value < (py_type) (std::numeric_limits<T>::min)() ||
+                       (py_value < (py_type) (std::numeric_limits<T>::min)() || 
                         py_value > (py_type) (std::numeric_limits<T>::max)()))) {
             bool type_error = py_err && PyErr_ExceptionMatches(
 #if PY_VERSION_HEX < 0x03000000 && !defined(PYPY_VERSION)

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -996,9 +996,9 @@ public:
 
         bool py_err = py_value == (py_type) -1 && PyErr_Occurred();
 
-		// Protect std::numeric_limits::min/max with parentheses
+        // Protect std::numeric_limits::min/max with parentheses
         if (py_err || (std::is_integral<T>::value && sizeof(py_type) != sizeof(T) &&
-                       (py_value < (py_type) (std::numeric_limits<T>::min)() || 
+                       (py_value < (py_type) (std::numeric_limits<T>::min)() ||
                         py_value > (py_type) (std::numeric_limits<T>::max)()))) {
             bool type_error = py_err && PyErr_ExceptionMatches(
 #if PY_VERSION_HEX < 0x03000000 && !defined(PYPY_VERSION)

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -996,8 +996,8 @@ public:
 
         bool py_err = py_value == (py_type) -1 && PyErr_Occurred();
         if (py_err || (std::is_integral<T>::value && sizeof(py_type) != sizeof(T) &&
-                       (py_value < (py_type) std::numeric_limits<T>::min() ||
-                        py_value > (py_type) std::numeric_limits<T>::max()))) {
+                       (py_value < (py_type) (std::numeric_limits<T>::min)() ||
+                        py_value > (py_type) (std::numeric_limits<T>::max)()))) {
             bool type_error = py_err && PyErr_ExceptionMatches(
 #if PY_VERSION_HEX < 0x03000000 && !defined(PYPY_VERSION)
                 PyExc_SystemError

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -113,10 +113,6 @@
 #include <frameobject.h>
 #include <pythread.h>
 
-#if defined(_WIN32) && (defined(min) || defined(max))
-#  error Macro clash with min and max -- define NOMINMAX when compiling your program on Windows
-#endif
-
 #if defined(isalnum)
 #  undef isalnum
 #  undef isalpha

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -495,7 +495,7 @@ protected:
 
                 function_call call(func, parent);
 
-                size_t args_to_copy = (std::min)(pos_args, n_args_in);
+                size_t args_to_copy = (std::min)(pos_args, n_args_in); // Protect std::min with parentheses
                 size_t args_copied = 0;
 
                 // 0. Inject new-style `self` argument

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -495,7 +495,7 @@ protected:
 
                 function_call call(func, parent);
 
-                size_t args_to_copy = std::min(pos_args, n_args_in);
+                size_t args_to_copy = (std::min)(pos_args, n_args_in);
                 size_t args_copied = 0;
 
                 // 0. Inject new-style `self` argument


### PR DESCRIPTION
Implements a fix for issue #1846