### PR TITLE
Fix -Wmissing-prototypes warning on Clang

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -164,7 +164,9 @@
 #define PYBIND11_STR_TYPE ::pybind11::str
 #define PYBIND11_BOOL_ATTR "__bool__"
 #define PYBIND11_NB_BOOL(ptr) ((ptr)->nb_bool)
+// Providing a separate declaration to make Clang's -Wmissing-prototypes happy
 #define PYBIND11_PLUGIN_IMPL(name) \
+    extern "C" PYBIND11_EXPORT PyObject *PyInit_##name();   \
     extern "C" PYBIND11_EXPORT PyObject *PyInit_##name()
 
 #else
@@ -188,8 +190,10 @@
 #define PYBIND11_STR_TYPE ::pybind11::bytes
 #define PYBIND11_BOOL_ATTR "__nonzero__"
 #define PYBIND11_NB_BOOL(ptr) ((ptr)->nb_nonzero)
+// Providing a separate PyInit decl to make Clang's -Wmissing-prototypes happy
 #define PYBIND11_PLUGIN_IMPL(name) \
     static PyObject *pybind11_init_wrapper();               \
+    extern "C" PYBIND11_EXPORT void init##name();           \
     extern "C" PYBIND11_EXPORT void init##name() {          \
         (void)pybind11_init_wrapper();                      \
     }                                                       \


### PR DESCRIPTION
Similarly to #1852 this is just a minor change with minimal impact :)

The `-Wmissing-prototypes` warning on Clang (or `-Wmissing-declarations` on GCC) is very useful to avoid accidents where a function definition in a source file doesn't match the corresponding declaration in a header file, as it would warn already during compilation and not fail much later during link time.

Unfortunately this means that exported functions defined only in the source file (usually the ones annotated with `extern "C"`) will cause this warning to be emitted too (on Clang, GCC has a [slightly different behavior](https://bugs.llvm.org/show_bug.cgi?id=16286) with `-Wmissing-declarations` and doesn't warn here). For example:

```
magnum.cpp:211:1: warning: no previous prototype for function 'PyInit__magnum' [-Wmissing-prototypes]
PYBIND11_MODULE(_magnum, m) {
^
/usr/include/pybind11/detail/common.h:285:5: note: expanded from macro 'PYBIND11_MODULE'
    PYBIND11_PLUGIN_IMPL(name) {                                               \
    ^
/usr/include/pybind11/detail/common.h:172:42: note: expanded from macro 'PYBIND11_PLUGIN_IMPL'
    extern "C" PYBIND11_EXPORT PyObject *PyInit_##name()
                                         ^
```

This fixes the warning by providing a matching declaration right before the definition, both for the Python 3 and Python 2 variant.