### PR TITLE
Detect whether we are running in a Conda environment and adjust get_include()

### DIFF
--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -9,10 +9,18 @@ def get_include(user=False):
     # Are we running in a virtual environment?
     virtualenv = hasattr(sys, 'real_prefix') or \
         sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    
+    # Are we running in a conda environment?
+    conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
 
     if virtualenv:
         return os.path.join(sys.prefix, 'include', 'site',
                             'python' + sys.version[:3])
+    elif conda:
+        if os.name == 'nt':
+            return os.path.join(sys.prefix, 'Library', 'include')
+        else:
+            return os.path.join(sys.prefix, 'include')
     else:
         dist = Distribution({'name': 'pybind11'})
         dist.parse_config_files()

--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -9,7 +9,7 @@ def get_include(user=False):
     # Are we running in a virtual environment?
     virtualenv = hasattr(sys, 'real_prefix') or \
         sys.prefix != getattr(sys, "base_prefix", sys.prefix)
-    
+
     # Are we running in a conda environment?
     conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
 


### PR DESCRIPTION
Try to address [this issue](https://github.com/conda-forge/pybind11-feedstock/pull/32#discussion_r293723814) with the conda-forge feedstock.

For the records, Conda packages install headers in `prefix/include` on Linux and `prefix\Library\include` on Windows.