### PR TITLE
Add const to buffer:request()

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1312,7 +1312,7 @@ class buffer : public object {
 public:
     PYBIND11_OBJECT_DEFAULT(buffer, object, PyObject_CheckBuffer)
 
-    buffer_info request(bool writable = false) {
+    buffer_info request(bool writable = false) const {
         int flags = PyBUF_STRIDES | PyBUF_FORMAT;
         if (writable) flags |= PyBUF_WRITABLE;
         Py_buffer *view = new Py_buffer();

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -78,7 +78,7 @@ TEST_SUBMODULE(buffers, m) {
     py::class_<Matrix>(m, "Matrix", py::buffer_protocol())
         .def(py::init<ssize_t, ssize_t>())
         /// Construct from a buffer
-        .def(py::init([](py::buffer b) {
+        .def(py::init([](py::buffer const b) {
             py::buffer_info info = b.request();
             if (info.format != py::format_descriptor<float>::format() || info.ndim != 2)
                 throw std::runtime_error("Incompatible buffer format!");


### PR DESCRIPTION
This PR simply marks `buffer::request()` as `const`.  Without the `const`, code cannot have a const py::buffer and request a buffer_info.

`request()` does not alter the object so it should be conceptually safe.