### PR TITLE
error_already_set::what() is now constructed lazily

### DIFF
--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -157,7 +157,7 @@ TEST_SUBMODULE(exceptions, m) {
             PyErr_SetString(PyExc_ValueError, "foo");
         try {
             throw py::error_already_set();
-        } catch (const std::runtime_error& e) {
+        } catch (const py::error_already_set& e) {
             if ((err && e.what() != std::string("ValueError: foo")) ||
                 (!err && e.what() != std::string("Unknown internal error occurred")))
             {


### PR DESCRIPTION
Prior to this commit throwing error_already_set was expensive due to the
eager construction of the error string (which required traversing the
Python stack). See #1853 for more context and an alternative take on the
issue.

Note that error_already_set no longer inherits from std::runtime_error
because the latter has no default constructor.