### PR TITLE
Narrows is_copy_constructible specialization for containers

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "pytypes.h"
+#include "detail/common.h"
 #include "detail/typeid.h"
 #include "detail/descr.h"
 #include "detail/internals.h"
@@ -775,7 +776,9 @@ template <typename T, typename SFINAE = void> struct is_copy_constructible : std
 // so, copy constructability depends on whether the value_type is copy constructible.
 template <typename Container> struct is_copy_constructible<Container, enable_if_t<all_of<
         std::is_copy_constructible<Container>,
-        std::is_same<typename Container::value_type &, typename Container::reference>
+        std::is_same<typename Container::value_type &, typename Container::reference>,
+        // Avoid infinite recursion
+        negation<std::is_same<Container, typename Container::value_type>>
     >::value>> : is_copy_constructible<typename Container::value_type> {};
 
 #if !defined(PYBIND11_CPP17)


### PR DESCRIPTION
This try to fix a corner use case that I came across where the type to bind looks like a container (e.g. it has `value_type` and `reference` with `reference = value_type&`) but it is more like a wrapper, something like:

```
template <typename T>
struct pixel
{
	typedef pixel value_type;
	typedef value_type& reference;
};
```

In this case, `is_copy_constructible` is called recursively with the same type and the compiler fails with `invalid use of incomplete type 'struct is_copy_constructible<pixel<char> >'`.

This PR narrows the availability of `is_copy_constructible` partial specialization for containers to types that really look like containers.