### PR TITLE
Catch exceptions thrown by repr() when called by the dispatcher

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -749,7 +749,11 @@ protected:
             for (size_t ti = overloads->is_constructor ? 1 : 0; ti < args_.size(); ++ti) {
                 if (!some_args) some_args = true;
                 else msg += ", ";
-                msg += pybind11::repr(args_[ti]);
+                try {
+                    msg += pybind11::repr(args_[ti]);
+                } catch (...) {
+                    msg += "<repr raised an exception>";
+                }
             }
             if (kwargs_in) {
                 auto kwargs = reinterpret_borrow<dict>(kwargs_in);

--- a/tests/test_constants_and_functions.py
+++ b/tests/test_constants_and_functions.py
@@ -1,3 +1,4 @@
+import pytest
 from pybind11_tests import constants_and_functions as m
 
 
@@ -37,3 +38,13 @@ def test_exception_specifiers():
     assert m.f2(53) == 55
     assert m.f3(86) == 89
     assert m.f4(140) == 144
+
+
+def test_incompatible_args_and_repr_exception():
+    """Checks repr exceptions are handled gracefully by the dispatcher."""
+    class ReprRaises(object):
+        def __repr__(self):
+            raise ValueError("repr")
+    with pytest.raises(TypeError,
+                       match="Invoked with: <repr raised an exception>"):
+        m.test_function(ReprRaises())


### PR DESCRIPTION
The dispatcher calls `repr()` if no overload matches, but `repr()` may throw causing the process to terminate with an uncaught exception. Handle that case more gracefully by catching the exception and instead using a string that simply says that `repr` threw.

With more work we could describe the exception but that seems unnecessary given the caller can just call `repr()` on the argument themselves if they want.

Fixes https://github.com/google/jax/issues/1257
