### PR TITLE
FIX: do not use un-documented CPython functions

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1949,8 +1949,8 @@ public:
                 if (!release)
                     pybind11_fail("scoped_acquire::dec_ref(): internal error!");
             #endif
+            PyThreadState_Delete(tstate);
             PyThreadState_Clear(tstate);
-            PyThreadState_DeleteCurrent();
             PYBIND11_TLS_DELETE_VALUE(detail::get_internals().tstate);
             release = false;
         }


### PR DESCRIPTION
In python 3.9 PyThreadState_DeleteCurrent was removed, instead use
PyThreadState_Delete and pass it the current tstate we are working on.

Re-order the calls so that we PyThreadState_Delete can have access to
the state carried by tstate before we clear it.

closes #1932