### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -9,7 +9,7 @@ You can download and install pybind11 using the `vcpkg <https://github.com/Micro
 
 .. code-block:: bash
 
-    git clone https://github.com/microsoft/vcpkg.git
+    git clone https://github.com/Microsoft/vcpkg.git
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -3,20 +3,6 @@
 Build systems
 #############
 
-Building with vcpkg
-===================
-You can download and install pybind11 using the `vcpkg <https://github.com/Microsoft/vcpkg/>`_ dependency manager:
-
-.. code-block:: bash
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    vcpkg install pybind11
-
-The pybind11 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg/>`_ on the vcpkg repository.
-
 Building with setuptools
 ========================
 
@@ -404,6 +390,25 @@ build system that works on all platforms including Windows.
     software). In this way, the plugin will work with both versions, instead
     of possibly importing a second Python library into a process that already
     contains one (which will lead to a segfault).
+
+
+Building with vcpkg
+===================
+You can download and install pybind11 using the Microsoft `vcpkg
+<https://github.com/Microsoft/vcpkg/>`_ dependency manager:
+
+.. code-block:: bash
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install pybind11
+
+The pybind11 port in vcpkg is kept up to date by Microsoft team members and
+community contributors. If the version is out of date, please `create an issue
+or pull request <https://github.com/Microsoft/vcpkg/>`_ on the vcpkg
+repository.
 
 Generating binding code automatically
 =====================================

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -3,6 +3,20 @@
 Build systems
 #############
 
+Building with vcpkg
+===================
+You can download and install pybind11 using the `vcpkg <https://github.com/Microsoft/vcpkg/>`_ dependency manager:
+
+.. code-block:: bash
+
+    git clone https://github.com/microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install pybind11
+
+The pybind11 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg/>`_ on the vcpkg repository.
+
 Building with setuptools
 ========================
 


### PR DESCRIPTION
pybind11 is available as a port in vcpkg. Adding installation instructions will help users get started by providing a single command they can use to build pybind11 and include it into their projects