### PR TITLE
Fix build with -Wmissing-prototypes

### DIFF
--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -18,11 +18,13 @@
 
 #if PY_MAJOR_VERSION >= 3
 #  define PYBIND11_EMBEDDED_MODULE_IMPL(name)            \
+      extern "C" PyObject *pybind11_init_impl_##name();  \
       extern "C" PyObject *pybind11_init_impl_##name() { \
           return pybind11_init_wrapper_##name();         \
       }
 #else
 #  define PYBIND11_EMBEDDED_MODULE_IMPL(name)            \
+      extern "C" void pybind11_init_impl_##name();       \
       extern "C" void pybind11_init_impl_##name() {      \
           pybind11_init_wrapper_##name();                \
       }


### PR DESCRIPTION
When building with `-Werror,-Wmissing-prototypes`, `clang` complains about missing prototypes for functions defined through macro expansions. This PR adds the missing prototypes.

```
error: no previous prototype for function 'pybind11_init_impl_embedded' [
-Werror,-Wmissing-prototypes]                                           
PYBIND11_EMBEDDED_MODULE(embedded, mod) {                                             
^                                                                           
external/pybind11/include/pybind11/embed.h:61:5: note: expanded from macro 'PYBIND11_EMBEDDED_MODULE'
    PYBIND11_EMBEDDED_MODULE_IMPL(name)                                       \
    ^                                                                         
external/pybind11/include/pybind11/embed.h:26:23: note: expanded from macro 'PYBIND11_EMBEDDED_MODULE_IMPL'
      extern "C" void pybind11_init_impl_##name() {      \                  
                      ^                                             
<scratch space>:380:1: note: expanded from here                     
pybind11_init_impl_embedded                                                                                                                      
^                                                                                                                                                
1 error generated.
```