### PR TITLE
guard sized deallocation with features test macro

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1003,7 +1003,7 @@ void call_operator_delete(T *p, size_t s, size_t) { T::operator delete(p, s); }
 
 inline void call_operator_delete(void *p, size_t s, size_t a) {
     (void)s; (void)a;
-#if defined(PYBIND11_CPP17)
+#if defined(PYBIND11_CPP17) && defined(__cpp_sized_deallocation)
     if (a > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
         ::operator delete(p, s, std::align_val_t(a));
     else


### PR DESCRIPTION
This adds a additional compile-time check for sized deallocation support; fixing #1604:

- clang has sized deallocation disabled by default. [C++ Support in Clang](https://clang.llvm.org/cxx_status.html#n3778)
- checking the language standard version is not sufficient, so also check [`__cpp_sized_deallocation`](https://en.cppreference.com/w/User:D41D8CD98F/feature_testing_macros#C.2B.2B17)
- with this patch the work-around mentioned in #1604 using `-fsized-deallocation` is no longer necessary / required

## Reproducible example code

build the unit tests with clang and C++17  (here: cmake 3.14.5, clang 8.0.0):
```
$ cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++ -DPYBIND11_CPP_STANDARD=-std=c++17
$ cmake --build build
[...]
../include/pybind11/pybind11.h:1008:9: error: no matching function for call to 'operator delete'
[...]
```