### PR TITLE
Add additional flag to disable C++17 style delete on demand 

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1003,7 +1003,7 @@ void call_operator_delete(T *p, size_t s, size_t) { T::operator delete(p, s); }
 
 inline void call_operator_delete(void *p, size_t s, size_t a) {
     (void)s; (void)a;
-#if defined(PYBIND11_CPP17)
+#if defined(PYBIND11_CPP17) && !defined(PYBIND11_CPP17_NO_ALIGNED_DELETE)
     if (a > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
         ::operator delete(p, s, std::align_val_t(a));
     else


### PR DESCRIPTION
Add additional flag to disable C++17 style delete on demand.

Useful to compile with Operating System / compilers that do not fully support the C++17 specification yet. ( OSX 10.12, Nix / nixpkgs over OSX ).

