### PR TITLE
Fixing SystemError when nb_bool/nb_nonzero sets a Python exception in type_caster<bool>::load

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1173,6 +1173,9 @@ public:
                 value = (bool) res;
                 return true;
             }
+            else {
+                PyErr_Clear();
+            }
         }
         return false;
     }

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -318,11 +318,15 @@ def test_numpy_bool():
     import numpy as np
     convert, noconvert = m.bool_passthrough, m.bool_passthrough_noconvert
 
+    def cant_convert(v):
+        pytest.raises(TypeError, convert, v)
+
     # np.bool_ is not considered implicit
     assert convert(np.bool_(True)) is True
     assert convert(np.bool_(False)) is False
     assert noconvert(np.bool_(True)) is True
     assert noconvert(np.bool_(False)) is False
+    cant_convert(np.zeros(2, dtype='int'))
 
 
 def test_int_long():


### PR DESCRIPTION
If the error indicator is set by a failing conversion in `type_caster<bool>::load` (e.g., by trying to convert a `numpy.ndarray` of 2 or more values, resulting in `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`), the error is not noticed and Python complains that a non-NULL value is returned while an error has been set (`SystemError: [...] returned a result with an error set`).

This PR should fix that.

NOTE: Without the changes to `cast.h`, the newly added test fails:
```
terminate called after throwing an instance of 'pybind11::error_already_set'
  what():  SystemError: <class 'type'> returned a result with an error set
```
Is that not unexpected as well? Shouldn't all `error_already_set` exceptions be caught by pybind11?