### PR TITLE
cast: Add C++ -> pytype caster

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1693,8 +1693,8 @@ T cast(const handle &handle) {
 }
 
 // pytype -> pytype (calls converting constructor)
-template <typename T, detail::enable_if_t<detail::is_pyobject<T>::value, int> = 0>
-T cast(const handle &handle) { return T(reinterpret_borrow<object>(handle)); }
+template <typename Py, detail::enable_if_t<detail::is_pyobject<Py>::value, int> = 0>
+Py cast(const handle &handle) { return Py(reinterpret_borrow<object>(handle)); }
 
 // C++ type -> py::object
 template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
@@ -1705,6 +1705,15 @@ object cast(const T &value, return_value_policy policy = return_value_policy::au
     else if (policy == return_value_policy::automatic_reference)
         policy = std::is_pointer<T>::value ? return_value_policy::reference : return_value_policy::copy;
     return reinterpret_steal<object>(detail::make_caster<T>::cast(value, policy, parent));
+}
+
+// C++ type -> pytype (calls borrowing constructor on intermediate object)
+template <typename Py, typename T,
+          detail::enable_if_t<detail::is_pyobject<Py>::value, int> = 0,
+          detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
+Py cast(T&& value, return_value_policy policy = return_value_policy::automatic_reference,
+       handle parent = handle()) {
+    return reinterpret_borrow<Py>(cast(std::forward<T>(value), policy, parent));
 }
 
 template <typename T> T handle::cast() const { return pybind11::cast<T>(*this); }

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -281,4 +281,9 @@ TEST_SUBMODULE(stl, m) {
     py::class_<Issue1561Outer>(m, "Issue1561Outer")
         .def(py::init<>())
         .def_readwrite("list", &Issue1561Outer::list);
+
+    m.def("cast_vector_pytype", []() {
+        std::vector<int> my_floats = {1, 2, 3};
+        return py::cast<py::list>(my_floats);
+    });
 }

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -239,3 +239,7 @@ def test_issue_1561():
     bar.list = [m.Issue1561Inner('bar')]
     bar.list
     assert bar.list[0].data == 'bar'
+
+
+def test_cast_vector_pytype():
+    assert m.cast_vector_pytype() == [1, 2, 3]


### PR DESCRIPTION
Regarding Gitter conversation:
https://gitter.im/pybind/Lobby?at=5dd190b250010612b2d6e84a

I'm not sure if this is a completely desirable API, but seems OK at a first glance?
Although I couldn't figure out a way to easily test that the borrowing constructor was indeed called (wasn't sure of an easy way to implement refcounting...).

\cc @bstaletic 