### PR TITLE
Add AutoWIG to list of binding generators

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -289,9 +289,9 @@ code by introspecting existing C++ codebases using LLVM/Clang. See the
 .. [binder] http://cppbinder.readthedocs.io/en/latest/about.html
 
 [AutoWIG]_ is a Python library that wraps automatically compiled libraries into
-high-level languages. Our approach consists in parsing C++ code using LLVM/Clang
-technologies and generating the wrappers using the Mako templating engine. Our
-approach is automatic, extensible, and applies to very complex C++ libraries,
-composed of thousands of classes or incorporating modern meta-programming constructs.
+high-level languages. It parses C++ code using LLVM/Clang technologies and
+generates the wrappers using the Mako templating engine. The approach is automatic,
+extensible, and applies to very complex C++ libraries, composed of thousands of
+classes or incorporating modern meta-programming constructs.
 
 .. [AutoWIG] https://github.com/StatisKit/AutoWIG

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -287,3 +287,11 @@ code by introspecting existing C++ codebases using LLVM/Clang. See the
 [binder]_ documentation for details.
 
 .. [binder] http://cppbinder.readthedocs.io/en/latest/about.html
+
+[AutoWIG]_ is a Python library that wraps automatically compiled libraries into
+high-level languages. Our approach consists in parsing C++ code using LLVM/Clang
+technologies and generating the wrappers using the Mako templating engine. Our
+approach is automatic, extensible, and applies to very complex C++ libraries,
+composed of thousands of classes or incorporating modern meta-programming constructs.
+
+.. [AutoWIG] https://github.com/StatisKit/AutoWIG


### PR DESCRIPTION
I'm not associated with the AutoWIG project in any way, but I ran across it yesterday and played around with it a bit today. It does what it claims to do -- namely, spit out pybind11 bindings (the default appears to be boost.python). Unfortunately, the documentation is non-existent and to use it effectively it seems you really need to be a conda/scons user, but perhaps this little bump will help others find it and improve it.

I grabbed the text verbatim from their github site.

CC @pfernique (AutoWIG author)