### PR TITLE
Add memoryview constructors for PyMemoryView_FromMemory

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1353,6 +1353,17 @@ public:
             pybind11_fail("Unable to create memoryview from buffer descriptor");
     }
 
+    #if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 3)
+    explicit memoryview(const uint8_t* buffer, const Py_ssize_t len) {
+        m_ptr = PyMemoryView_FromMemory(
+            reinterpret_cast<char*>(const_cast<uint8_t*>(buffer)), len, PyBUF_READ);
+    }
+    explicit memoryview(uint8_t* buffer, const Py_ssize_t len) {
+        m_ptr = PyMemoryView_FromMemory(
+            reinterpret_cast<char*>(buffer), len, PyBUF_READ | PyBUF_WRITE);
+    }
+    #endif
+
     PYBIND11_OBJECT_CVT(memoryview, object, PyMemoryView_Check, PyMemoryView_FromObject)
 };
 /// @} pytypes


### PR DESCRIPTION
I was looking for a way to expose a simple `memoryview` to python, i.e. pointer + size without additional overhead. [PyMemoryView_FromMemory()](https://docs.python.org/3/c-api/memoryview.html#c.PyMemoryView_FromMemory) seems to be well suited for this, but pybind11 has no matching constructor for it.

I added two alternative constructors for `py::memoryview` using the FromMemory creator, allowing for read/write access or read-only if `const` classified.