### PR TITLE
Polymorphic type hook base

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -835,19 +835,25 @@ NAMESPACE_END(detail)
 // You may specialize polymorphic_type_hook yourself for types that want to appear
 // polymorphic to Python but do not use C++ RTTI. (This is a not uncommon pattern
 // in performance-sensitive applications, used most notably in LLVM.)
+//
+// polymorphic_type_hook_base allows users to specialize polymorphic_type_hook with
+// std::enable_if. User provided specializations will always have higher priority than
+// the default implementation and specialization provided in polymorphic_type_hook_base.
 template <typename itype, typename SFINAE = void>
-struct polymorphic_type_hook
+struct polymorphic_type_hook_base
 {
     static const void *get(const itype *src, const std::type_info*&) { return src; }
 };
 template <typename itype>
-struct polymorphic_type_hook<itype, detail::enable_if_t<std::is_polymorphic<itype>::value>>
+struct polymorphic_type_hook_base<itype, detail::enable_if_t<std::is_polymorphic<itype>::value>>
 {
     static const void *get(const itype *src, const std::type_info*& type) {
         type = src ? &typeid(*src) : nullptr;
         return dynamic_cast<const void*>(src);
     }
 };
+template <typename itype, typename SFINAE = void>
+struct polymorphic_type_hook : public polymorphic_type_hook_base<itype> {};
 
 NAMESPACE_BEGIN(detail)
 

--- a/tests/test_tagbased_polymorphic.cpp
+++ b/tests/test_tagbased_polymorphic.cpp
@@ -12,6 +12,12 @@
 
 struct Animal
 {
+    // Make this type also a "standard" polymorphic type, to confirm that
+    // specializing polymorphic_type_hook using enable_if_t still works
+    // (https://github.com/pybind/pybind11/pull/2016/).
+    virtual ~Animal() = default;
+
+    // Enum for tag-based polymorphism.
     enum class Kind {
         Unknown = 0,
         Dog = 100, Labrador, Chihuahua, LastDog = 199,


### PR DESCRIPTION
Allows users to specialize polymorphic_type_hook with std::enable_if.

Creating pull request on behalf of Ken Oslund (https://github.com/kenoslund-google), the original author of the changes.

Currently user specializations of the form

template struct polymorphic_type_hook<itype, std::enable_if_t<...>> { ... };

will fail if itype is also polymorphic, because the existing specialization will also
be enabled, which leads to 2 equally viable candidates. With this change, user provided
specializations have higher priority than the built in specialization for polymorphic types.