### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ matrix:
     - PY_CMD=python3
     - $PY_CMD -m pip install --user --upgrade pip wheel setuptools
     install:
-    - $PY_CMD -m pip install --user --upgrade sphinx sphinx_rtd_theme breathe flake8 pep8-naming pytest
+    # breathe 4.14 doesn't work with bit fields. See https://github.com/michaeljones/breathe/issues/462
+    - $PY_CMD -m pip install --user --upgrade sphinx sphinx_rtd_theme breathe==4.13.1 flake8 pep8-naming pytest
     - curl -fsSL https://sourceforge.net/projects/doxygen/files/rel-1.8.15/doxygen-1.8.15.linux.bin.tar.gz/download | tar xz
     - export PATH="$PWD/doxygen-1.8.15/bin:$PATH"
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,7 @@ matrix:
     env: PYTHON=2.7 CPP=14 CLANG CMAKE=1
   - os: osx
     name: Python 3.7, c++14, AppleClang 9, Debug build
-    osx_image: xcode9
+    osx_image: xcode9.4
     env: PYTHON=3.7 CPP=14 CLANG DEBUG=1
   # Test a PyPy 2.7 build
   - os: linux


### PR DESCRIPTION
Currently, breathe has a bug that breaks pybind CI. See https://github.com/michaeljones/breathe/issues/462

The other thing that is broken is `brew upgrade python` on osx 9. Switching the Travis image to 9.4 works.

cc @YannickJadoul 