### PR TITLE
Fixes #1295: Handle debug interpreter

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -103,7 +103,7 @@
 #  endif
 #  pragma warning(push)
 #  pragma warning(disable: 4510 4610 4512 4005)
-#  if defined(_DEBUG)
+#  if defined(_DEBUG) && !defined(Py_DEBUG)
 #    define PYBIND11_DEBUG_MARKER
 #    undef _DEBUG
 #  endif


### PR DESCRIPTION
If a debug interpreter is detected, we allow linking with
pythonXX_d.lib under windows.