### PR TITLE
Fix OS X aligned new for older MACOSX targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,10 @@ matrix:
     name: Python 3.7, c++14, AppleClang 9, Debug build
     osx_image: xcode9.4
     env: PYTHON=3.7 CPP=14 CLANG DEBUG=1
+  - os: osx
+    name: Python 3.7, c++17, AppleClang 9, Min OSX 10.9, Debug build
+    osx_image: xcode9.4
+    env: PYTHON=3.7 CPP=17 CLANG DEBUG=1 MACOSX_VERSION_MIN=10.9
   # Test a PyPy 2.7 build
   - os: linux
     dist: trusty

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -595,7 +595,8 @@ public:
             if (type->operator_new) {
                 vptr = type->operator_new(type->type_size);
             } else {
-                #if defined(__cpp_aligned_new) && (!defined(_MSC_VER) || _MSC_VER >= 1912)
+                #if defined(__cpp_aligned_new) && (!defined(_MSC_VER) || _MSC_VER >= 1912) \
+                    && (!defined(__APPLE__) || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 101200)
                     if (type->type_align > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
                         vptr = ::operator new(type->type_size,
                                               std::align_val_t(type->type_align));

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1003,7 +1003,8 @@ void call_operator_delete(T *p, size_t s, size_t) { T::operator delete(p, s); }
 
 inline void call_operator_delete(void *p, size_t s, size_t a) {
     (void)s; (void)a;
-    #if defined(__cpp_aligned_new) && (!defined(_MSC_VER) || _MSC_VER >= 1912)
+    #if defined(__cpp_aligned_new) && (!defined(_MSC_VER) || _MSC_VER >= 1912) \
+        && (!defined(__APPLE__) || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 101200)
         if (a > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
             #ifdef __cpp_sized_deallocation
                 ::operator delete(p, s, std::align_val_t(a));


### PR DESCRIPTION
It seems like Clang can compile the aligned new and delete, but then issues an error if compiling with OS X targets aiming at anything below OS X 10.12 (I assume the standard library of these older targets doesn't ship with the necessary functions).

It says: `error: call to unavailable function 'operator delete': introduced in macOS 10.12`
E.g. in this build log: https://travis-ci.com/wolfv/pygal/jobs/268938454

This happened to me on conda when compiling with `-std=c++17` enabled (as conda-forge seems to target an OS X version of 10.9 or 10.8 at the moment).

This is the LLVM PR https://reviews.llvm.org/D34556