### PR TITLE
Towards a solution for rvalue holder arguments in wrapped functions

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -287,3 +287,11 @@ code by introspecting existing C++ codebases using LLVM/Clang. See the
 [binder]_ documentation for details.
 
 .. [binder] http://cppbinder.readthedocs.io/en/latest/about.html
+
+[AutoWIG]_ is a Python library that wraps automatically compiled libraries into
+high-level languages. It parses C++ code using LLVM/Clang technologies and
+generates the wrappers using the Mako templating engine. The approach is automatic,
+extensible, and applies to very complex C++ libraries, composed of thousands of
+classes or incorporating modern meta-programming constructs.
+
+.. [AutoWIG] https://github.com/StatisKit/AutoWIG

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1995,6 +1995,8 @@ private:
 
     template <size_t... Is>
     bool load_impl_sequence(function_call &call, index_sequence<Is...>) {
+        // BUG: When loading the arguments, the actual argument type (pointer, lvalue reference, rvalue reference)
+        // is already lost (argcasters only know the intrinsic type), while the behaviour should differ for them, e.g. for rvalue references.
         for (bool r : {std::get<Is>(argcasters).load(call.args[Is], call.args_convert[Is])...})
             if (!r)
                 return false;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1515,15 +1515,86 @@ template <typename T>
 class type_caster<std::shared_ptr<T>> : public copyable_holder_caster<T, std::shared_ptr<T>> { };
 
 template <typename type, typename holder_type>
-struct move_only_holder_caster {
-    static_assert(std::is_base_of<type_caster_base<type>, type_caster<type>>::value,
+struct move_only_holder_caster : public type_caster_base<type> {
+public:
+    using base = type_caster_base<type>;
+    static_assert(std::is_base_of<base, type_caster<type>>::value,
             "Holder classes are only supported for custom types");
+    using base::base;
+    using base::cast;
+    using base::typeinfo;
+    using base::value;
 
-    static handle cast(holder_type &&src, return_value_policy, handle) {
-        auto *ptr = holder_helper<holder_type>::get(src);
-        return type_caster_base<type>::cast_holder(ptr, std::addressof(src));
+    bool load(handle& src, bool convert) {
+        bool success = base::template load_impl<move_only_holder_caster<type, holder_type>>(src, convert);
+        if (success) // if loading was successful, the instance needs to be withdrawn from src
+            // However, setting the src pointer to None is not sufficient.
+            src.ptr() = none().release().ptr();
+        return success;
     }
-    static constexpr auto name = type_caster_base<type>::name;
+
+    template <typename T> using cast_op_type = detail::movable_cast_op_type<T>;
+
+    explicit operator type*() { return this->value; }
+    explicit operator type&() { return *(this->value); }
+    explicit operator holder_type*() { return std::addressof(holder); }
+
+    // Workaround for Intel compiler bug
+    // see pybind11 issue 94
+    #if defined(__ICC) || defined(__INTEL_COMPILER)
+    operator holder_type&() { return holder; }
+    #else
+    explicit operator holder_type&() { return holder; }
+    #endif
+    explicit operator holder_type&&() { value = nullptr; return std::move(holder); }
+
+    static handle cast(const holder_type &src, return_value_policy, handle) {
+        const auto *ptr = holder_helper<holder_type>::get(src);
+        return type_caster_base<type>::cast_holder(ptr, &src);
+    }
+
+protected:
+    friend class type_caster_generic;
+    void check_holder_compat() {
+//        if (typeinfo->default_holder)
+//            throw cast_error("Unable to load a custom holder type from a default-holder instance");
+    }
+
+    bool load_value(value_and_holder &&v_h) {
+        if (v_h.holder_constructed()) {
+            value = v_h.value_ptr();
+            holder = std::move(v_h.template holder<holder_type>());
+            return true;
+        } else {
+            throw cast_error("Unable to cast from non-held to held instance (T& to Holder<T>) "
+#if defined(NDEBUG)
+                             "(compile in debug mode for type information)");
+#else
+                             "of type '" + type_id<holder_type>() + "''");
+#endif
+        }
+    }
+
+    template <typename T = holder_type, detail::enable_if_t<!std::is_constructible<T, const T &, type*>::value, int> = 0>
+    bool try_implicit_casts(handle, bool) { return false; }
+
+    template <typename T = holder_type, detail::enable_if_t<std::is_constructible<T, const T &, type*>::value, int> = 0>
+    bool try_implicit_casts(handle src, bool convert) {
+        for (auto &cast : typeinfo->implicit_casts) {
+            move_only_holder_caster sub_caster(*cast.first);
+            if (sub_caster.load(src, convert)) {
+                value = cast.second(sub_caster.value);
+                holder = holder_type(sub_caster.holder, (type *) value);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool try_direct_conversions(handle) { return false; }
+
+
+    holder_type holder;
 };
 
 template <typename type, typename deleter>

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1534,9 +1534,6 @@ public:
 
     template <typename T> using cast_op_type = detail::movable_cast_op_type<T>;
 
-    explicit operator type*() { return this->value; }
-    explicit operator type&() { return *(this->value); }
-
     // Workaround for Intel compiler bug
     // see pybind11 issue 94
     #if !defined(__ICC) && !defined(__INTEL_COMPILER)

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -567,23 +567,9 @@ public:
 
     // Base methods for generic caster; there are overridden in copyable_holder_caster
     void load_value(value_and_holder &&v_h) {
-        auto *&vptr = v_h.value_ptr();
-        // Lazy allocation for unallocated values:
-        if (vptr == nullptr) {
-            auto *type = v_h.type ? v_h.type : typeinfo;
-            if (type->operator_new) {
-                vptr = type->operator_new(type->type_size);
-            } else {
-                #if defined(PYBIND11_CPP17)
-                    if (type->type_align > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
-                        vptr = ::operator new(type->type_size,
-                                              (std::align_val_t) type->type_align);
-                    else
-                #endif
-                vptr = ::operator new(type->type_size);
-            }
-        }
-        value = vptr;
+        value = v_h.value_ptr();
+        if (value == nullptr)
+            throw cast_error("Invalid object instance");
     }
     bool try_implicit_casts(handle src, bool convert) {
         for (auto &cast : typeinfo->implicit_casts) {
@@ -1528,7 +1514,7 @@ public:
     bool load(handle& src, bool convert) {
         bool success = base::template load_impl<move_only_holder_caster<type, holder_type>>(src, convert);
         if (success) // On success, remember src pointer to withdraw later
-            src_handle = std::addressof(src);
+            this->v_h = reinterpret_cast<instance *>(src.ptr())->get_value_and_holder();
         return success;
     }
 
@@ -1540,6 +1526,10 @@ public:
     explicit
     #endif
     operator holder_type&&() {
+        // In load_value() value_ptr was still valid. If it's invalid now, another argument consumed the same value before.
+        if (!v_h.value_ptr())
+            throw cast_error("Multiple access to moved argument");
+        v_h.value_ptr() = nullptr;
         // TODO: release object instance in python
         // clear_instance(src_handle->ptr()); ???
 
@@ -1562,6 +1552,8 @@ protected:
         if (v_h.holder_constructed()) {
             holder_ptr = std::addressof(v_h.template holder<holder_type>());
             value = const_cast<void*>(reinterpret_cast<const void*>(holder_helper<holder_type>::get(*holder_ptr)));
+            if (!value)
+                throw cast_error("Invalid object instance");
             return true;
         } else {
             throw cast_error("Unable to cast from non-held to held instance (T& to Holder<T>) "
@@ -1583,7 +1575,7 @@ protected:
 
 
     holder_type* holder_ptr = nullptr;
-    handle* src_handle = nullptr;
+    value_and_holder v_h;
 };
 
 template <typename type, typename deleter>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,7 +151,7 @@ function(pybind11_enable_warnings target_name)
   endif()
 endfunction()
 
-set(test_targets pybind11_tests)
+set(test_targets pybind11_tests test_move_arg)
 
 # Build pybind11_cross_module_tests if any test_whatever.py are being built that require it
 foreach(t ${PYBIND11_CROSS_MODULE_TESTS})

--- a/tests/test_move_arg.cpp
+++ b/tests/test_move_arg.cpp
@@ -59,5 +59,8 @@ PYBIND11_MODULE(test_move_arg, m) {
 		std::cout << "  old: " << item.get() << "\n  new: " << *sink.get() << "\n";
 	}, py::call_guard<py::scoped_ostream_redirect>());
 
+	m.def("consume_twice", [](my_ptr<Item>&& /*first*/, my_ptr<Item>&& /*second*/) {
+	}, py::call_guard<py::scoped_ostream_redirect>());
+
 	m.def("consume_str", [](std::string&& s) { std::string o(std::move(s)); });
 }

--- a/tests/test_move_arg.cpp
+++ b/tests/test_move_arg.cpp
@@ -1,0 +1,31 @@
+#include "test_move_arg.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/iostream.h>
+#include <sstream>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(test_move_arg, m) {
+	py::class_<Item>(m, "Item")
+		.def(py::init<int>(), py::call_guard<py::scoped_ostream_redirect>())
+		.def("__repr__", [](const Item& item) {
+			std::stringstream ss;
+			ss << "py " << item;
+			return ss.str();
+		}, py::call_guard<py::scoped_ostream_redirect>());
+
+	m.def("access", [](const Item& item) {
+		std::cout << "access " << item << "\n";
+	}, py::call_guard<py::scoped_ostream_redirect>());
+
+#if 0 // rvalue arguments fail during compilation
+	m.def("consume", [](Item&& item) {
+		std::cout << "consume " << item << "\n  ";
+		Item sink(std::move(item));
+		std::cout << "  old: " << item << "\n  new: " << sink << "\n";
+	}, py::call_guard<py::scoped_ostream_redirect>());
+#endif
+
+	m.def("working", [](int&& a) { std::cout << a << "\n"; },
+	      py::call_guard<py::scoped_ostream_redirect>());
+}

--- a/tests/test_move_arg.cpp
+++ b/tests/test_move_arg.cpp
@@ -26,6 +26,11 @@ PYBIND11_MODULE(test_move_arg, m) {
 	}, py::call_guard<py::scoped_ostream_redirect>());
 #endif
 
-	m.def("working", [](int&& a) { std::cout << a << "\n"; },
-	      py::call_guard<py::scoped_ostream_redirect>());
+	m.def("consume", [](std::unique_ptr<Item>&& item) {
+		std::cout << "consume " << *item.get() << "\n";
+		std::unique_ptr<Item> sink(std::move(item));
+		std::cout << "  old: " << item.get() << "\n  new: " << *sink.get() << "\n";
+	}, py::call_guard<py::scoped_ostream_redirect>());
+
+	m.def("consume_str", [](std::string&& s) { std::string o(std::move(s)); });
 }

--- a/tests/test_move_arg.h
+++ b/tests/test_move_arg.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <memory>
+#include <vector>
+#include <iostream>
+
+class Item;
+std::ostream& operator<<(std::ostream& os, const Item& item);
+
+/** Item class requires unique instances, i.e. only supports move construction */
+class Item
+{
+public:
+  Item(int value) : value_(std::make_unique<int>(value)) {
+    std::cout<< "new " << *this << "\n";
+  }
+  ~Item() {
+    std::cout << "destroy " << *this << "\n";
+  }
+  Item(const Item&) = delete;
+  Item(Item&& other) {
+    std::cout << "move " << other << " -> ";
+    value_ = std::move(other.value_);
+    std::cout << *this << "\n";
+  }
+
+  std::unique_ptr<int> value_;
+};
+
+std::ostream& operator<<(std::ostream& os, const Item& item) {
+  os << "item " << &item << "(";
+  if (item.value_) os << *item.value_;
+  os << ")";
+  return os;
+}

--- a/tests/test_move_arg.py
+++ b/tests/test_move_arg.py
@@ -10,14 +10,17 @@ def test():
     del item
     print(other)
 
-def test_produce():
+def test_consume():
     item = Item(42)
-    access(item)
     consume(item)
-    access(item)
+    access(item)  # should raise, because item is accessed after consumption
+
+def test_consume_twice():
+    item = Item(42)
+    consume_twice(item, item) # should raise, because item is consumed twice
 
 def test_foo():
     foo()
 
 if __name__ == "__main__":
-    test_produce()
+    test_consume()

--- a/tests/test_move_arg.py
+++ b/tests/test_move_arg.py
@@ -1,0 +1,14 @@
+import pytest
+from test_move_arg import Item, access
+
+
+def test():
+    item = Item(42)
+    other = item
+    access(item)
+    print(item)
+    del item
+    print(other)
+
+if __name__ == "__main__":
+    test()

--- a/tests/test_move_arg.py
+++ b/tests/test_move_arg.py
@@ -1,5 +1,5 @@
 import pytest
-from test_move_arg import Item, access
+from test_move_arg import *
 
 
 def test():
@@ -10,5 +10,14 @@ def test():
     del item
     print(other)
 
+def test_produce():
+    item = Item(42)
+    access(item)
+    consume(item)
+    access(item)
+
+def test_foo():
+    foo()
+
 if __name__ == "__main__":
-    test()
+    test_produce()


### PR DESCRIPTION
In #2040 I was complaining about a fundamental issue in pybind11, namely that rvalue function arguments (of custom types and particularly of `std::unique_ptr`) are not supported, i.e. the following function cannot be wrapped:
```c++
void consume(std::unique_ptr<CustomType>&& holder) {
  CustomType sink(std::move(*holder.release());
}
```
As this is a major blocker for my project to transition from boost::python to pybind11, I tried to investigate the issue in more detail.
It looks like, that a major design decision was to _explicitly_ forbid transferring ownership from python to C++. This allows maintaining a [_raw_ `value` pointer](https://github.com/pybind/pybind11/blob/f9f3bd711f266c435fa7cd8198e5696e3fb37eef/include/pybind11/detail/common.h#L400-L422) (in addition to the `holder`) for fast and direct access to the raw pointer. (I noticed that the holder's `get()` is only rarely called.)

If you are not willing to support this important use case, you should explicitly state this fact very prominently on some main documentation page(s). However, I hope that you _will_ add this feature in the future as pybind11 is a great replacement for boost::python, [providing many benefits](https://pybind11.readthedocs.io/en/stable/intro.html#goodies) and exhibiting much better code readability.

The above-mentioned design decision becomes noticeable - amongst other things - by the fact that [`move_only_holder_casters`](https://github.com/pybind/pybind11/blob/f9f3bd711f266c435fa7cd8198e5696e3fb37eef/include/pybind11/cast.h#L1559-L1569) do not support _loading_ of arguments and thus conversion from python to C++ is not possible for move-only holder types. 
The commits of this PR replace the existing implementation of `move_only_holder_caster` with that of `copyable_holder_caster` (with some minor tweaks), which essentially enables the requested feature. 
However, a major caveat remains: The holder pointer remains accessible after moving, while it should become `None` and thus raise an exception if accessed again. I tried to accomplish this [here](https://github.com/pybind/pybind11/commit/16bb1838ac59066a1e674844ed5e81c9ccc099a6#diff-e0d8df3cdf4b37acbf5e8712fb6ce80cR1532), but it didn't have the desired effect - I guess because pybind11 mainly accesses object instances by their raw value pointers instead of going through the holder.

Another major caveat comes from the overload-resolution process: During this process, several function overloads are tried to match in sequence, each one requiring to load the python arguments into the `type_caster`. However, this loading process already [_moves_ the holder into the caster](https://github.com/pybind/pybind11/commit/16bb1838ac59066a1e674844ed5e81c9ccc099a6#diff-e0d8df3cdf4b37acbf5e8712fb6ce80cR1566) and thus is only possible once.