### PR TITLE
[WIP] Towards a solution for custom-type rvalue arguments

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -644,6 +644,10 @@ public:
     // static_cast works around compiler error with MSVC 17 and CUDA 10.2
     // see issue #2180
     explicit operator type&() { return *(static_cast<type *>(this->value)); }
+
+    // holders only support copying, not moving
+    template <typename T> using cast_op_type = detail::cast_op_type<T>;
+
     explicit operator holder_type*() { return std::addressof(holder); }
     explicit operator holder_type&() { return holder; }
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -912,10 +912,12 @@ public:
             nullptr, nullptr, holder);
     }
 
-    template <typename T> using cast_op_type = detail::cast_op_type<T>;
+    // allow moving of custom types
+    template <typename T> using cast_op_type = detail::movable_cast_op_type<T>;
 
     operator itype*() { return (type *) value; }
     operator itype&() { if (!value) throw reference_cast_error(); return *((itype *) value); }
+    operator itype&&() && { if (!value) throw reference_cast_error(); return std::move(*((itype *) value)); }
 
 protected:
     using Constructor = void *(*)(const void *);

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -346,7 +346,7 @@ public:
 
     operator Type*() { return &value; }
     operator Type&() { return value; }
-    operator Type&&() && { return std::move(value); }
+    operator Type&&() { return std::move(value); }
     template <typename T> using cast_op_type = movable_cast_op_type<T>;
 
 private:

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -421,6 +421,7 @@ TEST_SUBMODULE(class_, m) {
     // test_exception_rvalue_abort
     struct PyPrintDestructor {
         PyPrintDestructor() = default;
+        PyPrintDestructor(const PyPrintDestructor&) = default;
         ~PyPrintDestructor() {
             py::print("Print from destructor");
         }

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -111,10 +111,10 @@ TEST_SUBMODULE(copy_move_policies, m) {
     // test_move_and_copy_casts
     m.def("move_and_copy_casts", [](py::object o) {
         int r = 0;
-        r += py::cast<MoveOrCopyInt>(o).value; /* moves */
+        r += py::cast<MoveOrCopyInt>(o).value; /* copies */
         r += py::cast<MoveOnlyInt>(o).value; /* moves */
         r += py::cast<CopyOnlyInt>(o).value; /* copies */
-        auto m1(py::cast<MoveOrCopyInt>(o)); /* moves */
+        auto m1(py::cast<MoveOrCopyInt>(o)); /* copies */
         auto m2(py::cast<MoveOnlyInt>(o)); /* moves */
         auto m3(py::cast<CopyOnlyInt>(o)); /* copies */
         r += m1.value + m2.value + m3.value;
@@ -124,7 +124,8 @@ TEST_SUBMODULE(copy_move_policies, m) {
 
     // test_move_and_copy_loads
     m.def("move_only", [](MoveOnlyInt m) { return m.value; });
-    m.def("move_or_copy", [](MoveOrCopyInt m) { return m.value; });
+    m.def("move", [](MoveOrCopyInt&& m) { return m.value; });
+    m.def("copy", [](MoveOrCopyInt m) { return m.value; });
     m.def("copy_only", [](CopyOnlyInt m) { return m.value; });
     m.def("move_pair", [](std::pair<MoveOnlyInt, MoveOrCopyInt> p) {
         return p.first.value + p.second.value;
@@ -184,15 +185,10 @@ TEST_SUBMODULE(copy_move_policies, m) {
 #ifdef PYBIND11_HAS_OPTIONAL
     // test_move_and_copy_load_optional
     m.attr("has_optional") = true;
-    m.def("move_optional", [](std::optional<MoveOnlyInt> o) {
-        return o->value;
-    });
-    m.def("move_or_copy_optional", [](std::optional<MoveOrCopyInt> o) {
-        return o->value;
-    });
-    m.def("copy_optional", [](std::optional<CopyOnlyInt> o) {
-        return o->value;
-    });
+    m.def("move_optional", [](std::optional<MoveOnlyInt> o) { return o->value; });
+    m.def("mc_move_optional", [](std::optional<MoveOrCopyInt>&& o) { return o->value; });
+    m.def("mc_copy_optional", [](std::optional<MoveOrCopyInt> o) { return o->value; });
+    m.def("copy_optional", [](std::optional<CopyOnlyInt> o) { return o->value; });
     m.def("move_optional_tuple", [](std::optional<std::tuple<MoveOrCopyInt, MoveOnlyInt, CopyOnlyInt>> x) {
         return std::get<0>(*x).value + std::get<1>(*x).value + std::get<2>(*x).value;
     });

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -34,11 +34,10 @@ struct lacking_move_ctor : public empty<lacking_move_ctor> {
 template <> lacking_move_ctor empty<lacking_move_ctor>::instance_ = {};
 
 /* Custom type caster move/copy test classes */
-class MoveOnlyInt {
-public:
-    MoveOnlyInt() { print_default_created(this); }
-    MoveOnlyInt(int v) : value{std::move(v)} { print_created(this, value); }
-    MoveOnlyInt(MoveOnlyInt &&m) { print_move_created(this, m.value); std::swap(value, m.value); }
+struct MoveOnlyInt {
+    MoveOnlyInt() : value{42} { print_default_created(this); }
+    MoveOnlyInt(int v) : value{v} { print_created(this, value); }
+    MoveOnlyInt(MoveOnlyInt &&m) : value{-1} { print_move_created(this, m.value); std::swap(value, m.value); }
     MoveOnlyInt &operator=(MoveOnlyInt &&m) { print_move_assigned(this, m.value); std::swap(value, m.value); return *this; }
     MoveOnlyInt(const MoveOnlyInt &) = delete;
     MoveOnlyInt &operator=(const MoveOnlyInt &) = delete;
@@ -46,11 +45,10 @@ public:
 
     int value;
 };
-class MoveOrCopyInt {
-public:
-    MoveOrCopyInt() { print_default_created(this); }
-    MoveOrCopyInt(int v) : value{std::move(v)} { print_created(this, value); }
-    MoveOrCopyInt(MoveOrCopyInt &&m) { print_move_created(this, m.value); std::swap(value, m.value); }
+struct MoveOrCopyInt {
+    MoveOrCopyInt() : value{42} { print_default_created(this); }
+    MoveOrCopyInt(int v) : value{v} { print_created(this, value); }
+    MoveOrCopyInt(MoveOrCopyInt &&m) : value{-1} { print_move_created(this, m.value); std::swap(value, m.value); }
     MoveOrCopyInt &operator=(MoveOrCopyInt &&m) { print_move_assigned(this, m.value); std::swap(value, m.value); return *this; }
     MoveOrCopyInt(const MoveOrCopyInt &c) { print_copy_created(this, c.value); value = c.value; }
     MoveOrCopyInt &operator=(const MoveOrCopyInt &c) { print_copy_assigned(this, c.value); value = c.value; return *this; }
@@ -58,16 +56,16 @@ public:
 
     int value;
 };
-class CopyOnlyInt {
-public:
-    CopyOnlyInt() { print_default_created(this); }
-    CopyOnlyInt(int v) : value{std::move(v)} { print_created(this, value); }
+struct CopyOnlyInt {
+    CopyOnlyInt() : value{42} { print_default_created(this); }
+    CopyOnlyInt(int v) : value{v} { print_created(this, value); }
     CopyOnlyInt(const CopyOnlyInt &c) { print_copy_created(this, c.value); value = c.value; }
     CopyOnlyInt &operator=(const CopyOnlyInt &c) { print_copy_assigned(this, c.value); value = c.value; return *this; }
     ~CopyOnlyInt() { print_destroyed(this); }
 
     int value;
 };
+
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
 template <> struct type_caster<MoveOnlyInt> {
@@ -156,6 +154,33 @@ TEST_SUBMODULE(copy_move_policies, m) {
         d["CopyOnlyInt"] = py::cast(co, py::return_value_policy::reference);
         return d;
     });
+
+    // test_move_copy_class_loads: similar tests as above, but with types exposed to python
+    struct MoveOnlyIntC : MoveOnlyInt { using MoveOnlyInt::MoveOnlyInt; };
+    py::class_<MoveOnlyIntC>(m, "MoveOnlyInt")
+        .def(py::init<int>())
+        .def_readonly("value", &MoveOnlyIntC::value)
+        .def_static("val", [](MoveOnlyIntC v) { return v.value; })
+        .def_static("rref", [](MoveOnlyIntC&& v) { MoveOnlyIntC sink(std::move(v)); return sink.value; })
+        .def_static("lref", [](const MoveOnlyIntC& v) { return v.value; })
+        ;
+    struct MoveOrCopyIntC : MoveOrCopyInt { using MoveOrCopyInt::MoveOrCopyInt; };
+    py::class_<MoveOrCopyIntC>(m, "MoveOrCopyInt")
+        .def(py::init<int>())
+        .def_readonly("value", &MoveOrCopyIntC::value)
+        .def_static("val", [](MoveOrCopyIntC v) { return v.value; })
+        .def_static("rref", [](MoveOrCopyIntC&& v) {  MoveOrCopyIntC sink(std::move(v)); return sink.value; })
+        .def_static("lref", [](const MoveOrCopyIntC& v) { return v.value; })
+        ;
+    struct CopyOnlyIntC : CopyOnlyInt { using CopyOnlyInt::CopyOnlyInt; };
+    py::class_<CopyOnlyIntC>(m, "CopyOnlyInt")
+        .def(py::init<int>())
+        .def_readonly("value", &CopyOnlyIntC::value)
+        .def_static("val", [](CopyOnlyIntC v) { return v.value; })
+        .def_static("rref", [](CopyOnlyIntC&& v) {  CopyOnlyIntC sink(std::move(v)); return sink.value; })
+        .def_static("lref", [](const CopyOnlyIntC& v) { return v.value; })
+        ;
+
 #ifdef PYBIND11_HAS_OPTIONAL
     // test_move_and_copy_load_optional
     m.attr("has_optional") = true;

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -20,9 +20,7 @@ def test_move_and_copy_casts():
 
     cstats = m.move_and_copy_cstats()
     c_m, c_mc, c_c = (
-        cstats["MoveOnlyInt"],
-        cstats["MoveOrCopyInt"],
-        cstats["CopyOnlyInt"],
+        cstats[name] for name in ["MoveOnlyInt", "MoveOrCopyInt", "CopyOnlyInt"]
     )
 
     # The type move constructions/assignments below each get incremented: the move assignment comes
@@ -48,9 +46,7 @@ def test_move_and_copy_loads():
 
     cstats = m.move_and_copy_cstats()
     c_m, c_mc, c_c = (
-        cstats["MoveOnlyInt"],
-        cstats["MoveOrCopyInt"],
-        cstats["CopyOnlyInt"],
+        cstats[name] for name in ["MoveOnlyInt", "MoveOrCopyInt", "CopyOnlyInt"]
     )
 
     assert m.move_only(10) == 10  # 1 move, c_m
@@ -74,15 +70,43 @@ def test_move_and_copy_loads():
     assert c_m.alive() + c_mc.alive() + c_c.alive() == 0
 
 
+def test_move_copy_class_loads():
+    """Call some functions that load custom type arguments and count the number of moves/copies"""
+
+    cs = m.move_and_copy_cstats()["MoveOnlyInt"]
+    o = m.MoveOnlyInt(3)
+    assert m.MoveOnlyInt.val(o) == 3
+    assert o.value == -1  # value becomes -1 after moving
+    o = m.MoveOnlyInt(4)
+    assert m.MoveOnlyInt.lref(o) == 4
+    assert m.MoveOnlyInt.rref(o) == 4
+    assert o.value == -1  # value becomes -1 after moving
+    assert (cs.copy_constructions, cs.move_constructions) == (0, 2)
+
+    cs = m.move_and_copy_cstats()["MoveOrCopyInt"]
+    o = m.MoveOrCopyInt(3)
+    assert m.MoveOrCopyInt.val(o) == 3
+    assert m.MoveOrCopyInt.lref(o) == 3
+    assert m.MoveOrCopyInt.rref(o) == 3
+    assert o.value == -1  # value becomes -1 after moving
+    assert (cs.copy_constructions, cs.move_constructions) == (1, 1)
+
+    cs = m.move_and_copy_cstats()["CopyOnlyInt"]
+    o = m.CopyOnlyInt(3)
+    assert m.CopyOnlyInt.val(o) == 3
+    assert m.CopyOnlyInt.lref(o) == 3
+    assert m.CopyOnlyInt.rref(o) == 3  # copies as well
+    assert o.value == 3  # value hasn't change
+    assert (cs.copy_constructions, cs.move_constructions) == (2, 0)
+
+
 @pytest.mark.skipif(not m.has_optional, reason="no <optional>")
 def test_move_and_copy_load_optional():
     """Tests move/copy loads of std::optional arguments"""
 
     cstats = m.move_and_copy_cstats()
     c_m, c_mc, c_c = (
-        cstats["MoveOnlyInt"],
-        cstats["MoveOrCopyInt"],
-        cstats["CopyOnlyInt"],
+        cstats[name] for name in ["MoveOnlyInt", "MoveOrCopyInt", "CopyOnlyInt"]
     )
 
     # The extra move/copy constructions below come from the std::optional move (which has to move

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -26,14 +26,15 @@ def test_move_and_copy_casts():
     # The type move constructions/assignments below each get incremented: the move assignment comes
     # from the type_caster load; the move construction happens when extracting that via a cast or
     # loading into an argument.
-    assert m.move_and_copy_casts(3) == 18
+    assert m.move_and_copy_casts(3) == 6 * 3
     assert c_m.copy_assignments + c_m.copy_constructions == 0
     assert c_m.move_assignments == 2
     assert c_m.move_constructions >= 2
     assert c_mc.alive() == 0
-    assert c_mc.copy_assignments + c_mc.copy_constructions == 0
+    assert c_mc.copy_assignments == 0
+    assert c_mc.copy_constructions == 2
     assert c_mc.move_assignments == 2
-    assert c_mc.move_constructions >= 2
+    assert c_mc.move_constructions == 0
     assert c_c.alive() == 0
     assert c_c.copy_assignments == 2
     assert c_c.copy_constructions >= 2
@@ -50,21 +51,23 @@ def test_move_and_copy_loads():
     )
 
     assert m.move_only(10) == 10  # 1 move, c_m
-    assert m.move_or_copy(11) == 11  # 1 move, c_mc
+    assert m.move(10) == 10  # 0 move (just ref), c_mc
+    assert m.copy(11) == 11  # 1 copy, c_mc
     assert m.copy_only(12) == 12  # 1 copy, c_c
-    assert m.move_pair((13, 14)) == 27  # 1 c_m move, 1 c_mc move
-    assert m.move_tuple((15, 16, 17)) == 48  # 2 c_m moves, 1 c_mc move
+    assert m.move_pair((13, 14)) == 27  # 1 c_m move, 1 c_mc copy
+    assert m.move_tuple((15, 16, 17)) == 48  # 2 c_m moves, 1 c_mc copy
     assert m.copy_tuple((18, 19)) == 37  # 2 c_c copies
-    # Direct constructions: 2 c_m moves, 2 c_mc moves, 1 c_c copy
+    # Direct constructions: 2 c_m moves, 2 c_mc copies, 1 c_c copy
     # Extra moves/copies when moving pairs/tuples: 3 c_m, 3 c_mc, 2 c_c
     assert m.move_copy_nested((1, ((2, 3, (4,)), 5))) == 15
 
     assert c_m.copy_assignments + c_m.copy_constructions == 0
     assert c_m.move_assignments == 6
     assert c_m.move_constructions == 9
-    assert c_mc.copy_assignments + c_mc.copy_constructions == 0
-    assert c_mc.move_assignments == 5
-    assert c_mc.move_constructions == 8
+    assert c_mc.copy_assignments == 0
+    assert c_mc.copy_constructions == 5
+    assert c_mc.move_assignments == 6
+    assert c_mc.move_constructions == 3
     assert c_c.copy_assignments == 4
     assert c_c.copy_constructions == 6
     assert c_m.alive() + c_mc.alive() + c_c.alive() == 0
@@ -111,8 +114,9 @@ def test_move_and_copy_load_optional():
 
     # The extra move/copy constructions below come from the std::optional move (which has to move
     # its arguments):
-    assert m.move_optional(10) == 10  # c_m: 1 move assign, 2 move construct
-    assert m.move_or_copy_optional(11) == 11  # c_mc: 1 move assign, 2 move construct
+    assert m.move_optional(10) == 10  # c_m: 1 move assign, +1 move construct
+    assert m.mc_move_optional(10) == 10  # c_mc: 1 move assign, +0 move construct
+    assert m.mc_copy_optional(11) == 11  # c_mc: 1 move assign, 1 copy construct
     assert m.copy_optional(12) == 12  # c_c: 1 copy assign, 2 copy construct
     # 1 move assign + move construct moves each of c_m, c_mc, 1 c_c copy
     # +1 move/copy construct each from moving the tuple
@@ -122,9 +126,10 @@ def test_move_and_copy_load_optional():
     assert c_m.copy_assignments + c_m.copy_constructions == 0
     assert c_m.move_assignments == 2
     assert c_m.move_constructions == 5
-    assert c_mc.copy_assignments + c_mc.copy_constructions == 0
-    assert c_mc.move_assignments == 2
-    assert c_mc.move_constructions == 5
+    assert c_mc.copy_assignments == 0
+    assert c_mc.copy_constructions == 2
+    assert c_mc.move_assignments == 3
+    assert c_mc.move_constructions == 4
     assert c_c.copy_assignments == 2
     assert c_c.copy_constructions == 5
     assert c_m.alive() + c_mc.alive() + c_c.alive() == 0

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -244,7 +244,7 @@ def test_args_refcount():
     myval = 54321
     expected = refcount(myval)
     assert m.arg_refcount_h(myval) == expected
-    assert m.arg_refcount_o(myval) == expected + 1
+    assert m.arg_refcount_o(myval) == expected + 2
     assert m.arg_refcount_h(myval) == expected
     assert refcount(myval) == expected
 
@@ -280,6 +280,6 @@ def test_args_refcount():
     # for the `py::args`; in the previous case, we could simply inc_ref and pass on Python's input
     # tuple without having to inc_ref the individual elements, but here we can't, hence the extra
     # refs.
-    assert m.mixed_args_refcount(myval, myval, myval) == (exp3 + 3, exp3 + 3, exp3 + 3)
+    assert m.mixed_args_refcount(myval, myval, myval) == (exp3 + 4, exp3 + 4, exp3 + 4)
 
     assert m.class_default_argument() == "<class 'decimal.Decimal'>"

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -206,6 +206,7 @@ TEST_SUBMODULE(numpy_array, sm) {
     struct ArrayClass {
         int data[2] = { 1, 2 };
         ArrayClass() { py::print("ArrayClass()"); }
+        ArrayClass(const ArrayClass&) = default;
         ~ArrayClass() { py::print("~ArrayClass()"); }
     };
     py::class_<ArrayClass>(sm, "ArrayClass")

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -161,6 +161,7 @@ public:
 class MyObject5 { // managed by huge_unique_ptr
 public:
     MyObject5(int value) : value{value} { print_created(this); }
+    MyObject5(const MyObject5&) = default;
     ~MyObject5() { print_destroyed(this); }
     int value;
 };
@@ -220,6 +221,7 @@ struct TypeForHolderWithAddressOf {
 // test_move_only_holder_with_addressof_operator
 struct TypeForMoveOnlyHolderWithAddressOf {
     TypeForMoveOnlyHolderWithAddressOf(int value) : value{value} { print_created(this); }
+    TypeForMoveOnlyHolderWithAddressOf(const TypeForMoveOnlyHolderWithAddressOf&) = default;
     ~TypeForMoveOnlyHolderWithAddressOf() { print_destroyed(this); }
     std::string toString() const {
         return "MoveOnlyHolderWithAddressOf[" + std::to_string(value) + "]";


### PR DESCRIPTION
pybind11 doesn't support rvalue function arguments for custom types, i.e. the following function cannot be wrapped:
```c++
void consume(CustomType&& object) {
  CustomType sink(std::move(object));
}
```
This issue is (more or less) unrelated to rvalue holder arguments as requested e.g. in #2040 or #2583.
While moving holder arguments essentially transfers ownership from python to C++, which is admittedly difficult, supporting functions like above shouldn't pose a conceptual problem:
The original object instance remains existing in python, but only its _internals_ are moved over to C++.

Currently, this use case is not supported, because the `cast_op_type` provided by `type_caster_base<T>` doesn't support moving. [Replacing it with `movable_cast_op_type<T>`](https://github.com/pybind/pybind11/commit/fb0ecaa0ec28528fac6138048831eaafb0eab9e8#diff-e0d8df3cdf4b37acbf5e8712fb6ce80cR883) and [providing a corresponding cast operator](https://github.com/pybind/pybind11/commit/fb0ecaa0ec28528fac6138048831eaafb0eab9e8#diff-e0d8df3cdf4b37acbf5e8712fb6ce80cR887) already solves the problem for my example.

However, this solution makes moving preferred over copying, which isn't desired either.
**EDIT:** A major rework of this PR solves this issue, see https://github.com/pybind/pybind11/pull/2047#issuecomment-724256796 and https://github.com/pybind/pybind11/pull/2047#issuecomment-791916065 for more details.