### PR TITLE
Allow perfect forwarding of method args

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -75,14 +75,14 @@ public:
     /// Construct a cpp_function from a class method (non-const)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     cpp_function(Return (Class::*f)(Arg...), const Extra&... extra) {
-        initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(args...); },
+        initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
                    (Return (*) (Class *, Arg...)) nullptr, extra...);
     }
 
     /// Construct a cpp_function from a class method (const)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     cpp_function(Return (Class::*f)(Arg...) const, const Extra&... extra) {
-        initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(args...); },
+        initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
                    (Return (*)(const Class *, Arg ...)) nullptr, extra...);
     }
 

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -21,6 +21,7 @@ public:
     ExampleMandA() { print_default_created(this); }
     ExampleMandA(int value) : value(value) { print_created(this, value); }
     ExampleMandA(const ExampleMandA &e) : value(e.value) { print_copy_created(this); }
+    ExampleMandA(std::string&&) {}
     ExampleMandA(ExampleMandA &&e) : value(e.value) { print_move_created(this); }
     ~ExampleMandA() { print_destroyed(this); }
 
@@ -42,6 +43,8 @@ public:
     void add8(const int &other) { value += other; }                 // passing by const reference
     void add9(int *other) { value += *other; }                      // passing by pointer
     void add10(const int *other) { value += *other; }               // passing by const pointer
+
+    void consume_str(std::string&&) {}
 
     ExampleMandA self1() { return *this; }                          // return by value
     ExampleMandA &self2() { return *this; }                         // return by reference
@@ -212,6 +215,7 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     py::class_<ExampleMandA> emna(m, "ExampleMandA");
     emna.def(py::init<>())
         .def(py::init<int>())
+        .def(py::init<std::string&&>())
         .def(py::init<const ExampleMandA&>())
         .def("add1", &ExampleMandA::add1)
         .def("add2", &ExampleMandA::add2)
@@ -223,6 +227,7 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         .def("add8", &ExampleMandA::add8)
         .def("add9", &ExampleMandA::add9)
         .def("add10", &ExampleMandA::add10)
+        .def("consume_str", &ExampleMandA::consume_str)
         .def("self1", &ExampleMandA::self1)
         .def("self2", &ExampleMandA::self2)
         .def("self3", &ExampleMandA::self3)

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -58,8 +58,8 @@ def test_methods_and_attributes():
     assert cstats.alive() == 0
     assert cstats.values() == ["32"]
     assert cstats.default_constructions == 1
-    assert cstats.copy_constructions == 3
-    assert cstats.move_constructions >= 1
+    assert cstats.copy_constructions == 2
+    assert cstats.move_constructions >= 2
     assert cstats.copy_assignments == 0
     assert cstats.move_assignments == 0
 


### PR DESCRIPTION
This fixes #1694. I wanted to contribute something after filing issues #2046 and #2047.
The fix just adds perfect forwarding for method args to support both, lvalue and rvalue arguments.
The [unit test required a minor adaptation](https://github.com/pybind/pybind11/commit/9df27bd983b55a7f39951da2863f5cba1823f79b#diff-290c8b2315630c8705b7373cbf1b8438L61-R62) as [`ExampleMandA::add1()`](https://github.com/pybind/pybind11/blob/2fda9d5dd876de2fc0c530e4a375b1f8c52e6758/tests/test_methods_and_attributes.cpp#L34) now copies and moves (instead of copying twice).