### PR TITLE
Inconsistent holder types cause crash

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -231,6 +231,7 @@ struct type_record {
 
     // Pointer to RTTI type_info data structure
     const std::type_info *type = nullptr;
+    const std::type_info *holder_type = nullptr;
 
     /// How large is the underlying C++ type?
     size_t type_size = 0;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -128,6 +128,7 @@ struct internals {
 struct type_info {
     PyTypeObject *type;
     const std::type_info *cpptype;
+    const std::type_info *holder_type = nullptr;
     size_t type_size, type_align, holder_size_in_ptrs;
     void *(*operator_new)(size_t);
     void (*init_instance)(instance *, const void *);
@@ -150,7 +151,7 @@ struct type_info {
 };
 
 /// Tracks the `internals` and `type_info` ABI version independent of the main library version
-#define PYBIND11_INTERNALS_VERSION 4
+#define PYBIND11_INTERNALS_VERSION 5
 
 /// On MSVC, debug and release builds are not ABI-compatible!
 #if defined(_MSC_VER) && defined(_DEBUG)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1042,6 +1042,7 @@ protected:
         auto *tinfo = new detail::type_info();
         tinfo->type = (PyTypeObject *) m_ptr;
         tinfo->cpptype = rec.type;
+        tinfo->holder_type = rec.holder_type;
         tinfo->type_size = rec.type_size;
         tinfo->type_align = rec.type_align;
         tinfo->operator_new = rec.operator_new;
@@ -1225,6 +1226,7 @@ public:
         record.scope = scope;
         record.name = name;
         record.type = &typeid(type);
+        record.holder_type = &typeid(holder_type);
         record.type_size = sizeof(conditional_t<has_alias, type_alias, type>);
         record.type_align = alignof(conditional_t<has_alias, type_alias, type>&);
         record.holder_size = sizeof(holder_type);

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -120,7 +120,7 @@ TEST_SUBMODULE(smart_ptr, m) {
     py::implicitly_convertible<py::int_, MyObject1>();
 
     m.def("make_object_1", []() -> Object * { return new MyObject1(1); });
-    m.def("make_object_2", []() -> ref<Object> { return new MyObject1(2); });
+    m.def("make_object_2", []() -> ref<MyObject1> { return new MyObject1(2); });
     m.def("make_myobject1_1", []() -> MyObject1 * { return new MyObject1(4); });
     m.def("make_myobject1_2", []() -> ref<MyObject1> { return new MyObject1(5); });
     m.def("print_object_1", [](const Object *obj) { py::print(obj->toString()); });

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -70,7 +70,7 @@ def test_smart_ptr(capture):
     assert cstats.alive() == 1
     o = None
     assert cstats.alive() == 0
-    assert cstats.values() == ["MyObject2[8]", "MyObject2[6]", "MyObject2[7]"]
+    assert cstats.values() == ["MyObject2[8]", "MyObject2[6]", "MyObject2[7]", "MyObject2[9]"]
     assert cstats.default_constructions == 0
     assert cstats.copy_constructions == 0
     # assert cstats.move_constructions >= 0 # Doesn't invoke any

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -59,6 +59,12 @@ def test_smart_ptr(capture):
             m.print_myobject2_3(o)
             m.print_myobject2_4(o)
         assert capture == "MyObject2[{i}]\n".format(i=i) * 4
+        with pytest.raises(RuntimeError):
+            m.print_myobject2_5(o)
+        with pytest.raises(RuntimeError):
+            m.print_myobject2_6(o)
+    with pytest.raises(RuntimeError):
+        m.make_myobject2_3()
 
     cstats = ConstructorStats.get(m.MyObject2)
     assert cstats.alive() == 1


### PR DESCRIPTION
Currently, pybind11 doesn't check for compatibility of holder types. A holder caster accesses the corresponding `value_and_holder` slot without any type checking, which can cause serious crashes if the actually requested holder type doesn't match the declared one.
The first commit of this PR illustrates the issue as a new test case and the second commit suggests a potential solution: namely storing the `typeinfo` of the declared holder and comparing it to the requested one.
The failing tests emphasize another issue: there is no dynamic type casting for holders yet.