### PR TITLE
Fix inconsistent && qualification in argument_loader's call functions

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1978,7 +1978,7 @@ private:
     }
 
     template <typename Return, typename Func, size_t... Is, typename Guard>
-    Return call_impl(Func &&f, index_sequence<Is...>, Guard &&) {
+    Return call_impl(Func &&f, index_sequence<Is...>, Guard &&) && {
         return std::forward<Func>(f)(cast_op<Args>(std::move(std::get<Is>(argcasters)))...);
     }
 


### PR DESCRIPTION
As discussed in #2044, all `call` methods should be consistently declared as `&&` to indicate that `*this` will be invalidated by the calls due to moving the `argcasters` members.