### PR TITLE
NumPy scalars

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -234,6 +234,13 @@ them mapping to respective C++ counterparts.
     NumPy type and nothing else (e.g., ``py::numpy_scalar<int64_t>`` will not
     accept built-in ``int`` or any other type for that matter).
 
+.. note::
+
+    Native C types are mapped to NumPy types in a platform specific way: for
+    instance, ``char`` may be mapped to either ``np.int8`` or ``np.uint8``
+    depending on the platform. If you want to ensure specific NumPy types,
+    it is recommended to use fixed-width aliases from ``<cstdint>>``.
+
 Vectorizing functions
 =====================
 

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -205,6 +205,35 @@ prevent many types of unsupported structures, it is still the user's
 responsibility to use only "plain" structures that can be safely manipulated as
 raw memory without violating invariants.
 
+Scalar types
+============
+
+In some cases we may want to accept or return NumPy scalar values such as
+``np.float32`` or ``np.uint16``. It is especially important in case of
+C-side single-precision floats which by default will be bound to Python's
+double-precision builtin floats, causing mismatch in float precision.
+
+Luckily, there's a helper type for this occasion - ``py::numpy_scalar``:
+
+.. code-block:: cpp
+
+    m.def("square_float", [](py::numpy_scalar<float> value) {
+        float v = value;
+        return py::make_scalar(v * v);
+    });
+
+This type is trivially convertible to and from the type it wraps; currently
+supported scalar types are NumPy arithmetic types: ``bool_``, ``int8``,
+``int8``, ``int16``, ``int32``, ``int64``, ``uint8``, ``uint16``, ``uint32``,
+``uint64``, ``float32``, ``float64``, all of them mapping to respective C++
+equivalents.
+
+.. note::
+
+    This is a strict type, it will only allow input arguments of the specified
+    NumPy type and nothing else (e.g., ``py::numpy_scalar<int64_t>`` will not
+    accept built-in ``int`` or any other type for that matter).
+
 Vectorizing functions
 =====================
 

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -225,8 +225,8 @@ Luckily, there's a helper type for this occasion - ``py::numpy_scalar``:
 This type is trivially convertible to and from the type it wraps; currently
 supported scalar types are NumPy arithmetic types: ``bool_``, ``int8``,
 ``int8``, ``int16``, ``int32``, ``int64``, ``uint8``, ``uint16``, ``uint32``,
-``uint64``, ``float32``, ``float64``, all of them mapping to respective C++
-equivalents.
+``uint64``, ``float32``, ``float64``, ``complex64``, ``complex128``, all of
+them mapping to respective C++ counterparts.
 
 .. note::
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -519,6 +519,11 @@ struct numpy_scalar {
     numpy_scalar& operator=(value_type value) { this->value = value; return *this; }
 };
 
+template<typename T>
+numpy_scalar<T> make_scalar(T value) {
+    return numpy_scalar<T>(value);
+}
+
 class dtype : public object {
 public:
     PYBIND11_OBJECT_DEFAULT(dtype, object, detail::npy_api::get().PyArrayDescr_Check_);

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -39,6 +39,8 @@ NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 class array; // Forward declaration
 
+template<typename> struct numpy_scalar; // Forward declaration
+
 NAMESPACE_BEGIN(detail)
 template <typename type, typename SFINAE = void> struct npy_format_descriptor;
 
@@ -471,6 +473,19 @@ template <typename T, ssize_t Dim>
 struct type_caster<unchecked_mutable_reference<T, Dim>> : type_caster<unchecked_reference<T, Dim>> {};
 
 NAMESPACE_END(detail)
+
+template<typename T>
+struct numpy_scalar {
+    using value_type = T;
+
+    value_type value;
+
+    numpy_scalar() = default;
+    numpy_scalar(value_type value) : value(value) {}
+
+    operator value_type() { return value; }
+    numpy_scalar& operator=(value_type value) { this->value = value; return *this; }
+};
 
 class dtype : public object {
 public:

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -256,6 +256,31 @@ private:
     }
 };
 
+template<typename T> struct numpy_scalar_info {};
+
+#define DECL_NPY_SCALAR(ctype_, name_, typenum_) \
+    template<> struct numpy_scalar_info<ctype_> { \
+        static constexpr auto name = _(name_); \
+        static constexpr int typenum = npy_api::typenum_##_; \
+    }
+
+DECL_NPY_SCALAR(bool, "bool", NPY_BOOL);
+
+DECL_NPY_SCALAR(int8_t, "int8", NPY_INT8);
+DECL_NPY_SCALAR(int16_t, "int16", NPY_INT16);
+DECL_NPY_SCALAR(int32_t, "int32", NPY_INT32);
+DECL_NPY_SCALAR(int64_t, "int64", NPY_INT64);
+
+DECL_NPY_SCALAR(uint8_t, "uint8", NPY_UINT8);
+DECL_NPY_SCALAR(uint16_t, "uint16", NPY_UINT16);
+DECL_NPY_SCALAR(uint32_t, "uint32", NPY_UINT32);
+DECL_NPY_SCALAR(uint64_t, "uint64", NPY_UINT64);
+
+DECL_NPY_SCALAR(float, "float32", NPY_FLOAT);
+DECL_NPY_SCALAR(double, "float64", NPY_DOUBLE);
+
+#undef DECL_NPY_SCALAR
+
 inline PyArray_Proxy* array_proxy(void* ptr) {
     return reinterpret_cast<PyArray_Proxy*>(ptr);
 }

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -208,7 +208,7 @@ private:
         API_PyArray_CopyInto = 82,
         API_PyArray_NewCopy = 85,
         API_PyArray_NewFromDescr = 94,
-        API_PyArray_DescrNewFromType = 9,
+        API_PyArray_DescrNewFromType = 96,
         API_PyArray_DescrConverter = 174,
         API_PyArray_EquivTypes = 182,
         API_PyArray_GetArrayParamsFromObject = 278,

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -305,22 +305,32 @@ template<typename T> struct numpy_scalar_info {};
         static constexpr int typenum = npy_api::typenum_##_; \
     }
 
+// boolean type
 DECL_NPY_SCALAR(bool, NPY_BOOL);
 
-DECL_NPY_SCALAR(int8_t, NPY_INT8);
-DECL_NPY_SCALAR(int16_t, NPY_INT16);
-DECL_NPY_SCALAR(int32_t, NPY_INT32);
-DECL_NPY_SCALAR(int64_t, NPY_INT64);
+// character types
+DECL_NPY_SCALAR(char, NPY_CHAR);
+DECL_NPY_SCALAR(signed char, NPY_BYTE);
+DECL_NPY_SCALAR(unsigned char, NPY_UBYTE);
 
-DECL_NPY_SCALAR(uint8_t, NPY_UINT8);
-DECL_NPY_SCALAR(uint16_t, NPY_UINT16);
-DECL_NPY_SCALAR(uint32_t, NPY_UINT32);
-DECL_NPY_SCALAR(uint64_t, NPY_UINT64);
+// signed integer types
+DECL_NPY_SCALAR(short, NPY_SHORT);
+DECL_NPY_SCALAR(int, NPY_INT);
+DECL_NPY_SCALAR(long, NPY_LONG);
+DECL_NPY_SCALAR(long long, NPY_LONGLONG);
 
+// unsigned integer types
+DECL_NPY_SCALAR(unsigned short, NPY_USHORT);
+DECL_NPY_SCALAR(unsigned int, NPY_UINT);
+DECL_NPY_SCALAR(unsigned long, NPY_ULONG);
+DECL_NPY_SCALAR(unsigned long long, NPY_ULONGLONG);
+
+// floating point types
 DECL_NPY_SCALAR(float, NPY_FLOAT);
 DECL_NPY_SCALAR(double, NPY_DOUBLE);
 DECL_NPY_SCALAR(long double, NPY_LONGDOUBLE);
 
+// complex types
 DECL_NPY_SCALAR(std::complex<float>, NPY_CFLOAT);
 DECL_NPY_SCALAR(std::complex<double>, NPY_CDOUBLE);
 DECL_NPY_SCALAR(std::complex<long double>, NPY_CLONGDOUBLE);

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -179,6 +179,7 @@ struct npy_api {
 
     unsigned int (*PyArray_GetNDArrayCFeatureVersion_)();
     PyObject *(*PyArray_DescrFromType_)(int);
+    PyObject *(*PyArray_TypeObjectFromType_)(int);
     PyObject *(*PyArray_NewFromDescr_)
         (PyTypeObject *, PyObject *, int, Py_intptr_t *,
          Py_intptr_t *, void *, int, PyObject *);
@@ -206,6 +207,7 @@ private:
         API_PyArrayDescr_Type = 3,
         API_PyVoidArrType_Type = 39,
         API_PyArray_DescrFromType = 45,
+        API_PyArray_TypeObjectFromType = 46,
         API_PyArray_DescrFromScalar = 57,
         API_PyArray_Scalar = 60,
         API_PyArray_ScalarAsCtype = 62,
@@ -239,6 +241,7 @@ private:
         DECL_NPY_API(PyVoidArrType_Type);
         DECL_NPY_API(PyArrayDescr_Type);
         DECL_NPY_API(PyArray_DescrFromType);
+        DECL_NPY_API(PyArray_TypeObjectFromType);
         DECL_NPY_API(PyArray_DescrFromScalar);
         DECL_NPY_API(PyArray_Scalar);
         DECL_NPY_API(PyArray_ScalarAsCtype);

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -14,6 +14,7 @@
 #include <numeric>
 #include <algorithm>
 #include <array>
+#include <complex>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -316,6 +317,11 @@ DECL_NPY_SCALAR(uint64_t, NPY_UINT64);
 
 DECL_NPY_SCALAR(float, NPY_FLOAT);
 DECL_NPY_SCALAR(double, NPY_DOUBLE);
+DECL_NPY_SCALAR(long double, NPY_LONGDOUBLE);
+
+DECL_NPY_SCALAR(std::complex<float>, NPY_CFLOAT);
+DECL_NPY_SCALAR(std::complex<double>, NPY_CDOUBLE);
+DECL_NPY_SCALAR(std::complex<long double>, NPY_CLONGDOUBLE);
 
 #undef DECL_NPY_SCALAR
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -187,6 +187,8 @@ struct npy_api {
     PyTypeObject *PyVoidArrType_Type_;
     PyTypeObject *PyArrayDescr_Type_;
     PyObject *(*PyArray_DescrFromScalar_)(PyObject *);
+    PyObject *(*PyArray_Scalar_)(void *, PyObject *, PyObject *);
+    void (*PyArray_ScalarAsCtype_)(PyObject *, void *);
     PyObject *(*PyArray_FromAny_) (PyObject *, PyObject *, int, int, int, PyObject *);
     int (*PyArray_DescrConverter_) (PyObject *, PyObject **);
     bool (*PyArray_EquivTypes_) (PyObject *, PyObject *);
@@ -203,6 +205,8 @@ private:
         API_PyVoidArrType_Type = 39,
         API_PyArray_DescrFromType = 45,
         API_PyArray_DescrFromScalar = 57,
+        API_PyArray_Scalar = 60,
+        API_PyArray_ScalarAsCtype = 62,
         API_PyArray_FromAny = 69,
         API_PyArray_Resize = 80,
         API_PyArray_CopyInto = 82,
@@ -234,6 +238,8 @@ private:
         DECL_NPY_API(PyArrayDescr_Type);
         DECL_NPY_API(PyArray_DescrFromType);
         DECL_NPY_API(PyArray_DescrFromScalar);
+        DECL_NPY_API(PyArray_Scalar);
+        DECL_NPY_API(PyArray_ScalarAsCtype);
         DECL_NPY_API(PyArray_FromAny);
         DECL_NPY_API(PyArray_Resize);
         DECL_NPY_API(PyArray_CopyInto);

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -164,6 +164,8 @@ struct npy_api {
             NPY_CDOUBLE_, NPY_CFLOAT_, NPY_CLONGDOUBLE_),
         NPY_COMPLEX128_ = platform_lookup<8, double, float, long double>(
             NPY_CDOUBLE_, NPY_CFLOAT_, NPY_CLONGDOUBLE_),
+        // Native character type
+        NPY_CHAR_ = std::is_signed<char>::value ? NPY_BYTE_ : NPY_UBYTE_,
     };
 
     typedef struct {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(PYBIND11_TEST_FILES
   test_multiple_inheritance.cpp
   test_numpy_array.cpp
   test_numpy_dtypes.cpp
+  test_numpy_scalars.cpp
   test_numpy_vectorize.cpp
   test_opaque_types.cpp
   test_operator_overloading.cpp

--- a/tests/test_numpy_scalars.cpp
+++ b/tests/test_numpy_scalars.cpp
@@ -7,6 +7,7 @@
   BSD-style license that can be found in the LICENSE file.
 */
 
+#include <complex>
 #include <cstdint>
 #include <string>
 #include <utility>
@@ -16,29 +17,44 @@
 
 namespace py = pybind11;
 
-template<typename T>
-void register_test(py::module& m, const char *name) {
+template<typename T, typename F>
+void register_test(py::module& m, const char *name, F&& func) {
     m.def("test_numpy_scalars", [=](py::numpy_scalar<T> v) {
-        return std::make_tuple(name, py::make_scalar(static_cast<T>(v.value + 1)));
+        return std::make_tuple(name, py::make_scalar(static_cast<T>(func(v.value))));
     }, py::arg("x"));
     m.def((std::string("test_") + name).c_str(), [=](py::numpy_scalar<T> v) {
-        return std::make_tuple(name, py::make_scalar(static_cast<T>(v.value + 1)));
+        return std::make_tuple(name, py::make_scalar(static_cast<T>(func(v.value))));
     }, py::arg("x"));
 }
+
+template<typename T>
+struct add {
+    T x;
+    add(T x) : x(x) {}
+    T operator()(T y) const { return static_cast<T>(x + y); }
+};
 
 TEST_SUBMODULE(numpy_scalars, m) {
     try { py::module::import("numpy"); }
     catch (...) { return; }
 
-    register_test<bool>(m, "bool");
-    register_test<int8_t>(m, "int8");
-    register_test<int16_t>(m, "int16");
-    register_test<int32_t>(m, "int32");
-    register_test<int64_t>(m, "int64");
-    register_test<uint8_t>(m, "uint8");
-    register_test<uint16_t>(m, "uint16");
-    register_test<uint32_t>(m, "uint32");
-    register_test<uint64_t>(m, "uint64");
-    register_test<float>(m, "float32");
-    register_test<double>(m, "float64");
+    using cfloat = std::complex<float>;
+    using cdouble = std::complex<double>;
+    using clongdouble = std::complex<long double>;
+
+    register_test<bool>(m, "bool", [](bool x) { return !x; });
+    register_test<int8_t>(m, "int8", add<int8_t>(-8));
+    register_test<int16_t>(m, "int16", add<int16_t>(-16));
+    register_test<int32_t>(m, "int32", add<int32_t>(-32));
+    register_test<int64_t>(m, "int64", add<int64_t>(-64));
+    register_test<uint8_t>(m, "uint8", add<uint8_t>(8));
+    register_test<uint16_t>(m, "uint16", add<uint16_t>(16));
+    register_test<uint32_t>(m, "uint32", add<uint32_t>(32));
+    register_test<uint64_t>(m, "uint64", add<uint64_t>(64));
+    register_test<float>(m, "float32", add<float>(0.125f));
+    register_test<double>(m, "float64", add<double>(0.25f));
+    register_test<long double>(m, "longdouble", add<long double>(0.5L));
+    register_test<cfloat>(m, "complex64", add<cfloat>({0, -0.125f}));
+    register_test<cdouble>(m, "complex128", add<cdouble>({0, -0.25}));
+    register_test<clongdouble>(m, "longcomplex", add<clongdouble>({0, -0.5L}));
 }

--- a/tests/test_numpy_scalars.cpp
+++ b/tests/test_numpy_scalars.cpp
@@ -1,0 +1,44 @@
+/*
+  tests/test_numpy_scalars.cpp -- strict NumPy scalars
+
+  Copyright (c) 2020 Ivan Smirnov
+
+  All rights reserved. Use of this source code is governed by a
+  BSD-style license that can be found in the LICENSE file.
+*/
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "pybind11_tests.h"
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+template<typename T>
+void register_test(py::module& m, const char *name) {
+    m.def("test_numpy_scalars", [=](py::numpy_scalar<T> v) {
+        return std::make_tuple(name, py::make_scalar(static_cast<T>(v.value + 1)));
+    }, py::arg("x"));
+    m.def((std::string("test_") + name).c_str(), [=](py::numpy_scalar<T> v) {
+        return std::make_tuple(name, py::make_scalar(static_cast<T>(v.value + 1)));
+    }, py::arg("x"));
+}
+
+TEST_SUBMODULE(numpy_scalars, m) {
+    try { py::module::import("numpy"); }
+    catch (...) { return; }
+
+    register_test<bool>(m, "bool");
+    register_test<int8_t>(m, "int8");
+    register_test<int16_t>(m, "int16");
+    register_test<int32_t>(m, "int32");
+    register_test<int64_t>(m, "int64");
+    register_test<uint8_t>(m, "uint8");
+    register_test<uint16_t>(m, "uint16");
+    register_test<uint32_t>(m, "uint32");
+    register_test<uint64_t>(m, "uint64");
+    register_test<float>(m, "float32");
+    register_test<double>(m, "float64");
+}

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -1,0 +1,69 @@
+import sys
+import pytest
+from pybind11_tests import numpy_scalars as m
+
+pytestmark = pytest.requires_numpy
+
+with pytest.suppress(ImportError):
+    import numpy as np
+
+
+@pytest.fixture(scope='module')
+def scalar_types():
+    return [
+        np.bool_,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.float32,
+        np.float64,
+    ]
+
+
+@pytest.fixture(scope='module')
+def other_types():
+    return [int, bool, float, bytes, str, np.complex64, type(None)]
+
+
+def signature(tp):
+    name = tp.__name__.rstrip('_')
+    return 'test_numpy_scalars(x: {tp}) -> Tuple[str, {tp}]'.format(tp=name)
+
+
+def test_numpy_scalars_single(scalar_types, other_types):
+    s_tp = 'str' if sys.version_info[0] >= 3 else 'unicode'
+    for scalar_type in scalar_types:
+        name = scalar_type.__name__.rstrip('_')
+        func = getattr(m, 'test_' + name)
+        sig = 'test_{tp}(x: {tp}) -> Tuple[{s_tp}, {tp}]\n'.format(tp=name, s_tp=s_tp)
+        assert func.__doc__ == sig
+        for tp in (scalar_types + other_types):
+            value = None if isinstance(None, tp) else tp()
+            if tp is scalar_type:
+                result = func(value)
+                assert result[0] == name
+                assert isinstance(result[1], tp)
+                assert result[1] == tp(1)
+            else:
+                with pytest.raises(TypeError):
+                    func(value)
+
+
+def test_numpy_scalars_overload(scalar_types, other_types):
+    func = m.test_numpy_scalars
+    for tp in (scalar_types + other_types):
+        value = None if isinstance(None, tp) else tp()
+        if tp in scalar_types:
+            name = tp.__name__.rstrip('_')
+            result = func(value)
+            assert result[0] == name
+            assert isinstance(result[1], tp)
+            assert result[1] == tp(1)
+        else:
+            with pytest.raises(TypeError):
+                func(value)

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -4,66 +4,85 @@ from pybind11_tests import numpy_scalars as m
 
 pytestmark = pytest.requires_numpy
 
+SCALAR_TYPES = {}
+
 with pytest.suppress(ImportError):
     import numpy as np
 
+    SCALAR_TYPES = dict([
+        (np.bool_, False),
+        (np.int8, -7),
+        (np.int16, -15),
+        (np.int32, -31),
+        (np.int64, -63),
+        (np.uint8, 9),
+        (np.uint16, 17),
+        (np.uint32, 33),
+        (np.uint64, 65),
+        (np.single, 1.125),
+        (np.double, 1.25),
+        (np.longdouble, 1.5),
+        (np.csingle, 1 - 0.125j),
+        (np.cdouble, 1 - 0.25j),
+        (np.clongdouble, 1 - 0.5j),
+    ])
 
-@pytest.fixture(scope='module')
-def scalar_types():
-    return [
-        np.bool_,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.float32,
-        np.float64,
-    ]
-
-
-@pytest.fixture(scope='module')
-def other_types():
-    return [int, bool, float, bytes, str, np.complex64, type(None)]
+ALL_TYPES = [int, bool, float, bytes, str, type(None)] + list(SCALAR_TYPES)
 
 
-def signature(tp):
-    name = tp.__name__.rstrip('_')
-    return 'test_numpy_scalars(x: {tp}) -> Tuple[str, {tp}]'.format(tp=name)
+def type_name(tp):
+    try:
+        if tp is np.longdouble:
+            return 'longdouble'
+        elif issubclass(tp, np.floating):
+            return 'float' + str(8 * tp().itemsize)
+        elif tp is np.clongdouble:
+            return 'longcomplex'
+        elif issubclass(tp, np.complexfloating):
+            return 'complex' + str(8 * tp().itemsize)
+        return tp.__name__.rstrip('_')
+    except BaseException:
+        # no numpy
+        return str(tp)
 
 
-def test_numpy_scalars_single(scalar_types, other_types):
-    s_tp = 'str' if sys.version_info[0] >= 3 else 'unicode'
-    for scalar_type in scalar_types:
-        name = scalar_type.__name__.rstrip('_')
-        func = getattr(m, 'test_' + name)
-        sig = 'test_{tp}(x: {tp}) -> Tuple[{s_tp}, {tp}]\n'.format(tp=name, s_tp=s_tp)
-        assert func.__doc__ == sig
-        for tp in (scalar_types + other_types):
-            value = None if isinstance(None, tp) else tp()
-            if tp is scalar_type:
-                result = func(value)
-                assert result[0] == name
-                assert isinstance(result[1], tp)
-                assert result[1] == tp(1)
-            else:
-                with pytest.raises(TypeError):
-                    func(value)
+@pytest.fixture(scope='module', params=list(SCALAR_TYPES), ids=type_name)
+def scalar_type(request):
+    return request.param
 
 
-def test_numpy_scalars_overload(scalar_types, other_types):
-    func = m.test_numpy_scalars
-    for tp in (scalar_types + other_types):
-        value = None if isinstance(None, tp) else tp()
-        if tp in scalar_types:
-            name = tp.__name__.rstrip('_')
+def expected_signature(tp):
+    s = 'str' if sys.version_info[0] >= 3 else 'unicode'
+    t = type_name(tp)
+    return 'test_{t}(x: {t}) -> Tuple[{s}, {t}]\n'.format(s=s, t=t)
+
+
+def test_numpy_scalars_single(scalar_type):
+    expected = SCALAR_TYPES[scalar_type]
+    name = type_name(scalar_type)
+    func = getattr(m, 'test_' + name)
+    assert func.__doc__ == expected_signature(scalar_type)
+    for tp in ALL_TYPES:
+        value = None if isinstance(None, tp) else tp(1)
+        if tp is scalar_type:
             result = func(value)
             assert result[0] == name
             assert isinstance(result[1], tp)
-            assert result[1] == tp(1)
+            assert result[1] == tp(expected)
+        else:
+            with pytest.raises(TypeError):
+                func(value)
+
+
+def test_numpy_scalars_overload():
+    func = m.test_numpy_scalars
+    for tp in ALL_TYPES:
+        value = None if isinstance(None, tp) else tp(1)
+        if tp in SCALAR_TYPES:
+            result = func(value)
+            assert result[0] == type_name(tp)
+            assert isinstance(result[1], tp)
+            assert result[1] == tp(SCALAR_TYPES[tp])
         else:
             with pytest.raises(TypeError):
                 func(value)


### PR DESCRIPTION
Closes #2036, #1512 

- Add `py::numpy_scalar<>` and `py::make_scalar()` as strict type casters between C and NumPy arithmetic types + tests + docs
- Fix a bug where `PyArray_DescrNewType` API code was wrong (although it's not really used at the moment, but still)