### PR TITLE
Fix conda include reporting [do not merge]

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -287,3 +287,11 @@ code by introspecting existing C++ codebases using LLVM/Clang. See the
 [binder]_ documentation for details.
 
 .. [binder] http://cppbinder.readthedocs.io/en/latest/about.html
+
+[AutoWIG]_ is a Python library that wraps automatically compiled libraries into
+high-level languages. It parses C++ code using LLVM/Clang technologies and
+generates the wrappers using the Mako templating engine. The approach is automatic,
+extensible, and applies to very complex C++ libraries, composed of thousands of
+classes or incorporating modern meta-programming constructs.
+
+.. [AutoWIG] https://github.com/StatisKit/AutoWIG

--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -10,17 +10,9 @@ def get_include(user=False):
     virtualenv = hasattr(sys, 'real_prefix') or \
         sys.prefix != getattr(sys, "base_prefix", sys.prefix)
 
-    # Are we running in a conda environment?
-    conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
-
     if virtualenv:
         return os.path.join(sys.prefix, 'include', 'site',
                             'python' + sys.version[:3])
-    elif conda:
-        if os.name == 'nt':
-            return os.path.join(sys.prefix, 'Library', 'include')
-        else:
-            return os.path.join(sys.prefix, 'include')
     else:
         dist = Distribution({'name': 'pybind11'})
         dist.parse_config_files()


### PR DESCRIPTION
The Conda-forge package is reporting the wrong directory. From local testing, the standard way of accessing the directory seems to be working correctly; it's just the injected special logic that is causing issues.

Is the virtualenv logic needed, or could it be removed as well?

Testing this in Conda-forge before making the PR non-draft.