### PR TITLE
stl_bind: add binding for std::vector::clear

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -136,6 +136,13 @@ void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_t
         return v.release();
     }));
 
+    cl.def("clear",
+        [](Vector &v) {
+            v.clear();
+        },
+        "Clear the contents"
+    );
+
     cl.def("extend",
        [](Vector &v, const Vector &src) {
            v.insert(v.end(), src.begin(), src.end());

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -64,6 +64,9 @@ def test_vector_int():
     del v_int2[-1]
     assert v_int2 == m.VectorInt([0, 99, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 88])
 
+    v_int2.clear()
+    assert len(v_int2) == 0
+
 # related to the PyPy's buffer protocol.
 @pytest.unsupported_on_pypy
 def test_vector_buffer():


### PR DESCRIPTION
This commit adds bindings for the std::vector::clear function when using pybind11::bind_vector.