### PR TITLE
Added ability to convert from numpy.datetime64 to system_clock::time_point

### DIFF
--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "pybind11.h"
+#include "numpy.h"
 #include <cmath>
 #include <ctime>
 #include <chrono>

--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -137,8 +137,7 @@ public:
             cal.tm_year  = 70;  // earliest available date for Python's datetime
             cal.tm_isdst = -1;
             msecs        = microseconds(PyDateTime_TIME_GET_MICROSECOND(src.ptr()));
-        } else if (strcmp(src.ptr()->ob_type->tp_name, "numpy.datetime64") == 0)
-        {
+        } else if (strcmp(src.ptr()->ob_type->tp_name, "numpy.datetime64") == 0) {
             long np_dt_long = array_t<long, 0>::ensure(src).data()[0];
 
             object py_dt;

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -95,10 +95,10 @@ def test_chrono_system_clock_roundtrip_time():
     assert date2.year == 1970
     assert date2.month == 1
     assert date2.day == 1
-    
+
 
 def test_numpy_chrono_system_clock_roundtrip_date():
-    date1    = datetime.datetime.today().date()
+    date1 = datetime.datetime.today().date()
     date1_np = np.datetime64(date1)
 
     # Roundtrip the time
@@ -110,7 +110,7 @@ def test_numpy_chrono_system_clock_roundtrip_date():
     assert isinstance(datetime2, datetime.datetime)
     assert isinstance(date2, datetime.date)
     assert isinstance(time2, datetime.time)
-    
+
     # There should be no time information
     assert time2.hour == 0
     assert time2.minute == 0
@@ -121,10 +121,10 @@ def test_numpy_chrono_system_clock_roundtrip_date():
     assert date2.year == date1.year
     assert date2.month == date1.month
     assert date2.day == date1.day
-   
+
 
 def test_numpy_chrono_system_clock_roundtrip_datetime():
-    datetime1    = datetime.datetime.today()
+    datetime1 = datetime.datetime.today()
     datetime1_np = np.datetime64(datetime1)
 
     # Roundtrip the time
@@ -136,13 +136,13 @@ def test_numpy_chrono_system_clock_roundtrip_datetime():
     assert isinstance(datetime2, datetime.datetime)
     assert isinstance(date2, datetime.date)
     assert isinstance(time2, datetime.time)
-    
+
     # They should be identical (no information lost on roundtrip)
     diff = abs(datetime1.date() - date2)
     assert diff.days == 0
     assert diff.seconds == 0
     assert diff.microseconds == 0
-    
+
     # Hour, Minute, Second & Microsecond should be the same after the round trip
     assert datetime1.hour == datetime2.hour
     assert datetime1.minute == datetime2.minute

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -1,6 +1,11 @@
 from pybind11_tests import chrono as m
 import datetime
-import numpy as np
+import pytest
+
+pytestmark = pytest.requires_numpy
+
+with pytest.suppress(ImportError):
+    import numpy as np
 
 
 def test_chrono_system_clock():

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -1,5 +1,6 @@
 from pybind11_tests import chrono as m
 import datetime
+import numpy as np
 
 
 def test_chrono_system_clock():
@@ -94,6 +95,64 @@ def test_chrono_system_clock_roundtrip_time():
     assert date2.year == 1970
     assert date2.month == 1
     assert date2.day == 1
+    
+
+def test_numpy_chrono_system_clock_roundtrip_date():
+    date1    = datetime.datetime.today().date()
+    date1_np = np.datetime64(date1)
+
+    # Roundtrip the time
+    datetime2 = m.test_chrono2(date1_np)
+    date2 = datetime2.date()
+    time2 = datetime2.time()
+
+    # The returned value should be a datetime
+    assert isinstance(datetime2, datetime.datetime)
+    assert isinstance(date2, datetime.date)
+    assert isinstance(time2, datetime.time)
+    
+    # There should be no time information
+    assert time2.hour == 0
+    assert time2.minute == 0
+    assert time2.second == 0
+    assert time2.microsecond == 0
+
+    # Year, Month & Day should be the same after the round trip
+    assert date2.year == date1.year
+    assert date2.month == date1.month
+    assert date2.day == date1.day
+   
+
+def test_numpy_chrono_system_clock_roundtrip_datetime():
+    datetime1    = datetime.datetime.today()
+    datetime1_np = np.datetime64(datetime1)
+
+    # Roundtrip the time
+    datetime2 = m.test_chrono2(datetime1_np)
+    date2 = datetime2.date()
+    time2 = datetime2.time()
+
+    # The returned value should be a datetime
+    assert isinstance(datetime2, datetime.datetime)
+    assert isinstance(date2, datetime.date)
+    assert isinstance(time2, datetime.time)
+    
+    # They should be identical (no information lost on roundtrip)
+    diff = abs(datetime1.date() - date2)
+    assert diff.days == 0
+    assert diff.seconds == 0
+    assert diff.microseconds == 0
+    
+    # Hour, Minute, Second & Microsecond should be the same after the round trip
+    assert datetime1.hour == datetime2.hour
+    assert datetime1.minute == datetime2.minute
+    assert datetime1.second == datetime2.second
+    assert datetime1.microsecond == datetime2.microsecond
+
+    # Year, Month & Day should be the same after the round trip
+    assert datetime1.year == datetime2.year
+    assert datetime1.month == datetime2.month
+    assert datetime1.day == datetime2.day
 
 
 def test_chrono_duration_roundtrip():


### PR DESCRIPTION
Added ability to convert from Python `numpy.datetime64` to C++ `system_clock::time_point`

As raised here: https://github.com/pybind/pybind11/issues/2078