### PR TITLE
Fix docstrings of enum methods

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1418,7 +1418,7 @@ struct enum_base {
                         return pybind11::str("{}.{}").format(type_name, kv.first);
                 }
                 return pybind11::str("{}.???").format(type_name);
-            }, is_method(m_base)
+            }, name("__repr__"), is_method(m_base)
         );
 
         m_base.attr("name") = property(cpp_function(
@@ -1429,7 +1429,7 @@ struct enum_base {
                         return pybind11::str(kv.first);
                 }
                 return "???";
-            }, is_method(m_base)
+            }, name("name"), is_method(m_base)
         ));
 
         m_base.attr("__doc__") = static_property(cpp_function(
@@ -1447,7 +1447,7 @@ struct enum_base {
                         docstring += " : " + (std::string) pybind11::str(comment);
                 }
                 return docstring;
-            }
+            }, name("__doc__")
         ), none(), none(), "");
 
         m_base.attr("__members__") = static_property(cpp_function(
@@ -1456,7 +1456,7 @@ struct enum_base {
                 for (const auto &kv : entries)
                     m[kv.first] = kv.second[int_(0)];
                 return m;
-            }), none(), none(), ""
+            }, name("__members__")), none(), none(), ""
         );
 
         #define PYBIND11_ENUM_OP_STRICT(op, expr, strict_behavior)                     \
@@ -1466,7 +1466,7 @@ struct enum_base {
                         strict_behavior;                                               \
                     return expr;                                                       \
                 },                                                                     \
-                is_method(m_base))
+                name(op), is_method(m_base))
 
         #define PYBIND11_ENUM_OP_CONV(op, expr)                                        \
             m_base.attr(op) = cpp_function(                                            \
@@ -1474,7 +1474,7 @@ struct enum_base {
                     int_ a(a_), b(b_);                                                 \
                     return expr;                                                       \
                 },                                                                     \
-                is_method(m_base))
+                name(op), is_method(m_base))
 
         #define PYBIND11_ENUM_OP_CONV_LHS(op, expr)                                    \
             m_base.attr(op) = cpp_function(                                            \
@@ -1482,7 +1482,7 @@ struct enum_base {
                     int_ a(a_);                                                        \
                     return expr;                                                       \
                 },                                                                     \
-                is_method(m_base))
+                name(op), is_method(m_base))
 
         if (is_convertible) {
             PYBIND11_ENUM_OP_CONV_LHS("__eq__", !b.is_none() &&  a.equal(b));
@@ -1500,7 +1500,7 @@ struct enum_base {
                 PYBIND11_ENUM_OP_CONV("__xor__",  a ^  b);
                 PYBIND11_ENUM_OP_CONV("__rxor__", a ^  b);
                 m_base.attr("__invert__") = cpp_function(
-                    [](object arg) { return ~(int_(arg)); }, is_method(m_base));
+                    [](object arg) { return ~(int_(arg)); }, name("__invert__"), is_method(m_base));
             }
         } else {
             PYBIND11_ENUM_OP_STRICT("__eq__",  int_(a).equal(int_(b)), return false);
@@ -1520,11 +1520,8 @@ struct enum_base {
         #undef PYBIND11_ENUM_OP_CONV
         #undef PYBIND11_ENUM_OP_STRICT
 
-        object getstate = cpp_function(
-            [](object arg) { return int_(arg); }, is_method(m_base));
-
-        m_base.attr("__getstate__") = getstate;
-        m_base.attr("__hash__") = getstate;
+        m_base.attr("__hash__") = cpp_function(
+                [](object arg) { return int_(arg); }, name("__hash__"), is_method(m_base));
     }
 
     PYBIND11_NOINLINE void value(char const* name_, object value, const char *doc = nullptr) {
@@ -1577,10 +1574,8 @@ public:
             def("__index__", [](Type value) { return (Scalar) value; });
         #endif
 
-        cpp_function setstate(
-            [](Type &value, Scalar arg) { value = static_cast<Type>(arg); },
-            is_method(*this));
-        attr("__setstate__") = setstate;
+        def(pickle([](Type value) { return static_cast<Scalar>(value); },
+                   [](Scalar arg) { return static_cast<Type>(arg); }));
     }
 
     /// Export enumeration entries into the parent scope


### PR DESCRIPTION
#1511 broke the docstrings of the `__repr__`, `__add__`, etc. methods of `enum_` types. E.g., the docstring of a `__repr__` now looks like this:

```
>>> example.AnEnum.__repr__.__doc__
'(self: handle) -> str\n'
```

This PR fixes that by passing the name to the `cpp_function` constructors, in the same was as `class_::def` would do:

```
>>> example.AnEnum.__repr__.__doc__
'__repr__(self: handle) -> str\n'
```

I also converted `__setstate__` and `__getstate__` to `pickle`, to get rid of the warnings about old- vs. new-style constructors.