### PR TITLE
Fix interface library target for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,14 +109,14 @@ if(NOT (CMAKE_VERSION VERSION_LESS 3.0))  # CMake >= 3.0
   endif()
   target_link_libraries(module INTERFACE pybind11::pybind11)
   if(WIN32 OR CYGWIN)
-    target_link_libraries(module INTERFACE $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
+    target_link_libraries(module INTERFACE ${PYTHON_LIBRARIES})
   elseif(APPLE)
     target_link_libraries(module INTERFACE "-undefined dynamic_lookup")
   endif()
 
   add_library(embed INTERFACE)
   add_library(pybind11::embed ALIAS embed)
-  target_link_libraries(embed INTERFACE pybind11::pybind11 $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
+  target_link_libraries(embed INTERFACE pybind11::pybind11 ${PYTHON_LIBRARIES})
 endif()
 
 if (PYBIND11_INSTALL)


### PR DESCRIPTION
When linking against the interface target `pybind11::module` on Windows, weird libraries such as `optimized.lib` are added to the dependencies. This is caused by the variable `${PYTHON_LIBRARIES}` extending to something like `optimized;_path_/_to_/_python_/libs/python37.lib;debug;_path_/_to_/_python_/libs/python37_d.lib` and that being used together with generator expressions. As detailed in https://gitlab.kitware.com/cmake/cmake/issues/18424, the `optimized` and `debug` keywords are not meant to be used together with generator expressions.

This PR is currently only a draft as what I implemented is just a quick "hack" and the semantics are different (essentially ignoring the value of BUILD_INTERFACE). One could go with their suggestion of creating an interface target for the python libs and linking against that on demand, but I'm not sure which consequences this may has.