### PR TITLE
Add the correct headers to test_sequences_and_iterators.cpp.

### DIFF
--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -10,6 +10,8 @@
 
 #include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include <algorithm>
+#include <utility>
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 


### PR DESCRIPTION
`<algorithm>` is added to call `count_if` and `find_if`. `<utility>` is added for `pair`.

This problem was exposed by https://github.com/microsoft/STL/pull/482