### PR TITLE
Fix #2115: `get_include()` considers `INSTALL_SCHEMES` in `distutils`

### DIFF
--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -3,10 +3,33 @@ from ._version import version_info, __version__  # noqa: F401 imported but unuse
 
 def get_include(user=False):
     import os
+    import sys
+    from distutils.command.install import INSTALL_SCHEMES
+    from site import USER_BASE, USER_SITE
+
     d = os.path.dirname(__file__)
-    if os.path.exists(os.path.join(d, "include")):
-        # Package is installed
-        return os.path.join(d, "include")
+
+    expand_list = [("$py_version_nodot", "%d%d" % sys.version_info[:2]),
+                   ("$py_version_short", "%d.%d" % sys.version_info[:2]),
+                   ("$abiflags", getattr(sys, "abiflags", "")),
+                   ("$usersite", USER_SITE),
+                   ("$userbase", USER_BASE),
+                   ("$dist_name", "pybind11")]
+
+    def expand_path(_path):
+        for _from, _to in expand_list:
+            _path = _path.replace(_from, _to)
+        return _path
+
+    purelib = os.path.dirname(d)
+
+    for v in INSTALL_SCHEMES.values():
+        relpath = os.path.relpath(expand_path(v["headers"]),
+                                  start=expand_path(v["purelib"]))
+        headers = os.path.realpath(os.path.join(purelib, relpath))
+        if os.path.exists(headers):
+            # Package is installed
+            return os.path.dirname(headers)
     else:
         # Package is from a source directory
         return os.path.join(os.path.dirname(d), "include")


### PR DESCRIPTION
Install directories are defined at `distutils.command.install`
https://github.com/python/cpython/blob/master/Lib/distutils/command/install.py

Depending on OS type, user site etc., one of the install schemes is selected.

This patch
  1. expand parameters (python version etc.) in `INSTALL_SCHEMES`
  2. calculates relative path from "purelib" to "headers"
  3. checks existence of "header" directory for all schemes one by one
  4. returns the include directory if it exists
  5.  falls back to the original non-installated case when no schemes match

This implementation should work as long as installation
tool (e.g. pip) uses standard `distutils`.

Notice:
  step 1 (expansion parameters) cannot be taken out from `distutils`
  source and copied by manually, which means `get_include()` will
  break when `distutils` changes its implementation.