### PR TITLE
Remove memory leaks, with this patch it doesn't leak anymore (Windows…

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -794,8 +794,7 @@ public:
     explicit module(const char *name, const char *doc = nullptr) {
         if (!options::show_user_defined_docstrings()) doc = nullptr;
 #if PY_MAJOR_VERSION >= 3
-        static PyModuleDef def2;
-        PyModuleDef* def = &def2;
+        PyModuleDef *def = new PyModuleDef();
         std::memset(def, 0, sizeof(PyModuleDef));
         def->m_name = name;
         def->m_doc = doc;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -794,7 +794,8 @@ public:
     explicit module(const char *name, const char *doc = nullptr) {
         if (!options::show_user_defined_docstrings()) doc = nullptr;
 #if PY_MAJOR_VERSION >= 3
-        PyModuleDef *def = new PyModuleDef();
+        static PyModuleDef def2;
+        PyModuleDef* def = &def2;
         std::memset(def, 0, sizeof(PyModuleDef));
         def->m_name = name;
         def->m_doc = doc;


### PR DESCRIPTION
… Visual Studio, checked using Visual Leak Detector, https://kinddragon.github.io/vld)

This patch uses Py_AtExit to make sure memory is deallocated at the very end. 
It may conflict with other platforms/configurations (embedded etc). 

The static PyModuleDef def2; assumes there is only one single PYBIND11_MODULE. 
In case more modules are allowed, that part of the patch can be removed and a more fancy solution for that deallocation is needed.

These leaks are similar to Issue #2062 
However, in my case I'm seeing memory leaks just using a simple plain Python plugin using pybind11 (not embedded).

