### PR TITLE
Bugfix/issue #1919 optional always move

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -266,8 +266,9 @@ template<typename T> struct optional_caster {
     static handle cast(T_ &&src, return_value_policy policy, handle parent) {
         if (!src)
             return none().inc_ref();
-        using dereference_type = decltype(*std::forward<T_>(src));
-        policy = return_value_policy_override<dereference_type>::policy(policy);
+        if (!std::is_lvalue_reference<T>::value) {
+            policy = return_value_policy_override<T>::policy(policy);
+        }
         return value_conv::cast(*std::forward<T_>(src), policy, parent);
     }
 

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -266,7 +266,8 @@ template<typename T> struct optional_caster {
     static handle cast(T_ &&src, return_value_policy policy, handle parent) {
         if (!src)
             return none().inc_ref();
-        policy = return_value_policy_override<typename T::value_type>::policy(policy);
+        using dereference_type = decltype(*std::forward<T_>(src));
+        policy = return_value_policy_override<dereference_type>::policy(policy);
         return value_conv::cast(*std::forward<T_>(src), policy, parent);
     }
 

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -50,6 +50,17 @@ namespace std {
 }
 
 
+template <template <typename> typename OptionalImpl, typename T>
+struct OptionalHolder
+{
+    OptionalHolder() = default;
+    bool member_initialized() const {
+        return member && member->initialized;
+    }
+    OptionalImpl<T> member = T{};
+};
+
+
 TEST_SUBMODULE(stl, m) {
     // test_vector
     m.def("cast_vector", []() { return std::vector<int>{1}; });
@@ -154,6 +165,23 @@ TEST_SUBMODULE(stl, m) {
         .def(py::init<>())
         .def(py::init<int>());
 
+
+    struct MoveOutDetector
+    {
+        MoveOutDetector() = default;
+        MoveOutDetector(const MoveOutDetector&) = default;
+        MoveOutDetector(MoveOutDetector&& other) noexcept
+         : initialized(other.initialized) {
+            // steal underlying resource
+            other.initialized = false;
+        }
+        bool initialized = true;
+    };
+    py::class_<MoveOutDetector>(m, "MoveOutDetector", "Class with move tracking")
+        .def(py::init<>())
+        .def_readonly("initialized", &MoveOutDetector::initialized);
+
+
 #ifdef PYBIND11_HAS_OPTIONAL
     // test_optional
     m.attr("has_optional") = true;
@@ -175,6 +203,12 @@ TEST_SUBMODULE(stl, m) {
 
     m.def("nodefer_none_optional", [](std::optional<int>) { return true; });
     m.def("nodefer_none_optional", [](py::none) { return false; });
+
+    using opt_holder = OptionalHolder<std::optional, MoveOutDetector>;
+    py::class_<opt_holder>(m, "OptionalHolder", "Class with optional member")
+        .def(py::init<>())
+        .def_readonly("member", &opt_holder::member)
+        .def("member_initialized", &opt_holder::member_initialized);
 #endif
 
 #ifdef PYBIND11_HAS_EXP_OPTIONAL
@@ -195,6 +229,12 @@ TEST_SUBMODULE(stl, m) {
     m.def("test_no_assign_exp", [](const exp_opt_no_assign &x) {
         return x ? x->value : 42;
     }, py::arg_v("x", std::experimental::nullopt, "None"));
+
+    using opt_exp_holder = OptionalHolder<std::experimental::optional, MoveOutDetector>;
+    py::class_<opt_exp_holder>(m, "OptionalExpHolder", "Class with optional member")
+        .def(py::init<>())
+        .def_readonly("member", &opt_exp_holder::member)
+        .def("member_initialized", &opt_exp_holder::member_initialized);
 #endif
 
 #ifdef PYBIND11_HAS_VARIANT

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -50,7 +50,7 @@ namespace std {
 }
 
 
-template <template <typename> typename OptionalImpl, typename T>
+template <template <typename> class OptionalImpl, typename T>
 struct OptionalHolder
 {
     OptionalHolder() = default;

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -127,6 +127,11 @@ def test_optional():
 
     assert m.nodefer_none_optional(None)
 
+    holder = m.OptionalHolder()
+    mvalue = holder.member
+    assert mvalue.initialized
+    assert holder.member_initialized()
+
 
 @pytest.mark.skipif(not hasattr(m, "has_exp_optional"), reason='no <experimental/optional>')
 def test_exp_optional():
@@ -147,6 +152,11 @@ def test_exp_optional():
     assert m.test_no_assign_exp(None) == 42
     assert m.test_no_assign_exp(m.NoAssign(43)) == 43
     pytest.raises(TypeError, m.test_no_assign_exp, 43)
+
+    holder = m.OptionalExpHolder()
+    mvalue = holder.member
+    assert mvalue.initialized
+    assert holder.member_initialized()
 
 
 @pytest.mark.skipif(not hasattr(m, "load_variant"), reason='no <variant>')


### PR DESCRIPTION
Added test which covers move-on-use bug for `std::optional`.
Fix is to correctly forward reference to `return_value_policy_override`.