### PR TITLE
Fix compilation with clang-cl (clang on Windows)

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1218,7 +1218,7 @@ private:
 #define PYBIND11_MAP_NEXT0(test, next, ...) next PYBIND11_MAP_OUT
 #define PYBIND11_MAP_NEXT1(test, next) PYBIND11_MAP_NEXT0 (test, next, 0)
 #define PYBIND11_MAP_NEXT(test, next)  PYBIND11_MAP_NEXT1 (PYBIND11_MAP_GET_END test, next)
-#ifdef _MSC_VER // MSVC is not as eager to expand macros, hence this workaround
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC is not as eager to expand macros, hence this workaround
 #define PYBIND11_MAP_LIST_NEXT1(test, next) \
     PYBIND11_EVAL0 (PYBIND11_MAP_NEXT0 (test, PYBIND11_MAP_COMMA next, 0))
 #else
@@ -1240,7 +1240,7 @@ private:
         (::std::vector<::pybind11::detail::field_descriptor> \
          {PYBIND11_MAP_LIST (PYBIND11_FIELD_DESCRIPTOR, Type, __VA_ARGS__)})
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #define PYBIND11_MAP2_LIST_NEXT1(test, next) \
     PYBIND11_EVAL0 (PYBIND11_MAP_NEXT0 (test, PYBIND11_MAP_COMMA next, 0))
 #else


### PR DESCRIPTION
Build and test passed.
```
$> cmake --build . --config Release
[20/42] Building CXX object tests\CMakeFiles\pybind11_tests.dir\test_operator_overloading.cpp.obj
..\tests\test_operator_overloading.cpp(99,23): warning: explicitly assigning value of variable of type 'const pybind11::detail::self_t' to itself [-Wself-assign-overloaded]
        .def(py::self -= py::self)
             ~~~~~~~~ ^  ~~~~~~~~
..\tests\test_operator_overloading.cpp(103,23): warning: explicitly assigning value of variable of type 'const pybind11::detail::self_t' to itself [-Wself-assign-overloaded]
        .def(py::self /= py::self)
             ~~~~~~~~ ^  ~~~~~~~~
2 warnings generated.
[42/42] Linking CXX shared module ..\tests\pybind11_tests.cp37-win_amd64.pyd
------ pybind11_tests.cp37-win_amd64.pyd file size: 10500096

$> pytest .
================================================= test session starts =================================================
platform win32 -- Python 3.7.4, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
plugins: arraydiff-0.3, doctestplus-0.4.0, openfiles-0.4.0, remotedata-0.3.2
collected 333 items

test_async.py ..                                                                                                 [  0%]
test_buffers.py ......                                                                                           [  2%]
test_builtin_casters.py ....s...........                                                                         [  7%]
test_call_policies.py ........                                                                                   [  9%]
test_callbacks.py .........                                                                                      [ 12%]
test_chrono.py ...........                                                                                       [ 15%]
test_class.py .................                                                                                  [ 20%]
test_constants_and_functions.py ....                                                                             [ 21%]
test_copy_move.py ....s..                                                                                        [ 24%]
test_docstring_options.py .                                                                                      [ 24%]
test_eigen.py .........................                                                                          [ 31%]
test_enum.py ......                                                                                              [ 33%]
test_eval.py .                                                                                                   [ 33%]
test_exceptions.py .......                                                                                       [ 36%]
test_factory_constructors.py .........                                                                           [ 38%]
test_gil_scoped.py .....                                                                                         [ 40%]
test_iostream.py ............                                                                                    [ 43%]
test_kwargs_and_defaults.py .....                                                                                [ 45%]
test_local_bindings.py ..........                                                                                [ 48%]
test_methods_and_attributes.py ....................                                                              [ 54%]
test_modules.py .....                                                                                            [ 55%]
test_multiple_inheritance.py ...........                                                                         [ 59%]
test_numpy_array.py ....................................                                                         [ 69%]
test_numpy_dtypes.py .............                                                                               [ 73%]
test_numpy_vectorize.py .......                                                                                  [ 75%]
test_opaque_types.py ..                                                                                          [ 76%]
test_operator_overloading.py ...                                                                                 [ 77%]
test_pickling.py .....                                                                                           [ 78%]
test_pytypes.py .............                                                                                    [ 82%]
test_sequences_and_iterators.py .......                                                                          [ 84%]
test_smart_ptr.py .............                                                                                  [ 88%]
test_stl.py ........sss.......                                                                                   [ 94%]
test_stl_binders.py .........                                                                                    [ 96%]
test_tagbased_polymorphic.py .                                                                                   [ 97%]
test_union.py .                                                                                                  [ 97%]
test_virtual_functions.py ........                                                                               [100%]
```