### PR TITLE
Throw TypeError when subclasses forget to call __init__

### DIFF
--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -149,6 +149,11 @@ memory for the C++ portion of the instance will be left uninitialized, which
 will generally leave the C++ instance in an invalid state and cause undefined
 behavior if the C++ instance is subsequently used.
 
+.. versionadded:: 2.5.1
+
+   The default pybind11 metaclass will throw a ``TypeError`` when it detects
+   that ``__init__`` was not called by a derived class.
+
 Here is an example:
 
 .. code-block:: python

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -156,6 +156,31 @@ extern "C" inline PyObject *pybind11_meta_getattro(PyObject *obj, PyObject *name
 }
 #endif
 
+/// metaclass `__call__` function that is used to create all pybind11 objects.
+extern "C" inline PyObject *pybind11_meta_call(PyObject *type, PyObject *args, PyObject *kwargs) {
+
+    // use the default metaclass call to create/initialize the object
+    PyObject *self = PyType_Type.tp_call(type, args, kwargs);
+    if (self == nullptr) {
+        return nullptr;
+    }
+
+    // This must be a pybind11 instance
+    auto instance = reinterpret_cast<detail::instance *>(self);
+
+    // Ensure that the base __init__ function(s) were called
+    for (auto vh : values_and_holders(instance)) {
+        if (!vh.holder_constructed()) {
+            PyErr_Format(PyExc_TypeError, "%.200s.__init__() must be called when overriding __init__",
+                         vh.type->type->tp_name);
+            Py_DECREF(self);
+            return nullptr;
+        }
+    }
+
+    return self;
+}
+
 /** This metaclass is assigned by default to all pybind11 types and is required in order
     for static properties to function correctly. Users may override this using `py::metaclass`.
     Return value: New reference. */
@@ -180,6 +205,8 @@ inline PyTypeObject* make_default_metaclass() {
     type->tp_name = name;
     type->tp_base = type_incref(&PyType_Type);
     type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
+
+    type->tp_call = pybind11_meta_call;
 
     type->tp_setattro = pybind11_meta_setattro;
 #if PY_MAJOR_VERSION >= 3

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -101,6 +101,27 @@ def test_inheritance(msg):
     assert "No constructor defined!" in str(excinfo.value)
 
 
+def test_inheritance_init(msg):
+
+    # Single base
+    class Python(m.Pet):
+        def __init__(self):
+            pass
+    with pytest.raises(TypeError) as exc_info:
+        Python()
+    assert msg(exc_info.value) == "m.class_.Pet.__init__() must be called when overriding __init__"
+
+    # Multiple bases
+    class RabbitHamster(m.Rabbit, m.Hamster):
+        def __init__(self):
+            m.Rabbit.__init__(self, "RabbitHamster")
+
+    with pytest.raises(TypeError) as exc_info:
+        RabbitHamster()
+    expected = "m.class_.Hamster.__init__() must be called when overriding __init__"
+    assert msg(exc_info.value) == expected
+
+
 def test_automatic_upcasting():
     assert type(m.return_class_1()).__name__ == "DerivedClass1"
     assert type(m.return_class_2()).__name__ == "DerivedClass2"


### PR DESCRIPTION
Forgetting to call `__init__` in inherited classes is one of the biggest issues my users run into (and it's frustrating because it typically causes a segfault), I'd love to see this merged. It would make pybind11 so much more usable!

... this probably causes a minor performance impact when creating new objects. I would expect it to be in the noise, though I haven't looked at the timing yet.

- Fixes #2103