### PR TITLE
Improve finding python with cmake >= 3.12.0

### DIFF
--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -55,17 +55,27 @@ if(PYTHONLIBS_FOUND AND PYTHON_MODULE_EXTENSION)
     return()
 endif()
 
-# Use the Python interpreter to find the libs.
-if(PythonLibsNew_FIND_REQUIRED)
-    find_package(PythonInterp ${PythonLibsNew_FIND_VERSION} REQUIRED)
+if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    set(PythonLibsNew_FIND_MODULE "PythonInterp")
 else()
-    find_package(PythonInterp ${PythonLibsNew_FIND_VERSION})
+    set(PythonLibsNew_FIND_MODULE "Python")
 endif()
 
-if(NOT PYTHONINTERP_FOUND)
+# Use the Python interpreter to find the libs.
+if(PythonLibsNew_FIND_REQUIRED)
+    find_package(${PythonLibsNew_FIND_MODULE} ${PythonLibsNew_FIND_VERSION} REQUIRED)
+else()
+    find_package(${PythonLibsNew_FIND_MODULE} ${PythonLibsNew_FIND_VERSION})
+endif()
+
+if(NOT (PYTHONINTERP_FOUND OR ${PythonLibsNew_FIND_MODULE}_FOUND))
     set(PYTHONLIBS_FOUND FALSE)
     set(PythonLibsNew_FOUND FALSE)
     return()
+endif()
+
+if(NOT PYTHONINTERP_FOUND)
+    set(PYTHON_EXECUTABLE "${${PythonLibsNew_FIND_MODULE}_EXECUTABLE}")
 endif()
 
 # According to http://stackoverflow.com/questions/646518/python-how-to-detect-debug-interpreter


### PR DESCRIPTION
Hi,

With this change, during setup, cmake uses the new "Python" cmake module instead of the old "PythonInterp" **if** the cmake version is >= 3.12.0. This has the advantage of properly detecting python3 even on systems where both python2 and python3 are installed and python2 preceedes python3 in the PATH environment variable.

I have the above situation here, and therefore would appreciate if you could merge that. It also applies to v.2.5 without changes.

Cheers
 -Fritz