### PR TITLE
Set libclang.so library path in Mkdocs script

### DIFF
--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -258,7 +258,7 @@ def read_args(args):
         # versions and distributions. LLVM switched to a monolithical setup
         # that includes everything under /usr/lib/llvm{version_number}/
         # We therefore glob for the library and select the highest version
-        library_file = sorted(glob("/usr/lib/llvm-*/lib/libclang.so"), reversed=True)[0]
+        library_file = sorted(glob("/usr/lib/llvm-*/lib/libclang.so"), reverse=True)[0]
         cindex.Config.set_library_file(library_file)
 
         # clang doesn't find its own base includes by default on Linux,

--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -258,8 +258,8 @@ def read_args(args):
         # versions and distributions. LLVM switched to a monolithical setup
         # that includes everything under /usr/lib/llvm{version_number}/
         # We therefore glob for the library and select the highest version
-        library_path = sorted(glob("/usr/lib/llvm-*/lib/"), reversed=True)[0]
-        cindex.Config.set_library_path(library_path)
+        library_file = sorted(glob("/usr/lib/llvm-*/lib/libclang.so"), reversed=True)[0]
+        cindex.Config.set_library_file(library_file)
 
         # clang doesn't find its own base includes by default on Linux,
         # but different distros install them in different paths.

--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -254,6 +254,13 @@ def read_args(args):
             parameters.append('-isysroot')
             parameters.append(sysroot_dir)
     elif platform.system() == 'Linux':
+        # cython.util.find_library does not find `libclang` for all clang
+        # versions and distributions. LLVM switched to a monolithical setup
+        # that includes everything under /usr/lib/llvm{version_number}/
+        # We therefore glob for the library and select the highest version
+        library_path = sorted(glob("/usr/lib/llvm-*/lib/"), reversed=True)[0]
+        cindex.Config.set_library_path(library_path)
+
         # clang doesn't find its own base includes by default on Linux,
         # but different distros install them in different paths.
         # Try to autodetect, preferring the highest numbered version.


### PR DESCRIPTION
The ctypes.util module method `find_library` relies on ldconfig and gcc to return the path to a shared_library.
This seems to fail at least on any ubuntu version. 
Apparently llvm switched to a monolithical release pattern and packs all the libraries under
`/usr/lib/llvm-{some_version_number}`

The following is the output if called without the fix. See the last line.
```
./lib/pybind11/tools/mkdoc.py some.h a.h
Processing "some.h" ..
Processing "a.h" ..
Waiting for jobs to finish ..
/*
  This file contains docstrings for the Python bindings.
  Do not edit! These were automatically extracted by mkdoc.py
 */

#define __EXPAND(x)                                      x
#define __COUNT(_1, _2, _3, _4, _5, _6, _7, COUNT, ...)  COUNT
#define __VA_SIZE(...)                                   __EXPAND(__COUNT(__VA_ARGS__, 7, 6, 5, 4, 3, 2, 1))
#define __CAT1(a, b)                                     a ## b
#define __CAT2(a, b)                                     __CAT1(a, b)
#define __DOC1(n1)                                       __doc_##n1
#define __DOC2(n1, n2)                                   __doc_##n1##_##n2
#define __DOC3(n1, n2, n3)                               __doc_##n1##_##n2##_##n3
#define __DOC4(n1, n2, n3, n4)                           __doc_##n1##_##n2##_##n3##_##n4
#define __DOC5(n1, n2, n3, n4, n5)                       __doc_##n1##_##n2##_##n3##_##n4##_##n5
#define __DOC6(n1, n2, n3, n4, n5, n6)                   __doc_##n1##_##n2##_##n3##_##n4##_##n5##_##n6
#define __DOC7(n1, n2, n3, n4, n5, n6, n7)               __doc_##n1##_##n2##_##n3##_##n4##_##n5##_##n6##_##n7
#define DOC(...)                                         __EXPAND(__EXPAND(__CAT2(__DOC, __VA_SIZE(__VA_ARGS__)))(__VA_ARGS__))

#if defined(__GNUG__)
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wunused-variable"
#endif


#if defined(__GNUG__)
#pragma GCC diagnostic pop
#endif
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/home/someuser/control/simulator/lib/pybind11/tools/clang/cindex.py", line 3840, in get_cindex_library
    library = cdll.LoadLibrary(self.get_filename())
  File "/usr/lib/python3.6/ctypes/__init__.py", line 426, in LoadLibrary
    return self._dlltype(name)
  File "/usr/lib/python3.6/ctypes/__init__.py", line 348, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libclang.so: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "./lib/pybind11/tools/mkdoc.py", line 229, in run
    cindex.conf.lib.clang_createIndex(False, True))
  File "/home/someuser/control/simulator/lib/pybind11/tools/clang/cindex.py", line 141, in __get__
    value = self.wrapped(instance)
  File "/home/someuser/control/simulator/lib/pybind11/tools/clang/cindex.py", line 3814, in lib
    lib = self.get_cindex_library()
  File "/home/someuser/control/simulator/lib/pybind11/tools/clang/cindex.py", line 3845, in get_cindex_library
    raise LibclangError(msg)
clang.cindex.LibclangError: libclang.so: cannot open shared object file: No such file or directory. To provide a path to libclang use Config.set_library_path() or Config.set_library_file().


Exception in thread Thread-1:
Traceback (most recent call last):
  File "/home/someuser/control/simulator/lib/pybind11/tools/clang/cindex.py", line 3840, in get_cindex_library
    library = cdll.LoadLibrary(self.get_filename())
  File "/usr/lib/python3.6/ctypes/__init__.py", line 426, in LoadLibrary
    return self._dlltype(name)
  File "/usr/lib/python3.6/ctypes/__init__.py", line 348, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libclang.so: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "./lib/pybind11/tools/mkdoc.py", line 229, in run
    cindex.conf.lib.clang_createIndex(False, True))
  File "/home/someuser/control/simulator/lib/pybind11/tools/clang/cindex.py", line 141, in __get__
    value = self.wrapped(instance)
  File "/home/someuser/control/simulator/lib/pybind11/tools/clang/cindex.py", line 3814, in lib
    lib = self.get_cindex_library()
  File "/home/someuser/control/simulator/lib/pybind11/tools/clang/cindex.py", line 3845, in get_cindex_library
    raise LibclangError(msg)
clang.cindex.LibclangError: libclang.so: cannot open shared object file: No such file or directory. To provide a path to libclang use Config.set_library_path() or Config.set_library_file().
```