### PR TITLE
pdoc3 integration

### DIFF
--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -304,3 +304,45 @@ the default settings are restored to prevent unwanted side effects.
 
 .. [#f4] http://www.sphinx-doc.org
 .. [#f5] http://github.com/pybind/python_example
+
+
+Generating documentation using pdoc3
+====================================
+
+pdoc3 [#f8]_ is an alternative for generate documentation without the need of a rather complex
+configuration like for Sphinx. It is especially usefull when documenting embedded python modules.
+
+It is recommended to enable the auto generation of function signaures and for a nice looking
+documentation of enums, you propably want to disable the ``enum_members_docstring`` option and
+enable the ``populate_enum_pdoc`` option:
+
+.. code-block:: cpp
+
+    PYBIND11_MODULE(example, m) {
+        py::options options;
+        options.enable_function_signatures();
+        options.disable_enum_members_docstring();
+        options.enable_enum_pdoc();
+
+        py::class_<Pet> pet(m, "Pet", "A pet.");
+
+        py::enum_<Pet::Kind>(pet, "Kind", "The kind of a pet.")
+            .value("Dog", Pet::Kind::Dog, "A dog.")
+            .value("Cat", Pet::Kind::Cat, "A cat.");
+    }
+
+To generate the documentation for embedded modules, you have to run pdoc3 inside your embedded
+python interpreter:
+
+.. code-block:: python
+
+    import example
+    import sys
+    import pdoc
+
+    html_str = pdoc.html("example", show_type_annotations=True)
+    f = open('./example_documentation.html', 'w')
+    print(html_str, file=f)
+    f.close()
+
+.. [#f8] https://pdoc3.github.io/pdoc/

--- a/include/pybind11/options.h
+++ b/include/pybind11/options.h
@@ -38,11 +38,17 @@ public:
 
     options& enable_function_signatures() & { global_state().show_function_signatures = true; return *this; }
 
+    options& disable_enum_members_docstring() & { global_state().show_enum_members_docstring = false; return *this; }
+
+    options& enable_enum_members_docstring() & { global_state().show_enum_members_docstring = true; return *this; }
+
     // Getter methods (return the global state):
 
     static bool show_user_defined_docstrings() { return global_state().show_user_defined_docstrings; }
 
     static bool show_function_signatures() { return global_state().show_function_signatures; }
+
+    static bool show_enum_members_docstring() { return global_state().show_enum_members_docstring; }
 
     // This type is not meant to be allocated on the heap.
     void* operator new(size_t) = delete;
@@ -52,6 +58,7 @@ private:
     struct state {
         bool show_user_defined_docstrings = true;  //< Include user-supplied texts in docstrings.
         bool show_function_signatures = true;      //< Include auto-generated function signatures in docstrings.
+        bool show_enum_members_docstring = true;   //< Include auto-generated member list in enum docstring.
     };
 
     static state &global_state() {

--- a/include/pybind11/options.h
+++ b/include/pybind11/options.h
@@ -42,6 +42,10 @@ public:
 
     options& enable_enum_members_docstring() & { global_state().show_enum_members_docstring = true; return *this; }
 
+    options& disable_enum_pdoc() & { global_state().populate_enum_pdoc = false; return *this; }
+
+    options& enable_enum_pdoc() & { global_state().populate_enum_pdoc = true; return *this; }
+
     // Getter methods (return the global state):
 
     static bool show_user_defined_docstrings() { return global_state().show_user_defined_docstrings; }
@@ -49,6 +53,8 @@ public:
     static bool show_function_signatures() { return global_state().show_function_signatures; }
 
     static bool show_enum_members_docstring() { return global_state().show_enum_members_docstring; }
+
+    static bool populate_enum_pdoc() { return global_state().populate_enum_pdoc; }
 
     // This type is not meant to be allocated on the heap.
     void* operator new(size_t) = delete;
@@ -59,6 +65,7 @@ private:
         bool show_user_defined_docstrings = true;  //< Include user-supplied texts in docstrings.
         bool show_function_signatures = true;      //< Include auto-generated function signatures in docstrings.
         bool show_enum_members_docstring = true;   //< Include auto-generated member list in enum docstring.
+        bool populate_enum_pdoc = false;           //< Add auto-generated __pdoc__ Dict for enum members.
     };
 
     static state &global_state() {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1540,6 +1540,15 @@ struct enum_base {
 
         entries[name] = std::make_pair(value, doc);
         m_base.attr(name) = value;
+
+        if (options::populate_enum_pdoc()) {
+            if (!hasattr(m_parent, "__pdoc__")) {
+                // Add the __pdoc__ dict to the  module if it isn't already there
+                m_parent.attr("__pdoc__") = dict();
+            }
+            auto doc_key = str("{}.{}").format(m_base.attr("__name__"), name);
+            m_parent.attr("__pdoc__")[doc_key] = doc;
+        }
     }
 
     PYBIND11_NOINLINE void export_values() {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1432,19 +1432,22 @@ struct enum_base {
             }, is_method(m_base)
         ));
 
+        bool show_enum_members = options::show_enum_members_docstring();
         m_base.attr("__doc__") = static_property(cpp_function(
-            [](handle arg) -> std::string {
+            [show_enum_members](handle arg) -> std::string {
                 std::string docstring;
-                dict entries = arg.attr("__entries");
                 if (((PyTypeObject *) arg.ptr())->tp_doc)
-                    docstring += std::string(((PyTypeObject *) arg.ptr())->tp_doc) + "\n\n";
-                docstring += "Members:";
-                for (const auto &kv : entries) {
-                    auto key = std::string(pybind11::str(kv.first));
-                    auto comment = kv.second[int_(1)];
-                    docstring += "\n\n  " + key;
-                    if (!comment.is_none())
-                        docstring += " : " + (std::string) pybind11::str(comment);
+                    docstring += std::string(((PyTypeObject *) arg.ptr())->tp_doc);
+                if (show_enum_members) {
+                    docstring += "\n\nMembers:";
+                    dict entries = arg.attr("__entries");
+                    for (const auto &kv : entries) {
+                        auto key = std::string(pybind11::str(kv.first));
+                        auto comment = kv.second[int_(1)];
+                        docstring += "\n\n  " + key;
+                        if (!comment.is_none())
+                            docstring += " : " + (std::string) pybind11::str(comment);
+                    }
                 }
                 return docstring;
             }


### PR DESCRIPTION
I wanted to document my embedded python module but on the one hand Sphinx was to complicated and didn't work for me and on the other hand pydoc wasn't able to generate a good looking documentation.
I found [pdoc3](https://pdoc3.github.io/pdoc/), which I was able to run from inside my embedded python interpreter and it was generating a [nice looking documentation for my project](https://knarfs.github.io/doc/smuview/0.0.4/python_bindings_api.html).

This PR contains three things:
1. An option to disable the list of the enum members in the docstring for the enum.
2. An optional [``__pdoc__`` module attribute](https://pdoc3.github.io/pdoc/doc/pdoc/#overriding-docstrings-with-__pdoc__) for the clean documentation of the enum members with pdoc3.
3. An initial chapter in the documentation about documenting with pdoc3.