### PR TITLE
Documentation Custom Type Caster: Change __init__(self) to __new__(cls)

### DIFF
--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -23,7 +23,7 @@ The following Python snippet demonstrates the intended usage from the Python sid
 .. code-block:: python
 
     class A:
-        def __int__(self):
+        def __new__(cls):
             return 123
 
     from example import print


### PR DESCRIPTION
```__init__(self)``` cannot return values. 

According to https://stackoverflow.com/questions/2491819/how-to-return-a-value-from-init-in-python ```__new__(cls)``` should be used, which works.