### PR TITLE
Function-like macro semicolon inconsistency fix

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2141,7 +2141,7 @@ template <class T> function get_overload(const T *this_ptr, const char *name) {
 \endrst */
 #define PYBIND11_OVERLOAD_NAME(ret_type, cname, name, fn, ...) \
     PYBIND11_OVERLOAD_INT(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__) \
-    return cname::fn(__VA_ARGS__)
+    return cname::fn(__VA_ARGS__);
 
 /** \rst
     Macro for pure virtual functions, this function is identical to :c:macro:`PYBIND11_OVERLOAD_NAME`, except that it


### PR DESCRIPTION
I was using pybind11 to wrap a class containing virtual and pure virtual functions. 

I noticed that the function-like macros: PYBIND11_OVERLOAD and PYBIND11_OVERLOAD_PURE behaved a bit differently when I was compiling my program. 

I ran into errors where the compiler complained that I was missing a semicolon when using PYBIND11_OVERLOAD but it did not complain when I was using PYBIND11_OVERLOAD_PURE. 
So there is an inconsistency here making PYBIND11_OVERLOAD_PURE statements ok without semicolons. 

What I am trying to say in code:

```
/* Compiler thinks this is fine */
PYBIND11_OVERLOAD_PURE( .... )
PYBIND11_OVERLOAD_PURE( .... )

/* Compiler does not think this is fine */
PYBIND11_OVERLOAD( .... )
PYBIND11_OVERLOAD( .... )

/* I must add semicolons to make it happy */
PYBIND11_OVERLOAD( .... );
PYBIND11_OVERLOAD( .... );
```
There is a slight inconsistency here.

I introduced a change so that PYBIND11_OVERLOAD can be called with or without semicolons and I thought perhaps maybe you would like to see it also.