### PR TITLE
Docstring generation tweaks

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1604,6 +1604,7 @@ template <typename base, typename deleter> struct is_holder_type<base, std::uniq
 
 template <typename T> struct handle_type_name { static constexpr auto name = _<T>(); };
 template <> struct handle_type_name<bytes> { static constexpr auto name = _(PYBIND11_BYTES_NAME); };
+template <> struct handle_type_name<int_> { static constexpr auto name = _("int"); };
 template <> struct handle_type_name<iterable> { static constexpr auto name = _("Iterable"); };
 template <> struct handle_type_name<iterator> { static constexpr auto name = _("Iterator"); };
 template <> struct handle_type_name<args> { static constexpr auto name = _("*args"); };

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1604,6 +1604,8 @@ template <typename base, typename deleter> struct is_holder_type<base, std::uniq
 
 template <typename T> struct handle_type_name { static constexpr auto name = _<T>(); };
 template <> struct handle_type_name<bytes> { static constexpr auto name = _(PYBIND11_BYTES_NAME); };
+template <> struct handle_type_name<iterable> { static constexpr auto name = _("Iterable"); };
+template <> struct handle_type_name<iterator> { static constexpr auto name = _("Iterator"); };
 template <> struct handle_type_name<args> { static constexpr auto name = _("*args"); };
 template <> struct handle_type_name<kwargs> { static constexpr auto name = _("**kwargs"); };
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -40,6 +40,9 @@ NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 class array; // Forward declaration
 
 NAMESPACE_BEGIN(detail)
+
+template <> struct handle_type_name<array> { static constexpr auto name = _("numpy.ndarray"); };
+
 template <typename type, typename SFINAE = void> struct npy_format_descriptor;
 
 struct PyArrayDescr_Proxy {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1007,14 +1007,14 @@ struct npy_format_descriptor_name;
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_integral<T>::value>> {
     static constexpr auto name = _<std::is_same<T, bool>::value>(
-        _("bool"), _<std::is_signed<T>::value>("int", "uint") + _<sizeof(T)*8>()
+        _("bool"), _<std::is_signed<T>::value>("numpy.int", "numpy.uint") + _<sizeof(T)*8>()
     );
 };
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_floating_point<T>::value>> {
     static constexpr auto name = _<std::is_same<T, float>::value || std::is_same<T, double>::value>(
-        _("float") + _<sizeof(T)*8>(), _("longdouble")
+        _("numpy.float") + _<sizeof(T)*8>(), _("numpy.longdouble")
     );
 };
 
@@ -1022,7 +1022,7 @@ template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<is_complex<T>::value>> {
     static constexpr auto name = _<std::is_same<typename T::value_type, float>::value
                                    || std::is_same<typename T::value_type, double>::value>(
-        _("complex") + _<sizeof(typename T::value_type)*16>(), _("longcomplex")
+        _("numpy.complex") + _<sizeof(typename T::value_type)*16>(), _("numpy.longcomplex")
     );
 };
 

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -79,15 +79,17 @@ def test_mutator_descriptors():
     m.fixed_mutator_a(zc)
     with pytest.raises(TypeError) as excinfo:
         m.fixed_mutator_r(zc)
-    assert ('(arg0: numpy.ndarray[float32[5, 6], flags.writeable, flags.c_contiguous]) -> None'
+    assert ('(arg0: numpy.ndarray[numpy.float32[5, 6],'
+            ' flags.writeable, flags.c_contiguous]) -> None'
             in str(excinfo.value))
     with pytest.raises(TypeError) as excinfo:
         m.fixed_mutator_c(zr)
-    assert ('(arg0: numpy.ndarray[float32[5, 6], flags.writeable, flags.f_contiguous]) -> None'
+    assert ('(arg0: numpy.ndarray[numpy.float32[5, 6],'
+            ' flags.writeable, flags.f_contiguous]) -> None'
             in str(excinfo.value))
     with pytest.raises(TypeError) as excinfo:
         m.fixed_mutator_a(np.array([[1, 2], [3, 4]], dtype='float32'))
-    assert ('(arg0: numpy.ndarray[float32[5, 6], flags.writeable]) -> None'
+    assert ('(arg0: numpy.ndarray[numpy.float32[5, 6], flags.writeable]) -> None'
             in str(excinfo.value))
     zr.flags.writeable = False
     with pytest.raises(TypeError):
@@ -179,7 +181,7 @@ def test_negative_stride_from_python(msg):
         m.double_threer(second_row)
     assert msg(excinfo.value) == """
         double_threer(): incompatible function arguments. The following argument types are supported:
-            1. (arg0: numpy.ndarray[float32[1, 3], flags.writeable]) -> None
+            1. (arg0: numpy.ndarray[numpy.float32[1, 3], flags.writeable]) -> None
 
         Invoked with: """ + repr(np.array([ 5.,  4.,  3.], dtype='float32'))  # noqa: E501 line too long
 
@@ -187,7 +189,7 @@ def test_negative_stride_from_python(msg):
         m.double_threec(second_col)
     assert msg(excinfo.value) == """
         double_threec(): incompatible function arguments. The following argument types are supported:
-            1. (arg0: numpy.ndarray[float32[3, 1], flags.writeable]) -> None
+            1. (arg0: numpy.ndarray[numpy.float32[3, 1], flags.writeable]) -> None
 
         Invoked with: """ + repr(np.array([ 7.,  4.,  1.], dtype='float32'))  # noqa: E501 line too long
 
@@ -607,17 +609,19 @@ def test_special_matrix_objects():
 
 def test_dense_signature(doc):
     assert doc(m.double_col) == """
-        double_col(arg0: numpy.ndarray[float32[m, 1]]) -> numpy.ndarray[float32[m, 1]]
+        double_col(arg0: numpy.ndarray[numpy.float32[m, 1]]) -> numpy.ndarray[numpy.float32[m, 1]]
     """
     assert doc(m.double_row) == """
-        double_row(arg0: numpy.ndarray[float32[1, n]]) -> numpy.ndarray[float32[1, n]]
+        double_row(arg0: numpy.ndarray[numpy.float32[1, n]]) -> numpy.ndarray[numpy.float32[1, n]]
     """
-    assert doc(m.double_complex) == """
-        double_complex(arg0: numpy.ndarray[complex64[m, 1]]) -> numpy.ndarray[complex64[m, 1]]
-    """
-    assert doc(m.double_mat_rm) == """
-        double_mat_rm(arg0: numpy.ndarray[float32[m, n]]) -> numpy.ndarray[float32[m, n]]
-    """
+    assert doc(m.double_complex) == ("""
+        double_complex(arg0: numpy.ndarray[numpy.complex64[m, 1]])"""
+                                     """ -> numpy.ndarray[numpy.complex64[m, 1]]
+    """)
+    assert doc(m.double_mat_rm) == ("""
+        double_mat_rm(arg0: numpy.ndarray[numpy.float32[m, n]])"""
+                                    """ -> numpy.ndarray[numpy.float32[m, n]]
+    """)
 
 
 def test_named_arguments():
@@ -654,10 +658,10 @@ def test_sparse():
 @pytest.requires_eigen_and_scipy
 def test_sparse_signature(doc):
     assert doc(m.sparse_copy_r) == """
-        sparse_copy_r(arg0: scipy.sparse.csr_matrix[float32]) -> scipy.sparse.csr_matrix[float32]
+        sparse_copy_r(arg0: scipy.sparse.csr_matrix[numpy.float32]) -> scipy.sparse.csr_matrix[numpy.float32]
     """  # noqa: E501 line too long
     assert doc(m.sparse_copy_c) == """
-        sparse_copy_c(arg0: scipy.sparse.csc_matrix[float32]) -> scipy.sparse.csc_matrix[float32]
+        sparse_copy_c(arg0: scipy.sparse.csc_matrix[numpy.float32]) -> scipy.sparse.csc_matrix[numpy.float32]
     """  # noqa: E501 line too long
 
 

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -286,13 +286,13 @@ def test_overload_resolution(msg):
         m.overloaded("not an array")
     assert msg(excinfo.value) == """
         overloaded(): incompatible function arguments. The following argument types are supported:
-            1. (arg0: numpy.ndarray[float64]) -> str
-            2. (arg0: numpy.ndarray[float32]) -> str
-            3. (arg0: numpy.ndarray[int32]) -> str
-            4. (arg0: numpy.ndarray[uint16]) -> str
-            5. (arg0: numpy.ndarray[int64]) -> str
-            6. (arg0: numpy.ndarray[complex128]) -> str
-            7. (arg0: numpy.ndarray[complex64]) -> str
+            1. (arg0: numpy.ndarray[numpy.float64]) -> str
+            2. (arg0: numpy.ndarray[numpy.float32]) -> str
+            3. (arg0: numpy.ndarray[numpy.int32]) -> str
+            4. (arg0: numpy.ndarray[numpy.uint16]) -> str
+            5. (arg0: numpy.ndarray[numpy.int64]) -> str
+            6. (arg0: numpy.ndarray[numpy.complex128]) -> str
+            7. (arg0: numpy.ndarray[numpy.complex64]) -> str
 
         Invoked with: 'not an array'
     """
@@ -307,8 +307,8 @@ def test_overload_resolution(msg):
     assert m.overloaded3(np.array([1], dtype='intc')) == 'int'
     expected_exc = """
         overloaded3(): incompatible function arguments. The following argument types are supported:
-            1. (arg0: numpy.ndarray[int32]) -> str
-            2. (arg0: numpy.ndarray[float64]) -> str
+            1. (arg0: numpy.ndarray[numpy.int32]) -> str
+            2. (arg0: numpy.ndarray[numpy.float64]) -> str
 
         Invoked with: """
 

--- a/tests/test_numpy_vectorize.py
+++ b/tests/test_numpy_vectorize.py
@@ -109,7 +109,7 @@ def test_type_selection():
 
 def test_docs(doc):
     assert doc(m.vectorized_func) == """
-        vectorized_func(arg0: numpy.ndarray[int32], arg1: numpy.ndarray[float32], arg2: numpy.ndarray[float64]) -> object
+        vectorized_func(arg0: numpy.ndarray[numpy.int32], arg1: numpy.ndarray[numpy.float32], arg2: numpy.ndarray[numpy.float64]) -> object
     """  # noqa: E501 line too long
 
 
@@ -160,12 +160,12 @@ def test_passthrough_arguments(doc):
     assert doc(m.vec_passthrough) == (
         "vec_passthrough(" + ", ".join([
             "arg0: float",
-            "arg1: numpy.ndarray[float64]",
-            "arg2: numpy.ndarray[float64]",
-            "arg3: numpy.ndarray[int32]",
+            "arg1: numpy.ndarray[numpy.float64]",
+            "arg2: numpy.ndarray[numpy.float64]",
+            "arg3: numpy.ndarray[numpy.int32]",
             "arg4: int",
             "arg5: m.numpy_vectorize.NonPODClass",
-            "arg6: numpy.ndarray[float64]"]) + ") -> object")
+            "arg6: numpy.ndarray[numpy.float64]"]) + ") -> object")
 
     b = np.array([[10, 20, 30]], dtype='float64')
     c = np.array([100, 200])  # NOT a vectorized argument

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -13,6 +13,10 @@
 TEST_SUBMODULE(pytypes, m) {
     // test_int
     m.def("get_int", []{return py::int_(0);});
+    // test_iterator
+    m.def("get_iterator", []{return py::iterator();});
+    // test_iterable
+    m.def("get_iterable", []{return py::iterable();});
     // test_list
     m.def("get_list", []() {
         py::list list;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -11,6 +11,8 @@
 
 
 TEST_SUBMODULE(pytypes, m) {
+    // test_int
+    m.def("get_int", []{return py::int_(0);});
     // test_list
     m.def("get_list", []() {
         py::list list;

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -5,6 +5,8 @@ import sys
 from pybind11_tests import pytypes as m
 from pybind11_tests import debug_enabled
 
+def test_int(doc):
+    assert doc(m.get_int) == "get_int() -> int"
 
 def test_list(capture, doc):
     with capture:

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -5,8 +5,18 @@ import sys
 from pybind11_tests import pytypes as m
 from pybind11_tests import debug_enabled
 
+
 def test_int(doc):
     assert doc(m.get_int) == "get_int() -> int"
+
+
+def test_iterator(doc):
+    assert doc(m.get_iterator) == "get_iterator() -> Iterator"
+
+
+def test_iterable(doc):
+    assert doc(m.get_iterable) == "get_iterable() -> Iterable"
+
 
 def test_list(capture, doc):
     with capture:


### PR DESCRIPTION
This PR contains a couple of trivial tweaks which make generated docstring a bit better. 

|  this PR | master | 
| ------------- |---------|
|  <pre>`a() -> numpy.ndarray[numpy.int32]`</pre> | <pre>`a() -> numpy.ndarray[int32]`</pre> | 
|  <pre>`b1(arg0: Iterator) -> None`<br>`b2(arg0: Iterable) -> None`</pre> | <pre>`b1(arg0: iterator) -> None`<br>`b2(arg0: iterable) -> None`</pre> | 
|  <pre>`c() -> numpy.ndarray`</pre> | <pre>`c() -> array`</pre> | 
|  <pre>`d() -> int`</pre> | <pre>`d() -> int_`</pre> | 


<details><summary><code>compare.cpp</code></summary>

```C++
#include "pybind11/pybind11.h"
#include "pybind11/stl_bind.h"
#include "pybind11/embed.h"
#include "pybind11/numpy.h"

namespace py = pybind11;

PYBIND11_EMBEDDED_MODULE(example, m) {

  std::array<int, 3> data = {1, 2, 3};
  m.def("a", [&]{ return py::array_t({3, 1}, data.data()); });
  m.def("b1", [](py::iterator&) { });
  m.def("b2", [](py::iterable&) { });
  m.def("c", []{ return py::array(); });
  m.def("d", []{ return py::int_(0); });
}

int main() {
  py::scoped_interpreter guard{};
  py::exec(R"(
      from example import *
      print(a.__doc__, end="")
      print(b1.__doc__, end="")
      print(b2.__doc__, end="")
      print(c.__doc__, end="")
      print(d.__doc__, end="")
)");
}
```
</details>