### PR TITLE
Add lvalue ref-qualified cpp_function constructors

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -80,6 +80,8 @@ public:
     }
 
     /// Construct a cpp_function from a class method (non-const, lvalue ref-qualifier)
+    /// Is a copy of the overload for non-const functions without explicit ref-qualifier
+    /// but with an added `&`.
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     cpp_function(Return (Class::*f)(Arg...)&, const Extra&... extra) {
         initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(args...); },
@@ -94,6 +96,8 @@ public:
     }
 
     /// Construct a cpp_function from a class method (const, lvalue ref-qualifier)
+    /// Is a copy of the overload for const functions without explicit ref-qualifier
+    /// but with an added `&`.
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     cpp_function(Return (Class::*f)(Arg...) const&, const Extra&... extra) {
         initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(args...); },

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -80,7 +80,7 @@ public:
     }
 
     /// Construct a cpp_function from a class method (non-const, lvalue ref-qualifier)
-    /// Is a copy of the overload for non-const functions without explicit ref-qualifier
+    /// A copy of the overload for non-const functions without explicit ref-qualifier
     /// but with an added `&`.
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     cpp_function(Return (Class::*f)(Arg...)&, const Extra&... extra) {
@@ -96,7 +96,7 @@ public:
     }
 
     /// Construct a cpp_function from a class method (const, lvalue ref-qualifier)
-    /// Is a copy of the overload for const functions without explicit ref-qualifier
+    /// A copy of the overload for const functions without explicit ref-qualifier
     /// but with an added `&`.
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     cpp_function(Return (Class::*f)(Arg...) const&, const Extra&... extra) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -72,16 +72,30 @@ public:
                    (detail::function_signature_t<Func> *) nullptr, extra...);
     }
 
-    /// Construct a cpp_function from a class method (non-const)
+    /// Construct a cpp_function from a class method (non-const, no ref-qualifier)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     cpp_function(Return (Class::*f)(Arg...), const Extra&... extra) {
         initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(args...); },
                    (Return (*) (Class *, Arg...)) nullptr, extra...);
     }
 
-    /// Construct a cpp_function from a class method (const)
+    /// Construct a cpp_function from a class method (non-const, lvalue ref-qualifier)
+    template <typename Return, typename Class, typename... Arg, typename... Extra>
+    cpp_function(Return (Class::*f)(Arg...)&, const Extra&... extra) {
+        initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(args...); },
+                   (Return (*) (Class *, Arg...)) nullptr, extra...);
+    }
+
+    /// Construct a cpp_function from a class method (const, no ref-qualifier)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     cpp_function(Return (Class::*f)(Arg...) const, const Extra&... extra) {
+        initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(args...); },
+                   (Return (*)(const Class *, Arg ...)) nullptr, extra...);
+    }
+
+    /// Construct a cpp_function from a class method (const, lvalue ref-qualifier)
+    template <typename Return, typename Class, typename... Arg, typename... Extra>
+    cpp_function(Return (Class::*f)(Arg...) const&, const Extra&... extra) {
         initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(args...); },
                    (Return (*)(const Class *, Arg ...)) nullptr, extra...);
     }

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -69,8 +69,6 @@ public:
 
     static py::str overloaded(float) { return "static float"; }
 
-    void refQualified(int other) & { value += other; }
-
     int value = 0;
 };
 
@@ -209,6 +207,14 @@ public:
     double sum() const { return rw_value + ro_value; }
 };
 
+// Test explicit lvalue ref-qualification
+struct RefQualified {
+    int value = 0;
+
+    void refQualified(int other) & { value += other; }
+    int constRefQualified(int other) const & { return value + other; }
+};
+
 TEST_SUBMODULE(methods_and_attributes, m) {
     // test_methods_and_attributes
     py::class_<ExampleMandA> emna(m, "ExampleMandA");
@@ -275,7 +281,6 @@ TEST_SUBMODULE(methods_and_attributes, m) {
             emna.def_static("overload_mixed2", static_cast<py::str (              *)(float   )>(&ExampleMandA::overloaded))
                 .def       ("overload_mixed2", static_cast<py::str (ExampleMandA::*)(int, int)>(&ExampleMandA::overloaded));
         })
-        .def("refQualified", &ExampleMandA::refQualified)
         .def("__str__", &ExampleMandA::toString)
         .def_readwrite("value", &ExampleMandA::value);
 
@@ -460,4 +465,11 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     m.def("custom_caster_destroy_const", []() -> const DestructionTester * { return new DestructionTester(); },
             py::return_value_policy::take_ownership); // Likewise (const doesn't inhibit destruction)
     m.def("destruction_tester_cstats", &ConstructorStats::get<DestructionTester>, py::return_value_policy::reference);
+
+    // test_methods_and_attributes
+    py::class_<RefQualified>(m, "RefQualified")
+        .def(py::init<>())
+        .def_readonly("value", &RefQualified::value)
+        .def("refQualified", &RefQualified::refQualified)
+        .def("constRefQualified", &RefQualified::constRefQualified);
 }

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -69,6 +69,8 @@ public:
 
     static py::str overloaded(float) { return "static float"; }
 
+    void refQualified(int other) & { value += other; }
+
     int value = 0;
 };
 
@@ -273,6 +275,7 @@ TEST_SUBMODULE(methods_and_attributes, m) {
             emna.def_static("overload_mixed2", static_cast<py::str (              *)(float   )>(&ExampleMandA::overloaded))
                 .def       ("overload_mixed2", static_cast<py::str (ExampleMandA::*)(int, int)>(&ExampleMandA::overloaded));
         })
+        .def("refQualified", &ExampleMandA::refQualified)
         .def("__str__", &ExampleMandA::toString)
         .def_readwrite("value", &ExampleMandA::value);
 

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -48,9 +48,7 @@ def test_methods_and_attributes():
     assert instance1.overloaded_float(1., 1) == "(float, float)"
     assert instance1.overloaded_float(1., 1.) == "(float, float)"
 
-    instance1.refQualified(1)
-    assert instance1.value == 321
-
+    assert instance1.value == 320
     instance1.value = 100
     assert str(instance1) == "ExampleMandA[value=100]"
 
@@ -512,3 +510,14 @@ def test_custom_caster_destruction():
 
     # Make sure we still only have the original object (from ..._no_destroy()) alive:
     assert cstats.alive() == 1
+
+
+def test_ref_qualified():
+    """Tests that explicit lvalue ref-qualified methods can be called just like their
+    non ref-qualified counterparts."""
+
+    r = m.RefQualified()
+    assert r.value == 0
+    r.refQualified(17)
+    assert r.value == 17
+    assert r.constRefQualified(23) == 40

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -48,7 +48,9 @@ def test_methods_and_attributes():
     assert instance1.overloaded_float(1., 1) == "(float, float)"
     assert instance1.overloaded_float(1., 1.) == "(float, float)"
 
-    assert instance1.value == 320
+    instance1.refQualified(1)
+    assert instance1.value == 321
+
     instance1.value = 100
     assert str(instance1) == "ExampleMandA[value=100]"
 


### PR DESCRIPTION
Hi there,

I tried and failed to bind a method with an explicit lvalue ref-qualifier (see [c++ reference](https://en.cppreference.com/w/cpp/language/member_functions)). I understand that we would not want to bind rvalue ref-qualified methods, but the lvalue counterparts should be safe..?

This PR adds two `cpp_function` constructor overloads for lvalue ref-qualified methods: one for const, the other for not.
I have also added a simple test method with an explicit lvalue ref-qualifier. The code would fail to compile without the additional constructors, now it compiles and works like it should (like a regular, non ref-qualified method).

Let me know what you think and thank you for all your hard work! pybind11 has been a joy to program against and it is used pretty much everywhere I worked.