### PR TITLE
Fix undefined memoryview format

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -18,3 +18,5 @@ ALIASES               += "endrst=\endverbatim"
 QUIET                  = YES
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = NO
+PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
+                         PY_MAJOR_VERSION=3

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -400,7 +400,7 @@ following:
         4, 5, 6, 7
     };
     m.def("get_memoryview2d", []() {
-        return py::memoryview::frombuffer(
+        return py::memoryview::from_buffer(
             buffer,                                    // buffer pointer
             { 2, 4 },                                  // shape (rows, cols)
             { sizeof(uint8_t) * 4, sizeof(uint8_t) }   // strides in bytes
@@ -412,12 +412,12 @@ managed by Python. The user is responsible for managing the lifetime of the
 buffer. Using a ``memoryview`` created in this way after deleting the buffer in
 C++ side results in undefined behavior.
 
-We can also use ``memoryview::frommemory`` for a simple 1D contiguous buffer:
+We can also use ``memoryview::from_memory`` for a simple 1D contiguous buffer:
 
 .. code-block:: cpp
 
     m.def("get_memoryview1d", []() {
-        return py::memoryview::frommemory(
+        return py::memoryview::from_memory(
             buffer,               // buffer pointer
             sizeof(uint8_t) * 8   // buffer size
         );
@@ -425,4 +425,4 @@ We can also use ``memoryview::frommemory`` for a simple 1D contiguous buffer:
 
 .. note::
 
-    ``memoryview::frommemory`` is not available in Python 2.
+    ``memoryview::from_memory`` is not available in Python 2.

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -407,10 +407,10 @@ following:
         );
     })
 
-This approach is meant for providing a ``memoryview`` for C/C++ buffer not
+This approach is meant for providing a ``memoryview`` for a C/C++ buffer not
 managed by Python. The user is responsible for managing the lifetime of the
-buffer. Using ``memoryview`` created from this approach after deleting the
-buffer in C++ side results in undefined behavior.
+buffer. Using a ``memoryview`` created in this way after deleting the buffer in
+C++ side results in undefined behavior.
 
 We can also use ``memoryview::frommemory`` for a simple 1D contiguous buffer:
 

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -54,7 +54,7 @@ struct buffer_info {
     explicit buffer_info(Py_buffer *view, bool ownview = true)
     : buffer_info(view->buf, view->itemsize, view->format, view->ndim,
             {view->shape, view->shape + view->ndim}, {view->strides, view->strides + view->ndim}, view->readonly) {
-        this->view = view;
+        this->m_view = view;
         this->ownview = ownview;
     }
 
@@ -73,16 +73,18 @@ struct buffer_info {
         ndim = rhs.ndim;
         shape = std::move(rhs.shape);
         strides = std::move(rhs.strides);
-        std::swap(view, rhs.view);
+        std::swap(m_view, rhs.m_view);
         std::swap(ownview, rhs.ownview);
         readonly = rhs.readonly;
         return *this;
     }
 
     ~buffer_info() {
-        if (view && ownview) { PyBuffer_Release(view); delete view; }
+        if (m_view && ownview) { PyBuffer_Release(m_view); delete m_view; }
     }
 
+    Py_buffer *view() const { return m_view; }
+    Py_buffer *&view() { return m_view; }
 private:
     struct private_ctr_tag { };
 
@@ -90,7 +92,7 @@ private:
                 detail::any_container<ssize_t> &&shape_in, detail::any_container<ssize_t> &&strides_in, bool readonly)
     : buffer_info(ptr, itemsize, format, ndim, std::move(shape_in), std::move(strides_in), readonly) { }
 
-    Py_buffer *view = nullptr;
+    Py_buffer *m_view = nullptr;
     bool ownview = false;
 };
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1377,14 +1377,34 @@ public:
             written to.
      \endrst */
     static memoryview frombuffer(
-        void *ptr, ssize_t itemsize, const char* format,
+        void *ptr, ssize_t itemsize, const char *format,
         detail::any_container<ssize_t> shape,
         detail::any_container<ssize_t> strides, bool readonly = false);
+
+    static memoryview frombuffer(
+        const void *ptr, ssize_t itemsize, const char *format,
+        detail::any_container<ssize_t> shape,
+        detail::any_container<ssize_t> strides) {
+        return memoryview::frombuffer(
+            const_cast<void*>(ptr), itemsize, format, shape, strides, true);
+    }
 
     template<typename T>
     static memoryview frombuffer(
         T *ptr, detail::any_container<ssize_t> shape,
-        detail::any_container<ssize_t> strides, bool readonly = false);
+        detail::any_container<ssize_t> strides, bool readonly = false) {
+        return memoryview::frombuffer(
+            reinterpret_cast<void*>(ptr), sizeof(T),
+            format_descriptor<T>::value, shape, strides, readonly);
+    }
+
+    template<typename T>
+    static memoryview frombuffer(
+        const T *ptr, detail::any_container<ssize_t> shape,
+        detail::any_container<ssize_t> strides) {
+        return memoryview::frombuffer(
+            const_cast<T*>(ptr), shape, strides, true);
+    }
 
 #if PY_MAJOR_VERSION >= 3
     /** \rst
@@ -1407,6 +1427,10 @@ public:
         if (!ptr)
             pybind11_fail("Could not allocate memoryview object!");
         return memoryview(object(ptr, stolen_t{}));
+    }
+
+    static memoryview frommemory(const void *mem, ssize_t size) {
+        return memoryview::frommemory(const_cast<void*>(mem), size, true);
     }
 #endif
 };
@@ -1440,15 +1464,6 @@ inline memoryview memoryview::frombuffer(
     return memoryview(object(obj, stolen_t{}));
 }
 #endif  // DOXYGEN_SHOULD_SKIP_THIS
-
-template<typename T>
-inline memoryview memoryview::frombuffer(
-    T *ptr, detail::any_container<ssize_t> shape,
-    detail::any_container<ssize_t> strides, bool readonly) {
-    return memoryview::frombuffer(
-        reinterpret_cast<void*>(ptr), sizeof(T),
-        format_descriptor<T>::value, shape, strides, readonly);
-}
 /// @} pytypes
 
 /// \addtogroup python_builtins

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1376,33 +1376,33 @@ public:
         :param readonly: Flag to indicate if the underlying storage may be
             written to.
      \endrst */
-    static memoryview frombuffer(
+    static memoryview from_buffer(
         void *ptr, ssize_t itemsize, const char *format,
         detail::any_container<ssize_t> shape,
         detail::any_container<ssize_t> strides, bool readonly = false);
 
-    static memoryview frombuffer(
+    static memoryview from_buffer(
         const void *ptr, ssize_t itemsize, const char *format,
         detail::any_container<ssize_t> shape,
         detail::any_container<ssize_t> strides) {
-        return memoryview::frombuffer(
+        return memoryview::from_buffer(
             const_cast<void*>(ptr), itemsize, format, shape, strides, true);
     }
 
     template<typename T>
-    static memoryview frombuffer(
+    static memoryview from_buffer(
         T *ptr, detail::any_container<ssize_t> shape,
         detail::any_container<ssize_t> strides, bool readonly = false) {
-        return memoryview::frombuffer(
+        return memoryview::from_buffer(
             reinterpret_cast<void*>(ptr), sizeof(T),
             format_descriptor<T>::value, shape, strides, readonly);
     }
 
     template<typename T>
-    static memoryview frombuffer(
+    static memoryview from_buffer(
         const T *ptr, detail::any_container<ssize_t> shape,
         detail::any_container<ssize_t> strides) {
-        return memoryview::frombuffer(
+        return memoryview::from_buffer(
             const_cast<T*>(ptr), shape, strides, true);
     }
 
@@ -1420,7 +1420,7 @@ public:
 
         .. _PyMemoryView_FromMemory: https://docs.python.org/c-api/memoryview.html#c.PyMemoryView_FromMemory
      \endrst */
-    static memoryview frommemory(void *mem, ssize_t size, bool readonly = false) {
+    static memoryview from_memory(void *mem, ssize_t size, bool readonly = false) {
         PyObject* ptr = PyMemoryView_FromMemory(
             reinterpret_cast<char*>(mem), size,
             (readonly) ? PyBUF_READ : PyBUF_WRITE);
@@ -1429,14 +1429,14 @@ public:
         return memoryview(object(ptr, stolen_t{}));
     }
 
-    static memoryview frommemory(const void *mem, ssize_t size) {
-        return memoryview::frommemory(const_cast<void*>(mem), size, true);
+    static memoryview from_memory(const void *mem, ssize_t size) {
+        return memoryview::from_memory(const_cast<void*>(mem), size, true);
     }
 #endif
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-inline memoryview memoryview::frombuffer(
+inline memoryview memoryview::from_buffer(
     void *ptr, ssize_t itemsize, const char* format,
     detail::any_container<ssize_t> shape,
     detail::any_container<ssize_t> strides, bool readonly) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -13,6 +13,7 @@
 #include "buffer_info.h"
 #include <utility>
 #include <type_traits>
+#include <algorithm>
 
 NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1336,9 +1336,14 @@ public:
         // Py_buffer uses signed sizes, strides and shape!..
         static std::vector<Py_ssize_t> py_strides { };
         static std::vector<Py_ssize_t> py_shape { };
+        static std::vector<std::string> formats = {
+            "?", "b", "B", "h", "H", "i", "I", "q", "Q", "f", "d", "g"
+        };
         buf.buf = info.ptr;
         buf.itemsize = info.itemsize;
-        buf.format = const_cast<char *>(info.format.c_str());
+        auto it = std::find(formats.begin(), formats.end(), info.format);
+        buf.format = (it == formats.end()) ?
+            nullptr : const_cast<char*>(it->c_str());
         buf.ndim = (int) info.ndim;
         buf.len = info.size;
         py_strides.clear();

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1333,10 +1333,12 @@ public:
 class memoryview : public object {
 public:
     PYBIND11_OBJECT_CVT(memoryview, object, PyMemoryView_Check, PyMemoryView_FromObject)
+#if PY_MAJOR_VERSION >= 3
     explicit memoryview(char *mem, ssize_t size, bool writable = false)
         : object(PyMemoryView_FromMemory(mem, size, (writable) ? PyBUF_WRITE : PyBUF_READ), stolen_t{}) {
         if (!m_ptr) pybind11_fail("Could not allocate memoryview object!");
     }
+#endif
     explicit memoryview(const buffer_info& info);
 };
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1400,9 +1400,10 @@ public:
 
         .. _PyMemoryView_FromMemory: https://docs.python.org/c-api/memoryview.html#c.PyMemoryView_FromMemory
      \endrst */
-    static memoryview frommemory(char *mem, ssize_t size, bool readonly = false) {
+    static memoryview frommemory(void *mem, ssize_t size, bool readonly = false) {
         PyObject* ptr = PyMemoryView_FromMemory(
-            mem, size, (readonly) ? PyBUF_READ : PyBUF_WRITE);
+            reinterpret_cast<char*>(mem), size,
+            (readonly) ? PyBUF_READ : PyBUF_WRITE);
         if (!ptr)
             pybind11_fail("Could not allocate memoryview object!");
         return memoryview(object(ptr, stolen_t{}));

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1460,7 +1460,7 @@ inline memoryview memoryview::frombuffer(
     view.internal = nullptr;
     PyObject* obj = PyMemoryView_FromBuffer(&view);
     if (!obj)
-        pybind11_fail("Unable to create memoryview from buffer structure");
+        throw error_already_set();
     return memoryview(object(obj, stolen_t{}));
 }
 #endif  // DOXYGEN_SHOULD_SKIP_THIS

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -332,15 +332,27 @@ TEST_SUBMODULE(pytypes, m) {
         static const int32_t arr[] = { 4, 7, 5 };
         unused.is_none();  // Only to suppress unused compiler warn.
         return py::memoryview::frombuffer(
-            const_cast<int32_t*>(arr), sizeof(int32_t), format, 1, { 3 },
+            const_cast<int32_t*>(arr), sizeof(int32_t), format, { 3 },
             { sizeof(int32_t) }, true);
+    });
+
+    m.def("test_memoryview_frombuffer_empty_shape", []() {
+        static const char* buf = "\x00\x01";
+        return py::memoryview::frombuffer(
+            const_cast<char*>(buf), 1, "B", { }, { });
+    });
+
+    m.def("test_memoryview_frombuffer_invalid_strides", []() {
+        static const char* buf = "\x02\x03\x04";
+        return py::memoryview::frombuffer(
+            const_cast<char*>(buf), 1, "B", { 3 }, { });
     });
 
 #if PY_MAJOR_VERSION >= 3
     m.def("test_memoryview_frommemory", []() {
         const char* buf = "\xff\xe1\xab\x37";
         return py::memoryview::frommemory(
-            const_cast<char*>(buf), strlen(buf), true);
+            const_cast<char*>(buf), static_cast<ssize_t>(strlen(buf)), true);
     });
 #endif
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -316,8 +316,11 @@ TEST_SUBMODULE(pytypes, m) {
         return py::memoryview(b.request());
     });
 
-    m.def("test_memoryview_frombuffer_new", []() {
-        const char* buf = "ghi";
-        return py::memoryview(py::buffer_info(buf, 3, 1));
+    m.def("test_memoryview_frombuffer_new", [](bool is_unsigned) {
+        static const int16_t si16[] = { 3, 1, 4, 1, 5 };
+        static const uint16_t ui16[] = { 2, 7, 1, 8 };
+        auto info = (is_unsigned) ?
+            py::buffer_info(ui16, 4, 1) : py::buffer_info(si16, 5, 1);
+        return py::memoryview(info);
     });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -344,6 +344,11 @@ TEST_SUBMODULE(pytypes, m) {
         return py::memoryview::frombuffer(buf, 1, "B", { 3 }, { });
     });
 
+    m.def("test_memoryview_frombuffer_nullptr", []() {
+        return py::memoryview::frombuffer(
+            static_cast<void*>(nullptr), 1, "B", { }, { });
+    });
+
 #if PY_MAJOR_VERSION >= 3
     m.def("test_memoryview_frommemory", []() {
         const char* buf = "\xff\xe1\xab\x37";

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -308,7 +308,20 @@ TEST_SUBMODULE(pytypes, m) {
         return a[py::slice(0, -1, 2)];
     });
 
-    m.def("test_memoryview", [](py::buffer b) {
+    m.def("test_memoryview_fromobject", [](py::buffer b) {
+        return py::memoryview(b);
+    });
+
+    m.def("test_memoryview_frombuffer_reference", [](py::buffer b) {
         return py::memoryview(b.request());
+    });
+
+    m.def("test_memoryview_frombuffer_new", []() {
+        const char* buf = "abc";
+        const char* buf2 = "\x00\x00\x00\x00";
+        auto mv = py::memoryview(py::buffer_info(buf, 3, 1));
+        // Call twice with a different buffer to check the view content.
+        py::memoryview(py::buffer_info(const_cast<char*>(buf2), 4, "i", 1));
+        return mv;
     });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -307,4 +307,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("test_list_slicing", [](py::list a) {
         return a[py::slice(0, -1, 2)];
     });
+
+    m.def("test_memoryview", [](py::buffer b) {
+        return py::memoryview(b.request());
+    });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -317,11 +317,7 @@ TEST_SUBMODULE(pytypes, m) {
     });
 
     m.def("test_memoryview_frombuffer_new", []() {
-        const char* buf = "abc";
-        const char* buf2 = "\x00\x00\x00\x00";
-        auto mv = py::memoryview(py::buffer_info(buf, 3, 1));
-        // Call twice with a different buffer to check the view content.
-        py::memoryview(py::buffer_info(const_cast<char*>(buf2), 4, "i", 1));
-        return mv;
+        const char* buf = "ghi";
+        return py::memoryview(py::buffer_info(buf, 3, 1));
     });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -327,17 +327,16 @@ TEST_SUBMODULE(pytypes, m) {
                 const_cast<int16_t*>(si16), { 5 }, { sizeof(int16_t) }, true);
     });
 
-    m.def("test_memoryview_frombuffer_nativeformat", [](py::none unused) {
+    m.def("test_memoryview_frombuffer_nativeformat", []() {
         static const char* format = "@i";
         static const int32_t arr[] = { 4, 7, 5 };
-        unused.is_none();  // Only to suppress unused compiler warn.
         return py::memoryview::frombuffer(
             const_cast<int32_t*>(arr), sizeof(int32_t), format, { 3 },
             { sizeof(int32_t) }, true);
     });
 
     m.def("test_memoryview_frombuffer_empty_shape", []() {
-        static const char* buf = "\x00\x01";
+        static const char* buf = "";
         return py::memoryview::frombuffer(
             const_cast<char*>(buf), 1, "B", { }, { });
     });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -321,37 +321,34 @@ TEST_SUBMODULE(pytypes, m) {
         static const uint16_t ui16[] = { 2, 7, 1, 8 };
         if (is_unsigned)
             return py::memoryview::frombuffer(
-                const_cast<uint16_t*>(ui16), { 4 }, { sizeof(uint16_t) }, true);
+                ui16, { 4 }, { sizeof(uint16_t) });
         else
             return py::memoryview::frombuffer(
-                const_cast<int16_t*>(si16), { 5 }, { sizeof(int16_t) }, true);
+                si16, { 5 }, { sizeof(int16_t) });
     });
 
     m.def("test_memoryview_frombuffer_nativeformat", []() {
         static const char* format = "@i";
         static const int32_t arr[] = { 4, 7, 5 };
         return py::memoryview::frombuffer(
-            const_cast<int32_t*>(arr), sizeof(int32_t), format, { 3 },
-            { sizeof(int32_t) }, true);
+            arr, sizeof(int32_t), format, { 3 }, { sizeof(int32_t) });
     });
 
     m.def("test_memoryview_frombuffer_empty_shape", []() {
         static const char* buf = "";
-        return py::memoryview::frombuffer(
-            const_cast<char*>(buf), 1, "B", { }, { });
+        return py::memoryview::frombuffer(buf, 1, "B", { }, { });
     });
 
     m.def("test_memoryview_frombuffer_invalid_strides", []() {
         static const char* buf = "\x02\x03\x04";
-        return py::memoryview::frombuffer(
-            const_cast<char*>(buf), 1, "B", { 3 }, { });
+        return py::memoryview::frombuffer(buf, 1, "B", { 3 }, { });
     });
 
 #if PY_MAJOR_VERSION >= 3
     m.def("test_memoryview_frommemory", []() {
         const char* buf = "\xff\xe1\xab\x37";
         return py::memoryview::frommemory(
-            const_cast<char*>(buf), static_cast<ssize_t>(strlen(buf)), true);
+            buf, static_cast<ssize_t>(strlen(buf)));
     });
 #endif
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -316,43 +316,43 @@ TEST_SUBMODULE(pytypes, m) {
         return py::memoryview(b.request());
     });
 
-    m.def("test_memoryview_frombuffer", [](bool is_unsigned) {
+    m.def("test_memoryview_from_buffer", [](bool is_unsigned) {
         static const int16_t si16[] = { 3, 1, 4, 1, 5 };
         static const uint16_t ui16[] = { 2, 7, 1, 8 };
         if (is_unsigned)
-            return py::memoryview::frombuffer(
+            return py::memoryview::from_buffer(
                 ui16, { 4 }, { sizeof(uint16_t) });
         else
-            return py::memoryview::frombuffer(
+            return py::memoryview::from_buffer(
                 si16, { 5 }, { sizeof(int16_t) });
     });
 
-    m.def("test_memoryview_frombuffer_nativeformat", []() {
+    m.def("test_memoryview_from_buffer_nativeformat", []() {
         static const char* format = "@i";
         static const int32_t arr[] = { 4, 7, 5 };
-        return py::memoryview::frombuffer(
+        return py::memoryview::from_buffer(
             arr, sizeof(int32_t), format, { 3 }, { sizeof(int32_t) });
     });
 
-    m.def("test_memoryview_frombuffer_empty_shape", []() {
+    m.def("test_memoryview_from_buffer_empty_shape", []() {
         static const char* buf = "";
-        return py::memoryview::frombuffer(buf, 1, "B", { }, { });
+        return py::memoryview::from_buffer(buf, 1, "B", { }, { });
     });
 
-    m.def("test_memoryview_frombuffer_invalid_strides", []() {
+    m.def("test_memoryview_from_buffer_invalid_strides", []() {
         static const char* buf = "\x02\x03\x04";
-        return py::memoryview::frombuffer(buf, 1, "B", { 3 }, { });
+        return py::memoryview::from_buffer(buf, 1, "B", { 3 }, { });
     });
 
-    m.def("test_memoryview_frombuffer_nullptr", []() {
-        return py::memoryview::frombuffer(
+    m.def("test_memoryview_from_buffer_nullptr", []() {
+        return py::memoryview::from_buffer(
             static_cast<void*>(nullptr), 1, "B", { }, { });
     });
 
 #if PY_MAJOR_VERSION >= 3
-    m.def("test_memoryview_frommemory", []() {
+    m.def("test_memoryview_from_memory", []() {
         const char* buf = "\xff\xe1\xab\x37";
-        return py::memoryview::frommemory(
+        return py::memoryview::from_memory(
             buf, static_cast<ssize_t>(strlen(buf)));
     });
 #endif

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -266,9 +266,9 @@ def test_list_slicing():
 @pytest.mark.parametrize('method, args, fmt, expected_view', [
     (m.test_memoryview_object, (b'red',), 'B', b'red'),
     (m.test_memoryview_buffer_info, (b'green',), 'B', b'green'),
-    (m.test_memoryview_frombuffer, (False,), 'h', [3, 1, 4, 1, 5]),
-    (m.test_memoryview_frombuffer, (True,), 'H', [2, 7, 1, 8]),
-    (m.test_memoryview_frombuffer_nativeformat, (), '@i', [4, 7, 5]),
+    (m.test_memoryview_from_buffer, (False,), 'h', [3, 1, 4, 1, 5]),
+    (m.test_memoryview_from_buffer, (True,), 'H', [2, 7, 1, 8]),
+    (m.test_memoryview_from_buffer_nativeformat, (), '@i', [4, 7, 5]),
 ])
 def test_memoryview(method, args, fmt, expected_view):
     view = method(*args)
@@ -298,8 +298,8 @@ def test_memoryview_refcount(method):
     assert list(view) == list(buf)
 
 
-def test_memoryview_frombuffer_empty_shape():
-    view = m.test_memoryview_frombuffer_empty_shape()
+def test_memoryview_from_buffer_empty_shape():
+    view = m.test_memoryview_from_buffer_empty_shape()
     assert isinstance(view, memoryview)
     assert view.format == 'B'
     if sys.version_info.major < 3:
@@ -309,22 +309,22 @@ def test_memoryview_frombuffer_empty_shape():
         assert bytes(view) == b''
 
 
-def test_test_memoryview_frombuffer_invalid_strides():
+def test_test_memoryview_from_buffer_invalid_strides():
     with pytest.raises(RuntimeError):
-        m.test_memoryview_frombuffer_invalid_strides()
+        m.test_memoryview_from_buffer_invalid_strides()
 
 
-def test_test_memoryview_frombuffer_nullptr():
+def test_test_memoryview_from_buffer_nullptr():
     if sys.version_info.major < 3:
-        m.test_memoryview_frombuffer_nullptr()
+        m.test_memoryview_from_buffer_nullptr()
     else:
         with pytest.raises(ValueError):
-            m.test_memoryview_frombuffer_nullptr()
+            m.test_memoryview_from_buffer_nullptr()
 
 
 @pytest.mark.skipif(sys.version_info.major < 3, reason='API not available')
-def test_memoryview_frommemory():
-    view = m.test_memoryview_frommemory()
+def test_memoryview_from_memory():
+    view = m.test_memoryview_from_memory()
     assert isinstance(view, memoryview)
     assert view.format == 'B'
     assert bytes(view) == b'\xff\xe1\xab\x37'

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -263,22 +263,26 @@ def test_list_slicing():
     assert li[::2] == m.test_list_slicing(li)
 
 
-@pytest.mark.parametrize('method, args, format', [
-    (m.test_memoryview_fromobject, (b'abc', ), 'B'),
-    (m.test_memoryview_frombuffer_reference, (b'abc',), 'B'),
-    (m.test_memoryview_frombuffer_new, tuple(), 'b'),
+@pytest.mark.parametrize('method, args, format, content', [
+    (m.test_memoryview_fromobject, (b'abc',), 'B', b'abc'),
+    (m.test_memoryview_frombuffer_reference, (b'def',), 'B', b'def'),
+    (m.test_memoryview_frombuffer_new, tuple(), 'b', b'ghi'),
 ])
-def test_memoryview(method, args, format):
+def test_memoryview(method, args, format, content):
     view = method(*args)
     assert isinstance(view, memoryview)
     assert view.format == format
-    assert view[0] == ord(b'a') if sys.version_info[0] == 3 else 'a'
-    assert len(view) == 3
+    assert view[:] == content
+    assert len(view) == len(content)
 
 
-def test_memoryview_refcount():
+@pytest.mark.parametrize('method', [
+    m.test_memoryview_frombuffer_reference,
+    m.test_memoryview_fromobject,
+])
+def test_memoryview_refcount(method):
     buf = b'\x00\x00\x00\x00'
     ref_before = sys.getrefcount(buf)
-    view = m.test_memoryview_frombuffer_reference(buf)
+    view = method(buf)
     ref_after = sys.getrefcount(buf)
     assert ref_before < ref_after

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -261,3 +261,11 @@ def test_number_protocol():
 def test_list_slicing():
     li = list(range(100))
     assert li[::2] == m.test_list_slicing(li)
+
+
+def test_memoryview():
+    import array
+    view = m.test_memoryview(b'abc')
+    _ = m.test_memoryview(array.array('I', [1, 1]))
+    assert view.format == 'B'
+    assert view[0] == ord(b'a')

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -270,4 +270,4 @@ def test_memoryview():
         # Python 2.7 array does not implement the new buffer protocol
         m.test_memoryview(array.array('I', [1, 1]))
     assert view.format == 'B'
-    assert view[0] == ord(b'a')
+    assert view[0] == ord(b'a') if sys.version_info[0] == 3 else 'a'

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -314,6 +314,11 @@ def test_test_memoryview_frombuffer_invalid_strides():
         m.test_memoryview_frombuffer_invalid_strides()
 
 
+def test_test_memoryview_frombuffer_nullptr():
+    with pytest.raises(ValueError):
+        m.test_memoryview_frombuffer_nullptr()
+
+
 @pytest.mark.skipif(sys.version_info.major < 3, reason='API not available')
 def test_memoryview_frommemory():
     view = m.test_memoryview_frommemory()

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -266,6 +266,8 @@ def test_list_slicing():
 def test_memoryview():
     import array
     view = m.test_memoryview(b'abc')
-    _ = m.test_memoryview(array.array('I', [1, 1]))
+    if sys.version_info[0] == 3:
+        # Python 2.7 array does not implement the new buffer protocol
+        m.test_memoryview(array.array('I', [1, 1]))
     assert view.format == 'B'
     assert view[0] == ord(b'a')

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -263,15 +263,15 @@ def test_list_slicing():
     assert li[::2] == m.test_list_slicing(li)
 
 
-@pytest.mark.parametrize('method, arg, fmt, expected_view', [
-    (m.test_memoryview_object, b'red', 'B', b'red'),
-    (m.test_memoryview_buffer_info, b'green', 'B', b'green'),
-    (m.test_memoryview_frombuffer, False, 'h', [3, 1, 4, 1, 5]),
-    (m.test_memoryview_frombuffer, True, 'H', [2, 7, 1, 8]),
-    (m.test_memoryview_frombuffer_nativeformat, None, '@i', [4, 7, 5]),
+@pytest.mark.parametrize('method, args, fmt, expected_view', [
+    (m.test_memoryview_object, (b'red',), 'B', b'red'),
+    (m.test_memoryview_buffer_info, (b'green',), 'B', b'green'),
+    (m.test_memoryview_frombuffer, (False,), 'h', [3, 1, 4, 1, 5]),
+    (m.test_memoryview_frombuffer, (True,), 'H', [2, 7, 1, 8]),
+    (m.test_memoryview_frombuffer_nativeformat, (), '@i', [4, 7, 5]),
 ])
-def test_memoryview(method, arg, fmt, expected_view):
-    view = method(arg)
+def test_memoryview(method, args, fmt, expected_view):
+    view = method(*args)
     assert isinstance(view, memoryview)
     assert view.format == fmt
     if isinstance(expected_view, bytes) or sys.version_info[0] >= 3:
@@ -298,13 +298,20 @@ def test_memoryview_refcount(method):
     assert list(view) == list(buf)
 
 
-@pytest.mark.parametrize('method', [
-    m.test_memoryview_frombuffer_empty_shape,
-    m.test_memoryview_frombuffer_invalid_strides,
-])
-def test_memoryview_failures(method):
+def test_memoryview_frombuffer_empty_shape():
+    view = m.test_memoryview_frombuffer_empty_shape()
+    assert isinstance(view, memoryview)
+    assert view.format == 'B'
+    if sys.version_info.major < 3:
+        # Python 2 behavior is weird, but Python 3 (the future) is fine.
+        assert bytes(view).startswith(b'<memory at ')
+    else:
+        assert bytes(view) == b''
+
+
+def test_test_memoryview_frombuffer_invalid_strides():
     with pytest.raises(RuntimeError):
-        method()
+        m.test_memoryview_frombuffer_invalid_strides()
 
 
 @pytest.mark.skipif(sys.version_info.major < 3, reason='API not available')

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -264,10 +264,11 @@ def test_list_slicing():
 
 
 @pytest.mark.parametrize('method, arg, fmt, expected_view', [
-    (m.test_memoryview_fromobject, b'red', 'B', b'red'),
-    (m.test_memoryview_frombuffer_reference, b'green', 'B', b'green'),
-    (m.test_memoryview_frombuffer_new, False, 'h', [3, 1, 4, 1, 5]),
-    (m.test_memoryview_frombuffer_new, True, 'H', [2, 7, 1, 8]),
+    (m.test_memoryview_object, b'red', 'B', b'red'),
+    (m.test_memoryview_buffer_info, b'green', 'B', b'green'),
+    (m.test_memoryview_frombuffer, False, 'h', [3, 1, 4, 1, 5]),
+    (m.test_memoryview_frombuffer, True, 'H', [2, 7, 1, 8]),
+    (m.test_memoryview_frombuffer_nativeformat, None, '@i', [4, 7, 5]),
 ])
 def test_memoryview(method, arg, fmt, expected_view):
     view = method(arg)
@@ -282,8 +283,8 @@ def test_memoryview(method, arg, fmt, expected_view):
 
 
 @pytest.mark.parametrize('method', [
-    m.test_memoryview_frombuffer_reference,
-    m.test_memoryview_fromobject,
+    m.test_memoryview_buffer_info,
+    m.test_memoryview_object,
 ])
 def test_memoryview_refcount(method):
     buf = b'\x0a\x0b\x0c\x0d'
@@ -292,3 +293,11 @@ def test_memoryview_refcount(method):
     ref_after = sys.getrefcount(buf)
     assert ref_before < ref_after
     assert list(view) == list(buf)
+
+
+@pytest.mark.skipif(sys.version_info.major < 3, reason='API not available')
+def test_memoryview_frommemory():
+    view = m.test_memoryview_frommemory()
+    assert isinstance(view, memoryview)
+    assert view.format == 'B'
+    assert bytes(view) == b'\xff\xe1\xab\x37'

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -282,9 +282,12 @@ def test_memoryview(method, arg, fmt, expected_view):
     assert view_as_list == list(expected_view)
 
 
+@pytest.mark.skipif(
+    not hasattr(sys, 'getrefcount'),
+    reason='getrefcount is not available')
 @pytest.mark.parametrize('method', [
-    m.test_memoryview_buffer_info,
     m.test_memoryview_object,
+    m.test_memoryview_buffer_info,
 ])
 def test_memoryview_refcount(method):
     buf = b'\x0a\x0b\x0c\x0d'
@@ -293,6 +296,15 @@ def test_memoryview_refcount(method):
     ref_after = sys.getrefcount(buf)
     assert ref_before < ref_after
     assert list(view) == list(buf)
+
+
+@pytest.mark.parametrize('method', [
+    m.test_memoryview_frombuffer_empty_shape,
+    m.test_memoryview_frombuffer_invalid_strides,
+])
+def test_memoryview_failures(method):
+    with pytest.raises(RuntimeError):
+        method()
 
 
 @pytest.mark.skipif(sys.version_info.major < 3, reason='API not available')

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -315,8 +315,11 @@ def test_test_memoryview_frombuffer_invalid_strides():
 
 
 def test_test_memoryview_frombuffer_nullptr():
-    with pytest.raises(ValueError):
+    if sys.version_info.major < 3:
         m.test_memoryview_frombuffer_nullptr()
+    else:
+        with pytest.raises(ValueError):
+            m.test_memoryview_frombuffer_nullptr()
 
 
 @pytest.mark.skipif(sys.version_info.major < 3, reason='API not available')


### PR DESCRIPTION
Current `py::memoryview` constructor accepts `py::buffer_info`, and use `info.format.c_str()` as a format to PyBuffer object. However, this `char*` pointer is used after `info` goes out of stack, leading to undefined behavior.

This PR attempts to fix this, using static variable inside the constructor. `test_memoryview` calls the constructor two times with different format and check that the first memoryview is not affected by the second call.

Note the format strings might be replaced by instantiated `py::format_string<T>` types, but initializer becomes complicated.