### PR TITLE
Disable defining (v)snprintf as macro in modern Visual Studio

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -96,6 +96,12 @@
 #define PYBIND11_VERSION_MINOR 5
 #define PYBIND11_VERSION_PATCH dev1
 
+/* Don't let Python.h #define (v)snprintf as macro because they are implemented
+   properly in Visual Studio since 2015. */
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+#  define HAVE_SNPRINTF 1
+#endif
+
 /// Include Python header, disable linking to pythonX_d.lib on Windows in debug mode
 #if defined(_MSC_VER)
 #  if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4)


### PR DESCRIPTION
Currently `Python.h` C API header on Windows defines  `(v)snprintf` as macro aliases to `_(v)snprintf` respectively, wreaking a havoc in other C++ libraries headers which expect proper implementations of those functions possibly within `std` namespace. According to Microsoft docs, `(v)snprintf` are properly implemented starting with the release of VS2015, so they can be used directly.

The purpose of this MR is to effectively disable macro definitions for `(v)snprintf` coming from `Python.h` on VS which are known to provide that directly (`_MSC_VER >= 1900`), so the projects using pybind11 together with another C++ libraries won't suffer from mysterious compilation errors depending on the order of `#include`s.