### PR TITLE
Render NaN default argument as numpy.nan

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1871,7 +1871,7 @@ public:
     arg_v(const arg &base, T &&x, const char *descr = nullptr)
         : arg_v(arg(base), std::forward<T>(x), descr) { }
 
-#if __cplusplus >= 201103L
+#ifdef PYBIND11_CPP14
 #define ARGV_NAN_DEFAULT_OVERLOAD(FLOAT_TYPE) \
     arg_v(const arg &base, FLOAT_TYPE x) \
         : arg_v(arg(base), x, std::isnan(x) ? "numpy.nan" : nullptr) {}

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -15,6 +15,7 @@
 #include "detail/descr.h"
 #include "detail/internals.h"
 #include <array>
+#include <cmath>
 #include <limits>
 #include <tuple>
 #include <type_traits>

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1871,6 +1871,16 @@ public:
     arg_v(const arg &base, T &&x, const char *descr = nullptr)
         : arg_v(arg(base), std::forward<T>(x), descr) { }
 
+#define ARGV_NAN_DEFAULT_OVERLOAD(FLOAT_TYPE) \
+    arg_v(const arg &base, FLOAT_TYPE x) \
+        : arg_v(arg(base), x, std::isnan(x) ? "numpy.nan" : nullptr) {}
+
+    ARGV_NAN_DEFAULT_OVERLOAD(float)
+    ARGV_NAN_DEFAULT_OVERLOAD(double)
+    ARGV_NAN_DEFAULT_OVERLOAD(long double)
+
+#undef ARGV_NAN_DEFAULT_OVERLOAD
+
     /// Same as `arg::noconvert()`, but returns *this as arg_v&, not arg&
     arg_v &noconvert(bool flag = true) { arg::noconvert(flag); return *this; }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1871,6 +1871,7 @@ public:
     arg_v(const arg &base, T &&x, const char *descr = nullptr)
         : arg_v(arg(base), std::forward<T>(x), descr) { }
 
+#if __cplusplus >= 201103L
 #define ARGV_NAN_DEFAULT_OVERLOAD(FLOAT_TYPE) \
     arg_v(const arg &base, FLOAT_TYPE x) \
         : arg_v(arg(base), x, std::isnan(x) ? "numpy.nan" : nullptr) {}
@@ -1880,6 +1881,7 @@ public:
     ARGV_NAN_DEFAULT_OVERLOAD(long double)
 
 #undef ARGV_NAN_DEFAULT_OVERLOAD
+#endif
 
     /// Same as `arg::noconvert()`, but returns *this as arg_v&, not arg&
     arg_v &noconvert(bool flag = true) { arg::noconvert(flag); return *this; }

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -13,6 +13,7 @@
 
 TEST_SUBMODULE(kwargs_and_defaults, m) {
     auto kw_func = [](int x, int y) { return "x=" + std::to_string(x) + ", y=" + std::to_string(y); };
+    auto kw_func_float = [](float x, double y, long double z) { return "x=" + std::to_string(x) + ", y=" + std::to_string(y) + ", y=" + std::to_string(z); };
 
     // test_named_arguments
     m.def("kw_func0", kw_func);
@@ -32,6 +33,13 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
 
     m.def("kw_func_udl", kw_func, "x"_a, "y"_a=300);
     m.def("kw_func_udl_z", kw_func, "x"_a, "y"_a=0);
+
+    m.def("kw_func_float_123", kw_func_float, "x"_a=1, "y"_a=2, "z"_a=3);
+    m.def("kw_func_float_nan", kw_func_float,
+        "x"_a=std::numeric_limits<float>::quiet_NaN(),
+        "y"_a=std::numeric_limits<double>::quiet_NaN(),
+        "z"_a=std::numeric_limits<long double>::quiet_NaN());
+
 
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -35,11 +35,12 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     m.def("kw_func_udl_z", kw_func, "x"_a, "y"_a=0);
 
     m.def("kw_func_float_123", kw_func_float, "x"_a=1, "y"_a=2, "z"_a=3);
+#if __cplusplus >= 201103L
     m.def("kw_func_float_nan", kw_func_float,
         "x"_a=std::numeric_limits<float>::quiet_NaN(),
         "y"_a=std::numeric_limits<double>::quiet_NaN(),
         "z"_a=std::numeric_limits<long double>::quiet_NaN());
-
+#endif
 
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -35,7 +35,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     m.def("kw_func_udl_z", kw_func, "x"_a, "y"_a=0);
 
     m.def("kw_func_float_123", kw_func_float, "x"_a=1, "y"_a=2, "z"_a=3);
-#if __cplusplus >= 201103L
+#ifdef PYBIND11_CPP14
     m.def("kw_func_float_nan", kw_func_float,
         "x"_a=std::numeric_limits<float>::quiet_NaN(),
         "y"_a=std::numeric_limits<double>::quiet_NaN(),

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -10,6 +10,8 @@ def test_function_signatures(doc):
     assert doc(m.kw_func4) == "kw_func4(myList: List[int] = [13, 17]) -> str"
     assert doc(m.kw_func_udl) == "kw_func_udl(x: int, y: int = 300) -> str"
     assert doc(m.kw_func_udl_z) == "kw_func_udl_z(x: int, y: int = 0) -> str"
+    assert doc(m.kw_func_float_123) == "kw_func_float_123(x: float = 1, y: float = 2, z: float = 3) -> str"
+    assert doc(m.kw_func_float_nan) == "kw_func_float_nan(x: float = numpy.nan, y: float = numpy.nan, z: float = numpy.nan) -> str"
     assert doc(m.args_function) == "args_function(*args) -> tuple"
     assert doc(m.args_kwargs_function) == "args_kwargs_function(*args, **kwargs) -> tuple"
     assert doc(m.KWClass.foo0) == \

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -10,8 +10,11 @@ def test_function_signatures(doc):
     assert doc(m.kw_func4) == "kw_func4(myList: List[int] = [13, 17]) -> str"
     assert doc(m.kw_func_udl) == "kw_func_udl(x: int, y: int = 300) -> str"
     assert doc(m.kw_func_udl_z) == "kw_func_udl_z(x: int, y: int = 0) -> str"
-    assert doc(m.kw_func_float_123) == "kw_func_float_123(x: float = 1, y: float = 2, z: float = 3) -> str"
-    assert doc(m.kw_func_float_nan) == "kw_func_float_nan(x: float = numpy.nan, y: float = numpy.nan, z: float = numpy.nan) -> str"
+    assert doc(m.kw_func_float_123) == "kw_func_float_123(x: float = 1, " \
+                                       "y: float = 2, z: float = 3) -> str"
+    if hasattr(m, "kw_func_float_nan"):
+        assert doc(m.kw_func_float_nan) == "kw_func_float_nan(x: float = numpy.nan, " \
+                                           "y: float = numpy.nan, z: float = numpy.nan) -> str"
     assert doc(m.args_function) == "args_function(*args) -> tuple"
     assert doc(m.args_kwargs_function) == "args_kwargs_function(*args, **kwargs) -> tuple"
     assert doc(m.KWClass.foo0) == \


### PR DESCRIPTION
This PR changes how nan values are rendered in docstring. 

| this PR | master | 
|-------------| ---------|
| <pre>`foo(x: float = numpy.nan) -> None`</pre> | <pre>`foo(x: float = nan) -> None`</pre> | 

Implemented via float overloads for `py::arg_v`. Might be considered as an overkill for such a small change. On the other hand `nan` values are quite common sentinel values so it might be worth it to generate more toolable docstrings. 

<details><summary><code>compare.cpp</code></summary>

```C++
#include "pybind11/pybind11.h"
#include "pybind11/embed.h"

namespace py = pybind11;

PYBIND11_EMBEDDED_MODULE(example, m) {
  m.def("foo", [](float x) {}, py::arg("x")=std::numeric_limits<float>::quiet_NaN()); 
}

int main() {
  py::scoped_interpreter guard{};
  py::exec(R"(
      from example import * 
      print(foo.__doc__, end="") 
)");
}
```
</details>