### PR TITLE
Render typed iterators (e.g. Iterator[int]) in docstrings

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1680,6 +1680,23 @@ struct iterator_state {
     bool first_or_done;
 };
 
+template<typename Iterator, typename Sentinel, return_value_policy Policy>
+struct type_caster<iterator_state<Iterator, Sentinel, false, Policy>> :
+    type_caster_base<iterator_state<Iterator, Sentinel, false, Policy>> {
+    using ValueType = decltype(*std::declval<Iterator>());
+public:
+    static constexpr auto name = _("Iterator[") + make_caster<ValueType>::name + _("]");
+};
+
+template<typename Iterator, typename Sentinel, return_value_policy Policy>
+struct type_caster<iterator_state<Iterator, Sentinel, true, Policy>> :
+    type_caster_base<iterator_state<Iterator, Sentinel, true, Policy>> {
+    using ValueType = decltype((*std::declval<Iterator>()).first);
+public:
+    static constexpr auto name = _("Iterator[") + make_caster<ValueType>::name + _("]");
+};
+
+
 NAMESPACE_END(detail)
 
 /// Makes a python iterator from a first and past-the-end C++ InputIterator.
@@ -1688,7 +1705,8 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Sentinel,
           typename ValueType = decltype(*std::declval<Iterator>()),
           typename... Extra>
-iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
+detail::iterator_state<Iterator, Sentinel, false, Policy>
+    make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
     typedef detail::iterator_state<Iterator, Sentinel, false, Policy> state;
 
     if (!detail::get_type_info(typeid(state), false)) {
@@ -1706,8 +1724,7 @@ iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
                 return *s.it;
             }, std::forward<Extra>(extra)..., Policy);
     }
-
-    return cast(state{first, last, true});
+    return state{first, last, true};
 }
 
 /// Makes an python iterator over the keys (`.first`) of a iterator over pairs from a
@@ -1717,7 +1734,8 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Sentinel,
           typename KeyType = decltype((*std::declval<Iterator>()).first),
           typename... Extra>
-iterator make_key_iterator(Iterator first, Sentinel last, Extra &&... extra) {
+detail::iterator_state<Iterator, Sentinel, true, Policy>
+    make_key_iterator(Iterator first, Sentinel last, Extra &&... extra) {
     typedef detail::iterator_state<Iterator, Sentinel, true, Policy> state;
 
     if (!detail::get_type_info(typeid(state), false)) {
@@ -1736,20 +1754,24 @@ iterator make_key_iterator(Iterator first, Sentinel last, Extra &&... extra) {
             }, std::forward<Extra>(extra)..., Policy);
     }
 
-    return cast(state{first, last, true});
+    return state{first, last, true};
 }
 
 /// Makes an iterator over values of an stl container or other container supporting
 /// `std::begin()`/`std::end()`
 template <return_value_policy Policy = return_value_policy::reference_internal,
-          typename Type, typename... Extra> iterator make_iterator(Type &value, Extra&&... extra) {
+          typename Type, typename... Extra>
+detail::iterator_state<decltype(std::begin(std::declval<Type&>())), decltype(std::end(std::declval<Type&>())), false, Policy>
+make_iterator(Type &value, Extra&&... extra) {
     return make_iterator<Policy>(std::begin(value), std::end(value), extra...);
 }
 
 /// Makes an iterator over the keys (`.first`) of a stl map-like container supporting
 /// `std::begin()`/`std::end()`
 template <return_value_policy Policy = return_value_policy::reference_internal,
-          typename Type, typename... Extra> iterator make_key_iterator(Type &value, Extra&&... extra) {
+          typename Type, typename... Extra>
+detail::iterator_state<decltype(std::begin(std::declval<Type&>())), decltype(std::end(std::declval<Type&>())), true, Policy>
+make_key_iterator(Type &value, Extra&&... extra) {
     return make_key_iterator<Policy>(std::begin(value), std::end(value), extra...);
 }
 

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -344,7 +344,7 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
 
     // test_iterator_passthrough
     // #181: iterator passthrough did not compile
-    m.def("iterator_passthrough", [](py::iterator s) -> py::iterator {
+    m.def("iterator_passthrough", [](py::iterator s) {
         return py::make_iterator(std::begin(s), std::end(s));
     });
 

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -275,3 +275,32 @@ def test_map_delitem():
     del um['ua']
     assert sorted(list(um)) == ['ub']
     assert sorted(list(um.items())) == [('ub', 2.6)]
+
+
+def test_map_docstrings(doc):
+    assert (doc(m.MapStringDouble.__iter__) ==
+            "__iter__(self: m.stl_binders.MapStringDouble)"
+            " -> Iterator[str]")
+    assert (doc(m.MapStringDouble.items) ==
+            "items(self: m.stl_binders.MapStringDouble)"
+            " -> Iterator[Tuple[str, float]]")
+    assert (doc(m.UnorderedMapStringDouble.__iter__) ==
+            "__iter__(self: m.stl_binders.UnorderedMapStringDouble)"
+            " -> Iterator[str]\n")
+    assert (doc(m.UnorderedMapStringDouble.items) ==
+            "items(self: m.stl_binders.UnorderedMapStringDouble)"
+            " -> Iterator[Tuple[str, float]]\n")
+
+
+def test_vector_docstrings(doc):
+    assert (doc(m.VectorInt.__iter__) ==
+            "__iter__(self: m.stl_binders.VectorInt)"
+            " -> Iterator[int]\n")
+
+
+@pytest.unsupported_on_pypy
+@pytest.requires_numpy
+def test_vector_docstring2(doc):
+    assert (doc(m.VectorStruct.__iter__) ==
+            "__iter__(self: m.stl_binders.VectorStruct)"
+            " -> Iterator[m.stl_binders.VStruct]")


### PR DESCRIPTION
This PR makes pybind11 generate much more informative typed iterators.

| this PR |
| ------------- |
| <pre>`__iter__(self: example.VectorInt) -> Iterator[int]`<br>`__iter__(self: example.MapTupleToComplex) -> Iterator[Tuple[int, str]]`<br>`items(self: example.MapTupleToComplex) -> Iterator[Tuple[Tuple[int, str], complex]]`</pre> |

| master |
| ------------- |
| <pre>`__iter__(self: example.VectorInt) -> iterator`<br>`__iter__(self: example.MapTupleToComplex) -> iterator`<br>`items(self: example.MapTupleToComplex) -> iterator`</pre> | 

Strictly speaking its a potential breaking change but seems like no existing code is affected, see below.

This PR makes `py::make_iterator` and `py::make_key_iterator` return `py::detail::iterator_state` instance instead of `py::iterator`.
It doesn't affect regular use of those functions (immediate return from `__iter__` lambda),
but requires changes in user code with implicit assignments/conversions, e.g.:

```c++
// next line is ok now, but will break with this PR
// fix on user side: apply py::cast() explicitly
py::iterator it = make_iterator(...); 
```

**Search for code that would break:**
To justify intuition about low frequency of "not-immediate-return" make_iterator usage I've turned to github search API for py::make_iterator. Search is limited to 1000 files, so can't tell only for first 1000 found files (~5726 in total [[web search](https://github.com/search?l=C%2B%2B&q=py%3A%3Amake_iterator&type=Code)]).

In 1000 files there are 229 unique strings with return `py:make_iterator`.
The only non-comment occurrence of `py::make_iterator` without preceding return was found in (pybind?) test code [here](https://github.com/chisuhua/graph/blob/bf82af49979297a1722832dc1468f4e7374862b8/tests/pybind/test_sequences_and_iterators.cpp#L510). This should also be no problem since cast should happen automatically.

`py::make_map_iterator` search find only two unique strings with preceding return in another 1000 files (did a separate search). No other usages. Looks like this function is much less popular.

While strictly speaking a breaking change was introduced it seems like it breaks no existing code.
If you think this argument is not applicable and change to `py::make_iterator` should go to major pybind release (e.g. 3.0).

<details><summary><code>compare.cpp</code></summary>

```C++
#include <map>
#include <complex>

#include "pybind11/pybind11.h"
#include "pybind11/stl_bind.h"
#include "pybind11/embed.h" 

namespace py = pybind11;

using map_tuple_to_complex = std::map<std::tuple<int,std::string>, std::complex<double>>;
PYBIND11_MAKE_OPAQUE(std::vector<int>);
PYBIND11_MAKE_OPAQUE(map_tuple_to_complex);

PYBIND11_EMBEDDED_MODULE(example, m) {
  py::bind_vector<std::vector<int>>(m, "VectorInt");
  py::bind_map<map_tuple_to_complex>(m, "MapTupleToComplex");
}

int main() {
  py::scoped_interpreter guard{};
  py::exec(R"(
      from example import *
      print(VectorInt.__iter__.__doc__, end="")
      print(MapTupleToComplex.__iter__.__doc__, end="")
      print(MapTupleToComplex.items.__doc__, end="")
)");
}
```
</details>