### PR TITLE
Respect rvp for registered_instances.

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -508,11 +508,13 @@ public:
         if (src == nullptr)
             return none().release();
 
-        auto it_instances = get_internals().registered_instances.equal_range(src);
-        for (auto it_i = it_instances.first; it_i != it_instances.second; ++it_i) {
-            for (auto instance_type : detail::all_type_info(Py_TYPE(it_i->second))) {
-                if (instance_type && same_type(*instance_type->cpptype, *tinfo->cpptype))
-                    return handle((PyObject *) it_i->second).inc_ref();
+        if (policy != return_value_policy::copy && policy != return_value_policy::move) {
+            auto it_instances = get_internals().registered_instances.equal_range(src);
+            for (auto it_i = it_instances.first; it_i != it_instances.second; ++it_i) {
+                for (auto instance_type : detail::all_type_info(Py_TYPE(it_i->second))) {
+                    if (instance_type && same_type(*instance_type->cpptype, *tinfo->cpptype))
+                        return handle((PyObject *) it_i->second).inc_ref();
+                }
             }
         }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -871,7 +871,7 @@ public:
 
     static handle cast(const itype &src, return_value_policy policy, handle parent) {
         if (policy == return_value_policy::automatic || policy == return_value_policy::automatic_reference)
-            policy = return_value_policy::copy;
+            policy = return_value_policy::reference;
         return cast(&src, policy, parent);
     }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1859,7 +1859,9 @@ private:
     arg_v(arg &&base, T &&x, const char *descr = nullptr)
         : arg(base),
           value(reinterpret_steal<object>(
-              detail::make_caster<T>::cast(x, return_value_policy::automatic, {})
+              std::is_rvalue_reference<decltype(x)>::value
+              ? detail::make_caster<T>::cast(x, return_value_policy::copy, {})
+              : detail::make_caster<T>::cast(x, return_value_policy::automatic, {})
           )),
           descr(descr)
 #if !defined(NDEBUG)

--- a/include/pybind11/operators.h
+++ b/include/pybind11/operators.h
@@ -56,11 +56,11 @@ template <op_id id, op_type ot, typename L, typename R> struct op_ {
         using L_type = conditional_t<std::is_same<L, self_t>::value, Base, L>;
         using R_type = conditional_t<std::is_same<R, self_t>::value, Base, R>;
         using op = op_impl<id, ot, Base, L_type, R_type>;
-        cl.def(op::name(), &op::execute, is_operator(), op::rvp(), extra...);
+        cl.def(op::name(), &op::execute, is_operator(), extra...);
         #if PY_MAJOR_VERSION < 3
         if (id == op_truediv || id == op_itruediv)
             cl.def(id == op_itruediv ? "__idiv__" : ot == op_l ? "__div__" : "__rdiv__",
-                    &op::execute, is_operator(), op::rvp(), extra...);
+                    &op::execute, is_operator(), extra...);
         #endif
     }
     template <typename Class, typename... Extra> void execute_cast(Class &cl, const Extra&... extra) const {
@@ -68,11 +68,11 @@ template <op_id id, op_type ot, typename L, typename R> struct op_ {
         using L_type = conditional_t<std::is_same<L, self_t>::value, Base, L>;
         using R_type = conditional_t<std::is_same<R, self_t>::value, Base, R>;
         using op = op_impl<id, ot, Base, L_type, R_type>;
-        cl.def(op::name(), &op::execute_cast, is_operator(), op::rvp(), extra...);
+        cl.def(op::name(), &op::execute_cast, is_operator(), extra...);
         #if PY_MAJOR_VERSION < 3
         if (id == op_truediv || id == op_itruediv)
             cl.def(id == op_itruediv ? "__idiv__" : ot == op_l ? "__div__" : "__rdiv__",
-                    &op::execute, is_operator(), op::rvp(), extra...);
+                    &op::execute, is_operator(), extra...);
         #endif
     }
 };
@@ -82,13 +82,11 @@ template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L
     static char const* name() { return "__" #id "__"; }                                \
     static auto execute(const L &l, const R &r) -> decltype(expr) { return (expr); }   \
     static B execute_cast(const L &l, const R &r) { return B(expr); }                  \
-    static return_value_policy rvp() { return return_value_policy::automatic; }        \
 };                                                                                     \
 template <typename B, typename L, typename R> struct op_impl<op_##id, op_r, B, L, R> { \
     static char const* name() { return "__" #rid "__"; }                               \
     static auto execute(const R &r, const L &l) -> decltype(expr) { return (expr); }   \
     static B execute_cast(const R &r, const L &l) { return B(expr); }                  \
-    static return_value_policy rvp() { return return_value_policy::automatic; }        \
 };                                                                                     \
 inline op_<op_##id, op_l, self_t, self_t> op(const self_t &, const self_t &) {         \
     return op_<op_##id, op_l, self_t, self_t>();                                       \
@@ -105,7 +103,6 @@ template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L
     static char const* name() { return "__" #id "__"; }                                \
     static auto execute(L &l, const R &r) -> decltype(expr) { return expr; }           \
     static B execute_cast(L &l, const R &r) { return B(expr); }                        \
-    static return_value_policy rvp() { return return_value_policy::reference; }        \
 };                                                                                     \
 template <typename T> op_<op_##id, op_l, self_t, T> op(const self_t &, const T &) {    \
     return op_<op_##id, op_l, self_t, T>();                                            \
@@ -116,7 +113,6 @@ template <typename B, typename L> struct op_impl<op_##id, op_u, B, L, undefined_
     static char const* name() { return "__" #id "__"; }                                \
     static auto execute(const L &l) -> decltype(expr) { return expr; }                 \
     static B execute_cast(const L &l) { return B(expr); }                              \
-    static return_value_policy rvp() { return return_value_policy::automatic; }        \
 };                                                                                     \
 inline op_<op_##id, op_u, self_t, undefined_t> op(const self_t &) {                    \
     return op_<op_##id, op_u, self_t, undefined_t>();                                  \

--- a/include/pybind11/operators.h
+++ b/include/pybind11/operators.h
@@ -56,11 +56,11 @@ template <op_id id, op_type ot, typename L, typename R> struct op_ {
         using L_type = conditional_t<std::is_same<L, self_t>::value, Base, L>;
         using R_type = conditional_t<std::is_same<R, self_t>::value, Base, R>;
         using op = op_impl<id, ot, Base, L_type, R_type>;
-        cl.def(op::name(), &op::execute, is_operator(), extra...);
+        cl.def(op::name(), &op::execute, is_operator(), op::rvp(), extra...);
         #if PY_MAJOR_VERSION < 3
         if (id == op_truediv || id == op_itruediv)
             cl.def(id == op_itruediv ? "__idiv__" : ot == op_l ? "__div__" : "__rdiv__",
-                    &op::execute, is_operator(), extra...);
+                    &op::execute, is_operator(), op::rvp(), extra...);
         #endif
     }
     template <typename Class, typename... Extra> void execute_cast(Class &cl, const Extra&... extra) const {
@@ -68,11 +68,11 @@ template <op_id id, op_type ot, typename L, typename R> struct op_ {
         using L_type = conditional_t<std::is_same<L, self_t>::value, Base, L>;
         using R_type = conditional_t<std::is_same<R, self_t>::value, Base, R>;
         using op = op_impl<id, ot, Base, L_type, R_type>;
-        cl.def(op::name(), &op::execute_cast, is_operator(), extra...);
+        cl.def(op::name(), &op::execute_cast, is_operator(), op::rvp(), extra...);
         #if PY_MAJOR_VERSION < 3
         if (id == op_truediv || id == op_itruediv)
             cl.def(id == op_itruediv ? "__idiv__" : ot == op_l ? "__div__" : "__rdiv__",
-                    &op::execute, is_operator(), extra...);
+                    &op::execute, is_operator(), op::rvp(), extra...);
         #endif
     }
 };
@@ -82,11 +82,13 @@ template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L
     static char const* name() { return "__" #id "__"; }                                \
     static auto execute(const L &l, const R &r) -> decltype(expr) { return (expr); }   \
     static B execute_cast(const L &l, const R &r) { return B(expr); }                  \
+    static return_value_policy rvp() { return return_value_policy::automatic; }        \
 };                                                                                     \
 template <typename B, typename L, typename R> struct op_impl<op_##id, op_r, B, L, R> { \
     static char const* name() { return "__" #rid "__"; }                               \
     static auto execute(const R &r, const L &l) -> decltype(expr) { return (expr); }   \
     static B execute_cast(const R &r, const L &l) { return B(expr); }                  \
+    static return_value_policy rvp() { return return_value_policy::automatic; }        \
 };                                                                                     \
 inline op_<op_##id, op_l, self_t, self_t> op(const self_t &, const self_t &) {         \
     return op_<op_##id, op_l, self_t, self_t>();                                       \
@@ -103,6 +105,7 @@ template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L
     static char const* name() { return "__" #id "__"; }                                \
     static auto execute(L &l, const R &r) -> decltype(expr) { return expr; }           \
     static B execute_cast(L &l, const R &r) { return B(expr); }                        \
+    static return_value_policy rvp() { return return_value_policy::reference; }        \
 };                                                                                     \
 template <typename T> op_<op_##id, op_l, self_t, T> op(const self_t &, const T &) {    \
     return op_<op_##id, op_l, self_t, T>();                                            \
@@ -113,6 +116,7 @@ template <typename B, typename L> struct op_impl<op_##id, op_u, B, L, undefined_
     static char const* name() { return "__" #id "__"; }                                \
     static auto execute(const L &l) -> decltype(expr) { return expr; }                 \
     static B execute_cast(const L &l) { return B(expr); }                              \
+    static return_value_policy rvp() { return return_value_policy::automatic; }        \
 };                                                                                     \
 inline op_<op_##id, op_u, self_t, undefined_t> op(const self_t &) {                    \
     return op_<op_##id, op_u, self_t, undefined_t>();                                  \


### PR DESCRIPTION
In `type_caster_generic::cast`, the rvp will be ignored if a returned object exists in `registered_instances`. This results in non-WYSIWYG behavior for `copy` and `move` policies.

This change adds a conditional around the registered_instances logic.

#### Example
```
#include <pybind11/pybind11.h>                                                  
namespace py = pybind11;                                                        
                                                                                
struct A {                                                                      
    A(int i) : x(i) { printf("A(%d) %p\n", x, this); }                          
    A(const A& a) : x(a.x) { printf("copy() %p\n", this); }                     
    ~A() { printf("~A() %p\n", this); }                                         
                                                                                
    void foo() { printf("foo() %p %d\n", this, x); }                            
    void inc() { printf("inc() %p %d\n", this, ++x); }                          
    int x;                                                                      
};                                                                              
                                                                                
A g(3);                                                                         
A& get() { printf("get() %p\n", &g); return g; }                                
void foo() { g.foo(); }                                                         
void inc() { g.inc(); }                                                         
                                                                                
PYBIND11_MODULE(example, m) {                                                   
    m.doc() = "an example module.";                                             
                                                                                
    py::class_<A>(m, "A")                                                       
        .def("foo", &A::foo)                                                    
        .def("inc", &A::inc);                                                   
                                                                                
    m.def("foo", foo);                                                          
    m.def("inc", inc);                                                          
                                                                                
    m.def("get_ref", &get, py::return_value_policy::reference);                 
    m.def("get_copy", &get, py::return_value_policy::copy);                     
}
```

```
from example import *                                                              
                                                                             
ref = get_ref()                       
# get() 0x2aaaac7f9004                    
copy = get_copy()
# get() 0x2aaaac7f9004               
# copy() 0x69f540                                                                  
                                                                                   
foo()
# foo() 0x2aaaac7f9004 3                                                                       
ref.foo()                                                                          
# foo() 0x2aaaac7f9004 3
copy.foo()                                                                         
# foo() 0x69f540 3     
                                                                                     
inc()                                                                              
# inc() 0x2aaaac7f9004 4

ref.foo()                                                                          
# foo() 0x2aaaac7f9004 4
copy.foo()
# foo() 0x69f540 3
```

#### Tests
~~This causes `test_methods_and_attributes` and `test_operator_overloading` to fail on `assert cstats.copy_constructions == XXX`. This suggests that previously, even with a `copy` or `move` policy, there was intent to have reference-like behavior (i.e. avoid a copy), or that the wrong policy was specified.~~  
Fixed 21679eb.