### PR TITLE
Bugfix/Check actual value when deregistering pybind11 instance

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -250,7 +250,7 @@ inline bool deregister_instance_impl(void *ptr, instance *self) {
     auto &registered_instances = get_internals().registered_instances;
     auto range = registered_instances.equal_range(ptr);
     for (auto it = range.first; it != range.second; ++it) {
-        if (Py_TYPE(self) == Py_TYPE(it->second)) {
+        if (self == it->second) {
             registered_instances.erase(it);
             return true;
         }

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -420,6 +420,16 @@ TEST_SUBMODULE(class_, m) {
     py::class_<PyPrintDestructor>(m, "PyPrintDestructor")
         .def(py::init<>())
         .def("throw_something", &PyPrintDestructor::throw_something);
+
+    struct SamePointer {};
+    static SamePointer samePointer;
+    py::class_<SamePointer, std::unique_ptr<SamePointer, py::nodelete>>(m, "SamePointer")
+        .def(py::init([]() { return &samePointer; }))
+        .def("__del__", [](SamePointer&) { py::print("__del__ called"); });
+
+    struct Empty {};
+    py::class_<Empty>(m, "Empty")
+        .def(py::init<>());
 }
 
 template <int N> class BreaksBase { public:

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -371,3 +371,18 @@ def test_non_final_final():
 def test_exception_rvalue_abort():
     with pytest.raises(RuntimeError):
         m.PyPrintDestructor().throw_something()
+
+
+# https://github.com/pybind/pybind11/issues/1568
+def test_multiple_instances_with_same_pointer(capture):
+    n = 100
+    instances = [m.SamePointer() for _ in range(n)]
+    for i in range(n):
+        # We need to reuse the same allocated memory for with a different type,
+        # to ensure the bug in `deregister_instance_impl` is detected. Otherwise
+        # `Py_TYPE(self) == Py_TYPE(it->second)` will still succeed, even though
+        # the `instance` is already deleted.
+        instances[i] = m.Empty()
+    # No assert: if this does not trigger the error
+    #   pybind11_fail("pybind11_object_dealloc(): Tried to deallocate unregistered instance!");
+    # and just completes without crashing, we're good.


### PR DESCRIPTION
In ```deregister_instance_impl``` the code iterates through all instances associated with a pointer in the multimap ```registered_instances``` and deregisters the first instance that matches the type. This may fail in cases where multiple instances of the same type are registered to the same underlying pointer. The fix is to additionally check if the instance to be deregistered is in fact the same. The following code (potentially) reproduces the issue

```
#include "pybind11/pybind11.h"
namespace py = pybind11;

template <typename T>
class shared_holder {
  struct deleter {
    bool owned;
    deleter(bool owned = true) : owned(owned) {}
    void operator()(T* obj) const {
      if(owned) delete obj;
    }
  };
  std::unique_ptr<T, deleter> impl;
public:
  shared_holder(T* p, bool owned = true) : impl(p, owned) {}
  shared_holder(T& p) : impl(&p, false) {}
  shared_holder(const shared_holder& r) : 
    impl((const_cast<shared_holder&>(r)).impl.release(), r.impl.get_deleter().owned) {}
  T* get() const { return impl.get(); }
};

PYBIND11_DECLARE_HOLDER_TYPE(T, shared_holder<T>);

struct A {
  int x;
  A(int x) : x(x) { printf("Default A: %p\n", this); }
  A(const A& a) : x(a.x) { printf("Copy A: %p\n", this); }
  ~A() { printf("Destroy A: %p\n", this); }
};

struct B {
  int x;
  B(int x) : x(x) { printf("Default B: %p\n", this); }
  B(const B& a) : x(a.x) { printf("Copy B: %p\n", this); }
  ~B() { printf("Destroy B: %p\n", this); }
};

A& foo(A& a) {
  return a;
}

PYBIND11_MODULE(example, m) {
  m.doc() = "pybind11 example plugin";
  py::class_<A, shared_holder<A>>(m, "A")
  .def(pybind11::init([](A* a) {
    printf("Shared A: %p\n", a); 
    return shared_holder<A>(a, false); 
  } ))
  .def(pybind11::init<int>());
  py::class_<B, shared_holder<B>>(m, "B")
  .def(pybind11::init([](B* a) {
    printf("Shared B: %p\n", b); 
    return shared_holder<B>(b, false);
  } ))
  .def(pybind11::init<int>());
  m.def("foo", foo);
}
```

```
from example import A, B
from example import foo

class AB(A, B):
  def __init__(self, val = 0, a = None):
    if a is None:
      A.__init__(self, val)
      B.__init__(self, val)
    else:
      A.__init__(self, a)
      B.__init__(self, a)

a = AB(val=100)
print "------------------------------------------"
b = AB(a=a)
print "------------------------------------------"
b = AB(a=a)
print "------------------------------------------"

print "Calling foo"
foo(a)
print "Calling foo...Done"
```

```
Default A: 0x707550
Default B: 0x7075b0
------------------------------------------
Shared A: 0x707550
Shared B: 0x7075b0
------------------------------------------
Shared A: 0x707550
Shared B: 0x7075b0
------------------------------------------
Calling foo
*** Error in `./a.out': double free or corruption (fasttop): ***
```