### PR TITLE
Avoid using deprecated API in CPython 3.9

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -273,7 +273,10 @@ PYBIND11_NOINLINE inline internals &get_internals() {
         auto *&internals_ptr = *internals_pp;
         internals_ptr = new internals();
 #if defined(WITH_THREAD)
-        PyEval_InitThreads();
+
+        #if PY_VERSION_HEX < 0x03090000
+                PyEval_InitThreads();
+        #endif
         PyThreadState *tstate = PyThreadState_Get();
         #if PY_VERSION_HEX >= 0x03070000
             internals_ptr->tstate = PyThread_tss_alloc();


### PR DESCRIPTION
`PyEval_InitThreads()` will be deprecated once python 3.9 is released.

This is a quote from the [what's new](https://docs.python.org/3.9/whatsnew/3.9.html#deprecated) page. Considering the advanced capabilities of pybind11, with regards to GIL, I don't know if this is the right thing to do about this deprecation.

> The `PyEval_InitThreads()` and `PyEval_ThreadsInitialized()` functions are now deprecated and will be removed in Python 3.11. Calling `PyEval_InitThreads()` now does nothing. The GIL is initialized by `Py_Initialize()` since Python 3.7.