### PR TITLE
Rectify docs for PYBIND11_OVERLOAD_NAME

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2152,8 +2152,8 @@ template <class T> function get_overload(const T *this_ptr, const char *name) {
         PYBIND11_OVERLOAD_NAME(
             std::string, // Return type (ret_type)
             Animal,      // Parent class (cname)
-            toString,    // Name of function in C++ (name)
-            "__str__",   // Name of method in Python (fn)
+            "__str__",   // Name of method in Python (name)
+            toString,    // Name of function in C++ (fn)
         );
       }
 \endrst */


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/pybind/pybind11/issues/2051

It is a small change, and a minor error, but it caused quite a bit of headache and confusion until I dove deep into the macro expansion.

The docs confuse the `name` and `fn` macro parameters.

## Explanation
Notice in these lines there is a call to `PYBIND11_OVERLOAD_INT`. Specifically with the third argument being `name`.

We can see that the `fn` argument in this case is used in `cname::fn(__VA_ARGS__)` to call the appropriate C++ class method of name `fn`.
https://github.com/pybind/pybind11/blob/63df87fa490d49244b76249854559ec8db22f119/include/pybind11/pybind11.h#L2160-L2162

But in `PYBIND11_OVERLOAD_INT`, we can see that the macro expects the `name` argument to be the name of the Python function/method name.
https://github.com/pybind/pybind11/blob/63df87fa490d49244b76249854559ec8db22f119/include/pybind11/pybind11.h#L2130-L2141

In fact, in the reference doc for `PYBIND11_OVERLOAD_INT` we see that this is the case also.

https://github.com/pybind/pybind11/blob/63df87fa490d49244b76249854559ec8db22f119/include/pybind11/pybind11.h#L2117-L2124

## Proposed solutions
While it would be nice to flip around the arguments, I think a less API breaking fix would just be to fix the docs.

This particular documentation error doesn't affect `PYBIND11_OVERLOAD` or `PYBIND11_OVERLOAD_PURE`, because in that case both bound method names on the C++ and Python side are identical. That's probably the reason why this issue has flown under the radar for so long.

Thanks for this extremely useful binding library!

- CH3EERS