### PR TITLE
Render `py::none` as `None` in docstrings

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1609,6 +1609,7 @@ template <> struct handle_type_name<bytes> { static constexpr auto name = _(PYBI
 template <> struct handle_type_name<int_> { static constexpr auto name = _("int"); };
 template <> struct handle_type_name<iterable> { static constexpr auto name = _("Iterable"); };
 template <> struct handle_type_name<iterator> { static constexpr auto name = _("Iterator"); };
+template <> struct handle_type_name<none> { static constexpr auto name = _("None"); };
 template <> struct handle_type_name<args> { static constexpr auto name = _("*args"); };
 template <> struct handle_type_name<kwargs> { static constexpr auto name = _("**kwargs"); };
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -32,6 +32,11 @@ TEST_SUBMODULE(pytypes, m) {
         for (auto item : list)
             py::print("list item {}: {}"_s.format(index++, item));
     });
+    // test_none
+    m.def("get_none", []{return py::none();});
+    m.def("print_none", [](py::none none) {
+        py::print("none: {}"_s.format(none));
+    });
 
     // test_set
     m.def("get_set", []() {

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -37,6 +37,11 @@ def test_list(capture, doc):
     assert doc(m.print_list) == "print_list(arg0: list) -> None"
 
 
+def test_none(capture, doc):
+    assert doc(m.get_none) == "get_none() -> None"
+    assert doc(m.print_none) == "print_none(arg0: None) -> None"
+
+
 def test_set(capture, doc):
     s = m.get_set()
     assert s == {"key1", "key2", "key3"}


### PR DESCRIPTION
Closes #2270