### PR TITLE
Fix DeprecationWarning about 'invalid escape sequence' in tools/docs Python scripts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -238,7 +238,7 @@ latex_elements = {
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-'preamble': '\DeclareUnicodeCharacter{00A0}{}',
+'preamble': r'\DeclareUnicodeCharacter{00A0}{}',
 
 # Latex figure (float) alignment
 #'figure_align': 'htbp',

--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -106,8 +106,8 @@ def process_comment(comment):
         result = result2
 
     # Doxygen tags
-    cpp_group = '([\w:]+)'
-    param_group = '([\[\w:\]]+)'
+    cpp_group = r'([\w:]+)'
+    param_group = r'([\[\w:\]]+)'
 
     s = result
     s = re.sub(r'\\c\s+%s' % cpp_group, r'``\1``', s)


### PR DESCRIPTION
Closes #2105