### PR TITLE
Rename embedded_module object's name

### DIFF
--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -61,7 +61,8 @@
         }                                                                     \
     }                                                                         \
     PYBIND11_EMBEDDED_MODULE_IMPL(name)                                       \
-    pybind11::detail::embedded_module name(PYBIND11_TOSTRING(name),           \
+    pybind11::detail::embedded_module PYBIND11_CONCAT(pybind11_module_, name) \
+                              (PYBIND11_TOSTRING(name),             \
                                PYBIND11_CONCAT(pybind11_init_impl_, name));   \
     void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &variable)
 


### PR DESCRIPTION
This avoids a potential conflict with names in the same scope of the
same name as the embedded module, like namespaces or other global
variables.

Fixes #2172