### PR TITLE
Update docs: mention setting `__hash__ = None` for custom `__eq__` method

### DIFF
--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -695,6 +695,13 @@ throwing a type error.
 
     To use the more convenient ``py::self`` notation, the additional
     header file :file:`pybind11/operators.h` must be included.
+    
+.. note::
+
+     A class that overrides ``__eq__()`` and does not define ``__hash__()`` will have its ``__hash__()`` implicitly set. 
+     This is a deviation from the standard Python behaviour where ``__hash__()`` is set to `None` when overriding ``__eq__()``. To restore the default behaviour 
+     one can use ``.attr("__hash__") = py::none()``. When set ``None`` the class will raise an appropriate TypeError when a program attempts to retrieve their 
+     hash value, and will also be correctly identified as unhashable when checking ``isinstance(obj, collections.abc.Hashable)``.
 
 .. seealso::
 

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -699,7 +699,7 @@ throwing a type error.
 .. note::
 
      A class that overrides ``__eq__()`` and does not define ``__hash__()`` will have its ``__hash__()`` implicitly set. 
-     This is a deviation from the standard Python behaviour where ``__hash__()`` is set to `None` when overriding ``__eq__()``. To restore the default behaviour 
+     This is a deviation from the standard Python behaviour where ``__hash__()`` is set to ``None`` when overriding ``__eq__()``. To restore the default behaviour 
      one can use ``.attr("__hash__") = py::none()``. When set ``None`` the class will raise an appropriate TypeError when a program attempts to retrieve their 
      hash value, and will also be correctly identified as unhashable when checking ``isinstance(obj, collections.abc.Hashable)``.
 


### PR DESCRIPTION
close #2191