### PR TITLE
Set __hash__ to None for types that defines __eq__ but not __hash__

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1047,6 +1047,13 @@ inline void call_operator_delete(void *p, size_t s, size_t a) {
     #endif
 }
 
+inline void add_class_method(object& cls, const char *name_, const cpp_function &cf) {
+    cls.attr(cf.name()) = cf;
+    if (strcmp(name_, "__eq__") == 0 && !cls.attr("__dict__").contains("__hash__")) {
+      cls.attr("__hash__") = none();
+    }
+}
+
 PYBIND11_NAMESPACE_END(detail)
 
 /// Given a pointer to a member function, cast it to its `Derived` version.
@@ -1144,7 +1151,7 @@ public:
     class_ &def(const char *name_, Func&& f, const Extra&... extra) {
         cpp_function cf(method_adaptor<type>(std::forward<Func>(f)), name(name_), is_method(*this),
                         sibling(getattr(*this, name_, none())), extra...);
-        attr(cf.name()) = cf;
+        add_class_method(*this, name_, cf);
         return *this;
     }
 

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -126,3 +126,19 @@ def test_nested():
     assert abase.value == 42
     del abase, b
     pytest.gc_collect()
+
+
+def test_overriding_eq_reset_hash():
+
+    assert m.Comparable(15) is not m.Comparable(15)
+    assert m.Comparable(15) == m.Comparable(15)
+
+    with pytest.raises(TypeError):
+        hash(m.Comparable(15))  # TypeError: unhashable type: 'm.Comparable'
+
+    for hashable in (m.Hashable, m.Hashable2):
+        assert hashable(15) is not hashable(15)
+        assert hashable(15) == hashable(15)
+
+        assert hash(hashable(15)) == 15
+        assert hash(hashable(15)) == hash(hashable(15))


### PR DESCRIPTION
PR patches `py::class_<>::def` as discussed in  https://github.com/pybind/pybind11/pull/2287

fixes #2191