### PR TITLE
Modified Vector STL bind initialization from a buffer type with optimization for simple arrays

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -401,15 +401,14 @@ vector_buffer(Class_& cl) {
         ssize_t step = info.strides[0] / static_cast<ssize_t>(sizeof(T));
         T *end = p + info.shape[0] * step;
         if (step == 1) {
-            auto vec = std::unique_ptr<Vector>(new Vector(p, end));
-            return vec.release();
+            return Vector(p, end);
         }
         else {
-            auto vec = std::unique_ptr<Vector>(new Vector());
-            vec->reserve((size_t) info.shape[0]);
+            Vector vec;
+            vec.reserve((size_t) info.shape[0]);
             for (; p != end; p += step)
-                vec->push_back(*p);
-            return vec.release();
+                vec.push_back(*p);
+            return vec;
         }
     }));
 

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -397,14 +397,20 @@ vector_buffer(Class_& cl) {
         if (!detail::compare_buffer_info<T>::compare(info) || (ssize_t) sizeof(T) != info.itemsize)
             throw type_error("Format mismatch (Python: " + info.format + " C++: " + format_descriptor<T>::format() + ")");
 
-        auto vec = std::unique_ptr<Vector>(new Vector());
-        vec->reserve((size_t) info.shape[0]);
         T *p = static_cast<T*>(info.ptr);
         ssize_t step = info.strides[0] / static_cast<ssize_t>(sizeof(T));
         T *end = p + info.shape[0] * step;
-        for (; p != end; p += step)
-            vec->push_back(*p);
-        return vec.release();
+        if (step == 1) {
+            auto vec = std::unique_ptr<Vector>(new Vector(p, end));
+            return vec.release();
+        }
+        else {
+            auto vec = std::unique_ptr<Vector>(new Vector());
+            vec->reserve((size_t) info.shape[0]);
+            for (; p != end; p += step)
+                vec->push_back(*p);
+            return vec.release();
+        }
     }));
 
     return;

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -84,9 +84,10 @@ def test_vector_buffer():
         mv[2] = '\x06'
     assert v[2] == 6
 
-    mv = memoryview(b)
-    v = m.VectorUChar(mv[::2])
-    assert v[1] == 3
+    if sys.version_info.major > 2:
+        mv = memoryview(b)
+        v = m.VectorUChar(mv[::2])
+        assert v[1] == 3
 
     with pytest.raises(RuntimeError) as excinfo:
         m.create_undeclstruct()  # Undeclared struct contents, no buffer interface

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -84,6 +84,10 @@ def test_vector_buffer():
         mv[2] = '\x06'
     assert v[2] == 6
 
+    mv = memoryview(b)
+    v = m.VectorUChar(mv[::2])
+    assert v[1] == 3
+
     with pytest.raises(RuntimeError) as excinfo:
         m.create_undeclstruct()  # Undeclared struct contents, no buffer interface
     assert "NumPy type info missing for " in str(excinfo.value)
@@ -117,6 +121,10 @@ def test_vector_buffer_numpy():
     v = m.VectorStruct(np.zeros(3, dtype=np.dtype([('w', 'bool'), ('x', 'I'),
                                                    ('y', 'float64'), ('z', 'bool')], align=True)))
     assert len(v) == 3
+
+    b = np.array([1, 2, 3, 4], dtype=np.uint8)
+    v = m.VectorUChar(b[::2])
+    assert v[1] == 3
 
 
 def test_vector_bool():


### PR DESCRIPTION
Added a check in the initialization of a bound vector from a buffer type to perform fast initialization if the buffer is a simple contiguous array.