### PR TITLE
Fix casters of STL containers with `char*`

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1347,7 +1347,7 @@ public:
         return StringCaster::cast(StringType(1, src), policy, parent);
     }
 
-    operator CharT*() { return none ? nullptr : const_cast<CharT *>(static_cast<StringType &>(str_caster).c_str()); }
+    operator CharT*() { return none ? nullptr : &static_cast<StringType &>(str_caster)[0]; }
     operator CharT&() {
         if (none)
             throw value_error("Cannot convert None to a character");


### PR DESCRIPTION
This cóuld fix #2245, I believe. Would you mind testing, if it does, @ codypiersall?

If it does, the question is if this is a price we're willing to pay for it?

On the one hand, the casters for `tuple`, `pair`, etc, also hold on to their subcasters. On the other hand, it might be a heavy price to "just" solve the issue with `char *`? Maybe there is a better way to keep the things `char*` point to alive?