### PR TITLE
ci: GHA basic format & pre-commit

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,19 @@
+name: Format
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+    - master
+    - stable
+    - "v*"
+
+jobs:
+  pre-commit:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.1.0
+  hooks:
+  - id: check-added-large-files
+  - id: check-case-conflict
+  - id: check-merge-conflict
+  - id: check-symlinks
+  - id: check-yaml
+  - id: debug-statements
+  - id: end-of-file-fixer
+  - id: mixed-line-ending
+  - id: requirements-txt-fixer
+  - id: trailing-whitespace
+  - id: fix-encoding-pragma
+
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.1.7
+  hooks:
+  - id: remove-tabs
+    exclude: (Makefile|debian/rules|.gitmodules)(\.in)?$
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.2
+  hooks:
+  - id: flake8
+    additional_dependencies: [flake8-bugbear]
+    exclude: ^(docs/.*|tools/.*)$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,15 @@ adhere to the following rules to make the process as smooth as possible:
   do add value by themselves.
 * Add tests for any new functionality and run the test suite (``make pytest``)
   to ensure that no existing features break.
-* Please run ``flake8`` and ``tools/check-style.sh`` to check your code matches
-  the project style. (Note that ``check-style.sh`` requires ``gawk``.)
+* Please run [``pre-commit``][pre-commit] and ``tools/check-style.sh`` to check
+  your code matches the project style. (Note that ``check-style.sh`` requires
+  ``gawk``.) Use `pre-commit run --all-files` before committing (or use
+  installed-mode, check pre-commit docs) to verify your code passes before
+  pushing to save time.
 * This project has a strong focus on providing general solutions using a
   minimal amount of code, thus small pull requests are greatly preferred.
+
+[pre-commit]: https://pre-commit.com
 
 ### Licensing of contributions
 

--- a/docs/advanced/cast/index.rst
+++ b/docs/advanced/cast/index.rst
@@ -39,4 +39,3 @@ the last case of the above list.
    chrono
    eigen
    custom
-

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -82,7 +82,7 @@ helper class that is defined as follows:
 
 The macro :c:macro:`PYBIND11_OVERLOAD_PURE` should be used for pure virtual
 functions, and :c:macro:`PYBIND11_OVERLOAD` should be used for functions which have
-a default implementation.  There are also two alternate macros 
+a default implementation.  There are also two alternate macros
 :c:macro:`PYBIND11_OVERLOAD_PURE_NAME` and :c:macro:`PYBIND11_OVERLOAD_NAME` which
 take a string-valued name argument between the *Parent class* and *Name of the
 function* slots, which defines the name of function in Python. This is required
@@ -1088,7 +1088,7 @@ Binding final classes
 
 Some classes may not be appropriate to inherit from. In C++11, classes can
 use the ``final`` specifier to ensure that a class cannot be inherited from.
-The ``py::is_final`` attribute can be used to ensure that Python classes 
+The ``py::is_final`` attribute can be used to ensure that Python classes
 cannot inherit from a specified type. The underlying C++ type does not need
 to be declared final.
 

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -218,7 +218,7 @@ collected:
 
 Both approaches also expose a potentially dangerous ``_cleanup`` attribute in
 Python, which may be undesirable from an API standpoint (a premature explicit
-call from Python might lead to undefined behavior). Yet another approach that 
+call from Python might lead to undefined behavior). Yet another approach that
 avoids this issue involves weak reference with a cleanup callback:
 
 .. code-block:: cpp
@@ -283,9 +283,9 @@ work, it is important that all lines are indented consistently, i.e.:
         ----------
     )mydelimiter");
 
-By default, pybind11 automatically generates and prepends a signature to the docstring of a function 
+By default, pybind11 automatically generates and prepends a signature to the docstring of a function
 registered with ``module::def()`` and ``class_::def()``. Sometimes this
-behavior is not desirable, because you want to provide your own signature or remove 
+behavior is not desirable, because you want to provide your own signature or remove
 the docstring completely to exclude the function from the Sphinx documentation.
 The class ``options`` allows you to selectively suppress auto-generated signatures:
 
@@ -298,8 +298,8 @@ The class ``options`` allows you to selectively suppress auto-generated signatur
         m.def("add", [](int a, int b) { return a + b; }, "A function which adds two numbers");
     }
 
-Note that changes to the settings affect only function bindings created during the 
-lifetime of the ``options`` instance. When it goes out of scope at the end of the module's init function, 
+Note that changes to the settings affect only function bindings created during the
+lifetime of the ``options`` instance. When it goes out of scope at the end of the module's init function,
 the default settings are restored to prevent unwanted side effects.
 
 .. [#f4] http://www.sphinx-doc.org

--- a/docs/advanced/pycpp/object.rst
+++ b/docs/advanced/pycpp/object.rst
@@ -60,7 +60,7 @@ This example obtains a reference to the Python ``Decimal`` class.
 Calling Python functions
 ========================
 
-It is also possible to call Python classes, functions and methods 
+It is also possible to call Python classes, functions and methods
 via ``operator()``.
 
 .. code-block:: cpp
@@ -75,7 +75,7 @@ via ``operator()``.
     py::object makedirs = os.attr("makedirs");
     makedirs("/tmp/path/to/somewhere");
 
-One can convert the result obtained from Python to a pure C++ version 
+One can convert the result obtained from Python to a pure C++ version
 if a ``py::class_`` or type conversion is defined.
 
 .. code-block:: cpp
@@ -99,8 +99,8 @@ Python method.
     py::print(py::str(exp_pi));
 
 In the example above ``pi.attr("exp")`` is a *bound method*: it will always call
-the method for that same instance of the class. Alternately one can create an 
-*unbound method* via the Python class (instead of instance) and pass the ``self`` 
+the method for that same instance of the class. Alternately one can create an
+*unbound method* via the Python class (instead of instance) and pass the ``self``
 object explicitly, followed by other arguments.
 
 .. code-block:: cpp

--- a/docs/benchmark.py
+++ b/docs/benchmark.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import random
 import os
 import time

--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -93,5 +93,3 @@ favor.
 .. only:: latex
 
     .. image:: pybind11_vs_boost_python2.png
-
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,8 +130,8 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 else:
     html_context = {
         'css_files': [
-            '//media.readthedocs.org/css/sphinx_rtd_theme.css',            
-            '//media.readthedocs.org/css/readthedocs-doc-embed.css',    
+            '//media.readthedocs.org/css/sphinx_rtd_theme.css',
+            '//media.readthedocs.org/css/readthedocs-doc-embed.css',
             '_static/theme_overrides.css'
         ]
     }

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -17,4 +17,3 @@ These features could be implemented but would lead to a significant increase in
 complexity. I've decided to draw the line here to keep this project simple and
 compact. Users who absolutely require these features are encouraged to fork
 pybind11.
-

--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from ._version import version_info, __version__  # noqa: F401 imported but unused
 
 

--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 import argparse

--- a/pybind11/_version.py
+++ b/pybind11/_version.py
@@ -1,2 +1,3 @@
+# -*- coding: utf-8 -*-
 version_info = (2, 5, 'dev1')
 __version__ = '.'.join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # Setup script for PyPI; use CMakeFile.txt to build extension modules
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """pytest configuration
 
 Extends output capture as needed by pybind11: ignore constructors, optional unordered lines.

--- a/tests/constructor_stats.h
+++ b/tests/constructor_stats.h
@@ -273,4 +273,3 @@ template <class T, typename... Values> void print_values(T *inst, Values &&...va
     print_constr_details(inst, ":", values...);
     track_values(inst, values...);
 }
-

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import asyncio
 import pytest
 from pybind11_tests import async_module as m

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import io
 import struct
 import sys

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -1,4 +1,4 @@
-# Python < 3 needs this: coding=utf-8
+# -*- coding: utf-8 -*-
 import pytest
 
 from pybind11_tests import builtin_casters as m

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import call_policies as m
 from pybind11_tests import ConstructorStats

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import callbacks as m
 from threading import Thread

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from pybind11_tests import chrono as m
 import datetime
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from pybind11_tests import class_ as m

--- a/tests/test_cmake_build/test.py
+++ b/tests/test_cmake_build/test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import sys
 import test_cmake_build
 

--- a/tests/test_constants_and_functions.py
+++ b/tests/test_constants_and_functions.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from pybind11_tests import constants_and_functions as m
 
 

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import copy_move_policies as m
 

--- a/tests/test_custom_type_casters.py
+++ b/tests/test_custom_type_casters.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import custom_type_casters as m
 

--- a/tests/test_docstring_options.py
+++ b/tests/test_docstring_options.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from pybind11_tests import docstring_options as m
 
 

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import ConstructorStats
 
@@ -143,7 +144,7 @@ def test_nonunit_stride_from_python():
 
     counting_3d = np.arange(27.0, dtype=np.float32).reshape((3, 3, 3))
     slices = [counting_3d[0, :, :], counting_3d[:, 0, :], counting_3d[:, :, 0]]
-    for slice_idx, ref_mat in enumerate(slices):
+    for ref_mat in slices:
         np.testing.assert_array_equal(m.double_mat_cm(ref_mat), 2.0 * ref_mat)
         np.testing.assert_array_equal(m.double_mat_rm(ref_mat), 2.0 * ref_mat)
 
@@ -172,7 +173,7 @@ def test_negative_stride_from_python(msg):
     counting_3d = np.arange(27.0, dtype=np.float32).reshape((3, 3, 3))
     counting_3d = counting_3d[::-1, ::-1, ::-1]
     slices = [counting_3d[0, :, :], counting_3d[:, 0, :], counting_3d[:, :, 0]]
-    for slice_idx, ref_mat in enumerate(slices):
+    for ref_mat in slices:
         np.testing.assert_array_equal(m.double_mat_cm(ref_mat), 2.0 * ref_mat)
         np.testing.assert_array_equal(m.double_mat_rm(ref_mat), 2.0 * ref_mat)
 

--- a/tests/test_embed/test_interpreter.py
+++ b/tests/test_embed/test_interpreter.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from widget_module import Widget
 
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import enums as m
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import pytest
 from pybind11_tests import eval_ as m

--- a/tests/test_eval_call.py
+++ b/tests/test_eval_call.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This file is called from 'test_eval.py'
 
 if 'call_test2' in locals():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from pybind11_tests import exceptions as m

--- a/tests/test_factory_constructors.py
+++ b/tests/test_factory_constructors.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 import re
 

--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import multiprocessing
 import threading
 from pybind11_tests import gil_scoped as m

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from pybind11_tests import iostream as m
 import sys
 

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import kwargs_and_defaults as m
 

--- a/tests/test_local_bindings.py
+++ b/tests/test_local_bindings.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from pybind11_tests import local_bindings as m

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import methods_and_attributes as m
 from pybind11_tests import ConstructorStats

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from pybind11_tests import modules as m
 from pybind11_tests.modules import subsubmodule as ms
 from pybind11_tests import ConstructorStats

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import ConstructorStats
 from pybind11_tests import multiple_inheritance as m

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import numpy_array as m
 

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import re
 import pytest
 from pybind11_tests import numpy_dtypes as m

--- a/tests/test_numpy_vectorize.py
+++ b/tests/test_numpy_vectorize.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import numpy_vectorize as m
 

--- a/tests/test_opaque_types.py
+++ b/tests/test_opaque_types.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import opaque_types as m
 from pybind11_tests import ConstructorStats, UserType

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import operators as m
 from pybind11_tests import ConstructorStats

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import pickling as m
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import division
 import pytest
 import sys

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import sequences_and_iterators as m
 from pybind11_tests import ConstructorStats

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from pybind11_tests import smart_ptr as m
 from pybind11_tests import ConstructorStats

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from pybind11_tests import stl as m

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 import sys
 from pybind11_tests import stl_binders as m
@@ -222,7 +223,8 @@ def test_noncopyable_containers():
         for j in range(0, 5):
             assert nvnc[i][j].value == j + 1
 
-    for k, v in nvnc.items():
+    # Note: maps do not have .values()
+    for _, v in nvnc.items():
         for i, j in enumerate(v, start=1):
             assert j.value == i
 
@@ -233,7 +235,7 @@ def test_noncopyable_containers():
             assert nmnc[i][j].value == 10 * j
 
     vsum = 0
-    for k_o, v_o in nmnc.items():
+    for _, v_o in nmnc.items():
         for k_i, v_i in v_o.items():
             assert v_i.value == 10 * k_i
             vsum += v_i.value
@@ -247,7 +249,7 @@ def test_noncopyable_containers():
             assert numnc[i][j].value == 10 * j
 
     vsum = 0
-    for k_o, v_o in numnc.items():
+    for _, v_o in numnc.items():
         for k_i, v_i in v_o.items():
             assert v_i.value == 10 * k_i
             vsum += v_i.value

--- a/tests/test_tagbased_polymorphic.py
+++ b/tests/test_tagbased_polymorphic.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from pybind11_tests import tagbased_polymorphic as m
 
 

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from pybind11_tests import union_ as m
 
 

--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from pybind11_tests import virtual_functions as m

--- a/tools/FindEigen3.cmake
+++ b/tools/FindEigen3.cmake
@@ -78,4 +78,3 @@ else (EIGEN3_INCLUDE_DIR)
   mark_as_advanced(EIGEN3_INCLUDE_DIR)
 
 endif(EIGEN3_INCLUDE_DIR)
-

--- a/tools/libsize.py
+++ b/tools/libsize.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function, division
 import os
 import sys
@@ -35,4 +36,3 @@ else:
 
 with open(save, 'w') as sf:
     sf.write(str(libsize))
-

--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 #  Syntax: mkdoc.py [-I<path> ..] [.. a list of header files ..]
 #


### PR DESCRIPTION
Implementing basic GHA formatting. Changes:

* Pre-commit support. All checks except for C++ format (to be added later) are available in pre-commit instead of custom `tools/check_style.sh` - also checks flake8. Many of the old warnings are now automatic fixes.
* GitHub Actions checks pre-commit style
* Flake8: Added bugbear - manually fixed a few resulting "unused variable" warnings
* pre-commit: Added encoding & whitespace fixes to several files automatically


I added tab -> 4 space automatic conversion, but there's also a mode that simply errors on any tabs. You always get to review changes with pre-commit before adding them in git, so automatic is usually better, but we could use the other mode for tabs.

