### PR TITLE
style: add clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+---
+# See all possible options and defaults with:
+# clang-format --style=llvm --dump-config
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignConsecutiveAssignments: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: All
+BreakConstructorInitializers: BeforeColon
+ColumnLimit: 99
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth: 4
+Language: Cpp
+SpaceAfterCStyleCast: true
+# SpaceInEmptyBlock: true # too new
+Standard: Cpp11
+TabWidth: 4
+...

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -176,10 +176,35 @@ name, pre-commit):
 pre-commit install
 ```
 
+### Clang-Format
+
+As of v2.6.2, pybind11 ships with a [`clang-format`][clang-format]
+configuration file at the top level of the repo (the filename is
+`.clang-format`). Currently, formatting is NOT applied automatically, but
+manually using `clang-format` for newly developed files is highly encouraged.
+To check if a file needs formatting:
+
+```bash
+clang-format -style=file --dry-run some.cpp
+```
+
+The output will show things to be fixed, if any. To actually format the file:
+
+```bash
+clang-format -style=file -i some.cpp
+```
+
+Note that the `-style-file` option searches the parent directories for the
+`.clang-format` file, i.e. the commands above can be run in any subdirectory
+of the pybind11 repo.
+
 ### Clang-Tidy
 
-To run Clang tidy, the following recipe should work. Files will be modified in
-place, so you can use git to monitor the changes.
+[`clang-tidy`][clang-tidy] performs deeper static code analyses and is
+more complex to run, compared to `clang-format`, but support for `clang-tidy`
+is built into the pybind11 CMake configuration. To run `clang-tidy`, the
+following recipe should work. Files will be modified in place, so you can
+use git to monitor the changes.
 
 ```bash
 docker run --rm -v $PWD:/pybind11 -it silkeh/clang:10
@@ -198,7 +223,7 @@ cmake -S . -B build-iwyu -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=$(which include-what-y
 cmake --build build
 ```
 
-The report is sent to stderr; you can pip it into a file if you wish.
+The report is sent to stderr; you can pipe it into a file if you wish.
 
 ### Build recipes
 
@@ -325,6 +350,8 @@ if you really want to.
 
 
 [pre-commit]: https://pre-commit.com
+[clang-format]: https://clang.llvm.org/docs/ClangFormat.html
+[clang-tidy]: https://clang.llvm.org/extra/clang-tidy/
 [pybind11.readthedocs.org]: http://pybind11.readthedocs.org/en/latest
 [issue tracker]: https://github.com/pybind/pybind11/issues
 [gitter]: https://gitter.im/pybind/Lobby

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -104,8 +104,10 @@ PYBIND11_NAMESPACE_END(detail)
     .. code-block:: cpp
 
         {
-            py::scoped_ostream_redirect output{std::cerr, py::module_::import("sys").attr("stderr")};
-            std::cerr << "Hello, World!";
+            py::scoped_ostream_redirect output{
+                std::cerr,
+                py::module::import("sys").attr("stderr")
+            };
         }
  \endrst */
 class scoped_ostream_redirect {

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,12 +43,7 @@ ignore =
     docs/**
     tools/**
     include/**
-    .appveyor.yml
-    .cmake-format.yaml
-    .gitmodules
-    .pre-commit-config.yaml
-    .readthedocs.yml
-    .clang-tidy
+    .*
     pybind11/include/**
     pybind11/share/**
     CMakeLists.txt


### PR DESCRIPTION
This is an attempt at using clang-format for the C++ style. If this is accepted, then a) we can drop the old check_style.sh script (will be done in this PR), b) all open PR's are likely to need to run `pre-commit` to become compatible again before merging. Due to point b), we probably will want to wait till a specific point to merge this - so for now, this should be seen more as a discussion for the format style file we would like to adopt (if we go this way).

A few points about how I came up with the style:
* It is based on LLVM as a start
* I was trying to mimic the old style as closely as possible, rather than making ideal choices - maybe some should change.
    * Quite a few places are inconsistent, so had to pick style over the other

And, about the style itself:
* PyBind follows LLVM's `int *x` convention, vs. `int* x` - I've seen good arguments for the latter, though the former is (only) better if you are listing multiple items, which you should not do. We should verify we want to keep it
* I've left the 2-space indent for public/private/protected.

```yaml
AlignConsecutiveAssignments: true # Varies in the source, sometimes aligned, sometimes not
AlwaysBreakTemplateDeclarations: Yes # Varies in the source, but more often than not
BinPackArguments: false # Varies in the source, but this looks better, IMO
BinPackParameters: false
BreakBeforeBinaryOperators: All # Mostly/always followed
BreakConstructorInitializers: BeforeComma 
ColumnLimit: 99 # Wasn't always followed - matching flake8 here
IndentPPDirectives: AfterHash # Often was not indented the same, though - 2 spaces instead of 4
IndentWidth: 4
Language: Cpp
SpaceAfterCStyleCast: true # Varied a little bit, but this seemed to be the most common
# SpaceInEmptyBlock: true # too new, so { } will be changed to {}
Standard: Cpp11
TabWidth: 4
```

Edit: Ignore failures for now, this is for a discussion of the style, should have skipped CI.

Also, since this is a fairly large change, I think we should also move again with a check_style merged into pre-commit check so we can continue with adding GHA. We can also consider applying black at roughly the same time, assuming the format looks okay, when this PR is ready to be accepted?