### PR TITLE
ci: adding pre-commit check-style.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,14 @@ repos:
   rev: 3.8.2
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear]
+    additional_dependencies: [flake8-bugbear, pep8-naming]
     exclude: ^(docs/.*|tools/.*)$
+
+- repo: local
+  hooks:
+  - id: check-style
+    name: Classic check-style
+    language: system
+    types:
+    - c++
+    entry: ./tools/check-style.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,12 @@ repos:
   - id: fix-encoding-pragma
 
 - repo: https://github.com/Lucas-C/pre-commit-hooks
-  rev: v1.1.7
+  rev: v1.1.9
   hooks:
   - id: remove-tabs
-    exclude: (Makefile|debian/rules|.gitmodules)(\.in)?$
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.2
+  rev: 3.8.3
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear, pep8-naming]

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   #   also tests the automatic discovery functions in CMake (Python version, C++ standard).
   - os: linux
     dist: xenial # Necessary to run doxygen 1.8.15
-    name: Style, docs, and pip
+    name: Docs and pip
     cache: false
     before_install:
     - pyenv global $(pyenv whence 2to3)  # activate all python versions
@@ -18,12 +18,10 @@ matrix:
     install:
     # breathe 4.14 doesn't work with bit fields. See https://github.com/michaeljones/breathe/issues/462
     # Latest breathe + Sphinx causes warnings and errors out
-    - $PY_CMD -m pip install --user --upgrade "sphinx<3" sphinx_rtd_theme breathe==4.13.1 flake8 pep8-naming pytest
+    - $PY_CMD -m pip install --user --upgrade "sphinx<3" sphinx_rtd_theme breathe==4.13.1 pytest
     - curl -fsSL https://sourceforge.net/projects/doxygen/files/rel-1.8.15/doxygen-1.8.15.linux.bin.tar.gz/download | tar xz
     - export PATH="$PWD/doxygen-1.8.15/bin:$PATH"
     script:
-    - tools/check-style.sh
-    - flake8
     - $PY_CMD -m sphinx -W -b html docs docs/.build
     - |
       # Make sure setup.py distributes and installs all the headers

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: cpp
+
+branches:
+  only:
+  - master
+  - stable
+  - /^v\d/
+
 matrix:
   include:
   # This config does a few things:
@@ -33,6 +40,7 @@ matrix:
       # Barebones build
       cmake -DCMAKE_BUILD_TYPE=Debug -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -DPYTHON_EXECUTABLE=$(which $PY_CMD) .
       make pytest -j 2 && make cpptest -j 2
+
   # The following are regular test configurations, including optional dependencies.
   # With regard to each other they differ in Python version, C++ standard and compiler.
   - os: linux

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,10 @@ adhere to the following rules to make the process as smooth as possible:
   do add value by themselves.
 * Add tests for any new functionality and run the test suite (``make pytest``)
   to ensure that no existing features break.
-* Please run [``pre-commit``][pre-commit] and ``tools/check-style.sh`` to check
-  your code matches the project style. (Note that ``check-style.sh`` requires
-  ``gawk``.) Use `pre-commit run --all-files` before committing (or use
-  installed-mode, check pre-commit docs) to verify your code passes before
-  pushing to save time.
+* Please run [``pre-commit``][pre-commit] to check your code matches the
+  project style. (Note that ``gawk`` is required.) Use `pre-commit run
+  --all-files` before committing (or use installed-mode, check pre-commit docs)
+  to verify your code passes before pushing to save time.
 * This project has a strong focus on providing general solutions using a
   minimal amount of code, thus small pull requests are greatly preferred.
 

--- a/tools/check-style.sh
+++ b/tools/check-style.sh
@@ -4,45 +4,19 @@
 #
 # This script currently checks for
 #
-# 1. use of tabs instead of spaces
-# 2. MSDOS-style CRLF endings
-# 3. trailing spaces
-# 4. missing space between keyword and parenthesis, e.g.: for(, if(, while(
-# 5. Missing space between right parenthesis and brace, e.g. 'for (...){'
-# 6. opening brace on its own line. It should always be on the same line as the
+# 1. missing space between keyword and parenthesis, e.g.: for(, if(, while(
+# 2. Missing space between right parenthesis and brace, e.g. 'for (...){'
+# 3. opening brace on its own line. It should always be on the same line as the
 #    if/while/for/do statement.
 #
-# Invoke as: tools/check-style.sh
+# Invoke as: tools/check-style.sh <filenames>
 #
 
 check_style_errors=0
 IFS=$'\n'
 
-found="$( GREP_COLORS='mt=41' GREP_COLOR='41' grep $'\t' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always )"
-if [ -n "$found" ]; then
-    # The mt=41 sets a red background for matched tabs:
-    echo -e '\033[31;01mError: found tab characters in the following files:\033[0m'
-    check_style_errors=1
-    echo "$found" | sed -e 's/^/    /'
-fi
 
-
-found="$( grep -IUlr $'\r' include tests/*.{cpp,py,h} docs/*.rst --color=always )"
-if [ -n "$found" ]; then
-    echo -e '\033[31;01mError: found CRLF characters in the following files:\033[0m'
-    check_style_errors=1
-    echo "$found" | sed -e 's/^/    /'
-fi
-
-found="$(GREP_COLORS='mt=41' GREP_COLOR='41' grep '[[:blank:]]\+$' include tests/*.{cpp,py,h} docs/*.rst -rn --color=always )"
-if [ -n "$found" ]; then
-    # The mt=41 sets a red background for matched trailing spaces
-    echo -e '\033[31;01mError: found trailing spaces in the following files:\033[0m'
-    check_style_errors=1
-    echo "$found" | sed -e 's/^/    /'
-fi
-
-found="$(grep '\<\(if\|for\|while\|catch\)(\|){' include tests/*.{cpp,h} -rn --color=always)"
+found="$(grep '\<\(if\|for\|while\|catch\)(\|){' $@ -rn --color=always)"
 if [ -n "$found" ]; then
     echo -e '\033[31;01mError: found the following coding style problems:\033[0m'
     check_style_errors=1
@@ -60,7 +34,7 @@ last && /^\s*{/ {
     last=""
 }
 { last = /(if|for|while|catch|switch)\s*\(.*\)\s*$/ ? $0 : "" }
-' $(find include -type f) tests/*.{cpp,h} docs/*.rst)"
+' $(find include -type f) $@)"
 if [ -n "$found" ]; then
     check_style_errors=1
     echo -e '\033[31;01mError: braces should occur on the same line as the if/while/.. statement. Found issues in the following files:\033[0m'


### PR DESCRIPTION
Run check-style through pre-commit. Slight change to check-style, you now list the files you want to run on, and it doesn't do things that are already checked. Updated description, removed style check from Travis. Also included the upstream fix for the tab pre-commit hook.