### PR TITLE
CMake improvement: support windows python with msys & mingw

### DIFF
--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -147,7 +147,7 @@ string(REGEX REPLACE "\\\\" "/" PYTHON_PREFIX "${PYTHON_PREFIX}")
 string(REGEX REPLACE "\\\\" "/" PYTHON_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}")
 string(REGEX REPLACE "\\\\" "/" PYTHON_SITE_PACKAGES "${PYTHON_SITE_PACKAGES}")
 
-if(CMAKE_HOST_WIN32 AND NOT (MINGW AND DEFINED ENV{MSYSTEM}))
+if(CMAKE_HOST_WIN32)
     set(PYTHON_LIBRARY
         "${PYTHON_PREFIX}/libs/python${PYTHON_LIBRARY_SUFFIX}.lib")
 
@@ -157,6 +157,20 @@ if(CMAKE_HOST_WIN32 AND NOT (MINGW AND DEFINED ENV{MSYSTEM}))
         get_filename_component(_PYTHON_ROOT ${PYTHON_INCLUDE_DIR} DIRECTORY)
         set(PYTHON_LIBRARY
             "${_PYTHON_ROOT}/libs/python${PYTHON_LIBRARY_SUFFIX}.lib")
+    endif()
+
+    # if we are in MSYS & MINGW, and we didn't find windows python lib, look for system python lib
+    if(DEFINED ENV{MSYSTEM} AND MINGW AND NOT EXISTS "${PYTHON_LIBRARY}")
+        if(PYTHON_MULTIARCH)
+            set(_PYTHON_LIBS_SEARCH "${PYTHON_LIBDIR}/${PYTHON_MULTIARCH}" "${PYTHON_LIBDIR}")
+        else()
+            set(_PYTHON_LIBS_SEARCH "${PYTHON_LIBDIR}")
+        endif()
+        unset(PYTHON_LIBRARY)
+        find_library(PYTHON_LIBRARY
+            NAMES "python${PYTHON_LIBRARY_SUFFIX}"
+            PATHS ${_PYTHON_LIBS_SEARCH}
+            NO_DEFAULT_PATH)
     endif()
 
     # raise an error if the python libs are still not found.


### PR DESCRIPTION
Change to `FindPythonLibsNew.cmake` behaviour:
  - on windows, look for windows python lib (including when using mingw and msys)
  - if python lib is not found and we are using msys, then look for system python lib

Previous behaviour was to skip the first step when using msys & mingw, so windows python libs are not found (see example [travis job](https://travis-ci.org/github/lkeegan/pybind11-msys-tests/jobs/710303307#L1548)):
```
-- Found PythonInterp: C:/Python38/python.exe (found version "3.8.2") 
-- Found PythonLibs: python38
```
i.e. doesn't find the python library

New behaviour with this PR (see example [travis job](https://travis-ci.org/github/lkeegan/pybind11-msys-tests/jobs/710303510#L1554)):
```
-- Found PythonInterp: C:/Python38/python.exe (found version "3.8.2") 
-- Found PythonLibs: C:/Python38/libs/python38.lib
```
