### PR TITLE
ci: cmake Configure test

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -1,0 +1,81 @@
+name: Configure
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable
+      - v*
+
+jobs:
+  cmake:
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+        - 2.7
+        - 3.8
+
+    name: CMake ${{ matrix.cmake }} Python ${{ matrix.python }} on ubuntu
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Prepare env
+      run: python -m pip install -r tests/requirements.txt
+
+    - name: Make build directories
+      run: |
+        mkdir build2.8
+        mkdir build3.7
+        mkdir build3.18
+
+    - name: Setup CMake 2.8
+      uses: jwlawson/actions-setup-cmake@v1.3
+      with:
+        cmake-version: 2.8
+
+    - name: Configure 2.8
+      working-directory: build2.8
+      run: >
+        cmake --version &&
+        cmake ..
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DPYTHON_EXECUTABLE=$(python -c "import sys; print(sys.executable)")
+
+    - name: Setup CMake 3.7
+      uses: jwlawson/actions-setup-cmake@v1.3
+      with:
+        cmake-version: 3.7
+
+    - name: Configure 3.7
+      working-directory: build3.7
+      run: >
+        cmake --version &&
+        cmake ..
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DPYTHON_EXECUTABLE=$(python -c "import sys; print(sys.executable)")
+
+    - name: Setup CMake 3.18
+      uses: jwlawson/actions-setup-cmake@v1.3
+      with:
+        cmake-version: 3.18
+
+    - name: Configure 3.18
+      working-directory: build3.18
+      run: >
+        cmake --version &&
+        cmake ..
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DPYTHON_EXECUTABLE=$(python -c "import sys; print(sys.executable)")


### PR DESCRIPTION
A few basic config checks to make sure we support what we say we do. Not building, just config. (note: the 2.8 build actually doesn't run the tests properly If you do have it run, the cpp tests "pass" in 0 seconds. We will drop the 2.8 test when we drop 2.8 support (very soon)).

We may split this test later into a "build test suite" and a "use as sub package / config" test (based on the current tests in the test suite so we can have a higher requirement for the test suite than for user code. This should let us simplify the test cmake code we have to maintain, and help us support nicer optional features (since we can then use them ourselves).