### PR TITLE
add support for std::integral_constant

### DIFF
--- a/docs/advanced/cast/stl.rst
+++ b/docs/advanced/cast/stl.rst
@@ -5,9 +5,10 @@ Automatic conversion
 ====================
 
 When including the additional header file :file:`pybind11/stl.h`, conversions
-between ``std::vector<>``/``std::deque<>``/``std::list<>``/``std::array<>``,
-``std::set<>``/``std::unordered_set<>``, and
-``std::map<>``/``std::unordered_map<>`` and the Python ``list``, ``set`` and
+between ``std::integral_constant<>``,
+``std::vector<>``/``std::deque<>``/``std::list<>``/``std::array<>``,
+``std::set<>``/``std::unordered_set<>``, and ``std::map<>``/``std::unordered_map<>``
+and the Python ``int`` data type, and the ``list``, ``set`` and
 ``dict`` data structures are automatically enabled. The types ``std::pair<>``
 and ``std::tuple<>`` are already supported out of the box with just the core
 :file:`pybind11/pybind11.h` header.

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -60,8 +60,8 @@ struct type_caster<std::integral_constant<Integral,constant>>{
         auto caster = make_caster<Integral>();
         return caster.load(source,convert) && cast_op<Integral>(caster) == constant;
     }
-    static handle cast(const IntegralConstant &source,return_value_policy policy,handle parent) {
-        return make_caster<Integral>::cast(source(),policy,parent);
+    static handle cast(const IntegralConstant &,return_value_policy policy,handle parent) {
+        return make_caster<Integral>::cast(IntegralConstant::value,policy,parent);
     }
 
     PYBIND11_TYPE_CASTER(IntegralConstant,_("Constant[") + make_caster<Integral>::name + _("(") + _<constant>() + _(")]"));

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -18,6 +18,7 @@
 #include <list>
 #include <deque>
 #include <valarray>
+#include <type_traits>
 
 #if defined(_MSC_VER)
 #pragma warning(push)
@@ -50,6 +51,21 @@
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
+
+template<typename Integral,Integral constant>
+struct type_caster<std::integral_constant<Integral,constant>>{
+    using IntegralConstant = std::integral_constant<Integral,constant>;
+
+    bool load(handle source, bool convert) const {
+        auto caster = make_caster<Integral>();
+        return caster.load(source,convert) && cast_op<Integral>(caster) == constant;
+    }
+    static handle cast(const IntegralConstant &source,return_value_policy policy,handle parent) {
+        return make_caster<Integral>::cast(source(),policy,parent);
+    }
+
+    PYBIND11_TYPE_CASTER(IntegralConstant,_("Constant[") + make_caster<Integral>::name + _("(") + _<constant>() + _(")]"));
+};
 
 /// Extracts an const lvalue reference or rvalue reference for U based on the type of T (e.g. for
 /// forwarding a container element).  Typically used indirect via forwarded_type(), below.

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -62,6 +62,13 @@ struct OptionalHolder
 
 
 TEST_SUBMODULE(stl, m) {
+
+    // test_integral_constant
+    m.def("cast_integral_constant_int_0", []() { return std::integral_constant<int,0>{}; });
+    m.def("load_integral_constant_int_0", [](std::integral_constant<int,0>) { return true; });
+    m.def("cast_integral_constant_size_t_5", []() { return std::integral_constant<std::size_t,5>{}; });
+    m.def("load_integral_constant_size_t_5", [](std::integral_constant<std::size_t,5>) { return true; });
+
     // test_vector
     m.def("cast_vector", []() { return std::vector<int>{1}; });
     m.def("load_vector", [](const std::vector<int> &v) { return v.at(0) == 1 && v.at(1) == 2; });

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -6,11 +6,26 @@ from pybind11_tests import UserType
 from pybind11_tests import ConstructorStats
 
 
+def test_integral_constant(doc):
+    """std::integral_constant<integer,value> <-> int(value)"""
+    int_0 = m.cast_integral_constant_int_0()
+    assert int_0 == int(0)
+    assert m.load_integral_constant_int_0(int(0))
+    pytest.raises(TypeError, m.load_integral_constant_int_0, 'foo')
+    pytest.raises(TypeError, m.load_integral_constant_int_0, 1)
+
+    size_t_5 = m.cast_integral_constant_size_t_5()
+    assert size_t_5 == int(5)
+    pytest.raises(TypeError, m.load_integral_constant_size_t_5, 'foo')
+    pytest.raises(TypeError, m.load_integral_constant_size_t_5, 1)
+
+
 def test_vector(doc):
     """std::vector <-> list"""
     lst = m.cast_vector()
     assert lst == [1]
     lst.append(2)
+
     assert m.load_vector(lst)
     assert m.load_vector(tuple(lst))
 


### PR DESCRIPTION
add a stl-caster for `std::integral_constant<>`, some tests and doc.