### PR TITLE
cast pointer to std::tuple and std::pair

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1421,6 +1421,17 @@ public:
         return cast_impl(std::forward<T>(src), policy, parent, indices{});
     }
 
+    // copied from the PYBIND11_TYPE_CASTER macro
+    template <typename T>
+    static handle cast(T *src, return_value_policy policy, handle parent) {
+        if (!src) return none().release();
+        if (policy == return_value_policy::take_ownership) {
+            auto h = cast(std::move(*src), policy, parent); delete src; return h;
+        } else {
+            return cast(*src, policy, parent);
+        }
+    }
+
     static constexpr auto name = _("Tuple[") + concat(make_caster<Ts>::name...) + _("]");
 
     template <typename T> using cast_op_type = type;

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -117,12 +117,16 @@ TEST_SUBMODULE(builtin_casters, m) {
         return std::make_pair(RValueCaster{}, std::make_tuple(RValueCaster{}, std::make_pair(RValueCaster{}, RValueCaster{}))); });
     m.def("lvalue_nested", []() -> const decltype(lvnested) & { return lvnested; });
 
+    static std::pair<int, std::string> int_string_pair{2, "items"};
+    m.def("int_string_pair", []() { return &int_string_pair; });
+
     // test_builtins_cast_return_none
     m.def("return_none_string", []() -> std::string * { return nullptr; });
     m.def("return_none_char",   []() -> const char *  { return nullptr; });
     m.def("return_none_bool",   []() -> bool *        { return nullptr; });
     m.def("return_none_int",    []() -> int *         { return nullptr; });
     m.def("return_none_float",  []() -> float *       { return nullptr; });
+    m.def("return_none_pair",   []() -> std::pair<int,int> * { return nullptr; });
 
     // test_none_deferred
     m.def("defer_none_cstring", [](char *) { return false; });

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -250,6 +250,8 @@ def test_tuple(doc):
     assert m.rvalue_nested() == ("rvalue", ("rvalue", ("rvalue", "rvalue")))
     assert m.lvalue_nested() == ("lvalue", ("lvalue", ("lvalue", "lvalue")))
 
+    assert m.int_string_pair() == (2, "items")
+
 
 def test_builtins_cast_return_none():
     """Casters produced with PYBIND11_TYPE_CASTER() should convert nullptr to None"""
@@ -258,6 +260,7 @@ def test_builtins_cast_return_none():
     assert m.return_none_bool() is None
     assert m.return_none_int() is None
     assert m.return_none_float() is None
+    assert m.return_none_pair() is None
 
 
 def test_none_deferred():


### PR DESCRIPTION
This PR copies `handle cast(T *src, ...)` from PYBIND11_TYPE_CASTER to tuple_caster.
It enables bindings to functions returning a pointer to std::tuple or std::pair - in the same way as pybind11 handles now pointers to int, std::string, std::array, and everything else.

I don't have a deep understanding of pybind11 internals - please double check this patch before applying.