### PR TITLE
Fixing pybind11::bytes() ambiguous overload issue and adding missing bytes type to test_constructors().

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -784,7 +784,9 @@ PYBIND11_NAMESPACE_END(detail)
         Name(handle h, stolen_t) : Parent(h, stolen_t{}) { } \
         PYBIND11_DEPRECATED("Use py::isinstance<py::python_type>(obj) instead") \
         bool check() const { return m_ptr != nullptr && (bool) CheckFun(m_ptr); } \
-        static bool check_(handle h) { return h.ptr() != nullptr && CheckFun(h.ptr()); }
+        static bool check_(handle h) { return h.ptr() != nullptr && CheckFun(h.ptr()); } \
+        template <typename Policy_> \
+        Name(const ::pybind11::detail::accessor<Policy_> &a) : Name(object(a)) { }
 
 #define PYBIND11_OBJECT_CVT(Name, Parent, CheckFun, ConvertFun) \
     PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun) \
@@ -794,9 +796,7 @@ PYBIND11_NAMESPACE_END(detail)
     { if (!m_ptr) throw error_already_set(); } \
     Name(object &&o) \
     : Parent(check_(o) ? o.release().ptr() : ConvertFun(o.ptr()), stolen_t{}) \
-    { if (!m_ptr) throw error_already_set(); } \
-    template <typename Policy_> \
-    Name(const ::pybind11::detail::accessor<Policy_> &a) : Name(object(a)) { }
+    { if (!m_ptr) throw error_already_set(); }
 
 #define PYBIND11_OBJECT(Name, Parent, CheckFun) \
     PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun) \

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -197,6 +197,7 @@ TEST_SUBMODULE(pytypes, m) {
     // test_constructors
     m.def("default_constructors", []() {
         return py::dict(
+            "bytes"_a=py::bytes(),
             "str"_a=py::str(),
             "bool"_a=py::bool_(),
             "int"_a=py::int_(),
@@ -210,6 +211,7 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.def("converting_constructors", [](py::dict d) {
         return py::dict(
+            "bytes"_a=py::bytes(d["bytes"]),
             "str"_a=py::str(d["str"]),
             "bool"_a=py::bool_(d["bool"]),
             "int"_a=py::int_(d["int"]),
@@ -225,6 +227,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("cast_functions", [](py::dict d) {
         // When converting between Python types, obj.cast<T>() should be the same as T(obj)
         return py::dict(
+            "bytes"_a=d["bytes"].cast<py::bytes>(),
             "str"_a=d["str"].cast<py::str>(),
             "bool"_a=d["bool"].cast<py::bool_>(),
             "int"_a=d["int"].cast<py::int_>(),

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -188,23 +188,29 @@ def test_accessors():
 
 def test_constructors():
     """C++ default and converting constructors are equivalent to type calls in Python"""
-    types = [str, bool, int, float, tuple, list, dict, set]
+    types = [bytes, str, bool, int, float, tuple, list, dict, set]
     expected = {t.__name__: t() for t in types}
+    if str is bytes:  # Python 2.
+        # Note that bytes.__name__ == 'str' in Python 2.
+        # pybind11::str is unicode even under Python 2.
+        expected["bytes"] = bytes()
+        expected["str"] = u""  # flake8 complains about unicode().
     assert m.default_constructors() == expected
 
     data = {
-        str: 42,
-        bool: "Not empty",
-        int: "42",
-        float: "+1e3",
-        tuple: range(3),
-        list: range(3),
-        dict: [("two", 2), ("one", 1), ("three", 3)],
-        set: [4, 4, 5, 6, 6, 6],
-        memoryview: b'abc'
+        "bytes": b'41',  # Currently no supported or working conversions.
+        "str": 42,
+        "bool": "Not empty",
+        "int": "42",
+        "float": "+1e3",
+        "tuple": range(3),
+        "list": range(3),
+        "dict": [("two", 2), ("one", 1), ("three", 3)],
+        "set": [4, 4, 5, 6, 6, 6],
+        "memoryview": b'abc'
     }
-    inputs = {k.__name__: v for k, v in data.items()}
-    expected = {k.__name__: k(v) for k, v in data.items()}
+    inputs = {k: v for k, v in data.items()}
+    expected = {k: eval(k)(v) for k, v in data.items()}
 
     assert m.converting_constructors(inputs) == expected
     assert m.cast_functions(inputs) == expected


### PR DESCRIPTION
Two of the additions work, but `pybind11::bytes(obj)` generates this compilation error (tested with c++11 & c++2a):

```
/usr/local/google/home/rwgk/forked/pybind11/tests/test_pytypes.cpp:214:23: error: ambiguous conversion for functional-style cast from 'pybind11::detail::item_accessor' (aka 'accessor<accessor_policies::generic_item>') to 'py::bytes'
            "bytes"_a=py::bytes(d["bytes"]),
                      ^~~~~~~~~~~~~~~~~~~~
/usr/local/google/home/rwgk/forked/pybind11/include/pybind11/detail/../pytypes.h:957:21: note: candidate constructor
    PYBIND11_OBJECT(bytes, object, PYBIND11_BYTES_CHECK)
                    ^
/usr/local/google/home/rwgk/forked/pybind11/include/pybind11/detail/../pytypes.h:957:21: note: candidate constructor
/usr/local/google/home/rwgk/forked/pybind11/include/pybind11/detail/../pytypes.h:987:15: note: candidate constructor
inline bytes::bytes(const pybind11::str &s) {
              ^
1 error generated.
```