### PR TITLE
Use PyErr_WriteUnraisable when an error occurs in a destructor

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1406,6 +1406,9 @@ private:
             );
         }
         v_h.value_ptr() = nullptr;
+        if (PyErr_Occurred()) {
+            PyErr_WriteUnraisable(v_h.type ? (PyObject*)v_h.type->type : nullptr);
+        }
     }
 
     static detail::function_record *get_function_record(handle h) {

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -390,6 +390,15 @@ TEST_SUBMODULE(class_, m) {
     py::class_<PyPrintDestructor>(m, "PyPrintDestructor")
         .def(py::init<>())
         .def("throw_something", &PyPrintDestructor::throw_something);
+
+    struct PyRaiseDestructor {
+        PyRaiseDestructor() {}
+        ~PyRaiseDestructor() {
+            PyErr_SetString(PyExc_ValueError, "unraisable error");
+        }
+    };
+    py::class_<PyRaiseDestructor>(m, "PyRaiseDestructor")
+        .def(py::init<>());
 }
 
 template <int N> class BreaksBase { public:

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -329,3 +329,21 @@ def test_non_final_final():
 def test_exception_rvalue_abort():
     with pytest.raises(RuntimeError):
         m.PyPrintDestructor().throw_something()
+
+
+def test_pyexception_destructor():
+    import sys
+
+    if hasattr(sys, "unraisablehook"):
+        old_hook = sys.unraisablehook
+        try:
+            ctxt = [None]
+
+            def new_hook(*args):
+                ctxt[0] = True
+
+            sys.unraisablehook = new_hook
+            m.PyRaiseDestructor()
+            assert ctxt[0] is not None
+        finally:
+            sys.unraisablehook = old_hook


### PR DESCRIPTION
Minor improvement to #2342

With the default hook, you end up with an error message looking something like so:

```
Exception ignored in: <class 'pybind11_tests.class_.PyRaiseDestructor'>
Traceback (most recent call last):
  File "<snip>/pybind11/tests/test_class.py", line 389, in test_pyexception_destructor
    m.PyRaiseDestructor()
ValueError: unraisable error
```