### PR TITLE
Enable py::ellipsis on Python 2

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -371,6 +371,8 @@ Ellipsis
 Python 3 provides a convenient ``...`` ellipsis notation that is often used to
 slice multidimensional arrays. For instance, the following snippet extracts the
 middle dimensions of a tensor with the first and last index set to zero.
+In Python 2, the syntactic sugar ``...`` is not available, but the singleton
+``Ellipsis`` (of type ``ellipsis``) can still be used directly.
 
 .. code-block:: python
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -736,9 +736,7 @@ inline bool PyIterable_Check(PyObject *obj) {
 }
 
 inline bool PyNone_Check(PyObject *o) { return o == Py_None; }
-#if PY_MAJOR_VERSION >= 3
 inline bool PyEllipsis_Check(PyObject *o) { return o == Py_Ellipsis; }
-#endif
 
 inline bool PyUnicode_Check_Permissive(PyObject *o) { return PyUnicode_Check(o) || PYBIND11_BYTES_CHECK(o); }
 
@@ -1020,13 +1018,11 @@ public:
     none() : object(Py_None, borrowed_t{}) { }
 };
 
-#if PY_MAJOR_VERSION >= 3
 class ellipsis : public object {
 public:
     PYBIND11_OBJECT(ellipsis, object, detail::PyEllipsis_Check)
     ellipsis() : object(Py_Ellipsis, borrowed_t{}) { }
 };
-#endif
 
 class bool_ : public object {
 public:

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -382,9 +382,7 @@ TEST_SUBMODULE(numpy_array, sm) {
         return a;
     });
 
-#if PY_MAJOR_VERSION >= 3
-        sm.def("index_using_ellipsis", [](py::array a) {
-            return a[py::make_tuple(0, py::ellipsis(), 0)];
-        });
-#endif
+    sm.def("index_using_ellipsis", [](py::array a) {
+        return a[py::make_tuple(0, py::ellipsis(), 0)];
+    });
 }

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -431,7 +431,6 @@ def test_array_create_and_resize(msg):
     assert(np.all(a == 42.))
 
 
-@pytest.unsupported_on_py2
 def test_index_using_ellipsis():
     a = m.index_using_ellipsis(np.zeros((5, 6, 7)))
     assert a.shape == (6,)


### PR DESCRIPTION
Not sure why #1502 disabled `py::ellipsis` for Python 2. `...` doesn't seem to exist as a shortcut for `Ellipsis` (the singleton instance of the `ellipsis` type; similar to `None` and `NoneType`), but `Ellipsis` still exists (https://docs.python.org/2/library/constants.html#Ellipsis), as well as the C Python interface (https://docs.python.org/2/c-api/slice.html#c.Py_Ellipsis).

Might not be véry useful in Python 2, but I see no reason not to include it, and it broke some tests in #2349 because I forgot to disable that part of the test for Python 2.