### PR TITLE
feat: py::type::of<T>() and py::type::of(h)

### DIFF
--- a/docs/advanced/cast/index.rst
+++ b/docs/advanced/cast/index.rst
@@ -1,3 +1,5 @@
+.. _type-conversions:
+
 Type conversions
 ################
 

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -1240,9 +1240,9 @@ You can get the type object from a C++ class that has already been registered us
 
 .. code-block:: python
 
-    auto T_py = py::type::of<T>();
+    py::type T_py = py::type::of<T>();
 
-You can directly use ``py::type(ob)`` to get the type object from any python
+You can directly use ``py::type::of(ob)`` to get the type object from any python
 object, just like ``type(ob)`` in Python.
 
 .. versionadded:: 2.6

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -1247,6 +1247,6 @@ object, just like ``type(ob)`` in Python.
 
 .. note::
 
-    Other types, like ``py::type::of<int>``, do not work, see :ref:`type-conversions`.
+    Other types, like ``py::type::of<int>()``, do not work, see :ref:`type-conversions`.
 
 .. versionadded:: 2.6

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -1232,3 +1232,17 @@ appropriate derived-class pointer (e.g. using
     more complete example, including a demonstration of how to provide
     automatic downcasting for an entire class hierarchy without
     writing one get() function for each class.
+
+Accessing the type object
+=========================
+
+You can get the type object from a C++ class that has already been registered using:
+
+.. code-block:: python
+
+    auto T_py = py::type::of<T>();
+
+You can directly use ``py::type(ob)`` to get the type object from any python
+object, just like ``type(ob)`` in Python.
+
+.. versionadded:: 2.6

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -1245,4 +1245,8 @@ You can get the type object from a C++ class that has already been registered us
 You can directly use ``py::type::of(ob)`` to get the type object from any python
 object, just like ``type(ob)`` in Python.
 
+.. note::
+
+    Other types, like ``py::type::of<int>``, do not work, see :ref:`type-conversions`.
+
 .. versionadded:: 2.6

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -2204,6 +2204,27 @@ object object_api<Derived>::call(Args &&...args) const {
 
 PYBIND11_NAMESPACE_END(detail)
 
+
+/** \ingroup python_builtins
+    \rst
+    Return the registered type object for a C++ class, given as a template parameter.
+    py::type<T>() returns the Python type object previously registered for T.
+\endrst */
+template<typename T>
+handle type() {
+    static_assert(
+      std::is_base_of<detail::type_caster_generic, detail::make_caster<T>>::value,
+      "This currently only works for registered C++ types. The type here is most likely type converted (using type_caster)."
+    );
+
+    return detail::get_type_handle(typeid(T), true);
+}
+
+inline handle type(handle h) {
+    PyObject* obj = (PyObject *) Py_TYPE(h.ptr());
+    return handle(obj);
+}
+
 #define PYBIND11_MAKE_OPAQUE(...) \
     namespace pybind11 { namespace detail { \
         template<> class type_caster<__VA_ARGS__> : public type_caster_base<__VA_ARGS__> { }; \

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -2209,7 +2209,7 @@ template<typename T>
 type type::of() {
    static_assert(
       std::is_base_of<detail::type_caster_generic, detail::make_caster<T>>::value,
-      "This currently only works for registered C++ types. The type here is most likely type converted (using type_caster)."
+      "py::type::of<T> only supports the case where T is a registered C++ types. The type here is most likely type converted (using type_caster)."
     );
 
     return type((PyTypeObject*) detail::get_type_handle(typeid(T), true).ptr());

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -2205,25 +2205,16 @@ object object_api<Derived>::call(Args &&...args) const {
 PYBIND11_NAMESPACE_END(detail)
 
 
-/** \ingroup python_builtins
-    \rst
-    Return the registered type object for a C++ class, given as a template parameter.
-    py::type<T>() returns the Python type object previously registered for T.
-\endrst */
 template<typename T>
-handle type() {
-    static_assert(
+type type::of() {
+   static_assert(
       std::is_base_of<detail::type_caster_generic, detail::make_caster<T>>::value,
       "This currently only works for registered C++ types. The type here is most likely type converted (using type_caster)."
     );
 
-    return detail::get_type_handle(typeid(T), true);
+    return type((PyTypeObject*) detail::get_type_handle(typeid(T), true).ptr());
 }
 
-inline handle type(handle h) {
-    PyObject* obj = (PyObject *) Py_TYPE(h.ptr());
-    return handle(obj);
-}
 
 #define PYBIND11_MAKE_OPAQUE(...) \
     namespace pybind11 { namespace detail { \

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -2209,10 +2209,10 @@ template<typename T>
 type type::of() {
    static_assert(
       std::is_base_of<detail::type_caster_generic, detail::make_caster<T>>::value,
-      "py::type::of<T> only supports the case where T is a registered C++ types. The type here is most likely type converted (using type_caster)."
+      "py::type::of<T> only supports the case where T is a registered C++ types."
     );
 
-    return type((PyTypeObject*) detail::get_type_handle(typeid(T), true).ptr());
+    return type((PyObject*) detail::get_type_handle(typeid(T), true).ptr(), borrowed_t());
 }
 
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -750,6 +750,10 @@ inline bool PyIterable_Check(PyObject *obj) {
     }
 }
 
+inline PyObject* Py_TYPE_Convert(PyObject *obj) {
+    return (PyObject*) Py_TYPE(obj);
+}
+
 inline bool PyNone_Check(PyObject *o) { return o == Py_None; }
 inline bool PyEllipsis_Check(PyObject *o) { return o == Py_Ellipsis; }
 
@@ -891,16 +895,15 @@ private:
     object value = {};
 };
 
+
+
 class type : public object {
 public:
-    PYBIND11_OBJECT_DEFAULT(type, object, PyType_Check);
-
-    // Explicit omitted here since PyTypeObject required (rather than just PyObject)
-    type(PyTypeObject* type_ptr) : object((PyObject*) type_ptr, borrowed_t()) {}
+    PYBIND11_OBJECT_CVT(type, object, PyType_Check, detail::Py_TYPE_Convert);
 
     /// Giving a handle/object gets the type from it
     static type of(const handle& h) {
-        return type(Py_TYPE(h.ptr()));
+        return type(detail::Py_TYPE_Convert(h.ptr()), borrowed_t());
     }
 
     /// Convert C++ type to py::type if prevously registered. Does not convert standard types, like int, float. etc. yet.

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -891,20 +891,21 @@ private:
     object value = {};
 };
 
-class type : public handle {
+class type : public object {
 public:
+    PYBIND11_OBJECT_DEFAULT(type, object, PyType_Check);
+
     // Explicit omitted here since PyTypeObject required (rather than just PyObject)
-    type(PyTypeObject* type_ptr) : handle((PyObject*) type_ptr) {}
+    type(PyTypeObject* type_ptr) : object((PyObject*) type_ptr, borrowed_t()) {}
 
     /// Giving a handle/object gets the type from it
-    explicit type(const handle& h) : handle((PyObject *) Py_TYPE(h.ptr())) {}
+    static type of(const handle& h) {
+        return type(Py_TYPE(h.ptr()));
+    }
 
     /// Convert C++ type to py::type if prevously registered. Does not convert standard types, like int, float. etc. yet.
     template<typename T>
     static type of();
-
-    /// Custom check function that also ensures this is a type
-    bool check() const { return ptr() != nullptr && PyType_Check(ptr());}
 };
 
 class iterable : public object {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -19,6 +19,7 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 /* A few forward declarations */
 class handle; class object;
 class str; class iterator;
+class type;
 struct arg; struct arg_v;
 
 PYBIND11_NAMESPACE_BEGIN(detail)
@@ -888,6 +889,22 @@ private:
 
 private:
     object value = {};
+};
+
+class type : public handle {
+public:
+    // Explicit omitted here since PyTypeObject required (rather than just PyObject)
+    type(PyTypeObject* type_ptr) : handle((PyObject*) type_ptr) {}
+
+    /// Giving a handle/object gets the type from it
+    explicit type(const handle& h) : handle((PyObject *) Py_TYPE(h.ptr())) {}
+
+    /// Convert C++ type to py::type if prevously registered. Does not convert standard types, like int, float. etc. yet.
+    template<typename T>
+    static type of();
+
+    /// Custom check function that also ensures this is a type
+    bool check() const { return ptr() != nullptr && PyType_Check(ptr());}
 };
 
 class iterable : public object {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -750,10 +750,6 @@ inline bool PyIterable_Check(PyObject *obj) {
     }
 }
 
-inline PyObject* Py_TYPE_Convert(PyObject *obj) {
-    return (PyObject*) Py_TYPE(obj);
-}
-
 inline bool PyNone_Check(PyObject *o) { return o == Py_None; }
 inline bool PyEllipsis_Check(PyObject *o) { return o == Py_Ellipsis; }
 
@@ -899,14 +895,13 @@ private:
 
 class type : public object {
 public:
-    PYBIND11_OBJECT_CVT(type, object, PyType_Check, detail::Py_TYPE_Convert);
+    PYBIND11_OBJECT_COMMON(type, object, PyType_Check)
 
-    /// Giving a handle/object gets the type from it
-    static type of(const handle& h) {
-        return type(detail::Py_TYPE_Convert(h.ptr()), borrowed_t());
-    }
+    explicit type(handle h): type((PyObject*) Py_TYPE(h.ptr()), borrowed_t{}) {}
+    explicit type(object ob): type((PyObject*) Py_TYPE(ob.ptr()), borrowed_t{}) {}
 
-    /// Convert C++ type to py::type if prevously registered. Does not convert standard types, like int, float. etc. yet.
+    /// Convert C++ type to py::type if previously registered. Does not convert
+    //standard types, like int, float. etc. yet.
     template<typename T>
     static type of();
 };

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -901,7 +901,8 @@ public:
     explicit type(object ob): type((PyObject*) Py_TYPE(ob.ptr()), borrowed_t{}) {}
 
     /// Convert C++ type to py::type if previously registered. Does not convert
-    //standard types, like int, float. etc. yet.
+    // standard types, like int, float. etc. yet.
+    // See https://github.com/pybind/pybind11/issues/2486
     template<typename T>
     static type of();
 };

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -895,10 +895,9 @@ private:
 
 class type : public object {
 public:
-    PYBIND11_OBJECT_COMMON(type, object, PyType_Check)
+    PYBIND11_OBJECT(type, object, PyType_Check)
 
-    explicit type(handle h): type((PyObject*) Py_TYPE(h.ptr()), borrowed_t{}) {}
-    explicit type(object ob): type((PyObject*) Py_TYPE(ob.ptr()), borrowed_t{}) {}
+    static type of(handle h) { return type((PyObject*) Py_TYPE(h.ptr()), borrowed_t{}); }
 
     /// Convert C++ type to py::type if previously registered. Does not convert
     // standard types, like int, float. etc. yet.

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -147,16 +147,8 @@ TEST_SUBMODULE(class_, m) {
             return py::type::of<Invalid>();
     });
 
-    m.def("get_type", [](py::handle h) {
-        return py::type::of(h);
-    });
-
-    m.def("get_type_direct", [](py::object ob) {
+    m.def("get_type", [](py::object ob) {
         return py::type(ob);
-    });
-
-    m.def("get_type_implicit", [](py::object ob) -> py::type {
-        return ob;
     });
 
     // test_mismatched_holder

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -139,6 +139,7 @@ TEST_SUBMODULE(class_, m) {
     // test_type
     m.def("check_type", [](int category) {
         // Currently not supported (via a fail at compile time)
+        // See https://github.com/pybind/pybind11/issues/2486
         // if (category == 2)
         //     return py::type::of<int>();
         if (category == 1)

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -134,6 +134,23 @@ TEST_SUBMODULE(class_, m) {
         );
     });
 
+    struct Invalid {};
+
+    // test_type
+    m.def("check_type", [](int category) {
+        // Currently not supported (via a fail at compile time)
+        // if (category == 2)
+        //     return py::type<int>();
+        if (category == 1)
+            return py::type<DerivedClass1>();
+        else
+            return py::type<Invalid>();
+    });
+
+    m.def("compute_type", [](py::handle h) {
+        return py::type(h);
+    });
+
     // test_mismatched_holder
     struct MismatchBase1 { };
     struct MismatchDerived1 : MismatchBase1 { };

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -140,11 +140,11 @@ TEST_SUBMODULE(class_, m) {
     m.def("check_type", [](int category) {
         // Currently not supported (via a fail at compile time)
         // if (category == 2)
-        //     return py::type<int>();
+        //     return py::type::of<int>();
         if (category == 1)
-            return py::type<DerivedClass1>();
+            return py::type::of<DerivedClass1>();
         else
-            return py::type<Invalid>();
+            return py::type::of<Invalid>();
     });
 
     m.def("compute_type", [](py::handle h) {

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -148,7 +148,7 @@ TEST_SUBMODULE(class_, m) {
     });
 
     m.def("compute_type", [](py::handle h) {
-        return py::type(h);
+        return py::type::of(h);
     });
 
     // test_mismatched_holder

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -147,8 +147,16 @@ TEST_SUBMODULE(class_, m) {
             return py::type::of<Invalid>();
     });
 
-    m.def("compute_type", [](py::handle h) {
+    m.def("get_type", [](py::handle h) {
         return py::type::of(h);
+    });
+
+    m.def("get_type_direct", [](py::object ob) {
+        return py::type(ob);
+    });
+
+    m.def("get_type_implicit", [](py::object ob) -> py::type {
+        return ob;
     });
 
     // test_mismatched_holder

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -148,8 +148,16 @@ TEST_SUBMODULE(class_, m) {
             return py::type::of<Invalid>();
     });
 
-    m.def("get_type", [](py::object ob) {
-        return py::type(ob);
+    m.def("get_type_of", [](py::object ob) {
+        return py::type::of(ob);
+    });
+
+    m.def("as_type", [](py::object ob) {
+        auto tp = py::type(ob);
+        if (py::isinstance<py::type>(ob))
+            return tp;
+        else
+            throw std::runtime_error("Invalid type");
     });
 
     // test_mismatched_holder

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -39,15 +39,25 @@ def test_type():
     # assert m.check_type(2) == int
 
 
-def test_type_py():
-    assert m.get_type(1) == int
-    assert m.get_type(m.DerivedClass1()) == m.DerivedClass1
-    assert m.get_type(int) == type
+def test_type_of_py():
+    assert m.get_type_of(1) == int
+    assert m.get_type_of(m.DerivedClass1()) == m.DerivedClass1
+    assert m.get_type_of(int) == type
 
 
-def test_type_py_nodelete():
+def test_type_of_py_nodelete():
     # If the above test deleted the class, this will segfault
-    assert m.get_type(m.DerivedClass1()) == m.DerivedClass1
+    assert m.get_type_of(m.DerivedClass1()) == m.DerivedClass1
+
+
+def test_as_type_py():
+    assert m.as_type(int) == int
+
+    with pytest.raises(RuntimeError):
+        assert m.as_type(1) == int
+
+    with pytest.raises(RuntimeError):
+        assert m.as_type(m.DerivedClass1()) == m.DerivedClass1
 
 
 def test_docstrings(doc):

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -35,6 +35,7 @@ def test_type():
     assert 'Invalid' in str(execinfo.value)
 
     # Currently not supported
+    # See https://github.com/pybind/pybind11/issues/2486
     # assert m.check_type(2) == int
 
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -44,23 +44,9 @@ def test_type_py():
     assert m.get_type(int) == type
 
 
-def test_type_implicit():
-    assert m.get_type_implicit(m.DerivedClass1()) == m.DerivedClass1
-    assert m.get_type_implicit(1) == int
-    assert m.get_type_implicit(int) == int
-
-
-def test_type_direct():
-    # Comment following line to avoid segfault (getting type of registered
-    # class twice causes segfault)
-    assert m.get_type_direct(m.DerivedClass1()) == m.DerivedClass1
-    assert m.get_type_direct(1) == int
-    assert m.get_type_direct(int) == int
-
-
-# Uncomment for segfault
-# def test_type_implicit_again():
-#    assert m.get_type_implicit(m.DerivedClass1()) == m.DerivedClass1
+def test_type_py_nodelete():
+    # If the above test deleted the class, this will segfault
+    assert m.get_type(m.DerivedClass1()) == m.DerivedClass1
 
 
 def test_docstrings(doc):

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -26,6 +26,23 @@ def test_instance(msg):
     assert cstats.alive() == 0
 
 
+def test_type():
+    assert m.check_type(1) == m.DerivedClass1
+    with pytest.raises(RuntimeError) as execinfo:
+        m.check_type(0)
+
+    assert 'pybind11::detail::get_type_info: unable to find type info' in str(execinfo.value)
+    assert 'Invalid' in str(execinfo.value)
+
+    # Currently not supported
+    # assert m.check_type(2) == int
+
+
+def test_type_py():
+    assert m.compute_type(1) == int
+    assert m.compute_type(m.DerivedClass1()) == m.DerivedClass1
+
+
 def test_docstrings(doc):
     assert doc(UserType) == "A `py::class_` type for testing"
     assert UserType.__name__ == "UserType"

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -39,8 +39,28 @@ def test_type():
 
 
 def test_type_py():
-    assert m.compute_type(1) == int
-    assert m.compute_type(m.DerivedClass1()) == m.DerivedClass1
+    assert m.get_type(1) == int
+    assert m.get_type(m.DerivedClass1()) == m.DerivedClass1
+    assert m.get_type(int) == type
+
+
+def test_type_implicit():
+    assert m.get_type_implicit(m.DerivedClass1()) == m.DerivedClass1
+    assert m.get_type_implicit(1) == int
+    assert m.get_type_implicit(int) == int
+
+
+def test_type_direct():
+    # Comment following line to avoid segfault (getting type of registered
+    # class twice causes segfault)
+    assert m.get_type_direct(m.DerivedClass1()) == m.DerivedClass1
+    assert m.get_type_direct(1) == int
+    assert m.get_type_direct(int) == int
+
+
+# Uncomment for segfault
+# def test_type_implicit_again():
+#    assert m.get_type_implicit(m.DerivedClass1()) == m.DerivedClass1
 
 
 def test_docstrings(doc):


### PR DESCRIPTION
This adds `py::type::of<T>()`, which provides a way to get the Python type associated with a C++ type. Currently there are two possible ways to do this (pointed out by @YannickJadoul and @bstaletic on Gitter about a year ago, IIRC), but they require usage of internal structures or the detail namespace. This provides a natural, pythonic way to get the type object without reverting to internal details.

This is very useful in templated code; for example, in boost-histogram, it is needed to get the templated storage from a templated histogram.

EDIT (@YannickJadoul):
Closes #1692