### PR TITLE
Receive PyModuleDef pointer in module's constructor 

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -818,7 +818,12 @@ public:
     PYBIND11_OBJECT_DEFAULT(module, object, PyModule_Check)
 
     /// Create a new top-level Python module with the given name and docstring
-    explicit module(const char *name, const char *doc = nullptr, PyModuleDef *def = nullptr) {
+    explicit module(const char *name, const char *doc = nullptr
+#if PY_MAJOR_VERSION >= 3
+                    , PyModuleDef *def = nullptr
+#endif
+                   )
+    {
         if (!options::show_user_defined_docstrings()) doc = nullptr;
 #if PY_MAJOR_VERSION >= 3
         if (!def) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -818,14 +818,16 @@ public:
     PYBIND11_OBJECT_DEFAULT(module, object, PyModule_Check)
 
     /// Create a new top-level Python module with the given name and docstring
-    explicit module(const char *name, const char *doc = nullptr) {
+    explicit module(const char *name, const char *doc = nullptr, PyModuleDef *def = nullptr) {
         if (!options::show_user_defined_docstrings()) doc = nullptr;
 #if PY_MAJOR_VERSION >= 3
-        PyModuleDef *def = new PyModuleDef();
-        std::memset(def, 0, sizeof(PyModuleDef));
-        def->m_name = name;
-        def->m_doc = doc;
-        def->m_size = -1;
+        if (!def) {
+            PyModuleDef *def = new PyModuleDef();
+            std::memset(def, 0, sizeof(PyModuleDef));
+            def->m_name = name;
+            def->m_doc = doc;
+            def->m_size = -1;
+        }
         Py_INCREF(def);
         m_ptr = PyModule_Create(def);
 #else

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -827,8 +827,8 @@ public:
             def->m_name = name;
             def->m_doc = doc;
             def->m_size = -1;
+            Py_INCREF(def);
         }
-        Py_INCREF(def);
         m_ptr = PyModule_Create(def);
 #else
         m_ptr = Py_InitModule3(name, nullptr, doc);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -822,7 +822,7 @@ public:
         if (!options::show_user_defined_docstrings()) doc = nullptr;
 #if PY_MAJOR_VERSION >= 3
         if (!def) {
-            PyModuleDef *def = new PyModuleDef();
+            def = new PyModuleDef();
             std::memset(def, 0, sizeof(PyModuleDef));
             def->m_name = name;
             def->m_doc = doc;


### PR DESCRIPTION
Optionally receiving a pre-defined  `PyModuleDef` pointer in `module`'s constructor helps some embedded Python applications a lot.