### PR TITLE
pybind11::str::raw_str simplification (for Python 2)

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -930,12 +930,12 @@ public:
 private:
     /// Return string representation -- always returns a new reference, even if already a str
     static PyObject *raw_str(PyObject *op) {
-        PyObject *str_value = PyObject_Str(op);
-        if (!str_value) throw error_already_set();
 #if PY_MAJOR_VERSION < 3
-        PyObject *unicode = PyUnicode_FromEncodedObject(str_value, "utf-8", nullptr);
-        Py_XDECREF(str_value); str_value = unicode;
+        PyObject *str_value = PyObject_Unicode(op);
+#else
+        PyObject *str_value = PyObject_Str(op);
 #endif
+        if (!str_value) throw error_already_set();
         return str_value;
     }
 };


### PR DESCRIPTION
For Python 2, convert directly to unicode (instead of converting to str first, followed by decoding).

Simpler code, and more obviously equivalent to `unicode(...)` in the interpreter.

PR is #2366 is meant to be a preparation for this PR.
They could be merged in any order, but it's best to merge #2366 first, re-base and re-test  this PR, then merge.