### PR TITLE
ci: include Python 3.9 RC1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,6 @@ jobs:
             arch: x64
             max-cxx-std: 17
 
-            # Currently can't build due to warning, fixed in CPython > 3.9b5
-          - runs-on: macos-latest
-            python: 3.9-dev
-            arch: x64
-            max-cxx-std: 17
-
             # Currently broken on embed_test
           - runs-on: windows-latest
             python: 3.8

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010/
 numpy==1.16.6; python_version<"3.6"
 numpy==1.18.0; platform_python_implementation=="PyPy" and sys_platform=="darwin" and python_version>="3.6"
-numpy==1.19.1; (platform_python_implementation!="PyPy" or sys_platform!="darwin") and python_version>="3.6"
+numpy==1.19.1; (platform_python_implementation!="PyPy" or sys_platform!="darwin") and python_version>="3.6" and python_version<"3.9"
 pytest==4.6.9; python_version<"3.5"
 pytest==5.4.3; python_version>="3.5"
 scipy==1.2.3; (platform_python_implementation!="PyPy" or sys_platform!="darwin") and python_version<"3.6"


### PR DESCRIPTION
The patch we submitted to Python should be included in yesterday's Python 3.9 RC1, so this should pass now. Fingers crossed!