### PR TITLE
Bytes constructor test change compatible with PR #2380

### DIFF
--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -190,6 +190,9 @@ def test_constructors():
     """C++ default and converting constructors are equivalent to type calls in Python"""
     types = [str, bool, int, float, tuple, list, dict, set]
     expected = {t.__name__: t() for t in types}
+    if str is bytes:  # Python 2.
+        # pybind11::str is unicode even under Python 2.
+        expected["str"] = u""  # flake8 complains about unicode().
     assert m.default_constructors() == expected
 
     data = {
@@ -205,6 +208,9 @@ def test_constructors():
     }
     inputs = {k.__name__: v for k, v in data.items()}
     expected = {k.__name__: k(v) for k, v in data.items()}
+    if str is bytes:  # Similar to the above. See comments above.
+        inputs["str"] = 42
+        expected["str"] = u"42"
 
     assert m.converting_constructors(inputs) == expected
     assert m.cast_functions(inputs) == expected

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -188,14 +188,17 @@ def test_accessors():
 
 def test_constructors():
     """C++ default and converting constructors are equivalent to type calls in Python"""
-    types = [str, bool, int, float, tuple, list, dict, set]
+    types = [bytes, str, bool, int, float, tuple, list, dict, set]
     expected = {t.__name__: t() for t in types}
     if str is bytes:  # Python 2.
+        # Note that bytes.__name__ == 'str' in Python 2.
         # pybind11::str is unicode even under Python 2.
+        expected["bytes"] = bytes()
         expected["str"] = u""  # flake8 complains about unicode().
     assert m.default_constructors() == expected
 
     data = {
+        bytes: b'41',  # Currently no supported or working conversions.
         str: 42,
         bool: "Not empty",
         int: "42",
@@ -209,7 +212,9 @@ def test_constructors():
     inputs = {k.__name__: v for k, v in data.items()}
     expected = {k.__name__: k(v) for k, v in data.items()}
     if str is bytes:  # Similar to the above. See comments above.
+        inputs["bytes"] = b'41'
         inputs["str"] = 42
+        expected["bytes"] = b'41'
         expected["str"] = u"42"
 
     assert m.converting_constructors(inputs) == expected

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -188,29 +188,23 @@ def test_accessors():
 
 def test_constructors():
     """C++ default and converting constructors are equivalent to type calls in Python"""
-    types = [bytes, str, bool, int, float, tuple, list, dict, set]
+    types = [str, bool, int, float, tuple, list, dict, set]
     expected = {t.__name__: t() for t in types}
-    if str is bytes:  # Python 2.
-        # Note that bytes.__name__ == 'str' in Python 2.
-        # pybind11::str is unicode even under Python 2.
-        expected["bytes"] = bytes()
-        expected["str"] = u""  # flake8 complains about unicode().
     assert m.default_constructors() == expected
 
     data = {
-        "bytes": b'41',  # Currently no supported or working conversions.
-        "str": 42,
-        "bool": "Not empty",
-        "int": "42",
-        "float": "+1e3",
-        "tuple": range(3),
-        "list": range(3),
-        "dict": [("two", 2), ("one", 1), ("three", 3)],
-        "set": [4, 4, 5, 6, 6, 6],
-        "memoryview": b'abc'
+        str: 42,
+        bool: "Not empty",
+        int: "42",
+        float: "+1e3",
+        tuple: range(3),
+        list: range(3),
+        dict: [("two", 2), ("one", 1), ("three", 3)],
+        set: [4, 4, 5, 6, 6, 6],
+        memoryview: b'abc'
     }
-    inputs = {k: v for k, v in data.items()}
-    expected = {k: eval(k)(v) for k, v in data.items()}
+    inputs = {k.__name__: v for k, v in data.items()}
+    expected = {k.__name__: k(v) for k, v in data.items()}
 
     assert m.converting_constructors(inputs) == expected
     assert m.cast_functions(inputs) == expected


### PR DESCRIPTION
Hi Yannick, note the 3 commits: 1. rollback, 2. cherry-pick, 3. tests based on the cherry-pick.
I think this is best pulled with "Rebase and merge".