### PR TITLE
ci: Remove "Setup Boost (macOS)" step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,6 @@ jobs:
       if: runner.os != 'macOS'
       run: echo "::set-env name=BOOST_ROOT::$BOOST_ROOT_1_72_0"
 
-    - name: Setup Boost (macOS)
-      if: runner.os == 'macOS'
-      run: brew install boost
-
     - name: Cache wheels
       if: runner.os == 'macOS'
       uses: actions/cache@v2


### PR DESCRIPTION
Per convo: https://github.com/pybind/pybind11/pull/2393#issuecomment-674186838 - slows down the macOS builds for very little gain.