### PR TITLE
Using recently added `pytest.PY2` instead of `str is bytes`.

### DIFF
--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -224,7 +224,7 @@ def test_pybind11_str_raw_str():
     # specifically to exercise pybind11::str::raw_str
     cvt = m.convert_to_pybind11_str
     assert cvt(u"Str") == u"Str"
-    assert cvt(b'Bytes') == u"Bytes" if str is bytes else "b'Bytes'"
+    assert cvt(b'Bytes') == u"Bytes" if pytest.PY2 else "b'Bytes'"
     assert cvt(None) == u"None"
     assert cvt(False) == u"False"
     assert cvt(True) == u"True"
@@ -237,8 +237,8 @@ def test_pybind11_str_raw_str():
     assert cvt([28]) == u"[28]"
     assert cvt({}) == u"{}"
     assert cvt({3: 4}) == u"{3: 4}"
-    assert cvt(set()) == u"set([])" if str is bytes else "set()"
-    assert cvt({3, 3}) == u"set([3])" if str is bytes else "{3}"
+    assert cvt(set()) == u"set([])" if pytest.PY2 else "set()"
+    assert cvt({3, 3}) == u"set([3])" if pytest.PY2 else "{3}"
 
     valid_orig = u"Ǳ"
     valid_utf8 = valid_orig.encode("utf-8")


### PR DESCRIPTION
Important gain: uniformity & therefore easier cleanup when we drop PY2 support.
Very slight loss: it was nice to have `str is bytes` as a reminder in this specific context.