### PR TITLE
static allocation for PyModuleDef, to avoid leak check errors.

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -307,13 +307,21 @@ extern "C" {
             });
         }
 \endrst */
+#if PY_MAJOR_VERSION >= 3
+#define PYBIND11_MODULE_DETAIL_CREATE(name)                                    \
+        static PyModuleDef mdef;                                               \
+        auto m = pybind11::module(PYBIND11_TOSTRING(name), nullptr, &mdef);
+#else
+#define PYBIND11_MODULE_DETAIL_CREATE(name)                                    \
+        auto m = pybind11::module(PYBIND11_TOSTRING(name));
+#endif
 #define PYBIND11_MODULE(name, variable)                                        \
     PYBIND11_MAYBE_UNUSED                                                      \
     static void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &);     \
     PYBIND11_PLUGIN_IMPL(name) {                                               \
         PYBIND11_CHECK_PYTHON_VERSION                                          \
         PYBIND11_ENSURE_INTERNALS_READY                                        \
-        auto m = pybind11::module(PYBIND11_TOSTRING(name));                    \
+        PYBIND11_MODULE_DETAIL_CREATE(name)                                    \
         try {                                                                  \
             PYBIND11_CONCAT(pybind11_init_, name)(m);                          \
             return m.ptr();                                                    \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -308,14 +308,19 @@ extern "C" {
         }
 \endrst */
 #if PY_MAJOR_VERSION >= 3
+#define PYBIND11_MODULE_DETAIL_STATIC_DEF(name)                                \
+    static PyModuleDef PYBIND11_CONCAT(pybind11_module_def_, name);
 #define PYBIND11_MODULE_DETAIL_CREATE(name)                                    \
-        static PyModuleDef mdef;                                               \
-        auto m = pybind11::module(PYBIND11_TOSTRING(name), nullptr, &mdef);
+        auto m = pybind11::module(                                             \
+            PYBIND11_TOSTRING(name), nullptr,                                  \
+            &PYBIND11_CONCAT(pybind11_module_def_, name));
 #else
+#define PYBIND11_MODULE_DETAIL_STATIC_DEF(name)
 #define PYBIND11_MODULE_DETAIL_CREATE(name)                                    \
         auto m = pybind11::module(PYBIND11_TOSTRING(name));
 #endif
 #define PYBIND11_MODULE(name, variable)                                        \
+    PYBIND11_MODULE_DETAIL_STATIC_DEF(name)                                    \
     PYBIND11_MAYBE_UNUSED                                                      \
     static void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &);     \
     PYBIND11_PLUGIN_IMPL(name) {                                               \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -308,25 +308,25 @@ extern "C" {
         }
 \endrst */
 #if PY_MAJOR_VERSION >= 3
-#define PYBIND11_MODULE_DETAIL_STATIC_DEF(name)                                \
+#define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                \
     static PyModuleDef PYBIND11_CONCAT(pybind11_module_def_, name);
-#define PYBIND11_MODULE_DETAIL_CREATE(name)                                    \
+#define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
         auto m = pybind11::module(                                             \
             PYBIND11_TOSTRING(name), nullptr,                                  \
             &PYBIND11_CONCAT(pybind11_module_def_, name));
 #else
-#define PYBIND11_MODULE_DETAIL_STATIC_DEF(name)
-#define PYBIND11_MODULE_DETAIL_CREATE(name)                                    \
+#define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)
+#define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
         auto m = pybind11::module(PYBIND11_TOSTRING(name));
 #endif
 #define PYBIND11_MODULE(name, variable)                                        \
-    PYBIND11_MODULE_DETAIL_STATIC_DEF(name)                                    \
+    PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                    \
     PYBIND11_MAYBE_UNUSED                                                      \
     static void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &);     \
     PYBIND11_PLUGIN_IMPL(name) {                                               \
         PYBIND11_CHECK_PYTHON_VERSION                                          \
         PYBIND11_ENSURE_INTERNALS_READY                                        \
-        PYBIND11_MODULE_DETAIL_CREATE(name)                                    \
+        PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
         try {                                                                  \
             PYBIND11_CONCAT(pybind11_init_, name)(m);                          \
             return m.ptr();                                                    \

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -863,7 +863,7 @@ public:
 
     /// Create a new top-level Python module with the given name and docstring
 #if PY_MAJOR_VERSION >= 3
-    explicit module(const char *name, const char *doc = nullptr, PyModuleDef *def = nullptr) {
+    explicit module_(const char *name, const char *doc = nullptr, PyModuleDef *def = nullptr) {
         if (!def) def = new PyModuleDef();
         def = new (def) PyModuleDef {  // Placement new (not an allocation).
             /* m_base */     PyModuleDef_HEAD_INIT,

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -862,18 +862,24 @@ public:
     PYBIND11_OBJECT_DEFAULT(module_, object, PyModule_Check)
 
     /// Create a new top-level Python module with the given name and docstring
-    explicit module_(const char *name, const char *doc = nullptr) {
-        if (!options::show_user_defined_docstrings()) doc = nullptr;
 #if PY_MAJOR_VERSION >= 3
-        auto *def = new PyModuleDef();
-        std::memset(def, 0, sizeof(PyModuleDef));
-        def->m_name = name;
-        def->m_doc = doc;
-        def->m_size = -1;
-        Py_INCREF(def);
+    explicit module(const char *name, const char *doc = nullptr, PyModuleDef *def = nullptr) {
+        if (!def) def = new PyModuleDef();
+        def = new (def) PyModuleDef {  // Placement new (not an allocation).
+            /* m_base */     PyModuleDef_HEAD_INIT,
+            /* m_name */     name,
+            /* m_doc */      options::show_user_defined_docstrings() ? doc : nullptr,
+            /* m_size */     -1,
+            /* m_methods */  nullptr,
+            /* m_slots */    nullptr,
+            /* m_traverse */ nullptr,
+            /* m_clear */    nullptr,
+            /* m_free */     nullptr
+        };
         m_ptr = PyModule_Create(def);
 #else
-        m_ptr = Py_InitModule3(name, nullptr, doc);
+    explicit module_(const char *name, const char *doc = nullptr) {
+        m_ptr = Py_InitModule3(name, nullptr, options::show_user_defined_docstrings() ? doc : nullptr);
 #endif
         if (m_ptr == nullptr)
             pybind11_fail("Internal error in module_::module_()");


### PR DESCRIPTION
This PR solves the same issue as #2019 (rolled back), but in a way that is certain to portably work for any leak checker.

The Python 3 documentation suggests `static` allocation for `PyModuleDef`:

  * https://docs.python.org/3/c-api/module.html#initializing-c-modules

  * The module definition struct, which holds all information needed to
    create a module object. There is usually only one statically initialized
    variable of this type for each module.

This PR changes the `PYBIND11_MODULE` macro accordingly: `static PyModuleDef ...;`

The `pybind11::module_::module_` code is slightly refactored, with the idea to make the future removal of Python 2 support straightforward.

Note: Potential follow-up change:
```diff
- if (!def) def = new PyModuleDef();
+ if (!def) pybind11_fail("PyModuleDef *def must not be a nullptr.");
```
This is best left for a separate PR, because it is an API change, requiring a pointer that didn't have to be passed before.

This PR passed extensive testing in the Google environment (~370 extensions, several 10k indirect dependents).