### PR TITLE
fix: respect PYTHON_VERSION if set in classic mode

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -147,7 +147,7 @@ if(PYBIND11_CPP_STANDARD)
   else()
     set(supported_standards 11 14 17 20)
     if("${VAL}" IN_LIST supported_standards)
-      message(WARNING "USE -DCMAKE_CXX_STANDARD=${VAL} instead of PYBIND11_PYTHON_VERSION")
+      message(WARNING "USE -DCMAKE_CXX_STANDARD=${VAL} instead of PYBIND11_CPP_STANDARD")
       set(CMAKE_CXX_STANDARD
           ${VAL}
           CACHE STRING "From PYBIND11_CPP_STANDARD")

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -14,6 +14,9 @@ endif()
 
 # If this is the first run, PYTHON_VERSION can stand in for PYBIND11_PYTHON_VERSION
 if(NOT DEFINED PYBIND11_PYTHON_VERSION AND DEFINED PYTHON_VERSION)
+  message(WARNING "Set PYBIND11_PYTHON_VERSION to search for a specific version, not "
+                  "PYTHON_VERSION (which is an output). Assuming that is what you "
+                  "meant to do and continuing anyway.")
   set(PYBIND11_PYTHON_VERSION
       "${PYTHON_VERSION}"
       CACHE STRING "Python version to use for compiling modules")

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -12,10 +12,17 @@ if(pybind11_FIND_QUIETLY)
   set(_pybind11_quiet QUIET)
 endif()
 
-# Add a CMake parameter for choosing a desired Python version
-if(NOT PYBIND11_PYTHON_VERSION)
+# If this is the first run, PYTHON_VERSION can stand in for PYBIND11_PYTHON_VERSION
+if(NOT DEFINED PYBIND11_PYTHON_VERSION AND DEFINED PYTHON_VERSION)
   set(PYBIND11_PYTHON_VERSION
-      ""
+      "${PYTHON_VERSION}"
+      CACHE STRING "Python version to use for compiling modules")
+  unset(PYTHON_VERSION)
+  unset(PYTHON_VERSION CACHE)
+else()
+  # If this is set as a normal variable, promote it, otherwise, make an empty cache variable.
+  set(PYBIND11_PYTHON_VERSION
+      "${PYBIND11_PYTHON_VERSION}"
       CACHE STRING "Python version to use for compiling modules")
 endif()
 


### PR DESCRIPTION
If PYBIND11_PYTHON_VERSION is not set, but PYTHON_VERSION is, on the first run, use that for the hint. We could add a warning or error instead - but the current behavior is a bit odd and unhelpful.