### PR TITLE
ci: reduce flakiness a little

### DIFF
--- a/tests/env.py
+++ b/tests/env.py
@@ -10,3 +10,5 @@ CPYTHON = platform.python_implementation() == "CPython"
 PYPY = platform.python_implementation() == "PyPy"
 
 PY2 = sys.version_info.major == 2
+
+PY = sys.version_info

--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 import multiprocessing
 import threading
+
+import pytest
+
+import env  # noqa: F401
+
 from pybind11_tests import gil_scoped as m
 
 
@@ -57,6 +62,8 @@ def test_python_to_cpp_to_python_from_thread():
     assert _run_in_process(_python_to_cpp_to_python_from_threads, 1) == 0
 
 
+# TODO: FIXME
+@pytest.mark.xfail("env.PY > (3,8) and env.MACOS", strict=False)
 def test_python_to_cpp_to_python_from_thread_multiple_parallel():
     """Makes sure there is no GIL deadlock when running in a thread multiple times in parallel.
 
@@ -73,6 +80,8 @@ def test_python_to_cpp_to_python_from_thread_multiple_sequential():
     assert _run_in_process(_python_to_cpp_to_python_from_threads, 8, parallel=False) == 0
 
 
+# TODO: FIXME
+@pytest.mark.xfail("env.PY > (3,8) and env.MACOS", strict=False)
 def test_python_to_cpp_to_python_from_process():
     """Makes sure there is no GIL deadlock when using processes.
 


### PR DESCRIPTION
See if we can reduce the flakiness from #2391 - also might help identify the possible failure and if it is macOS only. (won't stop the segfault). Doesn't fix anything; these still need to be worked on.