### PR TITLE
ci: update including annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   standard:
     strategy:
-      fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
         arch: [x64]
@@ -72,6 +71,7 @@ jobs:
 
     name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • ${{ matrix.arch }} ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ endsWith(matrix.python, 'dev') }}
 
     steps:
     - uses: actions/checkout@v2
@@ -102,7 +102,10 @@ jobs:
     - name: Prepare env
       run: python -m pip install -r tests/requirements.txt --prefer-binary
 
-    - name: Configure C++11 ${{ matrix.args1 }}
+    - name: Setup annotations
+      run: python -m pip install pytest-github-actions-annotate-failures
+
+    - name: Configure C++11 ${{ matrix.args }}
       run: >
         cmake -S . -B .
         -DPYBIND11_WERROR=ON


### PR DESCRIPTION
Adding GitHub Actions annotations. I've been working with @utgwkk on the `pytest-github-actions-annotate-failures` plugin, and I think [it's ready](https://github.com/utgwkk/pytest-github-actions-annotate-failures/pull/14) to be used here. (I have commit rights if something breaks - plus it is optional and CI only).

Will likely add the allowed fail properly to the 3.9-dev macOS job, then remove fail-fast false, to improve the quality of the output and speed up tests. Example when a test was intentionally broken below:

<img width="986" alt="Screen Shot 2020-08-23 at 11 25 34 AM" src="https://user-images.githubusercontent.com/4616906/90982175-6cd1c100-e533-11ea-8320-0e604b4548ad.png">
