### PR TITLE
Adapt code example in advanced/classes.rst to new handling of forgetting to call the superclass __init__

### DIFF
--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -159,7 +159,7 @@ Here is an example:
 
     class Dachshund(Dog):
         def __init__(self, name):
-            Dog.__init__(self) # Without this, undefined behavior may occur if the C++ portions are referenced.
+            Dog.__init__(self) # Without this, a TypeError is raised.
             self.name = name
         def bark(self):
             return "yap!"


### PR DESCRIPTION
Cfr. discussion in #2152

TODO: Check how easy it is to display different error when there is no `__init__`.