### PR TITLE
Add note that VS2017 requires /permissive- to build in C++17 mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
         arch: [x64]
-        max-cxx-std: [17]
         python:
         - 2.7
         - 3.5
@@ -28,34 +27,28 @@ jobs:
           - runs-on: ubuntu-latest
             python: 3.6
             arch: x64
-            max-cxx-std: 17
             args: >
               -DPYBIND11_FINDPYTHON=ON
           - runs-on: windows-2016
             python: 3.7
             arch: x86
-            max-cxx-std: 17
             args2: >
               -DCMAKE_CXX_FLAGS="/permissive- /EHsc /GR"
           - runs-on: windows-latest
             python: 3.6
             arch: x64
-            max-cxx-std: 17
             args: >
               -DPYBIND11_FINDPYTHON=ON
           - runs-on: windows-latest
             python: 3.7
             arch: x64
-            max-cxx-std: 17
 
           - runs-on: ubuntu-latest
             python: 3.9-dev
             arch: x64
-            max-cxx-std: 17
           - runs-on: macos-latest
             python: 3.9-dev
             arch: x64
-            max-cxx-std: 17
             args: >
               -DPYBIND11_FINDPYTHON=ON
 
@@ -64,21 +57,17 @@ jobs:
           - runs-on: windows-latest
             python: pypy2
             arch: x64
-            max-cxx-std: 17
           - runs-on: windows-latest
             python: pypy3
             arch: x64
-            max-cxx-std: 17
 
             # Currently broken on embed_test
           - runs-on: windows-latest
             python: 3.8
             arch: x64
-            max-cxx-std: 17
           - runs-on: windows-latest
             python: 3.9-dev
             arch: x64
-            max-cxx-std: 17
 
 
     name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • ${{ matrix.arch }} ${{ matrix.args }}"
@@ -113,7 +102,7 @@ jobs:
     - name: Prepare env
       run: python -m pip install -r tests/requirements.txt --prefer-binary
 
-    - name: Configure C++11 ${{ matrix.args }}
+    - name: Configure C++11 ${{ matrix.args1 }}
       run: >
         cmake -S . -B .
         -DPYBIND11_WERROR=ON
@@ -137,26 +126,26 @@ jobs:
     - name: Clean directory
       run: git clean -fdx
 
-    - name: Configure C++${{ matrix.max-cxx-std }} ${{ matrix.args }}
+    - name: Configure ${{ matrix.args2 }}
       run: >
         cmake -S . -B build2
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
-        -DCMAKE_CXX_STANDARD=${{ matrix.max-cxx-std }}
+        -DCMAKE_CXX_STANDARD=17
         ${{ matrix.args }}
         ${{ matrix.args2 }}
 
-    - name: Build C++${{ matrix.max-cxx-std }}
+    - name: Build
       run: cmake --build build2 -j 2
 
-    - name: Python tests C++${{ matrix.max-cxx-std }}
+    - name: Python tests
       run: cmake --build build2 --target pytest
 
-    - name: C++${{ matrix.max-cxx-std }} tests
+    - name: C++ tests
       run: cmake --build build2 --target cpptest
 
-    - name: Interface test C++${{ matrix.max-cxx-std }}
+    - name: Interface test
       run: cmake --build build2 --target test_cmake_build
 
   clang:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,20 @@ jobs:
             python: 3.6
             arch: x64
             max-cxx-std: 17
-            args: "-DPYBIND11_FINDPYTHON=ON"
-          - runs-on: macos-latest
-            python: 3.7
-            arch: x64
-            max-cxx-std: 17
-            args: "-DPYBIND11_FINDPYTHON=ON"
+            args: >
+              -DPYBIND11_FINDPYTHON=ON
           - runs-on: windows-2016
             python: 3.7
             arch: x86
-            max-cxx-std: 14
+            max-cxx-std: 17
+            args2: >
+              -DCMAKE_CXX_FLAGS="/permissive- /EHsc /GR"
           - runs-on: windows-latest
             python: 3.6
             arch: x64
             max-cxx-std: 17
-            args: "-DPYBIND11_FINDPYTHON=ON"
+            args: >
+              -DPYBIND11_FINDPYTHON=ON
           - runs-on: windows-latest
             python: 3.7
             arch: x64
@@ -57,6 +56,8 @@ jobs:
             python: 3.9-dev
             arch: x64
             max-cxx-std: 17
+            args: >
+              -DPYBIND11_FINDPYTHON=ON
 
         exclude:
             # Currently 32bit only, and we build 64bit
@@ -92,8 +93,7 @@ jobs:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.arch }}
 
-    - name: Setup Boost
-      if: runner.os != 'macOS'
+    - name: Setup Boost (Windows / Linux latest)
       run: echo "::set-env name=BOOST_ROOT::$BOOST_ROOT_1_72_0"
 
     - name: Update CMake
@@ -114,7 +114,6 @@ jobs:
       run: python -m pip install -r tests/requirements.txt --prefer-binary
 
     - name: Configure C++11 ${{ matrix.args }}
-      shell: bash
       run: >
         cmake -S . -B .
         -DPYBIND11_WERROR=ON
@@ -139,7 +138,6 @@ jobs:
       run: git clean -fdx
 
     - name: Configure C++${{ matrix.max-cxx-std }} ${{ matrix.args }}
-      shell: bash
       run: >
         cmake -S . -B build2
         -DPYBIND11_WERROR=ON
@@ -147,6 +145,7 @@ jobs:
         -DDOWNLOAD_EIGEN=ON
         -DCMAKE_CXX_STANDARD=${{ matrix.max-cxx-std }}
         ${{ matrix.args }}
+        ${{ matrix.args2 }}
 
     - name: Build C++${{ matrix.max-cxx-std }}
       run: cmake --build build2 -j 2

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -35,6 +35,14 @@ Windows
 On Windows, only **Visual Studio 2015** and newer are supported since pybind11 relies
 on various C++11 language features that break older versions of Visual Studio.
 
+.. Note::
+
+    To use the C++17 in Visual Studio 2017 (MSVC 14.1), pybind11 requires the flag
+    ``/permissive-`` to be passed to the compiler `to enforce standard conformance`_. When
+    building with Visual Studio 2019, this is not strictly necessary, but still adviced.
+
+..  _`to enforce standard conformance`: https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=vs-2017
+
 To compile and run the tests:
 
 .. code-block:: batch


### PR DESCRIPTION
As discussed on #2089, this (finally) adds a note to the docs that C++17 mode in VS2017 requires the /permissive- flag.

Closes #2089
Closes #2292﻿
