### PR TITLE
Fix bug roundtripping datetime.time objects after midnight in eastern hemisphere timezones (#2417)

### DIFF
--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -150,11 +150,9 @@ public:
         // Lazy initialise the PyDateTime import
         if (!PyDateTimeAPI) { PyDateTime_IMPORT; }
 
-        // Declare these special duration types so the conversions happen with the correct primitive types (int)
-        using us_t = duration<int, std::micro>;
-
         // Get out microseconds, and make sure they are positive, to avoid bug in eastern hemisphere time zones
         // (cfr. https://github.com/pybind/pybind11/issues/2417)
+        using us_t = duration<int, std::micro>;
         auto us = duration_cast<us_t>(src.time_since_epoch() % seconds(1));
         if (us.count() < 0)
             us += seconds(1);

--- a/tests/test_chrono.cpp
+++ b/tests/test_chrono.cpp
@@ -10,6 +10,7 @@
 
 #include "pybind11_tests.h"
 #include <pybind11/chrono.h>
+#include <chrono>
 
 TEST_SUBMODULE(chrono, m) {
     using system_time = std::chrono::system_clock::time_point;

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from pybind11_tests import chrono as m
 import datetime
+import pytest
 
 
 def test_chrono_system_clock():
@@ -70,9 +71,17 @@ def test_chrono_system_clock_roundtrip_date():
     assert time2.microsecond == 0
 
 
-def test_chrono_system_clock_roundtrip_time():
-    time1 = datetime.datetime.today().time()
-
+@pytest.mark.parametrize("time1", [
+    datetime.datetime.today().time(),
+    datetime.time(0, 0, 0),
+    datetime.time(0, 0, 0, 1),
+    datetime.time(0, 28, 45, 109827),
+    datetime.time(0, 59, 59, 999999),
+    datetime.time(1, 0, 0),
+    datetime.time(5, 59, 59, 0),
+    datetime.time(5, 59, 59, 1),
+])
+def test_chrono_system_clock_roundtrip_time(time1):
     # Roundtrip the time
     datetime2 = m.test_chrono2(time1)
     date2 = datetime2.date()

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -81,7 +81,14 @@ def test_chrono_system_clock_roundtrip_date():
     datetime.time(5, 59, 59, 0),
     datetime.time(5, 59, 59, 1),
 ])
-def test_chrono_system_clock_roundtrip_time(time1):
+@pytest.mark.parametrize("tz", [
+    "Europe/Brussels",
+    "Asia/Pyongyang",
+    "America/New_York",
+])
+def test_chrono_system_clock_roundtrip_time(time1, tz, monkeypatch):
+    monkeypatch.setenv("TZ", "/usr/share/zoneinfo/{}".format(tz))
+
     # Roundtrip the time
     datetime2 = m.test_chrono2(time1)
     date2 = datetime2.date()


### PR DESCRIPTION
Closes #2417; see description there of what goes wrong.

Many, many thanks to @henryiii and @bstaletic for helping with debugging and fixing this one!

EDIT: Added reviewable.io at @bstaletic's request. Let's give it a try?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pybind/pybind11/2438)
<!-- Reviewable:end -->
