### PR TITLE
fix: doc typo, drop second use of 'without'

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -240,7 +240,7 @@ public:
     ~object() { dec_ref(); }
 
     /** \rst
-        Resets the internal pointer to ``nullptr`` without without decreasing the
+        Resets the internal pointer to ``nullptr`` without decreasing the
         object's reference count. The function returns a raw handle to the original
         Python object.
     \endrst */


### PR DESCRIPTION
Closes #2437

EDIT (@YannickJadoul): making this PR close #2437 