### PR TITLE
[DOC] avoid C++ types in docstrings

### DIFF
--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -322,7 +322,8 @@ its C++ type name will be used instead to generate the signature in the docstrin
                                               ^^^^^^^
 
 
-This limitation can be circumvented by "forward declaring" bound classes:
+This limitation can be circumvented by ensuring that C++ classes are registered with pybind11
+before they are used as a parameter to a function:
 
 .. code-block:: cpp
 

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -311,7 +311,7 @@ Avoiding C++ types in docstrings
 ================================
 
 Docstrings are generated at the time of the declaration, e.g. when ``.def(...)`` is called.
-At this point argument and return types should be known to pybind11.
+At this point parameter and return types should be known to pybind11.
 If a custom type is not exposed yet through a ``py::class_`` constructor or a custom type caster,
 its C++ type name will be used instead to generate the signature in the docstring:
 
@@ -323,7 +323,7 @@ its C++ type name will be used instead to generate the signature in the docstrin
 
 
 This limitation can be circumvented by ensuring that C++ classes are registered with pybind11
-before they are used as a parameter to a function:
+before they are used as a parameter or return type of a function:
 
 .. code-block:: cpp
 

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -305,13 +305,15 @@ the default settings are restored to prevent unwanted side effects.
 .. [#f4] http://www.sphinx-doc.org
 .. [#f5] http://github.com/pybind/python_example
 
-.. _avoid-cpp-types-in-docstrings:
+.. _avoiding-cpp-types-in-docstrings:
 
-Avoid C++ types in docstrings
-=============================
+Avoiding C++ types in docstrings
+================================
 
-Most of docstrings are generated at the time of the declaration, e.g. when ``.def(...)`` is called.
-At this point arguments/return types should be known to pybind11, otherwise C++ types would be used instead:
+Docstrings are generated at the time of the declaration, e.g. when ``.def(...)`` is called.
+At this point argument and return types should be known to pybind11.
+If a custom type is not exposed yet through a ``py::class_`` constructor or a custom type caster,
+its C++ type name will be used instead to generate the signature in the docstring:
 
 .. code-block:: text
 
@@ -320,7 +322,7 @@ At this point arguments/return types should be known to pybind11, otherwise C++ 
                                               ^^^^^^^
 
 
-This limitation can be tolerated by "forward declaring" bound classes:
+This limitation can be circumvented by "forward declaring" bound classes:
 
 .. code-block:: cpp
 

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -304,3 +304,31 @@ the default settings are restored to prevent unwanted side effects.
 
 .. [#f4] http://www.sphinx-doc.org
 .. [#f5] http://github.com/pybind/python_example
+
+.. _avoid-cpp-types-in-docstrings:
+
+Avoid C++ types in docstrings
+=============================
+
+Most of docstrings are generated at the time of the declaration, e.g. when ``.def(...)`` is called.
+At this point arguments/return types should be known to pybind11, otherwise C++ types would be used instead:
+
+.. code-block:: text
+
+     |  __init__(...)
+     |      __init__(self: example.Foo, arg0: ns::Bar) -> None
+                                              ^^^^^^^
+
+
+This limitation can be tolerated by "forward declaring" bound classes:
+
+.. code-block:: cpp
+
+    PYBIND11_MODULE(example, m) {
+
+        auto pyFoo = py::class_<ns::Foo>(m, "Foo");
+        auto pyBar = py::class_<ns::Bar>(m, "Bar");
+
+        pyFoo.def(py::init<const ns::Bar&>());
+        pyBar.def(py::init<const ns::Foo&>());
+    }


### PR DESCRIPTION
Here is a small paragraph about docstring generation in pybind11. Also replicates @YannickJadoul 's example from #2263. 

I'm not sure if `misc.rst` is the best place for it. 

<details><summary>render</summary>

![image](https://user-images.githubusercontent.com/2975991/91483399-54093880-e8b0-11ea-96a7-83daf2b57b74.png)

</details>