### PR TITLE
fix: use classic extension handling unless otherwise requested

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -80,8 +80,13 @@ execute_process(
 execute_process(
   COMMAND "${${_Python}_EXECUTABLE}" "-c"
           "from distutils import sysconfig; print(sysconfig.get_config_var('SO'))"
-  OUTPUT_VARIABLE PYTHON_MODULE_EXTENSION
+  OUTPUT_VARIABLE _PYTHON_MODULE_EXTENSION
   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# This needs to be available for the pybind11_extension function
+set(PYTHON_MODULE_EXTENSION
+    "${_PYTHON_MODULE_EXTENSION}"
+    CACHE INTERNAL "")
 
 # Python debug libraries expose slightly different objects before 3.8
 # https://docs.python.org/3.6/c-api/intro.html#debugging-builds


### PR DESCRIPTION
WITH_SOABI is only defined in CMake 3.17+, and it doesn't really quite do the expected thing for PyPy (being fixed on the PyPy side). For now, let's use the classic method for adding the extension unless a user requests otherwise.