### PR TITLE
Add py::object casting example to embedding docs

### DIFF
--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -105,6 +105,25 @@ The two approaches can also be combined:
         std::cout << message;
     }
 
+Typically, a call to a function in a `py::module` returns a generic `py::object`,
+which can often be autmatically cast to a specialized pybind11 type:
+
+.. code-block:: cpp
+
+    py::module os = py::module::import("os");
+    py::module path = py::module::import("os.path");  // like 'import os.path as path'
+    py::module np = py::module::import("numpy");  // like 'import numpy as np'
+
+    py::str curdir_abs = path.attr("abspath")(path.attr("curdir"));
+    py::print(py::str("Current directory: ") + curdir_abs);
+    py::dict environ = os.attr("environ");
+    py::print(environ["HOME"]);
+    py::array_t<float> arr = np.attr("ones")(3, "dtype"_a="float32");
+    py::print(py::repr(arr + py::int_(1)));
+
+(Note that this example requires ``#include <pybind11/numpy.h>`` and
+``using namespace pybind11::literals;`` to work.)
+
 Importing modules
 =================
 

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -105,25 +105,6 @@ The two approaches can also be combined:
         std::cout << message;
     }
 
-Typically, a call to a function in a `py::module` returns a generic `py::object`,
-which can often be autmatically cast to a specialized pybind11 type:
-
-.. code-block:: cpp
-
-    py::module os = py::module::import("os");
-    py::module path = py::module::import("os.path");  // like 'import os.path as path'
-    py::module np = py::module::import("numpy");  // like 'import numpy as np'
-
-    py::str curdir_abs = path.attr("abspath")(path.attr("curdir"));
-    py::print(py::str("Current directory: ") + curdir_abs);
-    py::dict environ = os.attr("environ");
-    py::print(environ["HOME"]);
-    py::array_t<float> arr = np.attr("ones")(3, "dtype"_a="float32");
-    py::print(py::repr(arr + py::int_(1)));
-
-(Note that this example requires ``#include <pybind11/numpy.h>`` and
-``using namespace pybind11::literals;`` to work.)
-
 Importing modules
 =================
 

--- a/docs/advanced/pycpp/object.rst
+++ b/docs/advanced/pycpp/object.rst
@@ -209,7 +209,7 @@ C++ functions that require a specific subtype rather than a generic :class:`obje
 
 These implicit conversions are available for subclasses of :class:`object`; there
 is no need to call ``obj.cast()`` explicitly as for custom classes, see
-:ref:`_casting_back_and_forth`.
+:ref:`casting_back_and_forth`.
 
 .. note::
     If a trivial conversion via move constructor is not possible, both implicit and

--- a/docs/advanced/pycpp/object.rst
+++ b/docs/advanced/pycpp/object.rst
@@ -20,6 +20,8 @@ Available types include :class:`handle`, :class:`object`, :class:`bool_`,
     Be sure to review the :ref:`pytypes_gotchas` before using this heavily in
     your C++ API.
 
+.. _casting_back_and_forth:
+
 Casting back and forth
 ======================
 
@@ -61,6 +63,40 @@ This example obtains a reference to the Python ``Decimal`` class.
     // Try to import scipy
     py::object scipy = py::module::import("scipy");
     return scipy.attr("__version__");
+
+.. _implicit_casting:
+
+Implicit (automatic) casting
+============================
+
+Instead of using a generic :class:`object` as return type, it is possible to
+specialize to a subtype, e.g., to use the lookup syntax of :class:`dict`.
+
+.. note::
+    Casting to the wrong type will currently lead to downstream errors, e.g.,
+    when casting a Python dict to :class:`list` and using the ``append`` method.
+    In the future, such a bad cast will likely result in a :class:`cast_error`,
+    see `PR #2349 <https://github.com/pybind/pybind11/pull/2349>`_.
+
+.. code-block:: cpp
+    #include <pybind11/numpy.h>
+    using namespace pybind11::literals;
+
+    py::module os = py::module::import("os");
+    py::module path = py::module::import("os.path");  // like 'import os.path as path'
+    py::module np = py::module::import("numpy");  // like 'import numpy as np'
+
+    py::str curdir_abs = path.attr("abspath")(path.attr("curdir"));
+    py::print(py::str("Current directory: ") + curdir_abs);
+    py::dict environ = os.attr("environ");
+    py::print(environ["HOME"]);
+    py::array_t<float> arr = np.attr("ones")(3, "dtype"_a="float32");
+    py::print(py::repr(arr + py::int_(1)));
+
+This constructor syntax is available for subclasses of :class:`object`; there
+is no need to call ``obj.cast()`` explicitly as for custom classes, see
+:ref:`_casting_back_and_forth`.
+
 
 .. _calling_python_functions:
 

--- a/docs/advanced/pycpp/object.rst
+++ b/docs/advanced/pycpp/object.rst
@@ -184,11 +184,11 @@ Generalized unpacking according to PEP448_ is also supported:
 Implicit casting
 ================
 
-When using this C++ interface for Python types or calling Python functions,
-and objects of type :class:`object` are returned, it is possible to
-specialize to a subtype like :class:`dict`. The same holds for the proxy objects
+When using the C++ interface for Python types, or calling Python functions,
+objects of type :class:`object` are returned. It is possible to invoke implicit
+conversions to subclasses like :class:`dict`. The same holds for the proxy objects
 returned by ``operator[]`` or ``obj.attr()``.
-Casting to subtypes improves code readability and allows values to be used in
+Casting to subtypes improves code readability and allows values to be passed to
 C++ functions that require a specific subtype rather than a generic :class:`object`.
 
 .. code-block:: cpp


### PR DESCRIPTION
Some examples for auto-casting from `py::object` to subtypes. These were the simplest I could come up with; happy to take suggestions.

Closes: #1310 