### PR TITLE
Change base parameter type in register_exception and exception constructor from PyObject* to handle

### DIFF
--- a/docs/advanced/exceptions.rst
+++ b/docs/advanced/exceptions.rst
@@ -80,7 +80,7 @@ module and automatically converts any encountered exceptions of type ``CppExp``
 into Python exceptions of type ``PyExp``.
 
 It is possible to specify base class for the exception using the third
-parameter, a pointer to `PyObject`:
+parameter, a `handle`:
 
 .. code-block:: cpp
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1868,7 +1868,7 @@ template <typename type>
 class exception : public object {
 public:
     exception() = default;
-    exception(handle scope, const char *name, PyObject *base = PyExc_Exception) {
+    exception(handle scope, const char *name, handle base = PyExc_Exception) {
         std::string full_name = scope.attr("__name__").cast<std::string>() +
                                 std::string(".") + name;
         m_ptr = PyErr_NewException(const_cast<char *>(full_name.c_str()), base, NULL);
@@ -1901,7 +1901,7 @@ PYBIND11_NAMESPACE_END(detail)
 template <typename CppException>
 exception<CppException> &register_exception(handle scope,
                                             const char *name,
-                                            PyObject *base = PyExc_Exception) {
+                                            handle base = PyExc_Exception) {
     auto &ex = detail::get_exception_object<CppException>();
     if (!ex) ex = exception<CppException>(scope, name, base);
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1871,7 +1871,7 @@ public:
     exception(handle scope, const char *name, handle base = PyExc_Exception) {
         std::string full_name = scope.attr("__name__").cast<std::string>() +
                                 std::string(".") + name;
-        m_ptr = PyErr_NewException(const_cast<char *>(full_name.c_str()), base, NULL);
+        m_ptr = PyErr_NewException(const_cast<char *>(full_name.c_str()), base.ptr(), NULL);
         if (hasattr(scope, name))
             pybind11_fail("Error during initialization: multiple incompatible "
                           "definitions with name \"" + std::string(name) + "\"");


### PR DESCRIPTION
Follow-up of #2465. This should be the same, but is the pybind11 alternative, rather than a raw C API type.
