### PR TITLE
Adds check if `str(handle)` correctly converted the object, and throw py::error_already_set if not.

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -920,7 +920,7 @@ public:
         Return a string representation of the object. This is analogous to
         the ``str()`` function in Python.
     \endrst */
-    explicit str(handle h) : object(raw_str(h.ptr()), stolen_t{}) { }
+    explicit str(handle h) : object(raw_str(h.ptr()), stolen_t{}) { if (!m_ptr) throw error_already_set(); }
 
     operator std::string() const {
         object temp = *this;
@@ -945,8 +945,8 @@ private:
     /// Return string representation -- always returns a new reference, even if already a str
     static PyObject *raw_str(PyObject *op) {
         PyObject *str_value = PyObject_Str(op);
-        if (!str_value) throw error_already_set();
 #if PY_MAJOR_VERSION < 3
+        if (!str_value) throw error_already_set();
         PyObject *unicode = PyUnicode_FromEncodedObject(str_value, "utf-8", nullptr);
         Py_XDECREF(str_value); str_value = unicode;
 #endif

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -80,6 +80,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("str_from_bytes", []() { return py::str(py::bytes("boo", 3)); });
     m.def("str_from_object", [](const py::object& obj) { return py::str(obj); });
     m.def("repr_from_object", [](const py::object& obj) { return py::repr(obj); });
+    m.def("str_from_handle", [](py::handle h) { return py::str(h); });
 
     m.def("str_format", []() {
         auto s1 = "{} + {} = {}"_s.format(1, 2, 3);

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -114,7 +114,7 @@ def test_str(doc):
     malformed_utf8 = b"\x80"
     assert m.str_from_object(malformed_utf8) is malformed_utf8  # Probably surprising.
     if env.PY2:
-        with pytest.raises(TypeError):
+        with pytest.raises(UnicodeDecodeError):
             m.str_from_handle(malformed_utf8)
     else:
         assert m.str_from_handle(malformed_utf8) == "b'\\x80'"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -109,6 +109,16 @@ def test_str(doc):
     assert s1 == "1 + 2 = 3"
     assert s1 == s2
 
+    assert m.str_from_handle(A()) == "this is a str"
+
+    malformed_utf8 = b"\x80"
+    assert m.str_from_object(malformed_utf8) is malformed_utf8  # Probably surprising.
+    if env.PY2:
+        with pytest.raises(TypeError):
+            m.str_from_handle(malformed_utf8)
+    else:
+        assert m.str_from_handle(malformed_utf8) == "b'\\x80'"
+
 
 def test_bytes(doc):
     assert m.bytes_from_string().decode() == "foo"


### PR DESCRIPTION
Similar to #2392, but does not depend on #2409.
    
Splitting out this PR from #2409 to make that PR as simple as possible.
    
Net effects of this PR:
* Adds missing test coverage.
* Changes TypeError to UnicodeDecodeError for Python 2.
    
This PR has two commits. Please do not squash, to make the behavior change obvious in the commit history.
