### PR TITLE
Use defined for PYBIND11_HAS_OPTIONAL, PYBIND11_HAS_EXP_OPTIONAL, PYBIND11_HAS_VARIANT

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -289,7 +289,7 @@ template<typename T> struct optional_caster {
     PYBIND11_TYPE_CASTER(T, _("Optional[") + value_conv::name + _("]"));
 };
 
-#if PYBIND11_HAS_OPTIONAL
+#if defined(PYBIND11_HAS_OPTIONAL)
 template<typename T> struct type_caster<std::optional<T>>
     : public optional_caster<std::optional<T>> {};
 
@@ -297,7 +297,7 @@ template<> struct type_caster<std::nullopt_t>
     : public void_caster<std::nullopt_t> {};
 #endif
 
-#if PYBIND11_HAS_EXP_OPTIONAL
+#if defined(PYBIND11_HAS_EXP_OPTIONAL)
 template<typename T> struct type_caster<std::experimental::optional<T>>
     : public optional_caster<std::experimental::optional<T>> {};
 
@@ -369,7 +369,7 @@ struct variant_caster<V<Ts...>> {
     PYBIND11_TYPE_CASTER(Type, _("Union[") + detail::concat(make_caster<Ts>::name...) + _("]"));
 };
 
-#if PYBIND11_HAS_VARIANT
+#if defined(PYBIND11_HAS_VARIANT)
 template <typename... Ts>
 struct type_caster<std::variant<Ts...>> : variant_caster<std::variant<Ts...>> { };
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -197,7 +197,7 @@ function(pybind11_enable_warnings target_name)
     target_compile_options(${target_name} PRIVATE /W4)
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Intel|Clang)")
     target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wconversion -Wcast-qual
-                                                  -Wdeprecated)
+                                                  -Wdeprecated -Wundef)
   endif()
 
   if(PYBIND11_WERROR)

--- a/tests/test_operator_overloading.cpp
+++ b/tests/test_operator_overloading.cpp
@@ -88,11 +88,11 @@ std::string abs(const Vector2&) {
   // Here, we suppress the warning using `#pragma diagnostic`.
   // Taken from: https://github.com/RobotLocomotion/drake/commit/aaf84b46
   // TODO(eric): This could be resolved using a function / functor (e.g. `py::self()`).
-  #if (__APPLE__) && (__clang__)
+  #if defined(__APPLE__) && defined(__clang__)
     #if (__clang_major__ >= 10) && (__clang_minor__ >= 0) && (__clang_patchlevel__ >= 1)
       #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
     #endif
-  #elif (__clang__)
+  #elif defined(__clang__)
     #if (__clang_major__ >= 7)
       #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
     #endif

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -15,7 +15,7 @@
 #include <string>
 
 // Test with `std::variant` in C++17 mode, or with `boost::variant` in C++11/14
-#if PYBIND11_HAS_VARIANT
+#if defined(PYBIND11_HAS_VARIANT)
 using std::variant;
 #elif defined(PYBIND11_TEST_BOOST) && (!defined(_MSC_VER) || _MSC_VER >= 1910)
 #  include <boost/variant.hpp>


### PR DESCRIPTION
These variables are not set in certain circumstances, and if the project
using pybind11 sets -Wundef, the warnings will show.

In all other usages outside of stl.h, ifdef/defined has already been used,
this commit converts the remaining ones under stl.h.

The test build is also modified to catch the problem.

The errors looked like:

```
ext/pybind11/include/pybind11/stl.h:292:5: error: "PYBIND11_HAS_OPTIONAL" is not defined, evaluates to 0 [-Werror=undef]
  292 | #if PYBIND11_HAS_OPTIONAL
      |     ^~~~~~~~~~~~~~~~~~~~~
ext/pybind11/include/pybind11/stl.h:300:5: error: "PYBIND11_HAS_EXP_OPTIONAL" is not defined, evaluates to 0 [-Werror=undef]
  300 | #if PYBIND11_HAS_EXP_OPTIONAL
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
ext/pybind11/include/pybind11/stl.h:372:5: error: "PYBIND11_HAS_VARIANT" is not defined, evaluates to 0 [-Werror=undef]
  372 | #if PYBIND11_HAS_VARIANT
      |     ^~~~~~~~~~~~~~~~~~~~
```