### PR TITLE
style: clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@ Checks: '
 -*,
 llvm-namespace-comment,
 modernize-use-override,
+readability-container-size-empty,
 '
 
 HeaderFilterRegex: 'pybind11/.*h'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: '
 llvm-namespace-comment,
 modernize-use-override,
 readability-container-size-empty,
+modernize-use-using,
 '
 
 HeaderFilterRegex: 'pybind11/.*h'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ llvm-namespace-comment,
 modernize-use-override,
 readability-container-size-empty,
 modernize-use-using,
+modernize-use-equals-default,
 '
 
 HeaderFilterRegex: 'pybind11/.*h'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ modernize-use-override,
 readability-container-size-empty,
 modernize-use-using,
 modernize-use-equals-default,
+modernize-use-auto,
 '
 
 HeaderFilterRegex: 'pybind11/.*h'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ readability-container-size-empty,
 modernize-use-using,
 modernize-use-equals-default,
 modernize-use-auto,
+modernize-use-emplace,
 '
 
 HeaderFilterRegex: 'pybind11/.*h'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 FormatStyle: file
 
 Checks: '
--*,
 llvm-namespace-comment,
 modernize-use-override,
 readability-container-size-empty,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ FormatStyle: file
 Checks: '
 -*,
 llvm-namespace-comment,
+modernize-use-override,
 '
 
 HeaderFilterRegex: 'pybind11/.*h'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+FormatStyle: file
+
+Checks: '
+-*,
+llvm-namespace-comment,
+'
+
+HeaderFilterRegex: 'pybind11/.*h'

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -164,6 +164,30 @@ name, pre-commit):
 pre-commit install
 ```
 
+### Clang-Tidy
+
+To run Clang tidy, the following recipe should work. Files will be modified in
+place, so you can use git to monitor the changes.
+
+```bash
+docker run --rm -v $PWD:/pybind11 -it silkeh/clang:10
+apt-get update && apt-get install python3-dev python3-pytest
+cmake -S pybind11/ -B build -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-fix"
+cmake --build build
+```
+
+### Include what you use
+
+To run include what you use, install (`brew install include-what-you-use` on
+macOS), then run:
+
+```bash
+cmake -S . -B build-iwyu -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=$(which include-what-you-use)
+cmake --build build
+```
+
+The report is sent to stderr; you can pip it into a file if you wish.
+
 ### Build recipes
 
 This builds with the Intel compiler (assuming it is in your path, along with a
@@ -185,7 +209,6 @@ wget -qO- "https://cmake.org/files/v3.18/cmake-3.18.2-Linux-x86_64.tar.gz" | tar
 cmake -S pybind11/ -B build
 cmake --build build
 ```
-
 
 [pre-commit]: https://pre-commit.com
 [pybind11.readthedocs.org]: http://pybind11.readthedocs.org/en/latest

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,3 +17,19 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
+
+  clang-tidy:
+    name: Clang-Tidy
+    runs-on: ubuntu-latest
+    container: silkeh/clang:10
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install requirements
+      run: apt-get update && apt-get install -y python3-dev python3-pytest
+
+    - name: Configure
+      run: cmake -S . -B build -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);--warnings-as-errors=*"
+
+    - name: Build
+      run: cmake --build build -j 2

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -40,8 +40,9 @@ struct sibling { handle value; sibling(const handle &value) : value(value.ptr())
 
 /// Annotation indicating that a class derives from another given type
 template <typename T> struct base {
+
     PYBIND11_DEPRECATED("base<T>() was deprecated in favor of specifying 'T' as a template argument to class_")
-    base() { }
+    base() { } // NOLINT(modernize-use-equals-default): breaks MSVC 2015 when adding an attribute
 };
 
 /// Keep patient alive while nurse lives
@@ -61,7 +62,7 @@ struct metaclass {
     handle value;
 
     PYBIND11_DEPRECATED("py::metaclass() is no longer required. It's turned on by default now.")
-    metaclass() {}
+    metaclass() { } // NOLINT(modernize-use-equals-default): breaks MSVC 2015 when adding an attribute
 
     /// Override pybind11's default metaclass
     explicit metaclass(handle value) : value(value) { }

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -24,7 +24,7 @@ struct buffer_info {
     std::vector<ssize_t> strides; // Number of bytes between adjacent entries (for each per dimension)
     bool readonly = false;        // flag to indicate if the underlying storage may be written to
 
-    buffer_info() { }
+    buffer_info() = default;
 
     buffer_info(void *ptr, ssize_t itemsize, const std::string &format, ssize_t ndim,
                 detail::any_container<ssize_t> shape_in, detail::any_container<ssize_t> strides_in, bool readonly=false)

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -59,7 +59,7 @@ public:
         Py_CLEAR(ptr);
 
         // A heuristic to reduce the stack's capacity (e.g. after long recursive calls)
-        if (stack.capacity() > 16 && stack.size() != 0 && stack.capacity() / stack.size() > 2)
+        if (stack.capacity() > 16 && !stack.empty() && stack.capacity() / stack.size() > 2)
             stack.shrink_to_fit();
     }
 
@@ -163,7 +163,7 @@ inline const std::vector<detail::type_info *> &all_type_info(PyTypeObject *type)
  */
 PYBIND11_NOINLINE inline detail::type_info* get_type_info(PyTypeObject *type) {
     auto &bases = all_type_info(type);
-    if (bases.size() == 0)
+    if (bases.empty())
         return nullptr;
     if (bases.size() > 1)
         pybind11_fail("pybind11::detail::get_type_info: type has multiple pybind11-registered bases");

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -432,7 +432,7 @@ PYBIND11_NOINLINE inline std::string error_string() {
 
 #if !defined(PYPY_VERSION)
     if (scope.trace) {
-        PyTracebackObject *trace = (PyTracebackObject *) scope.trace;
+        auto *trace = (PyTracebackObject *) scope.trace;
 
         /* Get the deepest trace possible */
         while (trace->tb_next)
@@ -1244,7 +1244,7 @@ template <typename StringType, bool IsView = false> struct string_caster {
             load_src.ptr(), UTF_N == 8 ? "utf-8" : UTF_N == 16 ? "utf-16" : "utf-32", nullptr));
         if (!utfNbytes) { PyErr_Clear(); return false; }
 
-        const CharT *buffer = reinterpret_cast<const CharT *>(PYBIND11_BYTES_AS_STRING(utfNbytes.ptr()));
+        const auto *buffer = reinterpret_cast<const CharT *>(PYBIND11_BYTES_AS_STRING(utfNbytes.ptr()));
         size_t length = (size_t) PYBIND11_BYTES_SIZE(utfNbytes.ptr()) / sizeof(CharT);
         if (UTF_N > 8) { buffer++; length--; } // Skip BOM for UTF-16/32
         value = StringType(buffer, length);
@@ -1258,7 +1258,7 @@ template <typename StringType, bool IsView = false> struct string_caster {
 
     static handle cast(const StringType &src, return_value_policy /* policy */, handle /* parent */) {
         const char *buffer = reinterpret_cast<const char *>(src.data());
-        ssize_t nbytes = ssize_t(src.size() * sizeof(CharT));
+        auto nbytes = ssize_t(src.size() * sizeof(CharT));
         handle s = decode_utfN(buffer, nbytes);
         if (!s) throw error_already_set();
         return s;
@@ -1364,7 +1364,7 @@ public:
         // errors.  We also allow want to allow unicode characters U+0080 through U+00FF, as those
         // can fit into a single char value.
         if (StringCaster::UTF_N == 8 && str_len > 1 && str_len <= 4) {
-            unsigned char v0 = static_cast<unsigned char>(value[0]);
+            auto v0 = static_cast<unsigned char>(value[0]);
             size_t char0_bytes = !(v0 & 0x80) ? 1 : // low bits only: 0-127
                 (v0 & 0xE0) == 0xC0 ? 2 : // 0b110xxxxx - start of 2-byte sequence
                 (v0 & 0xF0) == 0xE0 ? 3 : // 0b1110xxxx - start of 3-byte sequence

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -220,7 +220,7 @@ struct value_and_holder {
     {}
 
     // Default constructor (used to signal a value-and-holder not found by get_value_and_holder())
-    value_and_holder() {}
+    value_and_holder() = default;
 
     // Used for past-the-end iterator
     value_and_holder(size_t index) : index{index} {}

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1929,7 +1929,7 @@ inline namespace literals {
     String literal version of `arg`
  \endrst */
 constexpr arg operator"" _a(const char *name, size_t) { return arg(name); }
-}
+} // namespace literals
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 

--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -33,9 +33,9 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 template <typename type> class duration_caster {
 public:
     typedef typename type::rep rep;
-    typedef typename type::period period;
+    using period = typename type::period;
 
-    typedef std::chrono::duration<uint_fast32_t, std::ratio<86400>> days;
+    using days = std::chrono::duration<uint_fast32_t, std::ratio<86400>>;
 
     bool load(handle src, bool) {
         using namespace std::chrono;
@@ -98,7 +98,7 @@ public:
 // This is for casting times on the system clock into datetime.datetime instances
 template <typename Duration> class type_caster<std::chrono::time_point<std::chrono::system_clock, Duration>> {
 public:
-    typedef std::chrono::time_point<std::chrono::system_clock, Duration> type;
+    using type = std::chrono::time_point<std::chrono::system_clock, Duration>;
     bool load(handle src, bool) {
         using namespace std::chrono;
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -592,7 +592,7 @@ inline PyObject* make_new_python_type(const type_record &rec) {
 
     auto &internals = get_internals();
     auto bases = tuple(rec.bases);
-    auto base = (bases.size() == 0) ? internals.instance_base
+    auto base = (bases.empty()) ? internals.instance_base
                                     : bases[0].ptr();
 
     /* Danger zone: from now (and until PyType_Ready), make sure to
@@ -616,7 +616,7 @@ inline PyObject* make_new_python_type(const type_record &rec) {
     type->tp_doc = tp_doc;
     type->tp_base = type_incref((PyTypeObject *)base);
     type->tp_basicsize = static_cast<ssize_t>(sizeof(instance));
-    if (bases.size() > 0)
+    if (!bases.empty())
         type->tp_bases = bases.release().ptr();
 
     /* Don't inherit base __init__ */

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -761,7 +761,7 @@ struct nodelete { template <typename T> void operator()(T*) { } };
 PYBIND11_NAMESPACE_BEGIN(detail)
 template <typename... Args>
 struct overload_cast_impl {
-    constexpr overload_cast_impl() {} // MSVC 2015 needs this
+    constexpr overload_cast_impl() {}; // NOLINT(modernize-use-equals-default):  MSVC 2015 needs this
 
     template <typename Return>
     constexpr auto operator()(Return (*pf)(Args...)) const noexcept

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -537,17 +537,17 @@ template <class T, template<class> class... Predicates> using satisfies_none_of 
 
 /// Strip the class from a method type
 template <typename T> struct remove_class { };
-template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...)> { typedef R type(A...); };
-template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...) const> { typedef R type(A...); };
+template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...)> { using type = R (A...); };
+template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...) const> { using type = R (A...); };
 
 /// Helper template to strip away type modifiers
-template <typename T> struct intrinsic_type                       { typedef T type; };
-template <typename T> struct intrinsic_type<const T>              { typedef typename intrinsic_type<T>::type type; };
-template <typename T> struct intrinsic_type<T*>                   { typedef typename intrinsic_type<T>::type type; };
-template <typename T> struct intrinsic_type<T&>                   { typedef typename intrinsic_type<T>::type type; };
-template <typename T> struct intrinsic_type<T&&>                  { typedef typename intrinsic_type<T>::type type; };
-template <typename T, size_t N> struct intrinsic_type<const T[N]> { typedef typename intrinsic_type<T>::type type; };
-template <typename T, size_t N> struct intrinsic_type<T[N]>       { typedef typename intrinsic_type<T>::type type; };
+template <typename T> struct intrinsic_type                       { using type = T; };
+template <typename T> struct intrinsic_type<const T>              { using type = typename intrinsic_type<T>::type; };
+template <typename T> struct intrinsic_type<T*>                   { using type = typename intrinsic_type<T>::type; };
+template <typename T> struct intrinsic_type<T&>                   { using type = typename intrinsic_type<T>::type; };
+template <typename T> struct intrinsic_type<T&&>                  { using type = typename intrinsic_type<T>::type; };
+template <typename T, size_t N> struct intrinsic_type<const T[N]> { using type = typename intrinsic_type<T>::type; };
+template <typename T, size_t N> struct intrinsic_type<T[N]>       { using type = typename intrinsic_type<T>::type; };
 template <typename T> using intrinsic_t = typename intrinsic_type<T>::type;
 
 /// Helper type to replace 'void' in some expressions

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -30,7 +30,7 @@ private:
     object pywrite;
     object pyflush;
 
-    int overflow(int c) {
+    int overflow(int c) override {
         if (!traits_type::eq_int_type(c, traits_type::eof())) {
             *pptr() = traits_type::to_char_type(c);
             pbump(1);
@@ -38,7 +38,7 @@ private:
         return sync() == 0 ? traits_type::not_eof(c) : traits_type::eof();
     }
 
-    int sync() {
+    int sync() override {
         if (pbase() != pptr()) {
             // This subtraction cannot be negative, so dropping the sign
             str line(pbase(), static_cast<size_t>(pptr() - pbase()));
@@ -67,7 +67,7 @@ public:
     pythonbuf(pythonbuf&&) = default;
 
     /// Sync before destroy
-    ~pythonbuf() {
+    ~pythonbuf() override {
         sync();
     }
 };

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -38,7 +38,10 @@ private:
         return sync() == 0 ? traits_type::not_eof(c) : traits_type::eof();
     }
 
-    int sync() override {
+    // This function must be non-virtual to be called in a destructor. If the
+    // rare MSVC test failure shows up with this version, then this should be
+    // simplified to a fully qualified call.
+    int _sync() {
         if (pbase() != pptr()) {
             // This subtraction cannot be negative, so dropping the sign
             str line(pbase(), static_cast<size_t>(pptr() - pbase()));
@@ -52,6 +55,10 @@ private:
             setp(pbase(), epptr());
         }
         return 0;
+    }
+
+    int sync() override {
+        return _sync();
     }
 
 public:
@@ -68,7 +75,7 @@ public:
 
     /// Sync before destroy
     ~pythonbuf() override {
-        sync();
+        _sync();
     }
 };
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1296,7 +1296,7 @@ public:
         m_strides.back() = static_cast<value_type>(strides.back());
         for (size_type i = m_strides.size() - 1; i != 0; --i) {
             size_type j = i - 1;
-            value_type s = static_cast<value_type>(shape[i]);
+            auto s = static_cast<value_type>(shape[i]);
             m_strides[j] = strides[j] + m_strides[i] - strides[i] * s;
         }
     }
@@ -1539,7 +1539,7 @@ private:
         ssize_t nd = 0;
         std::vector<ssize_t> shape(0);
         auto trivial = broadcast(buffers, nd, shape);
-        size_t ndim = (size_t) nd;
+        auto ndim = (size_t) nd;
 
         size_t size = std::accumulate(shape.begin(), shape.end(), (size_t) 1, std::multiplies<size_t>());
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -281,7 +281,7 @@ template <typename T> struct is_complex : std::false_type { };
 template <typename T> struct is_complex<std::complex<T>> : std::true_type { };
 
 template <typename T> struct array_info_scalar {
-    typedef T type;
+    using type = T;
     static constexpr bool is_array = false;
     static constexpr bool is_empty = false;
     static constexpr auto extents = _("");

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -165,7 +165,7 @@ protected:
             /* Get a pointer to the capture object */
             auto data = (sizeof(capture) <= sizeof(call.func.data)
                          ? &call.func.data : call.func.data[0]);
-            capture *cap = const_cast<capture *>(reinterpret_cast<const capture *>(data));
+            auto *cap = const_cast<capture *>(reinterpret_cast<const capture *>(data));
 
             /* Override policy for rvalues -- usually to enforce rvp::move on an rvalue */
             return_value_policy policy = return_value_policy_override<Return>::policy(call.func.policy);
@@ -420,7 +420,7 @@ protected:
         }
 
         /* Install docstring */
-        PyCFunctionObject *func = (PyCFunctionObject *) m_ptr;
+        auto *func = (PyCFunctionObject *) m_ptr;
         if (func->m_ml->ml_doc)
             std::free(const_cast<char *>(func->m_ml->ml_doc));
         func->m_ml->ml_doc = strdup(signatures.c_str());
@@ -465,7 +465,7 @@ protected:
                               *it = overloads;
 
         /* Need to know how many arguments + keyword arguments there are to pick the right overload */
-        const size_t n_args_in = (size_t) PyTuple_GET_SIZE(args_in);
+        const auto n_args_in = (size_t) PyTuple_GET_SIZE(args_in);
 
         handle parent = n_args_in > 0 ? PyTuple_GET_ITEM(args_in, 0) : nullptr,
                result = PYBIND11_TRY_NEXT_OVERLOAD;
@@ -860,7 +860,7 @@ public:
     explicit module(const char *name, const char *doc = nullptr) {
         if (!options::show_user_defined_docstrings()) doc = nullptr;
 #if PY_MAJOR_VERSION >= 3
-        PyModuleDef *def = new PyModuleDef();
+        auto *def = new PyModuleDef();
         std::memset(def, 0, sizeof(PyModuleDef));
         def->m_name = name;
         def->m_doc = doc;
@@ -1020,7 +1020,7 @@ protected:
     void install_buffer_funcs(
             buffer_info *(*get_buffer)(PyObject *, void *),
             void *get_buffer_data) {
-        PyHeapTypeObject *type = (PyHeapTypeObject*) m_ptr;
+        auto *type = (PyHeapTypeObject*) m_ptr;
         auto tinfo = detail::get_type_info(&type->ht_type);
 
         if (!type->ht_type.tp_as_buffer)
@@ -1242,7 +1242,7 @@ public:
 
     template <typename Func> class_& def_buffer(Func &&func) {
         struct capture { Func func; };
-        capture *ptr = new capture { std::forward<Func>(func) };
+        auto *ptr = new capture { std::forward<Func>(func) };
         install_buffer_funcs([](PyObject *obj, void *ptr) -> buffer_info* {
             detail::make_caster<type> caster;
             if (!caster.load(obj, false))

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -55,7 +55,7 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 /// Wraps an arbitrary C++ function/method/lambda function/.. into a callable Python object
 class cpp_function : public function {
 public:
-    cpp_function() { }
+    cpp_function() = default;
     cpp_function(std::nullptr_t) { }
 
     /// Construct a cpp_function from a vanilla function pointer

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1789,7 +1789,7 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
           typename KeyType = decltype((*std::declval<Iterator>()).first),
           typename... Extra>
 iterator make_key_iterator(Iterator first, Sentinel last, Extra &&... extra) {
-    typedef detail::iterator_state<Iterator, Sentinel, true, Policy> state;
+    using state = detail::iterator_state<Iterator, Sentinel, true, Policy>;
 
     if (!detail::get_type_info(typeid(state), false)) {
         class_<state>(handle(), "iterator", pybind11::module_local())

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -626,7 +626,7 @@ protected:
                 }
 
                 // 3. Check everything was consumed (unless we have a kwargs arg)
-                if (kwargs && kwargs.size() > 0 && !func.has_kwargs)
+                if (kwargs && !kwargs.empty() && !func.has_kwargs)
                     continue; // Unconsumed kwargs, but no py::kwargs argument to accept them
 
                 // 4a. If we have a py::args argument, create a new tuple with leftovers
@@ -814,7 +814,7 @@ protected:
             }
             if (kwargs_in) {
                 auto kwargs = reinterpret_borrow<dict>(kwargs_in);
-                if (kwargs.size() > 0) {
+                if (!kwargs.empty()) {
                     if (some_args) msg += "; ";
                     msg += "kwargs: ";
                     bool first = true;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -543,7 +543,7 @@ protected:
                         self_value_and_holder.type->dealloc(self_value_and_holder);
 
                     call.init_self = PyTuple_GET_ITEM(args_in, 0);
-                    call.args.push_back(reinterpret_cast<PyObject *>(&self_value_and_holder));
+                    call.args.emplace_back(reinterpret_cast<PyObject *>(&self_value_and_holder));
                     call.args_convert.push_back(false);
                     ++args_copied;
                 }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -35,7 +35,7 @@ namespace accessor_policies {
     struct sequence_item;
     struct list_item;
     struct tuple_item;
-}
+} // namespace accessor_policies
 using obj_attr_accessor = accessor<accessor_policies::obj_attr>;
 using str_attr_accessor = accessor<accessor_policies::str_attr>;
 using item_accessor = accessor<accessor_policies::generic_item>;
@@ -976,7 +976,7 @@ inline namespace literals {
     String literal version of `str`
  \endrst */
 inline str operator"" _s(const char *s, size_t size) { return {s, size}; }
-}
+} // namespace literals
 
 /// \addtogroup pytypes
 /// @{

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1351,7 +1351,7 @@ public:
     buffer_info request(bool writable = false) const {
         int flags = PyBUF_STRIDES | PyBUF_FORMAT;
         if (writable) flags |= PyBUF_WRITABLE;
-        Py_buffer *view = new Py_buffer();
+        auto *view = new Py_buffer();
         if (PyObject_GetBuffer(m_ptr, view, flags) != 0) {
             delete view;
             throw error_already_set();

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -331,7 +331,7 @@ public:
     error_already_set(const error_already_set &) = default;
     error_already_set(error_already_set &&) = default;
 
-    inline ~error_already_set();
+    inline ~error_already_set() override;
 
     /// Give the currently-held error back to Python, if any.  If there is currently a Python error
     /// already set it is cleared first.  After this call, the current object no longer stores the

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -223,7 +223,7 @@ void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_t
             if (!slice.compute(v.size(), &start, &stop, &step, &slicelength))
                 throw error_already_set();
 
-            Vector *seq = new Vector();
+            auto *seq = new Vector();
             seq->reserve((size_t) slicelength);
 
             for (size_t i=0; i<slicelength; ++i) {

--- a/tests/local_bindings.h
+++ b/tests/local_bindings.h
@@ -58,7 +58,7 @@ public:
     std::string name_;
     const std::string &name() { return name_; }
 };
-}
+} // namespace pets
 
 struct MixGL { int i; MixGL(int i) : i{i} {} };
 struct MixGL2 { int i; MixGL2(int i) : i{i} {} };

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -32,11 +32,11 @@ std::list<std::function<void(py::module &)>> &initializers() {
 }
 
 test_initializer::test_initializer(Initializer init) {
-    initializers().push_back(init);
+    initializers().emplace_back(init);
 }
 
 test_initializer::test_initializer(const char *submodule_name, Initializer init) {
-    initializers().push_back([=](py::module &parent) {
+    initializers().emplace_back([=](py::module &parent) {
         auto m = parent.def_submodule(submodule_name);
         init(m);
     });

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -425,14 +425,14 @@ template <int N> class BreaksBase { public:
 };
 template <int N> class BreaksTramp : public BreaksBase<N> {};
 // These should all compile just fine:
-typedef py::class_<BreaksBase<1>, std::unique_ptr<BreaksBase<1>>, BreaksTramp<1>> DoesntBreak1;
-typedef py::class_<BreaksBase<2>, BreaksTramp<2>, std::unique_ptr<BreaksBase<2>>> DoesntBreak2;
-typedef py::class_<BreaksBase<3>, std::unique_ptr<BreaksBase<3>>> DoesntBreak3;
-typedef py::class_<BreaksBase<4>, BreaksTramp<4>> DoesntBreak4;
-typedef py::class_<BreaksBase<5>> DoesntBreak5;
-typedef py::class_<BreaksBase<6>, std::shared_ptr<BreaksBase<6>>, BreaksTramp<6>> DoesntBreak6;
-typedef py::class_<BreaksBase<7>, BreaksTramp<7>, std::shared_ptr<BreaksBase<7>>> DoesntBreak7;
-typedef py::class_<BreaksBase<8>, std::shared_ptr<BreaksBase<8>>> DoesntBreak8;
+using DoesntBreak1 = py::class_<BreaksBase<1>, std::unique_ptr<BreaksBase<1>>, BreaksTramp<1>>;
+using DoesntBreak2 = py::class_<BreaksBase<2>, BreaksTramp<2>, std::unique_ptr<BreaksBase<2>>>;
+using DoesntBreak3 = py::class_<BreaksBase<3>, std::unique_ptr<BreaksBase<3>>>;
+using DoesntBreak4 = py::class_<BreaksBase<4>, BreaksTramp<4>>;
+using DoesntBreak5 = py::class_<BreaksBase<5>>;
+using DoesntBreak6 = py::class_<BreaksBase<6>, std::shared_ptr<BreaksBase<6>>, BreaksTramp<6>>;
+using DoesntBreak7 = py::class_<BreaksBase<7>, BreaksTramp<7>, std::shared_ptr<BreaksBase<7>>>;
+using DoesntBreak8 = py::class_<BreaksBase<8>, std::shared_ptr<BreaksBase<8>>>;
 #define CHECK_BASE(N) static_assert(std::is_same<typename DoesntBreak##N::type, BreaksBase<N>>::value, \
         "DoesntBreak" #N " has wrong type!")
 CHECK_BASE(1); CHECK_BASE(2); CHECK_BASE(3); CHECK_BASE(4); CHECK_BASE(5); CHECK_BASE(6); CHECK_BASE(7); CHECK_BASE(8);

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -103,7 +103,7 @@ TEST_SUBMODULE(class_, m) {
         BaseClass() = default;
         BaseClass(const BaseClass &) = default;
         BaseClass(BaseClass &&) = default;
-        virtual ~BaseClass() {}
+        virtual ~BaseClass() = default;
     };
     struct DerivedClass1 : BaseClass { };
     struct DerivedClass2 : BaseClass { };
@@ -353,7 +353,7 @@ TEST_SUBMODULE(class_, m) {
     // test_reentrant_implicit_conversion_failure
     // #1035: issue with runaway reentrant implicit conversion
     struct BogusImplicitConversion {
-        BogusImplicitConversion(const BogusImplicitConversion &) { }
+        BogusImplicitConversion(const BogusImplicitConversion &) = default;
     };
 
     py::class_<BogusImplicitConversion>(m, "BogusImplicitConversion")
@@ -407,7 +407,7 @@ TEST_SUBMODULE(class_, m) {
     py::class_<IsNonFinalFinal>(m, "IsNonFinalFinal", py::is_final());
 
     struct PyPrintDestructor {
-        PyPrintDestructor() {}
+        PyPrintDestructor() = default;
         ~PyPrintDestructor() {
             py::print("Print from destructor");
         }

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -74,7 +74,7 @@ struct C {
 #  pragma GCC diagnostic pop
 #endif
 };
-}
+} // namespace test_exc_sp
 
 
 TEST_SUBMODULE(constants_and_functions, m) {

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -19,14 +19,14 @@ struct empty {
 };
 
 struct lacking_copy_ctor : public empty<lacking_copy_ctor> {
-    lacking_copy_ctor() {}
+    lacking_copy_ctor() = default;
     lacking_copy_ctor(const lacking_copy_ctor& other) = delete;
 };
 
 template <> lacking_copy_ctor empty<lacking_copy_ctor>::instance_ = {};
 
 struct lacking_move_ctor : public empty<lacking_move_ctor> {
-    lacking_move_ctor() {}
+    lacking_move_ctor() = default;
     lacking_move_ctor(const lacking_move_ctor& other) = delete;
     lacking_move_ctor(lacking_move_ctor&& other) = delete;
 };

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -58,7 +58,8 @@ public:
         return py::none().release();
     }
 };
-}}
+} // namespace detail
+} // namespace pybind11
 
 // test_custom_caster_destruction
 class DestructionTester {
@@ -79,7 +80,8 @@ template <> struct type_caster<DestructionTester> {
         return py::bool_(true).release();
     }
 };
-}}
+} // namespace detail
+} // namespace pybind11
 
 TEST_SUBMODULE(custom_type_casters, m) {
     // test_custom_type_casters

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -13,7 +13,7 @@
 class MyException : public std::exception {
 public:
     explicit MyException(const char * m) : message{m} {}
-    virtual const char * what() const noexcept override {return message.c_str();}
+    const char * what() const noexcept override {return message.c_str();}
 private:
     std::string message = "";
 };
@@ -22,7 +22,7 @@ private:
 class MyException2 : public std::exception {
 public:
     explicit MyException2(const char * m) : message{m} {}
-    virtual const char * what() const noexcept override {return message.c_str();}
+    const char * what() const noexcept override {return message.c_str();}
 private:
     std::string message = "";
 };
@@ -41,7 +41,7 @@ private:
 class MyException4 : public std::exception {
 public:
     explicit MyException4(const char * m) : message{m} {}
-    virtual const char * what() const noexcept override {return message.c_str();}
+    const char * what() const noexcept override {return message.c_str();}
 private:
     std::string message = "";
 };

--- a/tests/test_factory_constructors.cpp
+++ b/tests/test_factory_constructors.cpp
@@ -58,13 +58,13 @@ class TestFactory4 : public TestFactory3 {
 public:
     TestFactory4() : TestFactory3() { print_default_created(this); }
     TestFactory4(int v) : TestFactory3(v) { print_created(this, v); }
-    virtual ~TestFactory4() { print_destroyed(this); }
+    ~TestFactory4() override { print_destroyed(this); }
 };
 // Another class for an invalid downcast test
 class TestFactory5 : public TestFactory3 {
 public:
     TestFactory5(int i) : TestFactory3(i) { print_created(this, i); }
-    virtual ~TestFactory5() { print_destroyed(this); }
+    ~TestFactory5() override { print_destroyed(this); }
 };
 
 class TestFactory6 {
@@ -88,8 +88,8 @@ public:
     PyTF6(PyTF6 &&f) : TestFactory6(std::move(f)) { print_move_created(this); }
     PyTF6(const PyTF6 &f) : TestFactory6(f) { print_copy_created(this); }
     PyTF6(std::string s) : TestFactory6((int) s.size()) { alias = true; print_created(this, s); }
-    virtual ~PyTF6() { print_destroyed(this); }
-    int get() override { PYBIND11_OVERRIDE(int, TestFactory6, get, /*no args*/); }
+    ~PyTF6() override { print_destroyed(this); }
+    int get() override { PYBIND11_OVERLOAD(int, TestFactory6, get, /*no args*/); }
 };
 
 class TestFactory7 {
@@ -109,8 +109,7 @@ public:
     PyTF7(int i) : TestFactory7(i) { alias = true; print_created(this, i); }
     PyTF7(PyTF7 &&f) : TestFactory7(std::move(f)) { print_move_created(this); }
     PyTF7(const PyTF7 &f) : TestFactory7(f) { print_copy_created(this); }
-    virtual ~PyTF7() { print_destroyed(this); }
-    int get() override { PYBIND11_OVERRIDE(int, TestFactory7, get, /*no args*/); }
+    ~PyTF7() override { print_destroyed(this); }
 };
 
 

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -212,7 +212,7 @@ TEST_SUBMODULE(numpy_array, sm) {
         .def(py::init<>())
         .def("numpy_view", [](py::object &obj) {
             py::print("ArrayClass::numpy_view()");
-            ArrayClass &a = obj.cast<ArrayClass&>();
+            auto &a = obj.cast<ArrayClass&>();
             return py::array_t<int>({2}, {4}, a.data, obj);
         }
     );
@@ -362,7 +362,7 @@ TEST_SUBMODULE(numpy_array, sm) {
     // test_array_resize
     // reshape array to 2D without changing size
     sm.def("array_reshape2", [](py::array_t<double> a) {
-        const ssize_t dim_sz = (ssize_t)std::sqrt(a.size());
+        const auto dim_sz = (ssize_t)std::sqrt(a.size());
         if (dim_sz * dim_sz != a.size())
             throw std::domain_error("array_reshape2: input array total size is not a squared integer");
         a.resize({dim_sz, dim_sz});

--- a/tests/test_opaque_types.cpp
+++ b/tests/test_opaque_types.cpp
@@ -60,7 +60,7 @@ TEST_SUBMODULE(opaque_types, m) {
     m.def("get_null_str_value", [](char *ptr) { return reinterpret_cast<std::intptr_t>(ptr); });
 
     m.def("return_unique_ptr", []() -> std::unique_ptr<StringList> {
-        StringList *result = new StringList();
+        auto *result = new StringList();
         result->push_back("some value");
         return std::unique_ptr<StringList>(result);
     });

--- a/tests/test_operator_overloading.cpp
+++ b/tests/test_operator_overloading.cpp
@@ -73,7 +73,7 @@ namespace std {
         // Not a good hash function, but easy to test
         size_t operator()(const Vector2 &) { return 4; }
     };
-}
+} // namespace std
 
 // Not a good abs function, but easy to test.
 std::string abs(const Vector2&) {

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -200,7 +200,7 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
             size_t start, stop, step, slicelength;
             if (!slice.compute(s.size(), &start, &stop, &step, &slicelength))
                 throw py::error_already_set();
-            Sequence *seq = new Sequence(slicelength);
+            auto *seq = new Sequence(slicelength);
             for (size_t i = 0; i < slicelength; ++i) {
                 (*seq)[i] = s[start]; start += step;
             }

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -27,7 +27,8 @@ namespace pybind11 { namespace detail {
     struct holder_helper<ref<T>> {
         static const T *get(const ref<T> &p) { return p.get_ptr(); }
     };
-}}
+} // namespace detail
+} // namespace pybind11
 
 // The following is not required anymore for std::shared_ptr, but it should compile without error:
 PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -98,9 +98,9 @@ TEST_SUBMODULE(smart_ptr, m) {
     class MyObject1 : public Object {
     public:
         MyObject1(int value) : value(value) { print_created(this, toString()); }
-        std::string toString() const { return "MyObject1[" + std::to_string(value) + "]"; }
+        std::string toString() const override { return "MyObject1[" + std::to_string(value) + "]"; }
     protected:
-        virtual ~MyObject1() { print_destroyed(this); }
+        ~MyObject1() override { print_destroyed(this); }
     private:
         int value;
     };
@@ -208,7 +208,7 @@ TEST_SUBMODULE(smart_ptr, m) {
     class MyObject4b : public MyObject4a {
     public:
         MyObject4b(int i) : MyObject4a(i) { print_created(this); }
-        ~MyObject4b() { print_destroyed(this); }
+        ~MyObject4b() override { print_destroyed(this); }
     };
     py::class_<MyObject4b, MyObject4a>(m, "MyObject4b")
         .def(py::init<int>());

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -339,7 +339,7 @@ TEST_SUBMODULE(smart_ptr, m) {
     // test_shared_ptr_gc
     // #187: issue involving std::shared_ptr<> return value policy & garbage collection
     struct ElementBase {
-        virtual ~ElementBase() { } /* Force creation of virtual table */
+        virtual ~ElementBase() = default; /* Force creation of virtual table */
         ElementBase() = default;
         ElementBase(const ElementBase&) = delete;
     };

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -47,7 +47,7 @@ struct TplCtorClass {
 namespace std {
     template <>
     struct hash<TplCtorClass> { size_t operator()(const TplCtorClass &) const { return 0; } };
-}
+} // namespace std
 
 
 template <template <typename> class OptionalImpl, typename T>

--- a/tests/test_tagbased_polymorphic.cpp
+++ b/tests/test_tagbased_polymorphic.cpp
@@ -117,7 +117,7 @@ namespace pybind11 {
         static const void *get(const itype *src, const std::type_info*& type)
         { type = src ? Animal::type_of_kind(src->kind) : nullptr; return src; }
     };
-}
+} // namespace pybind11
 
 TEST_SUBMODULE(tagbased_polymorphic, m) {
     py::class_<Animal>(m, "Animal")

--- a/tests/test_virtual_functions.cpp
+++ b/tests/test_virtual_functions.cpp
@@ -129,7 +129,7 @@ private:
 
 class NCVirt {
 public:
-    virtual ~NCVirt() { }
+    virtual ~NCVirt() = default;
     NCVirt() = default;
     NCVirt(const NCVirt&) = delete;
     virtual NonCopyable get_noncopyable(int a, int b) { return NonCopyable(a, b); }
@@ -227,7 +227,7 @@ TEST_SUBMODULE(virtual_functions, m) {
     struct A {
         A() = default;
         A(const A&) = delete;
-        virtual ~A() {}
+        virtual ~A() = default;
         virtual void f() { py::print("A.f()"); }
     };
 
@@ -255,7 +255,7 @@ TEST_SUBMODULE(virtual_functions, m) {
     struct A2 {
         A2() = default;
         A2(const A2&) = delete;
-        virtual ~A2() {}
+        virtual ~A2() = default;
         virtual void f() { py::print("A2.f()"); }
     };
 

--- a/tests/test_virtual_functions.cpp
+++ b/tests/test_virtual_functions.cpp
@@ -158,8 +158,8 @@ struct Base {
 };
 
 struct DispatchIssue : Base {
-    virtual std::string dispatch() const {
-        PYBIND11_OVERRIDE_PURE(std::string, Base, dispatch, /* no arguments */);
+    std::string dispatch() const override {
+        PYBIND11_OVERLOAD_PURE(std::string, Base, dispatch, /* no arguments */);
     }
 };
 
@@ -234,7 +234,7 @@ TEST_SUBMODULE(virtual_functions, m) {
     struct PyA : A {
         PyA() { py::print("PyA.PyA()"); }
         PyA(const PyA&) = delete;
-        ~PyA() { py::print("PyA.~PyA()"); }
+        ~PyA() override { py::print("PyA.~PyA()"); }
 
         void f() override {
             py::print("PyA.f()");
@@ -262,7 +262,7 @@ TEST_SUBMODULE(virtual_functions, m) {
     struct PyA2 : A2 {
         PyA2() { py::print("PyA2.PyA2()"); }
         PyA2(const PyA2&) = delete;
-        ~PyA2() { py::print("PyA2.~PyA2()"); }
+        ~PyA2() override { py::print("PyA2.~PyA2()"); }
         void f() override {
             py::print("PyA2.f()");
             PYBIND11_OVERRIDE(void, A2, f);


### PR DESCRIPTION
This adds the ability to run a clang-tidy list of checks in CI, and adds a few checks to get started. Due to the methodology used, _only checks that made changes_ (one commit per check) were added. Only extremely safe checks were added. Eventually, it would be nice to expand further; there are some very useful/powerful clang tidy checks. You can see the [groups here](https://clang.llvm.org/extra/clang-tidy/). You can do groups of checks, like `modernize-*` (that's C++11), `readability-*`, `portability-*`, `bugprone-*`, `cppcoreguidelines-*`, or `performance-*` (and remove ones that you don't support). You can also disable inline for special cases.

Checks added:
* Namespaces always have a closing comment
* `override` is always used when overriding
* `.empty()` is used to check empty containers instead of size comparisons
* `using` used instead of `typedef`
* `= default` used for trivial bodies (except where MSVC 2015 requires otherwise)
* `auto` used _when the typename would be otherwise duplicated on the same line_ (not everywhere, as that would be worse, not better!)
* `emplace` used instead of push back for containers

I've also added instructions for running this locally (where you can perform the fixes automatically).