### PR TITLE
Stop py::array_t arguments from accepting arrays that do not match the C- or F-contiguity flags

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -934,7 +934,8 @@ public:
     static bool check_(handle h) {
         const auto &api = detail::npy_api::get();
         return api.PyArray_Check_(h.ptr())
-               && api.PyArray_EquivTypes_(detail::array_proxy(h.ptr())->descr, dtype::of<T>().ptr());
+               && api.PyArray_EquivTypes_(detail::array_proxy(h.ptr())->descr, dtype::of<T>().ptr())
+               && detail::check_flags(h.ptr(), ExtraFlags & (array::c_style | array::f_style));
     }
 
 protected:

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -385,4 +385,42 @@ TEST_SUBMODULE(numpy_array, sm) {
     sm.def("index_using_ellipsis", [](py::array a) {
         return a[py::make_tuple(0, py::ellipsis(), 0)];
     });
+
+    // test_argument_conversions
+    sm.def("accept_double",
+           [](py::array_t<double, 0>) {},
+           py::arg("a"));
+    sm.def("accept_double_forcecast",
+           [](py::array_t<double, py::array::forcecast>) {},
+           py::arg("a"));
+    sm.def("accept_double_c_style",
+           [](py::array_t<double, py::array::c_style>) {},
+           py::arg("a"));
+    sm.def("accept_double_c_style_forcecast",
+           [](py::array_t<double, py::array::forcecast | py::array::c_style>) {},
+           py::arg("a"));
+    sm.def("accept_double_f_style",
+           [](py::array_t<double, py::array::f_style>) {},
+           py::arg("a"));
+    sm.def("accept_double_f_style_forcecast",
+           [](py::array_t<double, py::array::forcecast | py::array::f_style>) {},
+           py::arg("a"));
+    sm.def("accept_double_noconvert",
+           [](py::array_t<double, 0>) {},
+           py::arg("a").noconvert());
+    sm.def("accept_double_forcecast_noconvert",
+           [](py::array_t<double, py::array::forcecast>) {},
+           py::arg("a").noconvert());
+    sm.def("accept_double_c_style_noconvert",
+           [](py::array_t<double, py::array::c_style>) {},
+           py::arg("a").noconvert());
+    sm.def("accept_double_c_style_forcecast_noconvert",
+           [](py::array_t<double, py::array::forcecast | py::array::c_style>) {},
+           py::arg("a").noconvert());
+    sm.def("accept_double_f_style_noconvert",
+           [](py::array_t<double, py::array::f_style>) {},
+           py::arg("a").noconvert());
+    sm.def("accept_double_f_style_forcecast_noconvert",
+           [](py::array_t<double, py::array::forcecast | py::array::f_style>) {},
+           py::arg("a").noconvert());
 }


### PR DESCRIPTION
`noconvert` checks for `py::array_t` whether the passed type is compatible, but it doesn't check whether the `array::c_style` or `array::f_style` flags are satisifed. See #2455 for a demonstration.

Closes #2455