### PR TITLE
Avoid C style casts in the docs, at least for pointers

### DIFF
--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -360,7 +360,7 @@ like so:
 .. code-block:: cpp
 
     py::class_<MyClass>("MyClass")
-        .def("myFunction", py::arg("arg") = (SomeType *) nullptr);
+        .def("myFunction", py::arg("arg") = static_cast<SomeType *>(nullptr));
 
 Keyword-only arguments
 ======================

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -176,9 +176,9 @@ pybind11 version. Consider the following example:
 
 .. code-block:: cpp
 
-    auto data = (MyData *) py::get_shared_data("mydata");
+    auto data = reinterpret_cast<MyData *>(py::get_shared_data("mydata"));
     if (!data)
-        data = (MyData *) py::set_shared_data("mydata", new MyData(42));
+        data = static_cast<MyData *>(py::set_shared_data("mydata", new MyData(42)));
 
 If the above snippet was used in several separately compiled extension modules,
 the first one to be imported would create a ``MyData`` instance and associate

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -274,9 +274,9 @@ simply using ``vectorize``).
 
         py::buffer_info buf3 = result.request();
 
-        double *ptr1 = (double *) buf1.ptr,
-               *ptr2 = (double *) buf2.ptr,
-               *ptr3 = (double *) buf3.ptr;
+        double *ptr1 = static_cast<double *>(buf1.ptr);
+        double *ptr2 = static_cast<double *>(buf2.ptr);
+        double *ptr3 = static_cast<double *>(buf3.ptr);
 
         for (size_t idx = 0; idx < buf1.shape[0]; idx++)
             ptr3[idx] = ptr1[idx] + ptr2[idx];

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -373,8 +373,8 @@ sequence.
 
     py::class_<Pet>(m, "Pet")
        .def(py::init<const std::string &, int>())
-       .def("set", (void (Pet::*)(int)) &Pet::set, "Set the pet's age")
-       .def("set", (void (Pet::*)(const std::string &)) &Pet::set, "Set the pet's name");
+       .def("set", static_cast<void (Pet::*)(int)>(&Pet::set), "Set the pet's age")
+       .def("set", static_cast<void (Pet::*)(const std::string &)>(&Pet::set), "Set the pet's name");
 
 The overload signatures are also visible in the method's docstring:
 


### PR DESCRIPTION
When C++14, and thus `py::overload_cast`, isn't available the docs suggest a C style cast. A conservative `static_cast` seems a much better idea when working with function pointers.

EDIT: Let's hope I caught all C casts in the docs.