### PR TITLE
fix: use OVERRIDE instead of OVERLOAD

### DIFF
--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -196,9 +196,9 @@ Please take a look at the :ref:`macro_notes` before using this feature.
     The :c:macro:`PYBIND11_OVERRIDE` and accompanying macros used to be called
     ``PYBIND11_OVERLOAD`` up until pybind11 v2.5.0, and :func:`get_override`
     used to be called ``get_overload``. This naming was corrected and the older
-    macro and function names have been deprecated, in order to reduce confusion
-    with overloaded functions and methods and ``py::overload_cast`` (see
-    :ref:`classes`).
+    macro and function names may soon be deprecated, in order to reduce
+    confusion with overloaded functions and methods and ``py::overload_cast``
+    (see :ref:`classes`).
 
 .. seealso::
 

--- a/tests/test_factory_constructors.cpp
+++ b/tests/test_factory_constructors.cpp
@@ -89,7 +89,7 @@ public:
     PyTF6(const PyTF6 &f) : TestFactory6(f) { print_copy_created(this); }
     PyTF6(std::string s) : TestFactory6((int) s.size()) { alias = true; print_created(this, s); }
     ~PyTF6() override { print_destroyed(this); }
-    int get() override { PYBIND11_OVERLOAD(int, TestFactory6, get, /*no args*/); }
+    int get() override { PYBIND11_OVERRIDE(int, TestFactory6, get, /*no args*/); }
 };
 
 class TestFactory7 {
@@ -110,6 +110,7 @@ public:
     PyTF7(PyTF7 &&f) : TestFactory7(std::move(f)) { print_move_created(this); }
     PyTF7(const PyTF7 &f) : TestFactory7(f) { print_copy_created(this); }
     ~PyTF7() override { print_destroyed(this); }
+    int get() override { PYBIND11_OVERRIDE(int, TestFactory7, get, /*no args*/); }
 };
 
 

--- a/tests/test_virtual_functions.cpp
+++ b/tests/test_virtual_functions.cpp
@@ -159,7 +159,7 @@ struct Base {
 
 struct DispatchIssue : Base {
     std::string dispatch() const override {
-        PYBIND11_OVERLOAD_PURE(std::string, Base, dispatch, /* no arguments */);
+        PYBIND11_OVERRIDE_PURE(std::string, Base, dispatch, /* no arguments */);
     }
 };
 


### PR DESCRIPTION
@YannickJadoul, I undid a few changes from #2325 in #2478 due to a bad rebase (I had the change backwards for some reason). This should fix it, I think.

