### PR TITLE
refactor: replace .get_type with type::handle_of

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,10 +17,16 @@ See :ref:`upgrade-guide-2.6` for help upgrading to the new version.
   This reduces binary size quite substantially (~25%).
   `#2463 <https://github.com/pybind/pybind11/pull/2463>`_
 
-* Keyword-only argument supported in Python 2 or 3 with ``py::kw_only()``.
+* Keyword-only arguments supported in Python 2 or 3 with ``py::kw_only()``.
   `#2100 <https://github.com/pybind/pybind11/pull/2100>`_
 
-* Positional-only argument supported in Python 2 or 3 with ``py::pos_only()``.
+* Positional-only arguments supported in Python 2 or 3 with ``py::pos_only()``.
+  `#2459 <https://github.com/pybind/pybind11/pull/2459>`_
+
+* Access to the type object now provided with ``py::type::of<T>()`` and
+  ``py::type::of(h)``.
+  `#2364 <https://github.com/pybind/pybind11/pull/2364>`_
+
 
 * Perfect forwarding support for methods.
   `#2048 <https://github.com/pybind/pybind11/pull/2048>`_

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -17,6 +17,9 @@ An error is now thrown when ``__init__`` is forgotten on subclasses. This was
 incorrect before, but was not checked. Add a call to ``__init__`` if it is
 missing.
 
+The undocumented ``h.get_type()`` method has been deprecated and replaced by
+``py::type::of(h)``.
+
 If ``__eq__`` defined but not ``__hash__``, ``__hash__`` is now set to
 ``None``, as in normal CPython. You should add ``__hash__`` if you intended the
 class to be hashable, possibly using the new ``py::hash`` shortcut.

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -553,7 +553,7 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
         object matrix_type = sparse_module.attr(
             rowMajor ? "csr_matrix" : "csc_matrix");
 
-        if (!obj.get_type().is(matrix_type)) {
+        if (!type::handle_of(obj).is(matrix_type)) {
             try {
                 obj = matrix_type(obj);
             } catch (const error_already_set &) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1489,7 +1489,7 @@ struct enum_base {
 
         m_base.attr("__repr__") = cpp_function(
             [](handle arg) -> str {
-                handle type = arg.get_type();
+                handle type = type::handle_of(arg);
                 object type_name = type.attr("__name__");
                 dict entries = type.attr("__entries");
                 for (const auto &kv : entries) {
@@ -1503,7 +1503,7 @@ struct enum_base {
 
         m_base.attr("name") = property(cpp_function(
             [](handle arg) -> str {
-                dict entries = arg.get_type().attr("__entries");
+                dict entries = type::handle_of(arg).attr("__entries");
                 for (const auto &kv : entries) {
                     if (handle(kv.second[int_(0)]).equal(arg))
                         return pybind11::str(kv.first);
@@ -1542,7 +1542,7 @@ struct enum_base {
         #define PYBIND11_ENUM_OP_STRICT(op, expr, strict_behavior)                     \
             m_base.attr(op) = cpp_function(                                            \
                 [](object a, object b) {                                               \
-                    if (!a.get_type().is(b.get_type()))                                \
+                    if (!type::handle_of(a).is(type::handle_of(b)))                    \
                         strict_behavior;                                               \
                     return expr;                                                       \
                 },                                                                     \
@@ -2115,7 +2115,7 @@ inline function get_type_override(const void *this_ptr, const type_info *this_ty
     handle self = get_object_handle(this_ptr, this_type);
     if (!self)
         return function();
-    handle type = self.get_type();
+    handle type = type::handle_of(self);
     auto key = std::make_pair(type.ptr(), name);
 
     /* Cache functions that aren't overridden in Python to avoid

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1580,9 +1580,7 @@ template <typename D>
 str_attr_accessor object_api<D>::doc() const { return attr("__doc__"); }
 
 template <typename D>
-handle object_api<D>::get_type() const {
-    return (PyObject *) Py_TYPE(derived().ptr());
-}
+handle object_api<D>::get_type() const {return type::handle_of(*this);}
 
 template <typename D>
 bool object_api<D>::rich_compare(object_api const &other, int value) const {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1580,7 +1580,8 @@ template <typename D>
 str_attr_accessor object_api<D>::doc() const { return attr("__doc__"); }
 
 template <typename D>
-handle object_api<D>::get_type() const {return type::handle_of(*this);}
+PYBIND11_DEPRECATED("Use py::type::of(h) instead of h.get_type()")
+handle object_api<D>::get_type() const { return type::handle_of(*this); }
 
 template <typename D>
 bool object_api<D>::rich_compare(object_api const &other, int value) const {


### PR DESCRIPTION
Closes #2388

Added a `handle_of`, which returns a handle instead, so as not to introduce a lot of reference counting where we didn't have it before.