### PR TITLE
Include what you see in pybind11.h

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -45,6 +45,10 @@
 #include "options.h"
 #include "detail/class.h"
 #include "detail/init.h"
+#include <memory>
+#include <vector>
+#include <utility>
+#include <string>
 
 #if defined(__GNUG__) && !defined(__clang__)
 #  include <cxxabi.h>


### PR DESCRIPTION
Adding some includes that were missing in pybind11.h.

Add #include <memory> for unique_ptr<> (include/pybind11/pybind11.h:1132)
Add #include <vector> for vector<> (include/pybind11/pybind11.h:1735)
Add #include <string> for string (include/pybind11/pybind11.h:2139)
Add #include <utility> for move (include/pybind11/pybind11.h:2197)

**Ignore** the name of the commit, it was a rebased version of an old PR that was rendered pointless + this new change. 