### PR TITLE
Include what is used in pybind11.h

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -41,14 +41,15 @@
 #  endif
 #endif
 
-#include "attr.h"
-#include "options.h"
-#include "detail/class.h"
-#include "detail/init.h"
 #include <memory>
 #include <vector>
 #include <string>
 #include <utility>
+
+#include "attr.h"
+#include "options.h"
+#include "detail/class.h"
+#include "detail/init.h"
 
 #if defined(__GNUG__) && !defined(__clang__)
 #  include <cxxabi.h>

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -41,15 +41,15 @@
 #  endif
 #endif
 
-#include <memory>
-#include <vector>
-#include <string>
-#include <utility>
-
 #include "attr.h"
 #include "options.h"
 #include "detail/class.h"
 #include "detail/init.h"
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <utility>
 
 #if defined(__GNUG__) && !defined(__clang__)
 #  include <cxxabi.h>

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -45,6 +45,10 @@
 #include "options.h"
 #include "detail/class.h"
 #include "detail/init.h"
+#include <memory>
+#include <vector>
+#include <string>
+#include <utility>
 
 #if defined(__GNUG__) && !defined(__clang__)
 #  include <cxxabi.h>


### PR DESCRIPTION
Adding some includes that the file 'include/pybind11/pybind11.h' is depending on, but not including itself.

Add #include <memory> for unique_ptr<> (include/pybind11/pybind11.h:1132)
Add #include <vector> for vector<> (include/pybind11/pybind11.h:1735)
Add #include <string> for string  (include/pybind11/pybind11.h:2139)
Add #include <utility> for move  (include/pybind11/pybind11.h:2197)
