### PR TITLE
[WIP] example of different fix for module keyword-like behavior in C++20

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -852,12 +852,12 @@ protected:
 };
 
 /// Wrapper for Python extension modules
-class module_ : public object {
+class module : public object {
 public:
-    PYBIND11_OBJECT_DEFAULT(module_, object, PyModule_Check)
+    PYBIND11_OBJECT_DEFAULT(module, object, PyModule_Check)
 
     /// Create a new top-level Python module with the given name and docstring
-    explicit module_(const char *name, const char *doc = nullptr) {
+    explicit module(const char *name, const char *doc = nullptr) {
         if (!options::show_user_defined_docstrings()) doc = nullptr;
 #if PY_MAJOR_VERSION >= 3
         auto *def = new PyModuleDef();
@@ -871,7 +871,7 @@ public:
         m_ptr = Py_InitModule3(name, nullptr, doc);
 #endif
         if (m_ptr == nullptr)
-            pybind11_fail("Internal error in module_::module_()");
+            pybind11_fail("Internal error in module::module()");
         inc_ref();
     }
 
@@ -881,7 +881,7 @@ public:
         details on the ``Extra&& ... extra`` argument, see section :ref:`extras`.
     \endrst */
     template <typename Func, typename... Extra>
-    module_ &def(const char *name_, Func &&f, const Extra& ... extra) {
+    module &def(const char *name_, Func &&f, const Extra& ... extra) {
         cpp_function func(std::forward<Func>(f), name(name_), scope(*this),
                           sibling(getattr(*this, name_, none())), extra...);
         // NB: allow overwriting here because cpp_function sets up a chain with the intention of
@@ -900,10 +900,10 @@ public:
             py::module m2 = m.def_submodule("sub", "A submodule of 'example'");
             py::module m3 = m2.def_submodule("subsub", "A submodule of 'example.sub'");
     \endrst */
-    module_ def_submodule(const char *name, const char *doc = nullptr) {
+    [[]] module def_submodule(const char *name, const char *doc = nullptr) {
         std::string full_name = std::string(PyModule_GetName(m_ptr))
             + std::string(".") + std::string(name);
-        auto result = reinterpret_borrow<module_>(PyImport_AddModule(full_name.c_str()));
+        auto result = reinterpret_borrow<module>(PyImport_AddModule(full_name.c_str()));
         if (doc && options::show_user_defined_docstrings())
             result.attr("__doc__") = pybind11::str(doc);
         attr(name) = result;
@@ -911,11 +911,11 @@ public:
     }
 
     /// Import and return a module or throws `error_already_set`.
-    static module_ import(const char *name) {
+    static module import(const char *name) {
         PyObject *obj = PyImport_ImportModule(name);
         if (!obj)
             throw error_already_set();
-        return reinterpret_steal<module_>(obj);
+        return reinterpret_steal<module>(obj);
     }
 
     /// Reload the module or throws `error_already_set`.
@@ -923,7 +923,7 @@ public:
         PyObject *obj = PyImport_ReloadModule(ptr());
         if (!obj)
             throw error_already_set();
-        *this = reinterpret_steal<module_>(obj);
+        *this = reinterpret_steal<module>(obj);
     }
 
     // Adds an object to the module using the given name.  Throws if an object with the given name
@@ -940,7 +940,9 @@ public:
     }
 };
 
-using module = module_;
+class module;
+using module_ = module;
+
 
 /// \ingroup python_builtins
 /// Return a dictionary representing the global variables in the current execution frame,

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -793,9 +793,9 @@ PYBIND11_NAMESPACE_END(detail)
 #define PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun) \
     public: \
         PYBIND11_DEPRECATED("Use reinterpret_borrow<"#Name">() or reinterpret_steal<"#Name">()") \
-        Name(handle h, bool is_borrowed) : Parent(is_borrowed ? Parent(h, borrowed_t{}) : Parent(h, stolen_t{})) { } \
-        Name(handle h, borrowed_t) : Parent(h, borrowed_t{}) { } \
-        Name(handle h, stolen_t) : Parent(h, stolen_t{}) { } \
+        [[]] Name(handle h, bool is_borrowed) : Parent(is_borrowed ? Parent(h, borrowed_t{}) : Parent(h, stolen_t{})) { } \
+        [[]] Name(handle h, borrowed_t) : Parent(h, borrowed_t{}) { } \
+        [[]] Name(handle h, stolen_t) : Parent(h, stolen_t{}) { } \
         PYBIND11_DEPRECATED("Use py::isinstance<py::python_type>(obj) instead") \
         bool check() const { return m_ptr != nullptr && (bool) CheckFun(m_ptr); } \
         static bool check_(handle h) { return h.ptr() != nullptr && CheckFun(h.ptr()); } \
@@ -805,22 +805,22 @@ PYBIND11_NAMESPACE_END(detail)
 #define PYBIND11_OBJECT_CVT(Name, Parent, CheckFun, ConvertFun) \
     PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun) \
     /* This is deliberately not 'explicit' to allow implicit conversion from object: */ \
-    Name(const object &o) \
+    [[]] Name(const object &o) \
     : Parent(check_(o) ? o.inc_ref().ptr() : ConvertFun(o.ptr()), stolen_t{}) \
     { if (!m_ptr) throw error_already_set(); } \
-    Name(object &&o) \
+    [[]] Name(object &&o) \
     : Parent(check_(o) ? o.release().ptr() : ConvertFun(o.ptr()), stolen_t{}) \
     { if (!m_ptr) throw error_already_set(); }
 
 #define PYBIND11_OBJECT(Name, Parent, CheckFun) \
     PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun) \
     /* This is deliberately not 'explicit' to allow implicit conversion from object: */ \
-    Name(const object &o) : Parent(o) { } \
-    Name(object &&o) : Parent(std::move(o)) { }
+    [[]] Name(const object &o) : Parent(o) { } \
+    [[]] Name(object &&o) : Parent(std::move(o)) { }
 
 #define PYBIND11_OBJECT_DEFAULT(Name, Parent, CheckFun) \
     PYBIND11_OBJECT(Name, Parent, CheckFun) \
-    Name() : Parent() { }
+    [[]] Name() : Parent() { }
 
 /// \addtogroup pytypes
 /// @{


### PR DESCRIPTION
Follow up to #2489


If a user has:

```cpp
namespace pybind11 {
    class module;
```

Then the current situation breaks. This restores support for this predecleration for now.
