### PR TITLE
fix: AppleClang 12 warnings

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -2092,7 +2092,7 @@ private:
     }
 
     void process(list &args_list, detail::args_proxy ap) {
-        for (const auto &a : ap)
+        for (auto a : ap)
             args_list.append(a);
     }
 
@@ -2124,7 +2124,7 @@ private:
     void process(list &/*args_list*/, detail::kwargs_proxy kp) {
         if (!kp)
             return;
-        for (const auto &k : reinterpret_borrow<dict>(kp)) {
+        for (auto k : reinterpret_borrow<dict>(kp)) {
             if (m_kwargs.contains(k.first)) {
 #if defined(NDEBUG)
                 multiple_values_error();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1494,7 +1494,7 @@ struct enum_base {
                 handle type = type::handle_of(arg);
                 object type_name = type.attr("__name__");
                 dict entries = type.attr("__entries");
-                for (const auto &kv : entries) {
+                for (auto kv : entries) {
                     object other = kv.second[int_(0)];
                     if (other.equal(arg))
                         return pybind11::str("{}.{}").format(type_name, kv.first);
@@ -1506,7 +1506,7 @@ struct enum_base {
         m_base.attr("name") = property(cpp_function(
             [](handle arg) -> str {
                 dict entries = type::handle_of(arg).attr("__entries");
-                for (const auto &kv : entries) {
+                for (auto kv : entries) {
                     if (handle(kv.second[int_(0)]).equal(arg))
                         return pybind11::str(kv.first);
                 }
@@ -1521,7 +1521,7 @@ struct enum_base {
                 if (((PyTypeObject *) arg.ptr())->tp_doc)
                     docstring += std::string(((PyTypeObject *) arg.ptr())->tp_doc) + "\n\n";
                 docstring += "Members:";
-                for (const auto &kv : entries) {
+                for (auto kv : entries) {
                     auto key = std::string(pybind11::str(kv.first));
                     auto comment = kv.second[int_(1)];
                     docstring += "\n\n  " + key;
@@ -1535,7 +1535,7 @@ struct enum_base {
         m_base.attr("__members__") = static_property(cpp_function(
             [](handle arg) -> dict {
                 dict entries = arg.attr("__entries"), m;
-                for (const auto &kv : entries)
+                for (auto kv : entries)
                     m[kv.first] = kv.second[int_(0)];
                 return m;
             }, name("__members__")), none(), none(), ""
@@ -1623,7 +1623,7 @@ struct enum_base {
 
     PYBIND11_NOINLINE void export_values() {
         dict entries = m_base.attr("__entries");
-        for (const auto &kv : entries)
+        for (auto kv : entries)
             m_parent.attr(kv.first) = kv.second[int_(0)];
     }
 

--- a/tests/test_operator_overloading.cpp
+++ b/tests/test_operator_overloading.cpp
@@ -89,7 +89,7 @@ std::string abs(const Vector2&) {
   // Taken from: https://github.com/RobotLocomotion/drake/commit/aaf84b46
   // TODO(eric): This could be resolved using a function / functor (e.g. `py::self()`).
   #if defined(__APPLE__) && defined(__clang__)
-    #if (__clang_major__ >= 10) && (__clang_minor__ >= 0) && (__clang_patchlevel__ >= 1)
+    #if (__clang_major__ >= 10)
       #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
     #endif
   #elif defined(__clang__)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -128,7 +128,7 @@ TEST_SUBMODULE(pytypes, m) {
         d["basic_attr"] = o.attr("basic_attr");
 
         auto l = py::list();
-        for (const auto &item : o.attr("begin_end")) {
+        for (auto item : o.attr("begin_end")) {
             l.append(item);
         }
         d["begin_end"] = l;


### PR DESCRIPTION
Fixing two sets of warnings in AppleClang 12. First is a warning that you can't really take a reference to a temporary object, so this will actually always be a copy, and should be clearly written as such.

Second is a bug where 11.0.0 or 12.0.0 or X.X.0 AppleClang will produce a warning due not passing an if statement. It's just a pragma so it should be safe even if the version doesn't match? CC @EricCousineau-TRI  (I think).

Closes #2509 