### PR TITLE
WIP Show edge case with operator overloading, reversal, and mixing

### DIFF
--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -748,7 +748,7 @@ throwing a type error.
 
     The file :file:`tests/test_operator_overloading.cpp` contains a
     complete example that demonstrates how to work with overloaded operators in
-    more detail.
+    more detail, as well of some of the nuances you may encounter.
 
 .. _pickling:
 

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -143,3 +143,9 @@ def test_overriding_eq_reset_hash():
 
         assert hash(hashable(15)) == 15
         assert hash(hashable(15)) == hash(hashable(15))
+
+
+def test_reverse_operator_ambiguity():
+    assert int() + m.ReverseA() == 1
+    assert m.ReverseB() + m.ReverseA() == 2
+    assert m.ReverseA() + m.ReverseB() == 3


### PR DESCRIPTION
Trying to show issue I encountered in:
https://github.com/RobotLocomotion/drake/pull/14098
Here:
https://github.com/RobotLocomotion/drake/blob/5369d2ead17312db6172de52a969ce7172532670/bindings/pydrake/multibody/math_py.cc#L71-L79

However, this test passes, so some possible issues with my repro (on a pybind11 fork):
- [ ] In Drake, I implement `__matmul__` by simply aliasing `multiply`, so perhaps pybind11 has some magic that helps it disambiguate?
- In Drake, I just use the operators directly, so perhaps pybind11 has some magic?
