### PR TITLE
feat: setup_helpers parallel compile

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -68,6 +68,23 @@ that is supported via a ``build_ext`` command override; it will only affect
         ext_modules=ext_modules
     )
 
+Since pybind11 does not require NumPy when building, a light-weight replacement
+for NumPy's parallel compilation distutils tool is included. Use it like this:
+
+    from pybind11.setup_helpers import ParallelCompile
+
+    # Optional multithreaded build
+    ParallelCompile("NPY_NUM_BUILD_JOBS").install()
+
+    setup(...
+
+The argument is the name of an environment variable to control the number of
+threads, such as ``NPY_NUM_BUILD_JOBS`` (as used by NumPy), though you can set
+something different if you want. You can also pass ``default=N`` to set the
+default number of threads (0 will take the number of threads available) and
+``max=N``, the maximum number of threads; if you have a large extension you may
+want set this to a memory dependent number.
+
 .. _setup_helpers-pep518:
 
 PEP 518 requirements (Pip 10+ required)

--- a/tests/extra_setuptools/test_setuphelper.py
+++ b/tests/extra_setuptools/test_setuphelper.py
@@ -10,8 +10,9 @@ DIR = os.path.abspath(os.path.dirname(__file__))
 MAIN_DIR = os.path.dirname(os.path.dirname(DIR))
 
 
+@pytest.mark.parametrize("parallel", [False, True])
 @pytest.mark.parametrize("std", [11, 0])
-def test_simple_setup_py(monkeypatch, tmpdir, std):
+def test_simple_setup_py(monkeypatch, tmpdir, parallel, std):
     monkeypatch.chdir(tmpdir)
     monkeypatch.syspath_prepend(MAIN_DIR)
 
@@ -39,13 +40,18 @@ def test_simple_setup_py(monkeypatch, tmpdir, std):
                 cmdclass["build_ext"] = build_ext
 
 
+            parallel = {parallel}
+            if parallel:
+                from pybind11.setup_helpers import ParallelCompile
+                ParallelCompile().install()
+
             setup(
                 name="simple_setup_package",
                 cmdclass=cmdclass,
                 ext_modules=ext_modules,
             )
             """
-        ).format(MAIN_DIR=MAIN_DIR, std=std),
+        ).format(MAIN_DIR=MAIN_DIR, std=std, parallel=parallel),
         encoding="ascii",
     )
 


### PR DESCRIPTION
One of the most common needs for compiling a setuptools extensions is a parallel compile step. For tools like Cython that require NumPy to be present, NumPy provided a parallel compiler function, `distutils.ccompiler.CCompiler.compile = numpy.distutils.ccompiler.CCompiler_compile`; just adding that makes your build compile in parallel, and is controllable via the `NPY_NUM_BUILD_JOBS ` environment variable. However, pybind11 goes through a great deal of trouble to avoid forcing NumPy to be present when compiling, so this is not available to pybind11 extensions. This provides a lightweight replacement for it, also inspired by cppimport and some stack overflow discussions.

For boost-histogram, a parallel compile is about 4-7 times faster than sequential on my MacBook. About 2x faster on GHA.

---

Make a parallel compile function. Inspired by `numpy.distutils.ccompiler.CCompiler_compile` and `cppimport`. This takes several arguments that allow you to customize the compile function created:

* `envvar`: Set an environment variable to control the compilation threads, like `NPY_NUM_BUILD_JOBS` or something customized to your extension.
* `default`: 0 will automatically multithread, or 1 will only multithread if the envvar is set.
* `max`: The limit for automatic multithreading if non-zero.

To use:

```python
ParallelCompile("NPY_NUM_BUILD_JOBS").install()
```