### PR TITLE
fix: warning on latest AppleClang

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1489,7 +1489,7 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 
 inline str enum_name(handle arg) {
     dict entries = arg.get_type().attr("__entries");
-    for (const auto &kv : entries) {
+    for (auto kv : entries) {
         if (handle(kv.second[int_(0)]).equal(arg))
             return pybind11::str(kv.first);
     }


### PR DESCRIPTION
Fixed in #2510 but reintroduced on one line by #2126