### PR TITLE
Unify Python 2 & 3 py::module constructor, and make contructor with pre-allocated PyModuleDef private

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -311,7 +311,7 @@ extern "C" {
 #define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                \
     static PyModuleDef PYBIND11_CONCAT(pybind11_module_def_, name);
 #define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
-        auto m = pybind11::module(                                             \
+        auto m = pybind11::detail::create_top_level_module(                    \
             PYBIND11_TOSTRING(name), nullptr,                                  \
             &PYBIND11_CONCAT(pybind11_module_def_, name));
 #else


### PR DESCRIPTION
Up for discussion, whether this is worth the addition (@rwgk, @bstaletic, @henryiii, ... anyone else?). As far as I'm concerned, keeping the public, non-`detail` API clean, is something that might pay off in the future? And being able to use the pybind11 API from Python 3 and at least having it compile in 2 (before CI is getting tested), is a nice thing to have?

First stab at the general idea (as suggested here: https://github.com/pybind/pybind11/pull/2413#discussion_r481509064). I do hope we can make it a little bit cleaner.

I'll add this to the 2.6.0 milestone, since it would be nice to have a decision on it, so we don't release an API that we later change.