### PR TITLE
CMake: check for distutils presence when querying python extension module suffix

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -91,7 +91,13 @@ execute_process(
   COMMAND "${${_Python}_EXECUTABLE}" "-c"
           "from distutils import sysconfig; print(sysconfig.get_config_var('SO'))"
   OUTPUT_VARIABLE _PYTHON_MODULE_EXTENSION
-  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  ERROR_VARIABLE _PYTHON_MODULE_EXTENSION_ERR
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if (_PYTHON_MODULE_EXTENSION STREQUAL "")
+  message(FATAL_ERROR "pybind11 could not query the module file extension, likely the 'distutils'"
+         "package is not installed. Full error message:\n${_PYTHON_MODULE_EXTENSION_ERR}")
+endif()
 
 # This needs to be available for the pybind11_extension function
 set(PYTHON_MODULE_EXTENSION


### PR DESCRIPTION
On very incomplete python installations (e.g. within Docker), it's
possible that distutils is not installed. In that case, the
``execute_command`` statement that queries distutils for the Python
module extension fails, and pybind11 uses the empty string. This commit
adds an extra check that causes a CMake failure with more actionable
information (just spent a lot of time trying to track down this problem :))