### PR TITLE
fix: conda-forge patch

### DIFF
--- a/tools/setup_global.py.in
+++ b/tools/setup_global.py.in
@@ -39,15 +39,25 @@ headers = main_headers + detail_headers
 cmdclass = {"install_headers": InstallHeadersNested}
 $extra_cmd
 
+# This will _not_ affect installing from wheels,
+# only building wheels or installing from SDist.
+# Primarily intended on Windows, where this is sometimes
+# customized (for example, conda-forge uses Library/)
+base = os.environ.get("PYBIND11_GLOBAL_PREFIX", "")
+
+# Must have a separator
+if base and not base.endswith("/"):
+    base += "/"
+
 setup(
     name="pybind11_global",
     version="$version",
     packages=[],
     headers=headers,
     data_files=[
-        ("share/cmake/pybind11", cmake_files),
-        ("include/pybind11", main_headers),
-        ("include/pybind11/detail", detail_headers),
+        (base + "share/cmake/pybind11", cmake_files),
+        (base + "include/pybind11", main_headers),
+        (base + "include/pybind11/detail", detail_headers),
     ],
     cmdclass=cmdclass,
 )


### PR DESCRIPTION
Conda forge adds a special "Library" prefix to the library location on Windows, see [the docs](https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html):

> Unix-style packages on Windows, which are usually statically linked to executables, are built in a special Library directory under the build prefix. The environment variables listed in the following table are defined only on Windows.

See https://github.com/conda-forge/pybind11-feedstock/pull/52

This provides a hook to this for systems like conda-forge. 