### PR TITLE
ci: label PRs with changelog-needed

### DIFF
--- a/.github/labeler_merged.yml
+++ b/.github/labeler_merged.yml
@@ -1,0 +1,2 @@
+needs changelog:
+  - all: ['!docs/changelog.rst']

--- a/.github/workflows/pr_merged.yml
+++ b/.github/workflows/pr_merged.yml
@@ -1,0 +1,15 @@
+name: PR merged
+on:
+  pull_request:
+    - closed
+
+jobs:
+  label-merged:
+    name: Changelog needed
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        configuration-path: .github/labeler_merged.yml


### PR DESCRIPTION
Adds a changelog-needed label to all PRs that merge but don't have a changed changelog.
