### PR TITLE
Add std::valaray to docs/advanced/cast/stl.rst

### DIFF
--- a/docs/advanced/cast/stl.rst
+++ b/docs/advanced/cast/stl.rst
@@ -5,7 +5,7 @@ Automatic conversion
 ====================
 
 When including the additional header file :file:`pybind11/stl.h`, conversions
-between ``std::vector<>``/``std::deque<>``/``std::list<>``/``std::array<>``,
+between ``std::vector<>``/``std::deque<>``/``std::list<>``/``std::array<>``/``std::valarray<>``,
 ``std::set<>``/``std::unordered_set<>``, and
 ``std::map<>``/``std::unordered_map<>`` and the Python ``list``, ``set`` and
 ``dict`` data structures are automatically enabled. The types ``std::pair<>``


### PR DESCRIPTION
Cleaning up notifications, I came across this comment by @darkdragon-001: https://github.com/pybind/pybind11/pull/545#issuecomment-674075325

Bit silly in size as PR, but otherwise, we'll probably forget about it again. If necessary, I can still extend this PR by messing up some markdown and adding "an awesome project" in some places?
