### PR TITLE
fix: find_import didn't work properly for classic tools

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: pre-commit/action@v2.0.0
       with:
         # Slow hooks are marked with manual - slow is okay here, run them too
-        extra_args: --hook-stage manual
+        extra_args: --hook-stage manual --all-files
 
   clang-tidy:
     name: Clang-Tidy

--- a/docs/cmake/index.rst
+++ b/docs/cmake/index.rst
@@ -6,4 +6,3 @@ install with ``find_package(pybind11 CONFIG)``. The interface provided in
 either case is functionally identical.
 
 .. cmake-module:: ../../tools/pybind11Config.cmake.in
-

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@ commonmark==0.9.1
 recommonmark==0.6.0
 sphinx==3.2.1
 sphinx_rtd_theme==0.5.0
-sphinxcontrib-svg2pdfconverter==1.1.0
 sphinxcontrib-moderncmakedomain==3.13
+sphinxcontrib-svg2pdfconverter==1.1.0

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -196,7 +196,7 @@ else()
 
 endif()
 
-# --------------------- pybind11_check_import -------------------------------
+# --------------------- pybind11_find_import -------------------------------
 
 if(NOT _pybind11_nopython)
   # Check to see if modules are importable. Use REQUIRED to force an error if

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -94,9 +94,10 @@ execute_process(
   ERROR_VARIABLE _PYTHON_MODULE_EXTENSION_ERR
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-if (_PYTHON_MODULE_EXTENSION STREQUAL "")
-  message(FATAL_ERROR "pybind11 could not query the module file extension, likely the 'distutils'"
-         "package is not installed. Full error message:\n${_PYTHON_MODULE_EXTENSION_ERR}")
+if(_PYTHON_MODULE_EXTENSION STREQUAL "")
+  message(
+    FATAL_ERROR "pybind11 could not query the module file extension, likely the 'distutils'"
+                "package is not installed. Full error message:\n${_PYTHON_MODULE_EXTENSION_ERR}")
 endif()
 
 # This needs to be available for the pybind11_extension function

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -191,4 +191,6 @@ function(pybind11_add_module target_name)
 endfunction()
 
 # Provide general way to call common Python commands in "common" file.
-set(_Python PYTHON)
+set(_Python
+    PYTHON
+    CACHE INTERNAL "" FORCE)


### PR DESCRIPTION
`pybind11_find_import` didn't work correctly with the classic tools. Also fixed one place that the old name was left, and reran style.