### PR TITLE
Use PyModule_New in module_ public constructor

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -272,8 +272,10 @@ extern "C" {
 
     .. code-block:: cpp
 
+        static pybind11::module_::module_def example_module_def;
         PYBIND11_PLUGIN(example) {
-            pybind11::module_ m("example", "pybind11 example plugin");
+            auto m = pybind11::module_::create_extension_module(
+                "example", "pybind11 example plugin", &example_module_def);
             /// Set up bindings here
             return m.ptr();
         }


### PR DESCRIPTION
Alternative to the plan in #2534 and #2413: rather than making the `py::module` constructor private, we can turn it into a "normal" `py::object` constructor, and use `PyModule_New` to create a new `module` object (in the same way as `types.ModuleType("abc", "def")` would do so).

Modules create with `PyModule_New` *cannot* be used as extension modules (unfortunately). Python (3) complains if a module object is returned that doesn't have a `def`, so this is very unfortunately not a solution for the `static PyModuleDef` :-(

Things to note/judge/discuss:
- The old `PYBIND11_PLUGIN` example will nót work anymore (because the `py::module_` constructor has changed). This would also be the case if the constructor would be made private (though things would then just stop compiling). But, things don't segfault, and `PYBIND11_PLUGIN` has been deprecated for ages.
- For all other uses, except for `PYBIND11_PLUGIN`, things should work exactly the same. `PYBIND11_MODULE` now uses `pybind11::module_::create_extension_module`, so anything that's returned as top-level extension module is correctly constructed. For all other uses, the `module_` constructor should work.
- I've gotten rid of `detail::create_top_level_module` and just moved it to a public `static module_::create_extension_module`. Downside: Python 2 and 3 still differ in signature, but maybe I'm getting over that. Could be reverted, as well.
- One test uses the `py::module_` constructor. That's why I started thinking about keeping this constructor. That test still works, as the new constructor still creates a valid module object.

I'm adding this to v2.6.0, as a way of making sure we come up with a plan on what to include now and what to postpone for the future. E.g., right now, we could judge to just deprecate the public `module_` constructors, have users be warned in 2.6.0, and add this change in 2.7.0?