### PR TITLE
Deprecate public constructors of module_ class

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -19,4 +19,5 @@ QUIET                  = YES
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = NO
 PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
-                         PY_MAJOR_VERSION=3
+                         PY_MAJOR_VERSION=3 \
+                         PYBIND11_NOINLINE

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -261,20 +261,6 @@ extern "C" {
             return nullptr;                                                    \
         }                                                                      \
 
-#if PY_MAJOR_VERSION >= 3
-#define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                \
-    static PyModuleDef PYBIND11_CONCAT(pybind11_module_def_, name);
-#define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
-        auto m = ::pybind11::detail::create_top_level_module(                  \
-            PYBIND11_TOSTRING(name), nullptr,                                  \
-            &PYBIND11_CONCAT(pybind11_module_def_, name));
-#else
-#define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)
-#define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
-        auto m = ::pybind11::detail::create_top_level_module(                  \
-            PYBIND11_TOSTRING(name), nullptr);
-#endif
-
 /** \rst
     ***Deprecated in favor of PYBIND11_MODULE***
 
@@ -324,13 +310,16 @@ extern "C" {
         }
 \endrst */
 #define PYBIND11_MODULE(name, variable)                                        \
-    PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                    \
+    static ::pybind11::module_::module_def                                     \
+        PYBIND11_CONCAT(pybind11_module_def_, name);                           \
     PYBIND11_MAYBE_UNUSED                                                      \
     static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);  \
     PYBIND11_PLUGIN_IMPL(name) {                                               \
         PYBIND11_CHECK_PYTHON_VERSION                                          \
         PYBIND11_ENSURE_INTERNALS_READY                                        \
-        PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
+        auto m = ::pybind11::module_::create_extension_module(                 \
+            PYBIND11_TOSTRING(name), nullptr,                                  \
+            &PYBIND11_CONCAT(pybind11_module_def_, name));                     \
         try {                                                                  \
             PYBIND11_CONCAT(pybind11_init_, name)(m);                          \
             return m.ptr();                                                    \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -261,6 +261,20 @@ extern "C" {
             return nullptr;                                                    \
         }                                                                      \
 
+#if PY_MAJOR_VERSION >= 3
+#define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                \
+    static PyModuleDef PYBIND11_CONCAT(pybind11_module_def_, name);
+#define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
+        auto m = ::pybind11::detail::create_top_level_module(                  \
+            PYBIND11_TOSTRING(name), nullptr,                                  \
+            &PYBIND11_CONCAT(pybind11_module_def_, name));
+#else
+#define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)
+#define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
+        auto m = ::pybind11::detail::create_top_level_module(                  \
+            PYBIND11_TOSTRING(name), nullptr);
+#endif
+
 /** \rst
     ***Deprecated in favor of PYBIND11_MODULE***
 
@@ -309,19 +323,6 @@ extern "C" {
             });
         }
 \endrst */
-#if PY_MAJOR_VERSION >= 3
-#define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                \
-    static PyModuleDef PYBIND11_CONCAT(pybind11_module_def_, name);
-#define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
-        auto m = ::pybind11::detail::create_top_level_module(                  \
-            PYBIND11_TOSTRING(name), nullptr,                                  \
-            &PYBIND11_CONCAT(pybind11_module_def_, name));
-#else
-#define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)
-#define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
-        auto m = ::pybind11::detail::create_top_level_module(                  \
-            PYBIND11_TOSTRING(name), nullptr);
-#endif
 #define PYBIND11_MODULE(name, variable)                                        \
     PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                    \
     PYBIND11_MAYBE_UNUSED                                                      \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -313,18 +313,19 @@ extern "C" {
 #define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                \
     static PyModuleDef PYBIND11_CONCAT(pybind11_module_def_, name);
 #define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
-        auto m = pybind11::detail::create_top_level_module(                    \
+        auto m = ::pybind11::detail::create_top_level_module(                  \
             PYBIND11_TOSTRING(name), nullptr,                                  \
             &PYBIND11_CONCAT(pybind11_module_def_, name));
 #else
 #define PYBIND11_DETAIL_MODULE_STATIC_DEF(name)
 #define PYBIND11_DETAIL_MODULE_CREATE(name)                                    \
-        auto m = pybind11::module_(PYBIND11_TOSTRING(name));
+        auto m = ::pybind11::detail::create_top_level_module(                  \
+            PYBIND11_TOSTRING(name), nullptr);
 #endif
 #define PYBIND11_MODULE(name, variable)                                        \
     PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                    \
     PYBIND11_MAYBE_UNUSED                                                      \
-    static void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module_ &);     \
+    static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);  \
     PYBIND11_PLUGIN_IMPL(name) {                                               \
         PYBIND11_CHECK_PYTHON_VERSION                                          \
         PYBIND11_ENSURE_INTERNALS_READY                                        \
@@ -334,7 +335,7 @@ extern "C" {
             return m.ptr();                                                    \
         } PYBIND11_CATCH_INIT_EXCEPTIONS                                       \
     }                                                                          \
-    void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module_ &variable)
+    void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &variable)
 
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -46,10 +46,13 @@
         }
  \endrst */
 #define PYBIND11_EMBEDDED_MODULE(name, variable)                                \
-    PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                     \
+    static ::pybind11::module_::module_def                                      \
+        PYBIND11_CONCAT(pybind11_module_def_, name);                            \
     static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);   \
     static PyObject PYBIND11_CONCAT(*pybind11_init_wrapper_, name)() {          \
-        PYBIND11_DETAIL_MODULE_CREATE(name)                                     \
+        auto m = ::pybind11::module_::create_extension_module(                  \
+            PYBIND11_TOSTRING(name), nullptr,                                   \
+            &PYBIND11_CONCAT(pybind11_module_def_, name));                      \
         try {                                                                   \
             PYBIND11_CONCAT(pybind11_init_, name)(m);                           \
             return m.ptr();                                                     \

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -45,26 +45,27 @@
             });
         }
  \endrst */
-#define PYBIND11_EMBEDDED_MODULE(name, variable)                              \
-    static void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module_ &);    \
-    static PyObject PYBIND11_CONCAT(*pybind11_init_wrapper_, name)() {        \
-        auto m = pybind11::module_(PYBIND11_TOSTRING(name));                   \
-        try {                                                                 \
-            PYBIND11_CONCAT(pybind11_init_, name)(m);                         \
-            return m.ptr();                                                   \
-        } catch (pybind11::error_already_set &e) {                            \
-            PyErr_SetString(PyExc_ImportError, e.what());                     \
-            return nullptr;                                                   \
-        } catch (const std::exception &e) {                                   \
-            PyErr_SetString(PyExc_ImportError, e.what());                     \
-            return nullptr;                                                   \
-        }                                                                     \
-    }                                                                         \
-    PYBIND11_EMBEDDED_MODULE_IMPL(name)                                       \
-    pybind11::detail::embedded_module PYBIND11_CONCAT(pybind11_module_, name) \
-                              (PYBIND11_TOSTRING(name),             \
-                               PYBIND11_CONCAT(pybind11_init_impl_, name));   \
-    void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module_ &variable)
+#define PYBIND11_EMBEDDED_MODULE(name, variable)                                \
+    PYBIND11_DETAIL_MODULE_STATIC_DEF(name)                                     \
+    static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);   \
+    static PyObject PYBIND11_CONCAT(*pybind11_init_wrapper_, name)() {          \
+        PYBIND11_DETAIL_MODULE_CREATE(name)                                     \
+        try {                                                                   \
+            PYBIND11_CONCAT(pybind11_init_, name)(m);                           \
+            return m.ptr();                                                     \
+        } catch (::pybind11::error_already_set &e) {                            \
+            PyErr_SetString(PyExc_ImportError, e.what());                       \
+            return nullptr;                                                     \
+        } catch (const std::exception &e) {                                     \
+            PyErr_SetString(PyExc_ImportError, e.what());                       \
+            return nullptr;                                                     \
+        }                                                                       \
+    }                                                                           \
+    PYBIND11_EMBEDDED_MODULE_IMPL(name)                                         \
+    ::pybind11::detail::embedded_module PYBIND11_CONCAT(pybind11_module_, name) \
+                              (PYBIND11_TOSTRING(name),                         \
+                               PYBIND11_CONCAT(pybind11_init_impl_, name));     \
+    void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &variable)
 
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -874,7 +874,7 @@ public:
     PYBIND11_OBJECT_DEFAULT(module_, object, PyModule_Check)
 
     /// Create a new top-level Python module with the given name and docstring
-    PYBIND11_DEPRECATED("Use PYBIND11_MODULE, module_::def_submodule, or module_::import instead")
+    PYBIND11_DEPRECATED("Use PYBIND11_MODULE or module_::create_extension_module instead")
     explicit module_(const char *name, const char *doc = nullptr) {
 #if PY_MAJOR_VERSION >= 3
         *this = create_extension_module(name, doc, new PyModuleDef());

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -976,18 +976,19 @@ public:
             /* m_free */     nullptr
         };
         auto m = PyModule_Create(def);
-        if (m == nullptr)
-            pybind11_fail("Internal error in module_::create_extension_module()");
-        // TODO: Should be reinterpret_steal, but Python also steals it again when returned from PyInit_...
-        return reinterpret_borrow<module_>(m);
 #else
         // Ignore module_def *def; only necessary for Python 3
         (void) def;
         auto m = Py_InitModule3(name, nullptr, options::show_user_defined_docstrings() ? doc : nullptr);
-        if (m == nullptr)
-            pybind11_fail("Internal error in module_::create_extension_module()");
-        return reinterpret_borrow<module_>(m);
 #endif
+        if (m == nullptr) {
+            if (PyErr_Occurred())
+                throw error_already_set();
+            pybind11_fail("Internal error in module_::create_extension_module()");
+        }
+        // TODO: Sould be reinterpret_steal for Python 3, but Python also steals it again when returned from PyInit_...
+        //       For Python 2, reinterpret_borrow is correct.
+        return reinterpret_borrow<module_>(m);
     }
 };
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -944,11 +944,13 @@ public:
         *this = reinterpret_steal<module_>(obj);
     }
 
-    // Adds an object to the module using the given name.  Throws if an object with the given name
-    // already exists.
-    //
-    // overwrite should almost always be false: attempting to overwrite objects that pybind11 has
-    // established will, in most cases, break things.
+    /** \rst
+        Adds an object to the module using the given name.  Throws if an object with the given name
+        already exists.
+
+        ``overwrite`` should almost always be false: attempting to overwrite objects that pybind11 has
+        established will, in most cases, break things.
+    \endrst */
     PYBIND11_NOINLINE void add_object(const char *name, handle obj, bool overwrite = false) {
         if (!overwrite && hasattr(*this, name))
             pybind11_fail("Error during initialization: multiple incompatible definitions with name \"" +

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -62,7 +62,11 @@ TEST_SUBMODULE(modules, m) {
         class Dupe3 { };
         class DupeException { };
 
-        auto dm = py::module_("dummy");
+#if PY_MAJOR_VERSION >= 3
+        auto dm = py::detail::create_top_level_module("dummy", nullptr, new PyModuleDef);
+#else
+        auto dm = py::detail::create_top_level_module("dummy", nullptr);
+#endif
         auto failures = py::list();
 
         py::class_<Dupe1>(dm, "Dupe1");

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -62,11 +62,8 @@ TEST_SUBMODULE(modules, m) {
         class Dupe3 { };
         class DupeException { };
 
-#if PY_MAJOR_VERSION >= 3
-        auto dm = py::detail::create_top_level_module("dummy", nullptr, new PyModuleDef);
-#else
-        auto dm = py::detail::create_top_level_module("dummy", nullptr);
-#endif
+        // Go ahead and leak, until we have a non-leaking py::module_ constructor
+        auto dm = py::module_::create_extension_module("dummy", nullptr, new py::module_::module_def);
         auto failures = py::list();
 
         py::class_<Dupe1>(dm, "Dupe1");


### PR DESCRIPTION
OK, so, this does a few things. A summary:

Main goal
- Deprecate current public `module_` constructors (see discussion in #2534 and #2413 on how they actually are not/should not be used). The useful public constructor for Python 2 is moved to `detail::create_top_level_module`.
- Use the new way of creating modules (i.e, with a `static PyModuleDef`) also for `PYBIND11_EMBEDDED_MODULE`. (This is kind of a consequence of the previous bullet, since it the deprecation warnings make it clear this wasn't changed yet in #2413.)

Minor extra cleanup
- Fully qualify the `pybind11` namespace by using `::pybind11` in these module-related macros.
- Turn the comment above `module_::add_object` into a valid doxygen-documentation of the function (and teach Doxygen that  `PYBIND11_NOINLINE` isn't really a relevant part of the signature to generate docs).


Two more questions to be answered:
1. Should this still be part of 2.6.0? I'd argue "yes", since
    a) I don't see a lot of uses for a plain `py::module_` constructor (@rwgk also found out that `module_`'s constructor is hardly used in Google's code base, which strengthens the belief that there's not a lot of use for that constructor), and
    b) this will allow us to maybe reuse this constructor later? (cfr. #2551), and
    c) what's the point of postponing this, and delaying the pain (if any). That's what deprecation is for, no?

2. Should we have `pybind11::detail::create_top_level_module` or `static pybind11::module_::create_extension_module`? I.e., is this a public interface or an internal one? I know I was the one arguing for the latter, before, but I think this being a public, but  "named" constructor would work for me, as well.

EDIT: `pybind11::detail::create_top_level_module` was moved to `static pybind11::module_::create_extension_module`, with a unified signature, though @rwkg's suggestion of a typedef!