### PR TITLE
ci: test on Windows 3.8 and 3.9 (mostly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,6 @@ jobs:
             python: pypy3
             arch: x64
 
-            # Currently broken on embed_test
-          - runs-on: windows-latest
-            python: 3.8
-            arch: x64
-          - runs-on: windows-latest
-            python: 3.9
-            arch: x64
-
     name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • ${{ matrix.arch }} ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}
 
@@ -132,6 +124,8 @@ jobs:
       run: cmake --build . --target pytest -j 2
 
     - name: C++11 tests
+      # TODO: Figure out how to load the DLL on Python 3.8+
+      if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9))"
       run: cmake --build .  --target cpptest -j 2
 
     - name: Interface test C++11
@@ -158,6 +152,8 @@ jobs:
       run: cmake --build build2 --target pytest
 
     - name: C++ tests
+      # TODO: Figure out how to load the DLL on Python 3.8+
+      if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9))"
       run: cmake --build build2 --target cpptest
 
     - name: Interface test

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -90,7 +90,7 @@ In addition, the following changes may be of interest:
   pybind11 will cause pybind11 to use the new Python mechanisms instead of its
   own custom search, based on a patched version of classic ``FindPythonInterp``
   / ``FindPythonLibs``. In the future, this may become the default. A recent
-  (3.15+ or 3.18.2+) version of CMake recommended.
+  (3.15+ or 3.18.2+) version of CMake is recommended.
 
 
 


### PR DESCRIPTION
Enable 3.8 and 3.9 Windows testing, just drop the cpptest since I don't know how to get the DLLs to load in 3.8+.

This didn't work, though I thought it should have:

```diff
diff --git a/tests/test_embed/test_interpreter.cpp b/tests/test_embed/test_interpreter.cpp
index 944334c..017e160 100644
--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -107,6 +107,11 @@ bool has_pybind11_internals_static() {
​
 TEST_CASE("Restart the interpreter") {
     // Verify pre-restart state.
+    py::module_ os = py::module_::import("os");
+    if(py::hasattr(os, "add_dll_directory")) {
+        py::object cwd = os.attr("path").attr("abspath")(".");
+        os.attr("add_dll_directory")(cwd);
+    }
     REQUIRE(py::module_::import("widget_module").attr("add")(1, 2).cast<int>() == 3);
     REQUIRE(has_pybind11_internals_builtin());
     REQUIRE(has_pybind11_internals_static());
```