### PR TITLE
Do not use abi::__forced_unwind with libc++, even with gcc instead of clang

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -741,7 +741,7 @@ protected:
         } catch (error_already_set &e) {
             e.restore();
             return nullptr;
-#if defined(__GNUG__) && !defined(__clang__)
+#if defined(__GNUG__) && !defined(__clang__) && !defined(_LIBCPP_VERSION)
         } catch ( abi::__forced_unwind& ) {
             throw;
 #endif

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -741,7 +741,7 @@ protected:
         } catch (error_already_set &e) {
             e.restore();
             return nullptr;
-#if defined(__GNUG__) && !defined(__clang__) && !defined(_LIBCPP_VERSION)
+#if defined(__GNUG__) && !defined(_LIBCPP_VERSION)
         } catch ( abi::__forced_unwind& ) {
             throw;
 #endif


### PR DESCRIPTION
Fixes #2568 