### PR TITLE
CI: Intel icc/icpc via oneAPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,14 +409,14 @@ jobs:
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 
     - name: Add ICC & Python 3
-      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-python cmake
+      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro cmake python3-dev python3-numpy python3-pytest python3-pip libeigen3-dev
 
     - name: Update pip & pytest
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade pytest
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pytest
 
     - name: Configure
       shell: bash
@@ -428,7 +428,7 @@ jobs:
         -DDOWNLOAD_EIGEN=OFF    \
         -DCMAKE_CXX_STANDARD=11             \
         -DCMAKE_CXX_COMPILER=$(which icpc)  \
-        -DPYTHON_EXECUTABLE=$(python -c "import sys; print(sys.executable)")
+        -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,21 +396,20 @@ jobs:
       fail-fast: false
 
     name: "🐍 3 • ICC latest • x64"
-    container: "gcc"
 
     steps:
     - uses: actions/checkout@v1
 
     - name: Add apt repo
       run: |
-        apt-get update
-        apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
+        sudo apt-get update
+        sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 
     - name: Add ICC & Python 3
-      run: apt-get update; apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-python libc6-dev
+      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-python
 
     - name: Update pip & pytest
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,7 @@ jobs:
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake -S . -B build     \
         -DPYBIND11_WERROR=ON    \
-        -DDOWNLOAD_CATCH=ON     \
+        -DDOWNLOAD_CATCH=OFF    \
         -DDOWNLOAD_EIGEN=ON     \
         -DCMAKE_CXX_STANDARD=11             \
         -DCMAKE_CXX_COMPILER=$(which icpc)  \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,8 +442,7 @@ jobs:
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         sudo service apport stop
-        cmake --build build --target pytest; ls; ls /home/runner/work/pybind11/pybind11/build/tests
-        exit 1
+        cmake --build build --target check
 
     - name: C++ tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,8 +429,8 @@ jobs:
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake -S . -B build     \
         -DPYBIND11_WERROR=ON    \
-        -DDOWNLOAD_CATCH=OFF    \
-        -DDOWNLOAD_EIGEN=ON     \
+        -DDOWNLOAD_CATCH=ON     \
+        -DDOWNLOAD_EIGEN=OFF    \
         -DCMAKE_CXX_STANDARD=11             \
         -DCMAKE_CXX_COMPILER=$(which icpc)  \
         -DPYTHON_EXECUTABLE=$(python -c "import sys; print(sys.executable)")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,7 @@ jobs:
     - name: Interface test
       run: cmake3 --build build --target test_cmake_build
 
+
   # Testing on GCC using the GCC docker images (only recent images supported)
   gcc:
     runs-on: ubuntu-latest
@@ -386,6 +387,78 @@ jobs:
 
     - name: Interface test
       run: cmake --build build --target test_cmake_build
+
+
+  # Testing on ICC using the oneAPI apt repo
+  icc:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    name: "🐍 3 • ICC latest • x64"
+    container: "gcc"
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Add apt repo
+      run: |
+        apt-get update
+        apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
+
+    - name: Add ICC & Python 3
+      run: apt-get update; apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-python
+
+    - name: Update pip & pytest
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade pytest
+
+    - name: Setup CMake 3.18
+      uses: jwlawson/actions-setup-cmake@v1.4
+      with:
+        cmake-version: 3.18
+
+    - name: Configure
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        cmake -S . -B build     \
+        -DPYBIND11_WERROR=ON    \
+        -DDOWNLOAD_CATCH=ON     \
+        -DDOWNLOAD_EIGEN=ON     \
+        -DCMAKE_CXX_STANDARD=11             \
+        -DCMAKE_CXX_COMPILER=$(which icpc)  \
+        -DPYTHON_EXECUTABLE=$(python -c "import sys; print(sys.executable)")
+
+    - name: Build
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        cmake --build build -j 2
+
+    - name: Python tests
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        cmake --build build --target pytest
+
+    - name: C++ tests
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        cmake --build build --target cpptest
+
+    - name: Interface test
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        cmake --build build --target test_cmake_build
 
 
   # Testing on CentOS (manylinux uses a centos base, and this is an easy way

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,7 @@ jobs:
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 
     - name: Add ICC & Python 3
-      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-python
+      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-python cmake
 
     - name: Update pip & pytest
       shell: bash
@@ -417,11 +417,6 @@ jobs:
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         python -m pip install --upgrade pip
         python -m pip install --upgrade pytest
-
-    - name: Setup CMake 3.18
-      uses: jwlawson/actions-setup-cmake@v1.4
-      with:
-        cmake-version: 3.18
 
     - name: Configure
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,7 @@ jobs:
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 
     - name: Add ICC & Python 3
-      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro cmake python3-dev python3-numpy python3-pytest python3-pip
+      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic cmake python3-dev python3-numpy python3-pytest python3-pip
 
     - name: Update pip & pytest
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,7 +441,9 @@ jobs:
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build --target pytest
+        sudo service apport stop
+        cmake --build build --target pytest; ls; ls /home/runner/work/pybind11/pybind11/build/tests
+        exit 1
 
     - name: C++ tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,7 @@ jobs:
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 
     - name: Add ICC & Python 3
-      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro cmake python3-dev python3-numpy python3-pytest python3-pip libeigen3-dev
+      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro cmake python3-dev python3-numpy python3-pytest python3-pip
 
     - name: Update pip & pytest
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
 
   # Testing on ICC using the oneAPI apt repo
   icc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,12 +411,15 @@ jobs:
     - name: Add ICC & Python 3
       run: sudo apt-get update; sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic cmake python3-dev python3-numpy python3-pytest python3-pip
 
-    - name: Update pip & pytest
+    - name: Update pip
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade pytest==5.4.3
+
+    - name: Install dependencies
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        python3 -m pip install -r tests/requirements.txt --prefer-binary
 
     - name: Configure
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
 
   # Testing on ICC using the oneAPI apt repo
   icc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,7 @@ jobs:
         -DDOWNLOAD_EIGEN=OFF    \
         -DCMAKE_CXX_STANDARD=11             \
         -DCMAKE_CXX_COMPILER=$(which icpc)  \
+        -DCMAKE_VERBOSE_MAKEFILE=ON         \
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,6 +418,7 @@ jobs:
         python3 -m pip install --upgrade pip
 
     - name: Install dependencies
+      run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         python3 -m pip install -r tests/requirements.txt --prefer-binary
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,7 @@ jobs:
         echo "deb https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
 
     - name: Add ICC & Python 3
-      run: apt-get update; apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-python
+      run: apt-get update; apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-python libc6-dev
 
     - name: Update pip & pytest
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade pytest
+        python3 -m pip install --upgrade pytest==5.4.3
 
     - name: Configure
       shell: bash

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -185,7 +185,7 @@ TEST_SUBMODULE(builtin_casters, m) {
 
     // test_bool_caster
     m.def("bool_passthrough", [](bool arg) { return arg; });
-    m.def("bool_passthrough_noconvert", [](bool arg) { return arg; }, py::arg().noconvert());
+    m.def("bool_passthrough_noconvert", [](bool arg) { return arg; }, py::arg{}.noconvert());
 
     // test_reference_wrapper
     m.def("refwrap_builtin", [](std::reference_wrapper<int> p) { return 10 * p.get(); });

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -183,6 +183,8 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("load_nullptr_t", [](std::nullptr_t) {}); // not useful, but it should still compile
     m.def("cast_nullptr_t", []() { return std::nullptr_t{}; });
 
+    // [workaround(intel)] ICC 20/21 breaks with py::arg().stuff, using py::arg{}.stuff works.
+
     // test_bool_caster
     m.def("bool_passthrough", [](bool arg) { return arg; });
     m.def("bool_passthrough_noconvert", [](bool arg) { return arg; }, py::arg{}.noconvert());

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -119,8 +119,8 @@ TEST_SUBMODULE(callbacks, m) {
 
     class AbstractBase {
     public:
-        // ICC can't handle this being defaulted
-        virtual ~AbstractBase() {}; // NOLINT
+        // [workaround(intel)] = default does not work here
+        virtual ~AbstractBase() {};  // NOLINT(modernize-use-equals-default)
         virtual unsigned int func() = 0;
     };
     m.def("func_accepting_func_accepting_base", [](std::function<double(AbstractBase&)>) { });

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -119,7 +119,7 @@ TEST_SUBMODULE(callbacks, m) {
 
     class AbstractBase {
     public:
-        virtual ~AbstractBase() = default;
+        virtual ~AbstractBase() {};
         virtual unsigned int func() = 0;
     };
     m.def("func_accepting_func_accepting_base", [](std::function<double(AbstractBase&)>) { });

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -119,7 +119,8 @@ TEST_SUBMODULE(callbacks, m) {
 
     class AbstractBase {
     public:
-        virtual ~AbstractBase() {};
+        // ICC can't handle this being defaulted
+        virtual ~AbstractBase() {}; // NOLINT
         virtual unsigned int func() = 0;
     };
     m.def("func_accepting_func_accepting_base", [](std::function<double(AbstractBase&)>) { });

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -323,6 +323,7 @@ TEST_SUBMODULE(class_, m) {
 
     class PublicistB : public ProtectedB {
     public:
+    ~PublicistB() override {};
         using ProtectedB::foo;
     };
 

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -323,7 +323,8 @@ TEST_SUBMODULE(class_, m) {
 
     class PublicistB : public ProtectedB {
     public:
-        ~PublicistB() override {};  // NOLINT(modernize-use-equals-default) breaks ICPC
+        // [workaround(intel)] = default does not work here
+        ~PublicistB() override {};  // NOLINT(modernize-use-equals-default)
         using ProtectedB::foo;
     };
 

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -323,7 +323,7 @@ TEST_SUBMODULE(class_, m) {
 
     class PublicistB : public ProtectedB {
     public:
-    ~PublicistB() override {};
+        ~PublicistB() override {};  // NOLINT(modernize-use-equals-default) breaks ICPC
         using ProtectedB::foo;
     };
 

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -101,16 +101,16 @@ TEST_SUBMODULE(custom_type_casters, m) {
     };
     py::class_<ArgInspector>(m, "ArgInspector")
         .def(py::init<>())
-        .def("f", &ArgInspector::f, py::arg{}, py::arg{} = ArgAlwaysConverts())
-        .def("g", &ArgInspector::g, "a"_a.noconvert(), "b"_a, "c"_a.noconvert()=13, "d"_a=ArgInspector2(), py::arg{} = ArgAlwaysConverts())
-        .def_static("h", &ArgInspector::h, py::arg{}.noconvert(), py::arg{} = ArgAlwaysConverts())
+        .def("f", &ArgInspector::f, py::arg(), py::arg() = ArgAlwaysConverts())
+        .def("g", &ArgInspector::g, "a"_a.noconvert(), "b"_a, "c"_a.noconvert()=13, "d"_a=ArgInspector2(), py::arg() = ArgAlwaysConverts())
+        .def_static("h", &ArgInspector::h, py::arg{}.noconvert(), py::arg() = ArgAlwaysConverts())
         ;
     m.def("arg_inspect_func", [](ArgInspector2 a, ArgInspector1 b, ArgAlwaysConverts) { return a.arg + "\n" + b.arg; },
-            py::arg{}.noconvert(false), py::arg_v{nullptr, ArgInspector1()}.noconvert(true), py::arg{} = ArgAlwaysConverts());
+            py::arg{}.noconvert(false), py::arg_v(nullptr, ArgInspector1()).noconvert(true), py::arg() = ArgAlwaysConverts());
 
-    m.def("floats_preferred", [](double f) { return 0.5 * f; }, py::arg{"f"});
+    m.def("floats_preferred", [](double f) { return 0.5 * f; }, py::arg("f"));
     m.def("floats_only", [](double f) { return 0.5 * f; }, py::arg{"f"}.noconvert());
-    m.def("ints_preferred", [](int i) { return i / 2; }, py::arg{"i"});
+    m.def("ints_preferred", [](int i) { return i / 2; }, py::arg("i"));
     m.def("ints_only", [](int i) { return i / 2; }, py::arg{"i"}.noconvert());
 
     // test_custom_caster_destruction

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -101,17 +101,17 @@ TEST_SUBMODULE(custom_type_casters, m) {
     };
     py::class_<ArgInspector>(m, "ArgInspector")
         .def(py::init<>())
-        .def("f", &ArgInspector::f, py::arg(), py::arg() = ArgAlwaysConverts())
-        .def("g", &ArgInspector::g, "a"_a.noconvert(), "b"_a, "c"_a.noconvert()=13, "d"_a=ArgInspector2(), py::arg() = ArgAlwaysConverts())
-        .def_static("h", &ArgInspector::h, py::arg().noconvert(), py::arg() = ArgAlwaysConverts())
+        .def("f", &ArgInspector::f, py::arg{}, py::arg{} = ArgAlwaysConverts())
+        .def("g", &ArgInspector::g, "a"_a.noconvert(), "b"_a, "c"_a.noconvert()=13, "d"_a=ArgInspector2(), py::arg{} = ArgAlwaysConverts())
+        .def_static("h", &ArgInspector::h, py::arg{}.noconvert(), py::arg{} = ArgAlwaysConverts())
         ;
     m.def("arg_inspect_func", [](ArgInspector2 a, ArgInspector1 b, ArgAlwaysConverts) { return a.arg + "\n" + b.arg; },
-            py::arg().noconvert(false), py::arg_v(nullptr, ArgInspector1()).noconvert(true), py::arg() = ArgAlwaysConverts());
+            py::arg{}.noconvert(false), py::arg_v{nullptr, ArgInspector1()}.noconvert(true), py::arg{} = ArgAlwaysConverts());
 
-    m.def("floats_preferred", [](double f) { return 0.5 * f; }, py::arg("f"));
-    m.def("floats_only", [](double f) { return 0.5 * f; }, py::arg("f").noconvert());
-    m.def("ints_preferred", [](int i) { return i / 2; }, py::arg("i"));
-    m.def("ints_only", [](int i) { return i / 2; }, py::arg("i").noconvert());
+    m.def("floats_preferred", [](double f) { return 0.5 * f; }, py::arg{"f"});
+    m.def("floats_only", [](double f) { return 0.5 * f; }, py::arg{"f"}.noconvert());
+    m.def("ints_preferred", [](int i) { return i / 2; }, py::arg{"i"});
+    m.def("ints_only", [](int i) { return i / 2; }, py::arg{"i"}.noconvert());
 
     // test_custom_caster_destruction
     // Test that `take_ownership` works on types with a custom type caster when given a pointer

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -99,6 +99,7 @@ TEST_SUBMODULE(custom_type_casters, m) {
         }
         static ArgInspector2 h(ArgInspector2 a, ArgAlwaysConverts) { return a; }
     };
+    // [workaround(intel)] ICC 20/21 breaks with py::arg().stuff, using py::arg{}.stuff works.
     py::class_<ArgInspector>(m, "ArgInspector")
         .def(py::init<>())
         .def("f", &ArgInspector::f, py::arg(), py::arg() = ArgAlwaysConverts())
@@ -108,10 +109,10 @@ TEST_SUBMODULE(custom_type_casters, m) {
     m.def("arg_inspect_func", [](ArgInspector2 a, ArgInspector1 b, ArgAlwaysConverts) { return a.arg + "\n" + b.arg; },
             py::arg{}.noconvert(false), py::arg_v(nullptr, ArgInspector1()).noconvert(true), py::arg() = ArgAlwaysConverts());
 
-    m.def("floats_preferred", [](double f) { return 0.5 * f; }, py::arg("f"));
-    m.def("floats_only", [](double f) { return 0.5 * f; }, py::arg{"f"}.noconvert());
-    m.def("ints_preferred", [](int i) { return i / 2; }, py::arg("i"));
-    m.def("ints_only", [](int i) { return i / 2; }, py::arg{"i"}.noconvert());
+    m.def("floats_preferred", [](double f) { return 0.5 * f; }, "f"_a);
+    m.def("floats_only", [](double f) { return 0.5 * f; }, "f"_a.noconvert());
+    m.def("ints_preferred", [](int i) { return i / 2; }, "i"_a);
+    m.def("ints_only", [](int i) { return i / 2; }, "i"_a.noconvert());
 
     // test_custom_caster_destruction
     // Test that `take_ownership` works on types with a custom type caster when given a pointer

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -273,6 +273,7 @@ TEST_SUBMODULE(eigen, m) {
     m.def("cpp_ref_r", [](py::handle m) { return m.cast<Eigen::Ref<MatrixXdR>>()(1, 0); });
     m.def("cpp_ref_any", [](py::handle m) { return m.cast<py::EigenDRef<Eigen::MatrixXd>>()(1, 0); });
 
+    // [workaround(intel)] ICC 20/21 breaks with py::arg().stuff, using py::arg{}.stuff works.
 
     // test_nocopy_wrapper
     // Test that we can prevent copying into an argument that would normally copy: First a version

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -280,17 +280,17 @@ TEST_SUBMODULE(eigen, m) {
     m.def("get_elem", &get_elem);
     // Now this alternative that calls the tells pybind to fail rather than copy:
     m.def("get_elem_nocopy", [](Eigen::Ref<const Eigen::MatrixXd> m) -> double { return get_elem(m); },
-            py::arg().noconvert());
+            py::arg{}.noconvert());
     // Also test a row-major-only no-copy const ref:
     m.def("get_elem_rm_nocopy", [](Eigen::Ref<const Eigen::Matrix<long, -1, -1, Eigen::RowMajor>> &m) -> long { return m(2, 1); },
-            py::arg().noconvert());
+            py::arg{}.noconvert());
 
     // test_issue738
     // Issue #738: 1xN or Nx1 2D matrices were neither accepted nor properly copied with an
     // incompatible stride value on the length-1 dimension--but that should be allowed (without
     // requiring a copy!) because the stride value can be safely ignored on a size-1 dimension.
-    m.def("iss738_f1", &adjust_matrix<const Eigen::Ref<const Eigen::MatrixXd> &>, py::arg().noconvert());
-    m.def("iss738_f2", &adjust_matrix<const Eigen::Ref<const Eigen::Matrix<double, -1, -1, Eigen::RowMajor>> &>, py::arg().noconvert());
+    m.def("iss738_f1", &adjust_matrix<const Eigen::Ref<const Eigen::MatrixXd> &>, py::arg{}.noconvert());
+    m.def("iss738_f2", &adjust_matrix<const Eigen::Ref<const Eigen::Matrix<double, -1, -1, Eigen::RowMajor>> &>, py::arg{}.noconvert());
 
     // test_issue1105
     // Issue #1105: when converting from a numpy two-dimensional (Nx1) or (1xN) value into a dense

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -322,6 +322,8 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         m.def("should_fail", [](int, UnregisteredType) {}, py::arg(), py::arg() = UnregisteredType());
     });
 
+    // [workaround(intel)] ICC 20/21 breaks with py::arg().stuff, using py::arg{}.stuff works.
+
     // test_accepts_none
     py::class_<NoneTester, std::shared_ptr<NoneTester>>(m, "NoneTester")
         .def(py::init<>());
@@ -336,8 +338,8 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     m.def("ok_none4", &none4, py::arg{}.none(true));
     m.def("ok_none5", &none5);
 
-    m.def("no_none_kwarg", &none2, py::arg{"a"}.none(false));
-    m.def("no_none_kwarg_kw_only", &none2, py::kw_only(), py::arg{"a"}.none(false));
+    m.def("no_none_kwarg", &none2, "a"_a.none(false));
+    m.def("no_none_kwarg_kw_only", &none2, py::kw_only(), "a"_a.none(false));
 
     // test_str_issue
     // Issue #283: __str__ called on uninitialized instance when constructor arguments invalid

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -336,8 +336,8 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     m.def("ok_none4", &none4, py::arg{}.none(true));
     m.def("ok_none5", &none5);
 
-    m.def("no_none_kwarg", &none2, py::arg("a").none(false));
-    m.def("no_none_kwarg_kw_only", &none2, py::kw_only(), py::arg("a").none(false));
+    m.def("no_none_kwarg", &none2, py::arg{"a"}.none(false));
+    m.def("no_none_kwarg_kw_only", &none2, py::kw_only(), py::arg{"a"}.none(false));
 
     // test_str_issue
     // Issue #283: __str__ called on uninitialized instance when constructor arguments invalid

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -325,15 +325,15 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     // test_accepts_none
     py::class_<NoneTester, std::shared_ptr<NoneTester>>(m, "NoneTester")
         .def(py::init<>());
-    m.def("no_none1", &none1, py::arg().none(false));
-    m.def("no_none2", &none2, py::arg().none(false));
-    m.def("no_none3", &none3, py::arg().none(false));
-    m.def("no_none4", &none4, py::arg().none(false));
-    m.def("no_none5", &none5, py::arg().none(false));
+    m.def("no_none1", &none1, py::arg{}.none(false));
+    m.def("no_none2", &none2, py::arg{}.none(false));
+    m.def("no_none3", &none3, py::arg{}.none(false));
+    m.def("no_none4", &none4, py::arg{}.none(false));
+    m.def("no_none5", &none5, py::arg{}.none(false));
     m.def("ok_none1", &none1);
-    m.def("ok_none2", &none2, py::arg().none(true));
+    m.def("ok_none2", &none2, py::arg{}.none(true));
     m.def("ok_none3", &none3);
-    m.def("ok_none4", &none4, py::arg().none(true));
+    m.def("ok_none4", &none4, py::arg{}.none(true));
     m.def("ok_none5", &none5);
 
     m.def("no_none_kwarg", &none2, py::arg("a").none(false));

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -258,6 +258,8 @@ TEST_SUBMODULE(numpy_array, sm) {
     sm.def("overloaded2", [](py::array_t<std::complex<float>>) { return "float complex"; });
     sm.def("overloaded2", [](py::array_t<float>) { return "float"; });
 
+    // [workaround(intel)] ICC 20/21 breaks with py::arg().stuff, using py::arg{}.stuff works.
+
     // Only accept the exact types:
     sm.def("overloaded3", [](py::array_t<int>) { return "int"; }, py::arg{}.noconvert());
     sm.def("overloaded3", [](py::array_t<double>) { return "double"; }, py::arg{}.noconvert());
@@ -419,20 +421,20 @@ TEST_SUBMODULE(numpy_array, sm) {
            py::arg("a"));
     sm.def("accept_double_noconvert",
            [](py::array_t<double, 0>) {},
-           py::arg{"a"}.noconvert());
+           "a"_a.noconvert());
     sm.def("accept_double_forcecast_noconvert",
            [](py::array_t<double, py::array::forcecast>) {},
-           py::arg{"a"}.noconvert());
+           "a"_a.noconvert());
     sm.def("accept_double_c_style_noconvert",
            [](py::array_t<double, py::array::c_style>) {},
-           py::arg{"a"}.noconvert());
+           "a"_a.noconvert());
     sm.def("accept_double_c_style_forcecast_noconvert",
            [](py::array_t<double, py::array::forcecast | py::array::c_style>) {},
-           py::arg{"a"}.noconvert());
+           "a"_a.noconvert());
     sm.def("accept_double_f_style_noconvert",
            [](py::array_t<double, py::array::f_style>) {},
-           py::arg{"a"}.noconvert());
+           "a"_a.noconvert());
     sm.def("accept_double_f_style_forcecast_noconvert",
            [](py::array_t<double, py::array::forcecast | py::array::f_style>) {},
-           py::arg{"a"}.noconvert());
+           "a"_a.noconvert());
 }

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -259,8 +259,8 @@ TEST_SUBMODULE(numpy_array, sm) {
     sm.def("overloaded2", [](py::array_t<float>) { return "float"; });
 
     // Only accept the exact types:
-    sm.def("overloaded3", [](py::array_t<int>) { return "int"; }, py::arg().noconvert());
-    sm.def("overloaded3", [](py::array_t<double>) { return "double"; }, py::arg().noconvert());
+    sm.def("overloaded3", [](py::array_t<int>) { return "int"; }, py::arg{}.noconvert());
+    sm.def("overloaded3", [](py::array_t<double>) { return "double"; }, py::arg{}.noconvert());
 
     // Make sure we don't do unsafe coercion (e.g. float to int) when not using forcecast, but
     // rather that float gets converted via the safe (conversion to double) overload:
@@ -284,7 +284,7 @@ TEST_SUBMODULE(numpy_array, sm) {
         for (py::ssize_t i = 0; i < r.shape(0); i++)
             for (py::ssize_t j = 0; j < r.shape(1); j++)
                 r(i, j) += v;
-    }, py::arg().noconvert(), py::arg());
+    }, py::arg{}.noconvert(), py::arg());
 
     sm.def("proxy_init3", [](double start) {
         py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
@@ -338,7 +338,7 @@ TEST_SUBMODULE(numpy_array, sm) {
         for (py::ssize_t i = 0; i < r.shape(0); i++)
             for (py::ssize_t j = 0; j < r.shape(1); j++)
                 r(i, j) += v;
-    }, py::arg().noconvert(), py::arg());
+    }, py::arg{}.noconvert(), py::arg());
     sm.def("proxy_init3_dyn", [](double start) {
         py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
         auto r = a.mutable_unchecked();
@@ -419,20 +419,20 @@ TEST_SUBMODULE(numpy_array, sm) {
            py::arg("a"));
     sm.def("accept_double_noconvert",
            [](py::array_t<double, 0>) {},
-           py::arg("a").noconvert());
+           py::arg{"a"}.noconvert());
     sm.def("accept_double_forcecast_noconvert",
            [](py::array_t<double, py::array::forcecast>) {},
-           py::arg("a").noconvert());
+           py::arg{"a"}.noconvert());
     sm.def("accept_double_c_style_noconvert",
            [](py::array_t<double, py::array::c_style>) {},
-           py::arg("a").noconvert());
+           py::arg{"a"}.noconvert());
     sm.def("accept_double_c_style_forcecast_noconvert",
            [](py::array_t<double, py::array::forcecast | py::array::c_style>) {},
-           py::arg("a").noconvert());
+           py::arg{"a"}.noconvert());
     sm.def("accept_double_f_style_noconvert",
            [](py::array_t<double, py::array::f_style>) {},
-           py::arg("a").noconvert());
+           py::arg{"a"}.noconvert());
     sm.def("accept_double_f_style_forcecast_noconvert",
            [](py::array_t<double, py::array::forcecast | py::array::f_style>) {},
-           py::arg("a").noconvert());
+           py::arg{"a"}.noconvert());
 }


### PR DESCRIPTION
Add testing for Intel icc/icpc via the oneAPI images.
Intel oneAPI is in a late beta stage, currently shipping oneAPI beta09 with ICC 20.2.