### PR TITLE
Add support for custom smart pointers that don't have default constructors

### DIFF
--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -92,8 +92,8 @@ class non_null_ptr {
     std::shared_ptr<T> impl;
 public:
     non_null_ptr() = delete;
-    non_null_ptr(const non_null_ptr<T>& src) = default;
-    non_null_ptr(non_null_ptr<T>&& src) = default;
+    non_null_ptr(const non_null_ptr<T>&) = default;
+    non_null_ptr(non_null_ptr<T>&&) = default;
     template <typename U>
     non_null_ptr(U&& u) : impl(std::forward<U>(u)) {
         if (!impl)

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -289,3 +289,11 @@ def test_shared_ptr_gc():
     pytest.gc_collect()
     for i, v in enumerate(el.get()):
         assert i == v.value()
+
+
+def test_non_null_ptr():
+    ib = m.IntBox(3)
+    nnp = m.NonNullPointers()
+    ib2 = nnp.get()
+    assert ib2.value == 4
+    assert nnp.echo(ib) == 3


### PR DESCRIPTION
Trying to use [`PYBIND11_DECLARE_HOLDER_TYPE`](https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html#custom-smart-pointers) to register a smart pointer type that has no default constructor (such as [`gsl::not_null<T>`](https://github.com/microsoft/GSL/blob/master/include/gsl/pointers#L48)) results in a long, difficult-to-read compiler error ultimately caused by [the `holder` field in `struct copyable_holder_caster`](https://github.com/pybind/pybind11/blob/f537093/include/pybind11/cast.h#L1570) trying to default-construct an instance of `holder_type`.

We're working around this in our code with an explicit specialization of `copyable_holder_caster` that uses `unique_ptr<holder_type>` instead of using `holder_type` directly. But, this requires us to copy & paste the entire body of `copyable_holder_caster` (which is rather long) except for the last line. 

This PR attempts to create a more elegant solution by factoring out the storage from `copyable_holder_caster` to a separate `copyable_holder_base` that contains the `holder` and has a SFINAE partial-specialization that uses `unique_ptr<holder_type>` instead of just `holder_type` when `!std::is_default_constructible<holder_type>::value`.

Thanks!