### PR TITLE
Throw error_already_set in py::len on failing PyObject_Length

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1530,13 +1530,17 @@ inline memoryview memoryview::from_buffer(
 
 /// \addtogroup python_builtins
 /// @{
+
+/// Get the length of a Python object.
 inline size_t len(handle h) {
     ssize_t result = PyObject_Length(h.ptr());
     if (result < 0)
-        pybind11_fail("Unable to compute length of object");
+        throw error_already_set();
     return (size_t) result;
 }
 
+/// Get the length hint of a Python object.
+/// Returns 0 when this cannot be determined.
 inline size_t len_hint(handle h) {
 #if PY_VERSION_HEX >= 0x03040000
     ssize_t result = PyObject_LengthHint(h.ptr(), 0);

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -407,4 +407,7 @@ TEST_SUBMODULE(pytypes, m) {
             buf, static_cast<ssize_t>(strlen(buf)));
     });
 #endif
+
+    // test_builtin_functions
+    m.def("get_len", [](py::handle h) { return py::len(h); });
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -430,4 +430,5 @@ def test_builtin_functions():
     assert m.get_len([i for i in range(42)]) == 42
     with pytest.raises(TypeError) as exc_info:
         m.get_len(i for i in range(42))
-    assert str(exc_info.value) == "object of type 'generator' has no len()"
+    assert str(exc_info.value) in ["object of type 'generator' has no len()",
+                                   "'generator' has no length"]  # PyPy

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -424,3 +424,10 @@ def test_memoryview_from_memory():
     assert isinstance(view, memoryview)
     assert view.format == 'B'
     assert bytes(view) == b'\xff\xe1\xab\x37'
+
+
+def test_builtin_functions():
+    assert m.get_len([i for i in range(42)]) == 42
+    with pytest.raises(TypeError) as exc_info:
+        m.get_len(i for i in range(42))
+    assert str(exc_info.value) == "object of type 'generator' has no len()"


### PR DESCRIPTION
Found by @Stehsegler and reported [on Gitter﻿](https://gitter.im/pybind/Lobby?at=5f82f20a99e1ab4dd1f18adb).

Previously, `pybind11_fail` would throw an error when `PyObject_Length` indicates an error is thrown, but the error indicator is not cleared. A better approach seems to be to just pass on the Python error.

This should even be backwards compatible, since `py::error_already_set` is a subclass of `std::runtime_error` and `pybind11_fail` would just throw an instance of `std::runtime_error`. So try-catch statements in C++ should continue to work?

Can this still go into 2.6.0, as it's kind of a bugfix? I'll add it to the milestone, but if it's too late, we can just remove it again.