### PR TITLE
fix: valgrind-detected after-freeing access of PyMethodDef (macOS Python 3.9.0 segfaults)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,6 @@ jobs:
             python: pypy3
             arch: x64
 
-            # TODO: renable
-            # Currently segfaults on macOS Python 3.9
-          - runs-on: macos-latest
-            python: 3.9
-            arch: x64
-
     name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • ${{ matrix.arch }} ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -466,7 +466,7 @@ protected:
             }
             if (rec->def) {
                 std::free(const_cast<char *>(rec->def->ml_doc));
-                delete rec->def;
+                //delete rec->def;
             }
             delete rec;
             rec = next;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -452,6 +452,10 @@ protected:
 
     /// When a cpp_function is GCed, release any memory allocated by pybind11
     static void destruct(detail::function_record *rec) {
+        #if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 9
+            static bool is_zero = Py_GetVersion()[4] != '0';
+        #endif
+
         while (rec) {
             detail::function_record *next = rec->next;
             if (rec->free_data)
@@ -470,7 +474,7 @@ protected:
                 // If loaded on 3.9.0, let these leak (use Python 3.9.1 to fix)
                 // See https://github.com/python/cpython/pull/22670
                 #if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 9
-                    if (Py_GetVersion()[4] != '0')
+                    if (is_zero)
                         delete rec->def;
                 #else
                     delete rec->def;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -466,7 +466,15 @@ protected:
             }
             if (rec->def) {
                 std::free(const_cast<char *>(rec->def->ml_doc));
-                //delete rec->def;
+                // Python 3.9.0 decref's these in the wrong order; rec->def
+                // If loaded on 3.9.0, let these leak (use Python 3.9.1 to fix)
+                // See https://github.com/python/cpython/pull/22670
+                #if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 9
+                    if (Py_GetVersion()[4] != '0')
+                        delete rec->def;
+                #else
+                    delete rec->def;
+                #endif
             }
             delete rec;
             rec = next;


### PR DESCRIPTION
Python 3.9 added [this line to `meth_dealloc`](https://github.com/python/cpython/blob/c230fde8475e4e5581e74a4235654d17ccf4cff8/Objects/methodobject.c#L169), unfortunately for us, 2 lines too low.

Short summary of what goes wrong:
- pybind11 stores the `function_record` in a `capsule`, and passes this as the `self` argument to `PyCFunction_NewEx`
- The `PyCFunctionObject` object nicely keeps track of that, but decrefs `m->m_self` 2 lines before decrefing `PyCFunction_GET_CLASS(m)`. The `capsule` with the `function_record` with the `PyModuleDef` gets freed.
- `PyCFunction_GET_CLASS` accesses `m_ml -> ml_flags`, where `m_ml` now points to something that was destructed.
- _BOOM_

I guess this being so close explains why we don't often get a crash here. Maybe macOS protects its memory better?

- 61e40f6 demonstrates that leaking the `PyModuleDef` resolves the Python 3.9 crash on macOS.
- d10f154 would be a (the?) solution, if it weren't calling `cpp_function` during the construction of a `cpp_function` during the construction of a `cpp_function` during the construction of a `cpp_function` during ... and thus blowing up the stack.

Closes #2558

Related issue on bugs.python.org: https://bugs.python.org/issue41237
PR on CPython adding the line to `meth_dealloc` that makes things crash: https://github.com/python/cpython/pull/19936 