### PR TITLE
fix: Intel 18+ required

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ grown beyond Boost.Python in many ways, leading to dramatically simpler
 binding code in many common situations.
 
 Tutorial and reference documentation is provided at
-`pybind11.readthedocs.io <https://pybind11.readthedocs.io/en/latest>`_).
+`pybind11.readthedocs.io <https://pybind11.readthedocs.io/en/latest>`_.
 A PDF version of the manual is available
 `here <https://media.readthedocs.org/pdf/pybind11/master/pybind11.pdf>`_.
 And the source code is always available at
@@ -113,9 +113,7 @@ Supported compilers
    newer)
 2. GCC 4.8 or newer
 3. Microsoft Visual Studio 2015 Update 3 or newer
-4. Intel C++ compiler 17 or newer (16 with pybind11 v2.0 and 15 with
-   pybind11 v2.0 and a
-   `workaround <https://github.com/pybind/pybind11/issues/276>`_)
+4. Intel C++ compiler 18 or newer
 5. Cygwin/GCC (tested on 2.5.1)
 6. NVCC (CUDA 11 tested)
 7. NVIDIA PGI (20.7 and 20.9 tested)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,7 +48,7 @@ New features:
   to have a member with the same name as a parent (such as an enum).
   `#2335 <https://github.com/pybind/pybind11/pull/2335>`_
 
-Assisting in writing more correct code:
+Code correctness features:
 
 * Error now thrown when ``__init__`` is forgotten on subclasses.
   `#2152 <https://github.com/pybind/pybind11/pull/2152>`_
@@ -97,7 +97,7 @@ Packaging / building improvements:
     site-packages location in your ``CMAKE_MODULE_PATH``. Or you can use the
     new ``pybind11[global]`` extra when you install ``pybind11``, which
     installs the CMake files and headers into your base environment in the
-    standard location
+    standard location.
 
   * ``pybind11-config`` is another way to write ``python -m pybind11`` if you
     have your PATH set up.
@@ -213,6 +213,8 @@ Smaller or developer focused features:
 
 * NVIDIA PGI compilers now supported and tested in CI.
   `#2475 <https://github.com/pybind/pybind11/pull/2475>`_
+
+* Intel 18 now explicitly required.
 
 * Extensive style checking in CI, with `pre-commit`_ support. Code
   modernization, checked by clang-tidy.

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1512,14 +1512,7 @@ public:
     // see issue #2180
     explicit operator type&() { return *(static_cast<type *>(this->value)); }
     explicit operator holder_type*() { return std::addressof(holder); }
-
-    // Workaround for Intel compiler bug
-    // see pybind11 issue 94
-    #if defined(__ICC) || defined(__INTEL_COMPILER)
-    operator holder_type&() { return holder; }
-    #else
     explicit operator holder_type&() { return holder; }
-    #endif
 
     static handle cast(const holder_type &src, return_value_policy, handle) {
         const auto *ptr = holder_helper<holder_type>::get(src);

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -47,8 +47,8 @@
 
 // Compiler version assertions
 #if defined(__INTEL_COMPILER)
-#  if __INTEL_COMPILER < 1700
-#    error pybind11 requires Intel C++ compiler v17 or newer
+#  if __INTEL_COMPILER < 1800
+#    error pybind11 requires Intel C++ compiler v18 or newer
 #  endif
 #elif defined(__clang__) && !defined(__apple_build_version__)
 #  if __clang_major__ < 3 || (__clang_major__ == 3 && __clang_minor__ < 3)
@@ -508,10 +508,10 @@ template <bool... Bs> using select_indices = typename select_indices_impl<index_
 template <bool B> using bool_constant = std::integral_constant<bool, B>;
 template <typename T> struct negation : bool_constant<!T::value> { };
 
-// PGI cannot detect operator delete with the "compatible" void_t impl, so
+// PGI/Intel cannot detect operator delete with the "compatible" void_t impl, so
 // using the new one (C++14 defect, so generally works on newer compilers, even
 // if not in C++17 mode)
-#if defined(__PGIC__)
+#if defined(__PGIC__) || defined(__INTEL_COMPILER)
 template<typename... > using void_t = void;
 #else
 template <typename...> struct void_t_impl { using type = void; };

--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -163,7 +163,10 @@ def test_alias_delay_initialization2(capture):
 # PyPy: Reference count > 1 causes call with noncopyable instance
 # to fail in ncv1.print_nc()
 @pytest.mark.xfail("env.PYPY")
-@pytest.mark.skipif(not hasattr(m, "NCVirt"), reason="NCVirt test broken on ICPC")
+@pytest.mark.skipif(
+    not hasattr(m, "NCVirt"),
+    reason="NCVirt does not work on Intel/PGI/NVCC compilers"
+)
 def test_move_support():
     class NCVirtExt(m.NCVirt):
         def get_noncopyable(self, a, b):


### PR DESCRIPTION
Drops an old workaround for #94, and adds a workaround developed for PGI in #2479.

I've tried to build 2.5.0, 2.4.0, 2.3.0, 2.2.0, and 2.0.0 on Intel 17, and none of them can build the py::vectorize code in the tests. Intel 18 seems to be the first one that can. So I think we should simply say we support Intel 18+, and drop the list of older versions that support Intel 16 and 15, since the support wasn’t even complete and these versions are quite old now anyway.


- fix: Intel 18+ fully supported
- fix: Intel compiler workaround no longer needed

Also gathering a bit of readme cleanup I'd been collecting.

Tested on 18.0 and 19.1.