### PR TITLE
docs: PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description
+
+<!-- Include relevant issues or PRs here, describe what changed and why -->
+
+
+## Suggested changelog entry:
+
+<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->
+
+```rst
+
+```
+
+<!-- If the upgrade guide needs updating, note that here too -->


### PR DESCRIPTION
I've restored the classic changelog needed job, since it was not adding labels correctly, and if it did, syncing would make it hard to manage. As an alternative, this is a PR template that includes a spot for a changelog entry that we can manually collect.