### PR TITLE
docs: some final 2.6.0 updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,16 @@ pybind11 — Seamless operability between C++11 and Python
 
 .. warning::
 
-    Python 3.9.0 sometimes segfaults on exiting after running pybind11 modules,
-    mostly on macOS. Upgrade to pybind11 2.6.0 for a workaround or Python
-    3.9.1 when it is released to fix.
+   Combining older versions of pybind11 (< 2.6.0) with the brand-new Python
+   3.9.0 will trigger undefined behavior that typically manifests as crashes
+   during interpreter shutdown (but could also destroy your data. **You have been
+   warned.**)
+
+   We recommend that you wait for Python 3.9.1 slated for release in December,
+   which will include a `fix <https://github.com/python/cpython/pull/22670>`_
+   that resolves this problem.  In the meantime, please update to the latest
+   version of pybind11 (2.6.0 or newer), which includes a temporary workaround
+   specifically when Python 3.9.0 is detected at runtime.
 
 **pybind11** is a lightweight header-only library that exposes C++ types
 in Python and vice versa, mainly to create Python bindings of existing

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,12 @@ pybind11 — Seamless operability between C++11 and Python
 
 |Latest Documentation Status| |Stable Documentation Status| |Gitter chat| |CI| |Build status|
 
+.. warning::
+
+    Python 3.9.0 sometimes segfaults on exiting after running pybind11 modules,
+    mostly on macOS. Upgrade to pybind11 2.6.0 for a workaround or Python
+    3.9.1 when it is released to fix.
+
 **pybind11** is a lightweight header-only library that exposes C++ types
 in Python and vice versa, mainly to create Python bindings of existing
 C++ code. Its goals and syntax are similar to the excellent
@@ -114,8 +120,9 @@ Supported compilers
 2. GCC 4.8 or newer
 3. Microsoft Visual Studio 2015 Update 3 or newer
 4. Intel C++ compiler 18 or newer
+   (`possible issue <https://github.com/pybind/pybind11/pull/2573>`_) on 20.2)
 5. Cygwin/GCC (tested on 2.5.1)
-6. NVCC (CUDA 11 tested)
+6. NVCC (CUDA 11.0 tested)
 7. NVIDIA PGI (20.7 and 20.9 tested)
 
 About

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -140,7 +140,7 @@ Packaging / building improvements:
   size quite substantially (~25% on some platforms).
   `#2463 <https://github.com/pybind/pybind11/pull/2463>`_
 
-Smaller or developer focused features:
+Smaller or developer focused features and fixes:
 
 * Moved ``mkdoc.py`` to a new repo, `pybind11-mkdoc`_. There are no longer
   submodules in the main repo.
@@ -182,6 +182,9 @@ Smaller or developer focused features:
 * Fix crash when different instances share the same pointer of the same type.
   `#2252 <https://github.com/pybind/pybind11/pull/2252>`_
 
+* Fix for ``py::len`` not clearing Python's error state when it fails and throws.
+  `#2575 <https://github.com/pybind/pybind11/pull/2575>`_
+
 * Bugfixes related to more extensive testing, new GitHub Actions CI.
   `#2321 <https://github.com/pybind/pybind11/pull/2321>`_
 
@@ -196,16 +199,22 @@ Smaller or developer focused features:
   requested ordering.
   `#2484 <https://github.com/pybind/pybind11/pull/2484>`_
 
-* PyPy fixes, PyPy 7.3.x now supported, including PyPy3.
+* Avoid a segfault on some compilers when types are removed in Python.
+  `#2564 <https://github.com/pybind/pybind11/pull/2564>`_
+
+* PyPy fixes, PyPy 7.3.x now supported, including now supporting PyPy3.
   `#2146 <https://github.com/pybind/pybind11/pull/2146>`_
 
-* CPython 3.9 fixes.
+* CPython 3.9.0 workaround for undefined behavior (macOS segfault).
+  `#2576 <https://github.com/pybind/pybind11/pull/2576>`_
+
+* CPython 3.9 warning fixes.
   `#2253 <https://github.com/pybind/pybind11/pull/2253>`_
 
-* More C++20 support.
+* Improved C++20 support.
   `#2489 <https://github.com/pybind/pybind11/pull/2489>`_
 
-* Debug Python interpreter support.
+* Improved but still incomplete debug Python interpreter support.
   `#2025 <https://github.com/pybind/pybind11/pull/2025>`_
 
 * NVCC (CUDA 11) now supported and tested in CI.
@@ -214,7 +223,8 @@ Smaller or developer focused features:
 * NVIDIA PGI compilers now supported and tested in CI.
   `#2475 <https://github.com/pybind/pybind11/pull/2475>`_
 
-* Intel 18 now explicitly required.
+* At least Intel 18 now explicitly required when compiling with Intel.
+  `#2577 <https://github.com/pybind/pybind11/pull/2577>`_
 
 * Extensive style checking in CI, with `pre-commit`_ support. Code
   modernization, checked by clang-tidy.

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -31,18 +31,11 @@ These are issues that hopefully will one day be fixed, but currently are
 unsolved. If you know how to help with one of these issues, contributions
 are welcome!
 
-- The test suite currently segfaults on macOS and Python 3.9.0 when exiting the
-  interpreter.  This was suspected to be related to the cross module GIL code,
-  but could be a broader Python 3.9.0 issue.
-  `#2558 <https://github.com/pybind/pybind11/issues/2558>`_
+- Intel 20.2 is currently having an issue with the test suite.
+  `#2573 <https://github.com/pybind/pybind11/pull/2573>`_
 
-- The ``cpptest`` does not run on Windows with Python 3.8 or newer, due to DLL
-  loader changes. User code that is correctly installed should not be affected.
-  `#2560 <https://github.com/pybind/pybind11/pull/2560>`_
-
-- There may be a rare issue with leakage under some compilers, exposed by
-  adding an unrelated test to the test suite.
-  `#2335 <https://github.com/pybind/pybind11/pull/2335>`_
+- Debug mode Python does not support 1-5 tests in the test suite currently.
+  `#2422 <https://github.com/pybind/pybind11/pull/2422>`_
 
 Known limitations
 ^^^^^^^^^^^^^^^^^
@@ -54,3 +47,7 @@ clean, well written patch would likely be accepted to solve them.
   `#2527 <https://github.com/pybind/pybind11/issues/2527>`_
   One consequence is that containers of ``char *`` are currently not supported.
   `#2245 <https://github.com/pybind/pybind11/issues/2245>`_
+
+- The ``cpptest`` does not run on Windows with Python 3.8 or newer, due to DLL
+  loader changes. User code that is correctly installed should not be affected.
+  `#2560 <https://github.com/pybind/pybind11/issue/2560>`_


### PR DESCRIPTION
Polishing a bit, and highlighting the 3.9.0 issue (is this too high up? Should it be lower down?)