### PR TITLE
setup_helpers: fix bug in _add_lflags

### DIFF
--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -99,7 +99,7 @@ class Pybind11Extension(_Extension):
 
     def _add_lflags(self, *flags):
         for flag in flags:
-            if flag not in self.extra_compile_args:
+            if flag not in self.extra_link_args:
                 self.extra_link_args.append(flag)
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Description

Fix minor bug in setup_helpers that allows a link flag to be added more than once.

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

```rst
Fix minor bug in setup_helpers that allows a link flag to be added more than once.
```

<!-- If the upgrade guide needs updating, note that here too -->
