### PR TITLE
fix: minor correctness check (smaller alternative to #2588)

### DIFF
--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -18,7 +18,7 @@ def print_includes():
     # Make unique but preserve order
     unique_dirs = []
     for d in dirs:
-        if d not in unique_dirs:
+        if d and d not in unique_dirs:
             unique_dirs.append(d)
 
     print(" ".join("-I" + d for d in unique_dirs))


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Backporting a correctness fix from #2588 for 2.6.0. If #2588 is too large to go into 2.6.0, we can do this instead, and save #2588  for later.

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

None needed.

<!-- If the upgrade guide needs updating, note that here too -->
