### PR TITLE
fix: ipo should be off for debug or relwithdebinfo

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -264,8 +264,15 @@ As stated above, LTO is enabled by default. Some newer compilers also support
 different flavors of LTO such as `ThinLTO`_. Setting ``THIN_LTO`` will cause
 the function to prefer this flavor if available. The function falls back to
 regular LTO if ``-flto=thin`` is not available. If
-``CMAKE_INTERPROCEDURAL_OPTIMIZATION`` is set (either ON or OFF), then that
-will be respected instead of the built-in flag search.
+``CMAKE_INTERPROCEDURAL_OPTIMIZATION`` is set (either ``ON`` or ``OFF``), then
+that will be respected instead of the built-in flag search.
+
+.. note::
+
+   If you want to set the property form on targets or the
+   ``CMAKE_INTERPROCEDURAL_OPTIMIZATION_<CONFIG>`` versions of this, you should
+   still use ``set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)`` (otherwise a
+   no-op) to disable pybind11's ipo flags.
 
 The ``OPT_SIZE`` flag enables size-based optimization equivalent to the
 standard ``/Os`` or ``-Os`` compiler flags and the ``MinSizeRel`` build type,

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -327,7 +327,7 @@ function(_pybind11_generate_lto target prefer_thin_lto)
 
   # Enable LTO flags if found, except for Debug builds
   if(PYBIND11_LTO_CXX_FLAGS)
-    # CONFIG takes multiple values in CMake 3.19+
+    # CONFIG takes multiple values in CMake 3.19+, until then we have to use OR
     set(is_debug "$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>")
     set(not_debug "$<NOT:${is_debug}>")
     set(cxx_lang "$<COMPILE_LANGUAGE:CXX>")

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -327,7 +327,9 @@ function(_pybind11_generate_lto target prefer_thin_lto)
 
   # Enable LTO flags if found, except for Debug builds
   if(PYBIND11_LTO_CXX_FLAGS)
-    set(not_debug "$<NOT:$<CONFIG:Debug>>")
+    # CONFIG takes multiple values in CMake 3.19+
+    set(is_debug "$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>")
+    set(not_debug "$<NOT:${is_debug}>")
     set(cxx_lang "$<COMPILE_LANGUAGE:CXX>")
     if(MSVC AND CMAKE_VERSION VERSION_LESS 3.11)
       set(genex "${not_debug}")


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Closes #2587 by counting "RelWithDebInfo" like "Debug" for turning off our IPO flags.

If someone wants to make IPO + RelWithDebInfo, they should use the built-in CMake feature and not our old flag method. As a reminder, if `CMAKE_INTERPROCEDURAL_OPTIMIZATION` is set (even to OFF), our IPO flags disable and the built-in CMake feature is respected. You can even set `CMAKE_INTERPROCEDURAL_OPTIMIZATION_<CONFIG>`.

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

None needed.

<!-- If the upgrade guide needs updating, note that here too -->
