### PR TITLE
ci: add numpy (even if slow)

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010/
 numpy==1.16.6; python_version<"3.6"
 numpy==1.18.0; platform_python_implementation=="PyPy" and sys_platform=="darwin" and python_version>="3.6"
-numpy==1.19.1; (platform_python_implementation!="PyPy" or sys_platform!="darwin") and python_version>="3.6" and python_version<"3.9"
+numpy==1.19.2; (platform_python_implementation!="PyPy" or sys_platform!="darwin") and python_version>="3.6" and python_version<"3.10"
 pytest==4.6.9; python_version<"3.5"
 pytest==5.4.3; python_version>="3.5"
 scipy==1.2.3; (platform_python_implementation!="PyPy" or sys_platform!="darwin") and python_version<"3.6"


### PR DESCRIPTION
## Description

Hoping to hit the problem in #2596. Though NumPy is not actually needed to compile the code, so probably unlikely.

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

None needed.

<!-- If the upgrade guide needs updating, note that here too -->
