### PR TITLE
fix: win32 PyPy3 and C++20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
-        arch: [x64]
         python:
         - 2.7
         - 3.5
@@ -36,41 +35,26 @@ jobs:
           # Just add a key
           - runs-on: ubuntu-latest
             python: 3.6
-            arch: x64
             args: >
               -DPYBIND11_FINDPYTHON=ON
           - runs-on: windows-latest
             python: 3.6
-            arch: x64
             args: >
               -DPYBIND11_FINDPYTHON=ON
           - runs-on: ubuntu-latest
             python: 3.8
-            arch: x64
             args: >
               -DPYBIND11_FINDPYTHON=ON
-
-          # New runs
-          - runs-on: windows-2016
-            python: 3.7
-            arch: x86
-            args2: >
-              -DCMAKE_CXX_FLAGS="/permissive- /EHsc /GR"
-          - runs-on: windows-latest
-            python: 3.7
-            arch: x64
 
         # These items will be removed from the build matrix, keys must match.
         exclude:
             # Currently 32bit only, and we build 64bit
           - runs-on: windows-latest
             python: pypy2
-            arch: x64
           - runs-on: windows-latest
             python: pypy3
-            arch: x64
 
-    name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • ${{ matrix.arch }} ${{ matrix.args }}"
+    name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}
 
     steps:
@@ -80,7 +64,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-        architecture: ${{ matrix.arch }}
 
     - name: Setup Boost (Windows / Linux latest)
       shell: bash
@@ -98,7 +81,7 @@ jobs:
         # for ways to do this more generally
         path: ~/Library/Caches/pip
         # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ matrix.python }}-${{ matrix.arch }}-${{ hashFiles('tests/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python }}-x64-${{ hashFiles('tests/requirements.txt') }}
 
     - name: Prepare env
       run: python -m pip install -r tests/requirements.txt --prefer-binary
@@ -191,12 +174,19 @@ jobs:
           - 3.6
           - 3.7
           - 3.9
-          - 5
           - 7
-          - 10
           - dev
+        std:
+          - 11
+        include:
+          - clang: 5
+            std: 14
+          - clang: 10
+            std: 20
+          - clang: 10
+            std: 17
 
-    name: "🐍 3 • Clang ${{ matrix.clang }} • x64"
+    name: "🐍 3 • Clang ${{ matrix.clang }} • C++${{ matrix.std }} • x64"
     container: "silkeh/clang:${{ matrix.clang }}"
 
     steps:
@@ -211,6 +201,7 @@ jobs:
         cmake -S . -B build
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
+        -DCMAKE_CXX_STANDARD=${{ matrix.std }}
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build
@@ -346,8 +337,13 @@ jobs:
         gcc:
           - 7
           - latest
+        std:
+          - 11
+        include:
+          - gcc: 10
+            std: 20
 
-    name: "🐍 3 • GCC ${{ matrix.gcc }} • x64"
+    name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }}• x64"
     container: "gcc:${{ matrix.gcc }}"
 
     steps:
@@ -370,7 +366,7 @@ jobs:
         cmake -S . -B build
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
-        -DCMAKE_CXX_STANDARD=11
+        -DCMAKE_CXX_STANDARD=${{ matrix.std }}
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build
@@ -514,3 +510,151 @@ jobs:
         python3 -m pip install --user -U ../dist/*
         installed=$(python3 -c "import pybind11; print(pybind11.get_include() + '/pybind11')")
         diff -rq $installed ./pybind11
+
+  win32:
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+        - 3.5
+        - 3.8
+        - 3.9
+        - pypy3
+        # TODO: fix hang on pypy2
+
+        include:
+          - python: 3.9
+            args: -DCMAKE_CXX_STANDARD=20 -DDOWNLOAD_EIGEN=OFF
+          - python: 3.8
+            args: -DCMAKE_CXX_STANDARD=17
+
+    name: "🐍 ${{ matrix.python }} • MSVC 2019 • x86 ${{ matrix.args }}"
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+        architecture: x86
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.4
+
+    - name: Prepare MSVC
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x86
+
+    - name: Prepare env
+      run: python -m pip install -r tests/requirements.txt --prefer-binary
+
+    # First build - C++11 mode and inplace
+    - name: Configure ${{ matrix.args }}
+      run: >
+        cmake -S . -B build
+        -G "Visual Studio 16 2019" -A Win32
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DDOWNLOAD_EIGEN=ON
+        ${{ matrix.args }}
+    - name: Build C++11
+      run: cmake --build build -j 2
+
+    - name: Run tests
+      run: cmake --build build -t pytest
+
+  win32-msvc2015:
+    name: "🐍 ${{ matrix.python }} • MSVC 2015 • x64"
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - 2.7
+          - 3.6
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup 🐍 ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.4
+
+    - name: Prepare MSVC
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        toolset: 14.0
+
+    - name: Prepare env
+      run: python -m pip install -r tests/requirements.txt --prefer-binary
+
+    # First build - C++11 mode and inplace
+    - name: Configure
+      run: >
+        cmake -S . -B build
+        -G "Visual Studio 14 2015" -A x64
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DDOWNLOAD_EIGEN=ON
+
+    - name: Build C++14
+      run: cmake --build build -j 2
+
+    - name: Run all checks
+      run: cmake --build build -t check
+
+
+  win32-msvc2017:
+    name: "🐍 ${{ matrix.python }} • MSVC 2017 • x64"
+    runs-on: windows-2016
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - 3.7
+        std:
+          - 14
+
+        include:
+          - python: 2.7
+            std: 17
+            args: >
+              -DCMAKE_CXX_FLAGS="/permissive- /EHsc /GR"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup 🐍 ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.4
+
+    - name: Prepare env
+      run: python -m pip install -r tests/requirements.txt --prefer-binary
+
+    # First build - C++11 mode and inplace
+    - name: Configure
+      run: >
+        cmake -S . -B build
+        -G "Visual Studio 15 2017" -A x64
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DDOWNLOAD_EIGEN=ON
+        -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+        ${{ matrix.args }}
+
+    - name: Build ${{ matrix.std }}
+      run: cmake --build build -j 2
+
+    - name: Run all checks
+      run: cmake --build build -t check

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -57,11 +57,11 @@ specification.
 
     struct buffer_info {
         void *ptr;
-        ssize_t itemsize;
+        py::ssize_t itemsize;
         std::string format;
-        ssize_t ndim;
-        std::vector<ssize_t> shape;
-        std::vector<ssize_t> strides;
+        py::ssize_t ndim;
+        std::vector<py::ssize_t> shape;
+        std::vector<py::ssize_t> strides;
     };
 
 To create a C++ function that can take a Python buffer object as an argument,
@@ -309,17 +309,17 @@ where ``N`` gives the required dimensionality of the array:
     m.def("sum_3d", [](py::array_t<double> x) {
         auto r = x.unchecked<3>(); // x must have ndim = 3; can be non-writeable
         double sum = 0;
-        for (ssize_t i = 0; i < r.shape(0); i++)
-            for (ssize_t j = 0; j < r.shape(1); j++)
-                for (ssize_t k = 0; k < r.shape(2); k++)
+        for (py::ssize_t i = 0; i < r.shape(0); i++)
+            for (py::ssize_t j = 0; j < r.shape(1); j++)
+                for (py::ssize_t k = 0; k < r.shape(2); k++)
                     sum += r(i, j, k);
         return sum;
     });
     m.def("increment_3d", [](py::array_t<double> x) {
         auto r = x.mutable_unchecked<3>(); // Will throw if ndim != 3 or flags.writeable is false
-        for (ssize_t i = 0; i < r.shape(0); i++)
-            for (ssize_t j = 0; j < r.shape(1); j++)
-                for (ssize_t k = 0; k < r.shape(2); k++)
+        for (py::ssize_t i = 0; i < r.shape(0); i++)
+            for (py::ssize_t j = 0; j < r.shape(1); j++)
+                for (py::ssize_t k = 0; k < r.shape(2); k++)
                     r(i, j, k) += 1.0;
     }, py::arg().noconvert());
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -204,7 +204,8 @@ Smaller or developer focused features and fixes:
 * Avoid a segfault on some compilers when types are removed in Python.
   `#2564 <https://github.com/pybind/pybind11/pull/2564>`_
 
-* PyPy fixes, PyPy 7.3.x now supported, including now supporting PyPy3.
+* PyPy fixes, PyPy 7.3.x now supported, including PyPy3. (Known issue with
+  PyPy2 and Windows `#2596 <https://github.com/pybind/pybind11/issues/2596>`_).
   `#2146 <https://github.com/pybind/pybind11/pull/2146>`_
 
 * CPython 3.9.0 workaround for undefined behavior (macOS segfault).
@@ -213,8 +214,9 @@ Smaller or developer focused features and fixes:
 * CPython 3.9 warning fixes.
   `#2253 <https://github.com/pybind/pybind11/pull/2253>`_
 
-* Improved C++20 support.
+* Improved C++20 support, now tested in CI.
   `#2489 <https://github.com/pybind/pybind11/pull/2489>`_
+  `#2599 <https://github.com/pybind/pybind11/pull/2599>`_
 
 * Improved but still incomplete debug Python interpreter support.
   `#2025 <https://github.com/pybind/pybind11/pull/2025>`_

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -37,6 +37,8 @@ are welcome!
 - Debug mode Python does not support 1-5 tests in the test suite currently.
   `#2422 <https://github.com/pybind/pybind11/pull/2422>`_
 
+- PyPy3 7.3.1 and 7.3.2 have issues with several tests on 32-bit Windows.
+
 Known limitations
 ^^^^^^^^^^^^^^^^^
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -34,7 +34,9 @@
    whole npy_intp / ssize_t / Py_intptr_t business down to just ssize_t for all size
    and dimension types (e.g. shape, strides, indexing), instead of inflicting this
    upon the library user. */
-static_assert(sizeof(ssize_t) == sizeof(Py_intptr_t), "ssize_t != Py_intptr_t");
+static_assert(sizeof(::pybind11::ssize_t) == sizeof(Py_intptr_t), "ssize_t != Py_intptr_t");
+static_assert(std::is_signed<Py_intptr_t>::value, "Py_intptr_t must be signed");
+// We now can reinterpret_cast between py::ssize_t and Py_intptr_t (MSVC + PyPy cares)
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
@@ -590,7 +592,10 @@ public:
 
         auto &api = detail::npy_api::get();
         auto tmp = reinterpret_steal<object>(api.PyArray_NewFromDescr_(
-            api.PyArray_Type_, descr.release().ptr(), (int) ndim, shape->data(), strides->data(),
+            api.PyArray_Type_, descr.release().ptr(), (int) ndim,
+            // Use reinterpret_cast for PyPy on Windows (remove if fixed, checked on 7.3.1)
+            reinterpret_cast<Py_intptr_t*>(shape->data()),
+            reinterpret_cast<Py_intptr_t*>(strides->data()),
             const_cast<void *>(ptr), flags, nullptr));
         if (!tmp)
             throw error_already_set();
@@ -762,7 +767,9 @@ public:
     /// then resize will succeed only if it makes a reshape, i.e. original size doesn't change
     void resize(ShapeContainer new_shape, bool refcheck = true) {
         detail::npy_api::PyArray_Dims d = {
-            new_shape->data(), int(new_shape->size())
+            // Use reinterpret_cast for PyPy on Windows (remove if fixed, checked on 7.3.1)
+            reinterpret_cast<Py_intptr_t*>(new_shape->data()),
+            int(new_shape->size())
         };
         // try to resize, set ordering param to -1 cause it's not used anyway
         object new_array = reinterpret_steal<object>(

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <string>
 #include <functional>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include <typeindex>
@@ -326,6 +327,12 @@ template <typename T> using is_pod_struct = all_of<
     satisfies_any_of<T, std::has_trivial_copy_constructor, std::has_trivial_copy_assign>,
 #endif
     satisfies_none_of<T, std::is_reference, std::is_array, is_std_array, std::is_arithmetic, is_complex, std::is_enum>
+>;
+
+// Replacement for std::is_pod (deprecated in C++20)
+template <typename T> using is_pod = all_of<
+    std::is_standard_layout<T>,
+    std::is_trivial<T>
 >;
 
 template <ssize_t Dim = 0, typename Strides> ssize_t byte_offset_unsafe(const Strides &) { return 0; }
@@ -1448,7 +1455,7 @@ struct vectorize_arg {
     using call_type = remove_reference_t<T>;
     // Is this a vectorized argument?
     static constexpr bool vectorize =
-        satisfies_any_of<call_type, std::is_arithmetic, is_complex, std::is_pod>::value &&
+        satisfies_any_of<call_type, std::is_arithmetic, is_complex, is_pod>::value &&
         satisfies_none_of<call_type, std::is_pointer, std::is_array, is_std_array, std::is_enum>::value &&
         (!std::is_reference<T>::value ||
          (std::is_lvalue_reference<T>::value && std::is_const<call_type>::value));

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -29,6 +29,7 @@
 #  pragma warning(disable: 4996) // warning C4996: The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name
 #  pragma warning(disable: 4702) // warning C4702: unreachable code
 #  pragma warning(disable: 4522) // warning C4522: multiple assignment operators specified
+#  pragma warning(disable: 4505) // warning C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
 #elif defined(__GNUG__) && !defined(__clang__)
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wunused-but-set-parameter"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -174,7 +174,7 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
       message(FATAL_ERROR "CMake 3.11+ required when using DOWNLOAD_EIGEN")
     endif()
 
-    set(EIGEN3_VERSION_STRING "3.3.7")
+    set(EIGEN3_VERSION_STRING "3.3.8")
 
     include(FetchContent)
     FetchContent_Declare(

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010/
-numpy==1.16.6; python_version<"3.6"
+numpy==1.16.6; python_version<"3.6" and sys_platform!="win32"
 numpy==1.18.0; platform_python_implementation=="PyPy" and sys_platform=="darwin" and python_version>="3.6"
-numpy==1.19.1; (platform_python_implementation!="PyPy" or sys_platform!="darwin") and python_version>="3.6" and python_version<"3.9"
+numpy==1.19.1; (platform_python_implementation!="PyPy" or sys_platform=="linux") and python_version>="3.6" and python_version<"3.9"
 pytest==4.6.9; python_version<"3.5"
 pytest==5.4.3; python_version>="3.5"
-scipy==1.2.3; (platform_python_implementation!="PyPy" or sys_platform!="darwin") and python_version<"3.6"
-scipy==1.5.2; (platform_python_implementation!="PyPy" or sys_platform!="darwin") and python_version>="3.6" and python_version<"3.9"
+scipy==1.2.3; (platform_python_implementation!="PyPy" or sys_platform=="linux") and python_version<"3.6"
+scipy==1.5.2; (platform_python_implementation!="PyPy" or sys_platform=="linux") and python_version>="3.6" and python_version<"3.9"

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -15,7 +15,7 @@ TEST_SUBMODULE(buffers, m) {
     // test_from_python / test_to_python:
     class Matrix {
     public:
-        Matrix(ssize_t rows, ssize_t cols) : m_rows(rows), m_cols(cols) {
+        Matrix(py::ssize_t rows, py::ssize_t cols) : m_rows(rows), m_cols(cols) {
             print_created(this, std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
             m_data = new float[(size_t) (rows*cols)];
             memset(m_data, 0, sizeof(float) * (size_t) (rows * cols));
@@ -59,25 +59,25 @@ TEST_SUBMODULE(buffers, m) {
             return *this;
         }
 
-        float operator()(ssize_t i, ssize_t j) const {
+        float operator()(py::ssize_t i, py::ssize_t j) const {
             return m_data[(size_t) (i*m_cols + j)];
         }
 
-        float &operator()(ssize_t i, ssize_t j) {
+        float &operator()(py::ssize_t i, py::ssize_t j) {
             return m_data[(size_t) (i*m_cols + j)];
         }
 
         float *data() { return m_data; }
 
-        ssize_t rows() const { return m_rows; }
-        ssize_t cols() const { return m_cols; }
+        py::ssize_t rows() const { return m_rows; }
+        py::ssize_t cols() const { return m_cols; }
     private:
-        ssize_t m_rows;
-        ssize_t m_cols;
+        py::ssize_t m_rows;
+        py::ssize_t m_cols;
         float *m_data;
     };
     py::class_<Matrix>(m, "Matrix", py::buffer_protocol())
-        .def(py::init<ssize_t, ssize_t>())
+        .def(py::init<py::ssize_t, py::ssize_t>())
         /// Construct from a buffer
         .def(py::init([](py::buffer const b) {
             py::buffer_info info = b.request();
@@ -93,12 +93,12 @@ TEST_SUBMODULE(buffers, m) {
        .def("cols", &Matrix::cols)
 
         /// Bare bones interface
-       .def("__getitem__", [](const Matrix &m, std::pair<ssize_t, ssize_t> i) {
+       .def("__getitem__", [](const Matrix &m, std::pair<py::ssize_t, py::ssize_t> i) {
             if (i.first >= m.rows() || i.second >= m.cols())
                 throw py::index_error();
             return m(i.first, i.second);
         })
-       .def("__setitem__", [](Matrix &m, std::pair<ssize_t, ssize_t> i, float v) {
+       .def("__setitem__", [](Matrix &m, std::pair<py::ssize_t, py::ssize_t> i, float v) {
             if (i.first >= m.rows() || i.second >= m.cols())
                 throw py::index_error();
             m(i.first, i.second) = v;
@@ -118,11 +118,11 @@ TEST_SUBMODULE(buffers, m) {
     // test_inherited_protocol
     class SquareMatrix : public Matrix {
     public:
-        SquareMatrix(ssize_t n) : Matrix(n, n) { }
+        SquareMatrix(py::ssize_t n) : Matrix(n, n) { }
     };
     // Derived classes inherit the buffer protocol and the buffer access function
     py::class_<SquareMatrix, Matrix>(m, "SquareMatrix")
-        .def(py::init<ssize_t>());
+        .def(py::init<py::ssize_t>());
 
 
     // test_pointer_to_member_fn

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -71,7 +71,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
         py::tuple t(a.size());
         for (size_t i = 0; i < a.size(); i++)
             // Use raw Python API here to avoid an extra, intermediate incref on the tuple item:
-            t[i] = (int) Py_REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<ssize_t>(i)));
+            t[i] = (int) Py_REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i)));
         return t;
     });
     m.def("mixed_args_refcount", [](py::object o, py::args a) {
@@ -80,7 +80,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
         t[0] = o.ref_count();
         for (size_t i = 0; i < a.size(); i++)
             // Use raw Python API here to avoid an extra, intermediate incref on the tuple item:
-            t[i + 1] = (int) Py_REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<ssize_t>(i)));
+            t[i + 1] = (int) Py_REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i)));
         return t;
     });
 

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -89,23 +89,23 @@ template<typename... Ix> arr data_t(const arr_t& a, Ix... index) {
 
 template<typename... Ix> arr& mutate_data(arr& a, Ix... index) {
     auto ptr = (uint8_t *) a.mutable_data(index...);
-    for (ssize_t i = 0; i < a.nbytes() - a.offset_at(index...); i++)
+    for (py::ssize_t i = 0; i < a.nbytes() - a.offset_at(index...); i++)
         ptr[i] = (uint8_t) (ptr[i] * 2);
     return a;
 }
 
 template<typename... Ix> arr_t& mutate_data_t(arr_t& a, Ix... index) {
     auto ptr = a.mutable_data(index...);
-    for (ssize_t i = 0; i < a.size() - a.index_at(index...); i++)
+    for (py::ssize_t i = 0; i < a.size() - a.index_at(index...); i++)
         ptr[i]++;
     return a;
 }
 
-template<typename... Ix> ssize_t index_at(const arr& a, Ix... idx) { return a.index_at(idx...); }
-template<typename... Ix> ssize_t index_at_t(const arr_t& a, Ix... idx) { return a.index_at(idx...); }
-template<typename... Ix> ssize_t offset_at(const arr& a, Ix... idx) { return a.offset_at(idx...); }
-template<typename... Ix> ssize_t offset_at_t(const arr_t& a, Ix... idx) { return a.offset_at(idx...); }
-template<typename... Ix> ssize_t at_t(const arr_t& a, Ix... idx) { return a.at(idx...); }
+template<typename... Ix> py::ssize_t index_at(const arr& a, Ix... idx) { return a.index_at(idx...); }
+template<typename... Ix> py::ssize_t index_at_t(const arr_t& a, Ix... idx) { return a.index_at(idx...); }
+template<typename... Ix> py::ssize_t offset_at(const arr& a, Ix... idx) { return a.offset_at(idx...); }
+template<typename... Ix> py::ssize_t offset_at_t(const arr_t& a, Ix... idx) { return a.offset_at(idx...); }
+template<typename... Ix> py::ssize_t at_t(const arr_t& a, Ix... idx) { return a.at(idx...); }
 template<typename... Ix> arr_t& mutate_at_t(arr_t& a, Ix... idx) { a.mutable_at(idx...)++; return a; }
 
 #define def_index_fn(name, type) \
@@ -159,9 +159,9 @@ TEST_SUBMODULE(numpy_array, sm) {
     // test_array_attributes
     sm.def("ndim", [](const arr& a) { return a.ndim(); });
     sm.def("shape", [](const arr& a) { return arr(a.ndim(), a.shape()); });
-    sm.def("shape", [](const arr& a, ssize_t dim) { return a.shape(dim); });
+    sm.def("shape", [](const arr& a, py::ssize_t dim) { return a.shape(dim); });
     sm.def("strides", [](const arr& a) { return arr(a.ndim(), a.strides()); });
-    sm.def("strides", [](const arr& a, ssize_t dim) { return a.strides(dim); });
+    sm.def("strides", [](const arr& a, py::ssize_t dim) { return a.strides(dim); });
     sm.def("writeable", [](const arr& a) { return a.writeable(); });
     sm.def("size", [](const arr& a) { return a.size(); });
     sm.def("itemsize", [](const arr& a) { return a.itemsize(); });
@@ -281,33 +281,33 @@ TEST_SUBMODULE(numpy_array, sm) {
     // test_array_unchecked_fixed_dims
     sm.def("proxy_add2", [](py::array_t<double> a, double v) {
         auto r = a.mutable_unchecked<2>();
-        for (ssize_t i = 0; i < r.shape(0); i++)
-            for (ssize_t j = 0; j < r.shape(1); j++)
+        for (py::ssize_t i = 0; i < r.shape(0); i++)
+            for (py::ssize_t j = 0; j < r.shape(1); j++)
                 r(i, j) += v;
     }, py::arg().noconvert(), py::arg());
 
     sm.def("proxy_init3", [](double start) {
         py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
         auto r = a.mutable_unchecked<3>();
-        for (ssize_t i = 0; i < r.shape(0); i++)
-        for (ssize_t j = 0; j < r.shape(1); j++)
-        for (ssize_t k = 0; k < r.shape(2); k++)
+        for (py::ssize_t i = 0; i < r.shape(0); i++)
+        for (py::ssize_t j = 0; j < r.shape(1); j++)
+        for (py::ssize_t k = 0; k < r.shape(2); k++)
             r(i, j, k) = start++;
         return a;
     });
     sm.def("proxy_init3F", [](double start) {
         py::array_t<double, py::array::f_style> a({ 3, 3, 3 });
         auto r = a.mutable_unchecked<3>();
-        for (ssize_t k = 0; k < r.shape(2); k++)
-        for (ssize_t j = 0; j < r.shape(1); j++)
-        for (ssize_t i = 0; i < r.shape(0); i++)
+        for (py::ssize_t k = 0; k < r.shape(2); k++)
+        for (py::ssize_t j = 0; j < r.shape(1); j++)
+        for (py::ssize_t i = 0; i < r.shape(0); i++)
             r(i, j, k) = start++;
         return a;
     });
     sm.def("proxy_squared_L2_norm", [](py::array_t<double> a) {
         auto r = a.unchecked<1>();
         double sumsq = 0;
-        for (ssize_t i = 0; i < r.shape(0); i++)
+        for (py::ssize_t i = 0; i < r.shape(0); i++)
             sumsq += r[i] * r(i); // Either notation works for a 1D array
         return sumsq;
     });
@@ -335,17 +335,17 @@ TEST_SUBMODULE(numpy_array, sm) {
     sm.def("proxy_add2_dyn", [](py::array_t<double> a, double v) {
         auto r = a.mutable_unchecked();
         if (r.ndim() != 2) throw std::domain_error("error: ndim != 2");
-        for (ssize_t i = 0; i < r.shape(0); i++)
-            for (ssize_t j = 0; j < r.shape(1); j++)
+        for (py::ssize_t i = 0; i < r.shape(0); i++)
+            for (py::ssize_t j = 0; j < r.shape(1); j++)
                 r(i, j) += v;
     }, py::arg().noconvert(), py::arg());
     sm.def("proxy_init3_dyn", [](double start) {
         py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
         auto r = a.mutable_unchecked();
         if (r.ndim() != 3) throw std::domain_error("error: ndim != 3");
-        for (ssize_t i = 0; i < r.shape(0); i++)
-        for (ssize_t j = 0; j < r.shape(1); j++)
-        for (ssize_t k = 0; k < r.shape(2); k++)
+        for (py::ssize_t i = 0; i < r.shape(0); i++)
+        for (py::ssize_t j = 0; j < r.shape(1); j++)
+        for (py::ssize_t k = 0; k < r.shape(2); k++)
             r(i, j, k) = start++;
         return a;
     });
@@ -374,7 +374,7 @@ TEST_SUBMODULE(numpy_array, sm) {
     // test_array_resize
     // reshape array to 2D without changing size
     sm.def("array_reshape2", [](py::array_t<double> a) {
-        const auto dim_sz = (ssize_t)std::sqrt(a.size());
+        const auto dim_sz = (py::ssize_t)std::sqrt(a.size());
         if (dim_sz * dim_sz != a.size())
             throw std::domain_error("array_reshape2: input array total size is not a squared integer");
         a.resize({dim_sz, dim_sz});

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -168,7 +168,7 @@ py::list print_recarray(py::array_t<S, 0> arr) {
     const auto req = arr.request();
     const auto ptr = static_cast<S*>(req.ptr);
     auto l = py::list();
-    for (ssize_t i = 0; i < req.size; i++) {
+    for (py::ssize_t i = 0; i < req.size; i++) {
         std::stringstream ss;
         ss << ptr[i];
         l.append(py::str(ss.str()));
@@ -180,8 +180,8 @@ py::array_t<int32_t, 0> test_array_ctors(int i) {
     using arr_t = py::array_t<int32_t, 0>;
 
     std::vector<int32_t> data { 1, 2, 3, 4, 5, 6 };
-    std::vector<ssize_t> shape { 3, 2 };
-    std::vector<ssize_t> strides { 8, 4 };
+    std::vector<py::ssize_t> shape { 3, 2 };
+    std::vector<py::ssize_t> strides { 8, 4 };
 
     auto ptr = data.data();
     auto vptr = (void *) ptr;
@@ -398,7 +398,7 @@ TEST_SUBMODULE(numpy_dtypes, m) {
         if (non_empty) {
             auto req = arr.request();
             auto ptr = static_cast<StringStruct*>(req.ptr);
-            for (ssize_t i = 0; i < req.size * req.itemsize; i++)
+            for (py::ssize_t i = 0; i < req.size * req.itemsize; i++)
                 static_cast<char*>(req.ptr)[i] = 0;
             ptr[1].a[0] = 'a'; ptr[1].b[0] = 'a';
             ptr[2].a[0] = 'a'; ptr[2].b[0] = 'a';

--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -83,8 +83,8 @@ TEST_SUBMODULE(numpy_vectorize, m) {
                 py::array_t<float, py::array::forcecast> arg2,
                 py::array_t<double, py::array::forcecast> arg3
                 ) {
-        ssize_t ndim;
-        std::vector<ssize_t> shape;
+        py::ssize_t ndim;
+        std::vector<py::ssize_t> shape;
         std::array<py::buffer_info, 3> buffers {{ arg1.request(), arg2.request(), arg3.request() }};
         return py::detail::broadcast(buffers, ndim, shape);
     });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -404,7 +404,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("test_memoryview_from_memory", []() {
         const char* buf = "\xff\xe1\xab\x37";
         return py::memoryview::from_memory(
-            buf, static_cast<ssize_t>(strlen(buf)));
+            buf, static_cast<py::ssize_t>(strlen(buf)));
     });
 #endif
 

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -83,7 +83,7 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
     py::class_<Sliceable>(m,"Sliceable")
         .def(py::init<int>())
         .def("__getitem__",[](const Sliceable &s, py::slice slice) {
-          ssize_t start, stop, step, slicelength;
+          py::ssize_t start, stop, step, slicelength;
           if (!slice.compute(s.size, &start, &stop, &step, &slicelength))
               throw py::error_already_set();
           int istart = static_cast<int>(start);

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -115,7 +115,7 @@ print('.'.join(str(v) for v in sys.version_info));
 print(sys.prefix);
 print(s.get_python_inc(plat_specific=True));
 print(s.get_python_lib(plat_specific=True));
-print(s.get_config_var('SO'));
+print(s.get_config_var('SO') or s.get_config_var('EXT_SUFFIX'));
 print(hasattr(sys, 'gettotalrefcount')+0);
 print(struct.calcsize('@P'));
 print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -69,7 +69,7 @@ if(PYBIND11_MASTER_PROJECT)
     if(NOT DEFINED PYPY_VERSION)
       execute_process(
         COMMAND ${PYTHON_EXECUTABLE} -c
-                [=[import sys; print(".".join(map(str, sys.pypy_version_info[:3])))]=]
+                [=[import sys; sys.stdout.write(".".join(map(str, sys.pypy_version_info[:3])))]=]
         OUTPUT_VARIABLE pypy_version)
       set(PYPY_VERSION
           ${pypy_version}


### PR DESCRIPTION
## Description

This adds the fixes from #2598 and additions to the CI:
* Eigen is now 3.3.8 (still no C++20 support)
* Using `py::ssize_t` in more places instead of POSIX `ssize_t`
* Avoid `std::is_pod` (deprecated in C++20)
* Fix warning on PyPy + MSVC (could be fixed upstream?)
* Use reinterpret cast as required by PyPy on Windows
* Fix the extension produced by the classic tooling on PyPy + Windows (at least for 7.3.1, not sure if 7.3.2 would have been better)
* Drop extra new line in PYPY_VERSION
* Add lots of new tests to the CI: C++20 Clang, GCC, and MSVC; 32-bit Windows (including PyPy3 for the first time); and MSVC 2015 and improved MSVC 2017. We can now drop AppVeyor if we want to.

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

Done.

<!-- If the upgrade guide needs updating, note that here too -->
