### PR TITLE
fix: Reject keyword argument `None` with `.none(false)`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -204,6 +204,9 @@ Smaller or developer focused features and fixes:
 * Avoid a segfault on some compilers when types are removed in Python.
   `#2564 <https://github.com/pybind/pybind11/pull/2564>`_
 
+* ``py::arg::none()`` is now also respected when passing keyword arguments.
+  `#2611 <https://github.com/pybind/pybind11/pull/2611>`_
+
 * PyPy fixes, PyPy 7.3.x now supported, including PyPy3. (Known issue with
   PyPy2 and Windows `#2596 <https://github.com/pybind/pybind11/issues/2596>`_).
   `#2146 <https://github.com/pybind/pybind11/pull/2146>`_

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -606,15 +606,15 @@ protected:
                 // 1.5. Fill in any missing pos_only args from defaults if they exist
                 if (args_copied < func.nargs_pos_only) {
                     for (; args_copied < func.nargs_pos_only; ++args_copied) {
-                        const auto &arg = func.args[args_copied];
+                        const auto &arg_rec = func.args[args_copied];
                         handle value;
 
-                        if (arg.value) {
-                            value = arg.value;
+                        if (arg_rec.value) {
+                            value = arg_rec.value;
                         }
                         if (value) {
                             call.args.push_back(value);
-                            call.args_convert.push_back(arg.convert);
+                            call.args_convert.push_back(arg_rec.convert);
                         } else
                             break;
                     }
@@ -628,11 +628,11 @@ protected:
                     bool copied_kwargs = false;
 
                     for (; args_copied < num_args; ++args_copied) {
-                        const auto &arg = func.args[args_copied];
+                        const auto &arg_rec = func.args[args_copied];
 
                         handle value;
-                        if (kwargs_in && arg.name)
-                            value = PyDict_GetItemString(kwargs.ptr(), arg.name);
+                        if (kwargs_in && arg_rec.name)
+                            value = PyDict_GetItemString(kwargs.ptr(), arg_rec.name);
 
                         if (value) {
                             // Consume a kwargs value
@@ -640,14 +640,18 @@ protected:
                                 kwargs = reinterpret_steal<dict>(PyDict_Copy(kwargs.ptr()));
                                 copied_kwargs = true;
                             }
-                            PyDict_DelItemString(kwargs.ptr(), arg.name);
-                        } else if (arg.value) {
-                            value = arg.value;
+                            PyDict_DelItemString(kwargs.ptr(), arg_rec.name);
+                        } else if (arg_rec.value) {
+                            value = arg_rec.value;
+                        }
+
+                        if (!arg_rec.none && value.is_none()) {
+                            break;
                         }
 
                         if (value) {
                             call.args.push_back(value);
-                            call.args_convert.push_back(arg.convert);
+                            call.args_convert.push_back(arg_rec.convert);
                         }
                         else
                             break;

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -336,8 +336,8 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     m.def("ok_none4", &none4, py::arg().none(true));
     m.def("ok_none5", &none5);
 
-    m.def("no_none_kw", &none5, py::arg("a").none(false));
-    m.def("no_none_kw_only", &none5, py::kw_only(), py::arg("a").none(false));
+    m.def("no_none_kwarg", &none2, py::arg("a").none(false));
+    m.def("no_none_kwarg_kw_only", &none2, py::kw_only(), py::arg("a").none(false));
 
     // test_str_issue
     // Issue #283: __str__ called on uninitialized instance when constructor arguments invalid

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -330,6 +330,7 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     m.def("no_none3", &none3, py::arg().none(false));
     m.def("no_none4", &none4, py::arg().none(false));
     m.def("no_none5", &none5, py::arg().none(false));
+    m.def("no_none5_kw", &none5, py::arg("a").none(false));
     m.def("ok_none1", &none1);
     m.def("ok_none2", &none2, py::arg().none(true));
     m.def("ok_none3", &none3);

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -330,12 +330,14 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     m.def("no_none3", &none3, py::arg().none(false));
     m.def("no_none4", &none4, py::arg().none(false));
     m.def("no_none5", &none5, py::arg().none(false));
-    m.def("no_none5_kw", &none5, py::arg("a").none(false));
     m.def("ok_none1", &none1);
     m.def("ok_none2", &none2, py::arg().none(true));
     m.def("ok_none3", &none3);
     m.def("ok_none4", &none4, py::arg().none(true));
     m.def("ok_none5", &none5);
+
+    m.def("no_none_kw", &none5, py::arg("a").none(false));
+    m.def("no_none_kw_only", &none5, py::kw_only(), py::arg("a").none(false));
 
     // test_str_issue
     // Issue #283: __str__ called on uninitialized instance when constructor arguments invalid

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -384,9 +384,6 @@ def test_accepts_none(msg):
     with pytest.raises(TypeError) as excinfo:
         m.no_none5(None)
     assert "incompatible function arguments" in str(excinfo.value)
-    with pytest.raises(TypeError) as excinfo:
-        m.no_none5_kw(a=None)
-    assert "incompatible function arguments" in str(excinfo.value)
 
     # The first one still raises because you can't pass None as a lvalue reference arg:
     with pytest.raises(TypeError) as excinfo:
@@ -406,6 +403,19 @@ def test_accepts_none(msg):
     assert m.ok_none3(None) == -1
     assert m.ok_none4(None) == -1
     assert m.ok_none5(None) == -1
+
+    with pytest.raises(TypeError) as excinfo:
+        m.no_none_kw(None)
+    assert "incompatible function arguments" in str(excinfo.value)
+    with pytest.raises(TypeError) as excinfo:
+        m.no_none_kw(a=None)
+    assert "incompatible function arguments" in str(excinfo.value)
+    with pytest.raises(TypeError) as excinfo:
+        m.no_none_kw_only(None)
+    assert "incompatible function arguments" in str(excinfo.value)
+    with pytest.raises(TypeError) as excinfo:
+        m.no_none_kw_only(a=None)
+    assert "incompatible function arguments" in str(excinfo.value)
 
 
 def test_str_issue(msg):

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -405,16 +405,16 @@ def test_accepts_none(msg):
     assert m.ok_none5(None) == -1
 
     with pytest.raises(TypeError) as excinfo:
-        m.no_none_kw(None)
+        m.no_none_kwarg(None)
     assert "incompatible function arguments" in str(excinfo.value)
     with pytest.raises(TypeError) as excinfo:
-        m.no_none_kw(a=None)
+        m.no_none_kwarg(a=None)
     assert "incompatible function arguments" in str(excinfo.value)
     with pytest.raises(TypeError) as excinfo:
-        m.no_none_kw_only(None)
+        m.no_none_kwarg_kw_only(None)
     assert "incompatible function arguments" in str(excinfo.value)
     with pytest.raises(TypeError) as excinfo:
-        m.no_none_kw_only(a=None)
+        m.no_none_kwarg_kw_only(a=None)
     assert "incompatible function arguments" in str(excinfo.value)
 
 

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -384,6 +384,9 @@ def test_accepts_none(msg):
     with pytest.raises(TypeError) as excinfo:
         m.no_none5(None)
     assert "incompatible function arguments" in str(excinfo.value)
+    with pytest.raises(TypeError) as excinfo:
+        m.no_none5_kw(a=None)
+    assert "incompatible function arguments" in str(excinfo.value)
 
     # The first one still raises because you can't pass None as a lvalue reference arg:
     with pytest.raises(TypeError) as excinfo:


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Demo a failing test case where passing keyword as `None` to `py::arg("a").none(false)` is still accepted.

```cpp
m.def("no_none", [](T*){}, py::arg("a").none(false));
```

```python
m.no_none(None)    # ok raises `TypeError` 
m.no_none(a=None)  # not ok, this is accepted
```

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->
N/A.
This PR is to show a failing test case that can be used as a starting point.


<!-- If the upgrade guide needs updating, note that here too -->
