### PR TITLE
Remove friend declaration of py::class_ in py::detail::generic_type

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1027,7 +1027,6 @@ inline dict globals() {
 PYBIND11_NAMESPACE_BEGIN(detail)
 /// Generic support for creating new Python heap types
 class generic_type : public object {
-    template <typename...> friend class class_;
 public:
     PYBIND11_OBJECT_DEFAULT(generic_type, object, PyType_Check)
 protected:


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

This line had two bugs:

1. It declares `py::detail::class_` as `friend`.
2. After fixing that, we would have to change it to
   `template <typename, typename...>`

The first one was introduced ~5 years ago, when a large refactoring was
made, probably as an intermediate step during refactoring.

The second was made when `generic_type` was made to be agnostic with
respect to the order of `py::class_` template parameters.

&nbsp;

We're removing the declaration altogether, because it was never relied
on. This is what makes me think that it was an intermediate step in
refactoring that shouldn't have ended up in commit history.


## Suggested changelog entry:

None needed. This is just changing the internals.
