### PR TITLE
Add __builtins__ to globals argument of `py::exec` and `py::eval` if not present

### DIFF
--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -14,6 +14,22 @@
 #include "pybind11.h"
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+inline void ensure_builtins_in_globals(object &global) {
+    #if PY_VERSION_HEX < 0x03080000
+        // Running exec and eval on Python 2 and 3 adds `builtins` module under
+        // `__builtins__` key to globals if not yet present.
+        // Python 3.8 made PyRun_String behave similarly. Let's also do that for
+        // older versions, for consistency.
+        if (!global.contains("__builtins__"))
+            global["__builtins__"] = module_::import(PYBIND11_BUILTINS_MODULE);
+    #else
+        (void) global;
+    #endif
+}
+
+PYBIND11_NAMESPACE_END(detail)
 
 enum eval_mode {
     /// Evaluate a string containing an isolated expression
@@ -31,14 +47,7 @@ object eval(str expr, object global = globals(), object local = object()) {
     if (!local)
         local = global;
 
-#if PY_VERSION_HEX < 0x03080000
-    // Running exec and eval on Python 2 and 3 adds `builtins` module under
-    // `__builtins__` key to globals if not yet present.
-    // Python 3.8 made PyRun_String behave similarly. Let's also do that for
-    // older versions, for consistency.
-    if (!global.contains("__builtins__"))
-        global["__builtins__"] = module_::import(PYBIND11_BUILTINS_MODULE);
-#endif
+    detail::ensure_builtins_in_globals(global);
 
     /* PyRun_String does not accept a PyObject / encoding specifier,
        this seems to be the only alternative */
@@ -94,11 +103,7 @@ object eval_file(str fname, object global = globals(), object local = object()) 
     if (!local)
         local = global;
 
-#if PY_VERSION_HEX < 0x03080000
-    // See `eval` above.
-    if (!global.contains("__builtins__"))
-        global["__builtins__"] = module_::import(PYBIND11_BUILTINS_MODULE);
-#endif
+    detail::ensure_builtins_in_globals(global);
 
     int start;
     switch (mode) {

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -88,4 +88,12 @@ TEST_SUBMODULE(eval_, m) {
         }
         return false;
     });
+
+    // test_eval_empty_globals
+    m.def("eval_empty_globals", [](py::object global) {
+        if (global.is_none())
+            global = py::dict();
+        auto int_class = py::eval("isinstance(42, int)", global);
+        return global;
+    });
 }

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -25,3 +25,11 @@ def test_eval_file():
     assert m.test_eval_file(filename)
 
     assert m.test_eval_file_failure()
+
+
+def test_eval_empty_globals():
+    assert "__builtins__" in m.eval_empty_globals(None)
+
+    g = {}
+    assert "__builtins__" in m.eval_empty_globals(g)
+    assert "__builtins__" in g


### PR DESCRIPTION
## Description

Python (even 2.7!) adds `__builtins__` when calling `exec` or `eval`:

```
Python 3.6.9 (default, Oct  8 2020, 12:12:24) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> d = {}
>>> d.keys()
dict_keys([])
>>> exec("print(42)", d)
42
>>> d.keys()
dict_keys(['__builtins__'])
```

```
Python 2.7.17 (default, Sep 30 2020, 13:38:04) 
[GCC 7.5.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> d = {}
>>> exec("print 42", d)
42
>>> d.keys()
['__builtins__']
```

For the C API's `PyRun_String`, this only happens since Python 3.8 (python/cpython#13362; see https://github.com/pybind/pybind11/issues/1091#issuecomment-668594173). It would make sense to me to backport/downport/sideport/<whatever>port this to pybind11 on all versions of Python, for the sake of consistency. No?

Closes #1091
Closes #2557
Closes #1654 (thanks, @bstaletic!)

## Suggested changelog entry:

```rst
`py::exec`, `py::eval`, and `py::eval_file` now add the builtins module as ``"__builtins__"`` to their ``globals`` argument, better matching `exec` and `eval` in pure Python.
```