### PR TITLE
fix: turn on extra warnings for tests

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1904,7 +1904,7 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
 template <typename InputType, typename OutputType> void implicitly_convertible() {
     struct set_flag {
         bool &flag;
-        set_flag(bool &flag) : flag(flag) { flag = true; }
+        set_flag(bool &value) : flag(value) { flag = true; }
         ~set_flag() { flag = false; }
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -243,8 +243,23 @@ function(pybind11_enable_warnings target_name)
   if(MSVC)
     target_compile_options(${target_name} PRIVATE /W4)
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Intel|Clang)" AND NOT PYBIND11_CUDA_TESTS)
-    target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wconversion -Wcast-qual
-                                                  -Wdeprecated -Wundef)
+    target_compile_options(
+      ${target_name}
+      PRIVATE -Wall
+              -Wextra
+              -Wconversion
+              -Wcast-qual
+              -Wdeprecated
+              -Wundef
+              -Wshadow
+              -Wswitch-enum
+              -pedantic
+              -Wno-gnu-zero-variadic-macro-arguments)
+  endif()
+
+  # Buggy in GCC 4.8
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
+    target_compile_options(${target_name} PRIVATE -Weffc++)
   endif()
 
   if(PYBIND11_WERROR)


### PR DESCRIPTION
## Description

Inspired by and closes #1417

We'll need to work though the warnings. EffC++ can be overkill sometimes, but might have good suggestions. Almost everything may be overkill, but worth checking.

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

```rst
* Turn on more warnings in tests
```

<!-- If the upgrade guide needs updating, note that here too -->
