### PR TITLE
fix: min macos

### DIFF
--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -45,6 +45,7 @@ import shutil
 import sys
 import tempfile
 import threading
+import platform
 import warnings
 
 try:
@@ -177,10 +178,14 @@ class Pybind11Extension(_Extension):
 
         if MACOS and "MACOSX_DEPLOYMENT_TARGET" not in os.environ:
             # C++17 requires a higher min version of macOS. An earlier version
-            # can be set manually via environment variable if you are careful
-            # in your feature usage, but 10.14 is the safest setting for
-            # general use.
-            macosx_min = "-mmacosx-version-min=" + ("10.9" if level < 17 else "10.14")
+            # (10.12 or 10.13) can be set manually via environment variable if
+            # you are careful in your feature usage, but 10.14 is the safest
+            # setting for general use. However, never set higher than the
+            # current macOS version!
+            current_macos = tuple(int(x) for x in platform.mac_ver()[0].split(".")[:2])
+            desired_macos = (10, 9) if level < 17 else (10, 14)
+            macos_string = ".".join(str(x) for x in min(current_macos, desired_macos))
+            macosx_min = "-mmacosx-version-min=" + macos_string
             self.extra_compile_args.append(macosx_min)
             self.extra_link_args.append(macosx_min)
 


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Closes #2620. On macOS 10.13, with automatic discovery on, the C++17 flag would work, and the min macOS version would be set to 10.14!

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

```rst
* setup_helpers will no longer set a minimum macOS version lower than the current version.
```

<!-- If the upgrade guide needs updating, note that here too -->
