### PR TITLE
clang -Wnon-virtual-dtor compatibility

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -243,8 +243,15 @@ function(pybind11_enable_warnings target_name)
   if(MSVC)
     target_compile_options(${target_name} PRIVATE /W4)
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Intel|Clang)" AND NOT PYBIND11_CUDA_TESTS)
-    target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wconversion -Wcast-qual
-                                                  -Wdeprecated -Wundef)
+    target_compile_options(
+      ${target_name}
+      PRIVATE -Wall
+              -Wextra
+              -Wconversion
+              -Wcast-qual
+              -Wdeprecated
+              -Wundef
+              -Wnon-virtual-dtor)
   endif()
 
   if(PYBIND11_WERROR)

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -117,7 +117,11 @@ TEST_SUBMODULE(callbacks, m) {
         }
     });
 
-    class AbstractBase { public: virtual unsigned int func() = 0; };
+    class AbstractBase {
+    public:
+        virtual ~AbstractBase() = default;
+        virtual unsigned int func() = 0;
+    };
     m.def("func_accepting_func_accepting_base", [](std::function<double(AbstractBase&)>) { });
 
     struct MovableObject {

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -32,6 +32,13 @@ class MyException3 {
 public:
     explicit MyException3(const char * m) : message{m} {}
     virtual const char * what() const noexcept {return message.c_str();}
+    // Rule of 5 BEGIN: to preempt compiler warnings.
+    MyException3(const MyException3&) = default;
+    MyException3(MyException3&&) = default;
+    MyException3& operator=(const MyException3&) = default;
+    MyException3& operator=(MyException3&&) = default;
+    virtual ~MyException3() = default;
+    // Rule of 5 END.
 private:
     std::string message = "";
 };


### PR DESCRIPTION
## Description

Adding missing virtual destructors to silence `clang -Wnon-virtual-dtor` warnings.

Tested with clang version 9.0.1-12 under an Ubuntu-like OS.
Originally discovered in the Google-internal environment.

## Suggested changelog entry:

```rst
`clang -Wnon-virtual-dtor` compatibility.
```