### PR TITLE
Use weakref to clean up captured function object in def_buffer

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1315,7 +1315,8 @@ public:
         return *this;
     }
 
-    template <typename Func> class_& def_buffer(Func &&func) {
+    template <typename Func>
+    class_& def_buffer(Func &&func) {
         struct capture { Func func; };
         auto *ptr = new capture { std::forward<Func>(func) };
         install_buffer_funcs([](PyObject *obj, void *ptr) -> buffer_info* {
@@ -1324,6 +1325,10 @@ public:
                 return nullptr;
             return new buffer_info(((capture *) ptr)->func(caster));
         }, ptr);
+        weakref(m_ptr, cpp_function([ptr](handle wr) {
+            delete ptr;
+            wr.dec_ref();
+        })).release();
         return *this;
     }
 


### PR DESCRIPTION
## Description

Leak discovered independently by @bstaletic (see https://github.com/pybind/pybind11/issues/2578#issuecomment-718913643) and @rwgk. This is one solution that cleans up after itself.

A few things to be considered:

- I would think this is safe, and the order of destruction with the `class_` object shouldn't matter? (cfr. #856) But I wouldn't mind a few people sanity-checking this, please :-)

- Another solution, suggested by @rwgk, would be to delete the `capture` as part of destructing `detail::type_info`. In order to do so, we would need some extra type info (since the `class_<T, ...>::get_buffer<F>::capture *` gets type-erased to `void *`); one solution would be to use a `shared_ptr<void>` (which remembers its deleter), or similar. Is this a better solution?

- If we do consider the solution above as better: this does require increasing the ABI version counter. Do we want to do this now, or go with the previous solution until we have a few ABI-breaking changes together and do them all at once? (Meanwhile, we could create a list of things we'd like to do that would break the ABI.)

## Suggested changelog entry:

```rst
Seal a leak in `def_buffer`, cleaning up the `capture` object after the `class_` object goes out of scope.
```