### PR TITLE
fix: Python include directory was missing from DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,10 +142,17 @@ endif()
 string(REPLACE "include/" "${CMAKE_CURRENT_SOURCE_DIR}/include/" PYBIND11_HEADERS
                "${PYBIND11_HEADERS}")
 
-# Cache variables so pybind11_add_module can be used in parent projects
-set(PYBIND11_INCLUDE_DIR
+# Cache variable so this can be used in parent projects
+set(pybind11_INCLUDE_DIR
     "${CMAKE_CURRENT_LIST_DIR}/include"
-    CACHE INTERNAL "")
+    CACHE INTERNAL "Directory where pybind11 headers are located")
+
+# Backward compatible variable for add_subdirectory mode
+if(NOT PYBIND11_MASTER_PROJECT)
+  set(PYBIND11_INCLUDE_DIR
+      "${pybind11_INCLUDE_DIR}"
+      CACHE INTERNAL "")
+endif()
 
 # Note: when creating targets, you cannot use if statements at configure time -
 # you need generator expressions, because those will be placed in the target file.
@@ -170,14 +177,14 @@ endif()
 
 # Fill in headers target
 target_include_directories(
-  pybind11_headers ${pybind11_system} INTERFACE $<BUILD_INTERFACE:${PYBIND11_INCLUDE_DIR}>
+  pybind11_headers ${pybind11_system} INTERFACE $<BUILD_INTERFACE:${pybind11_INCLUDE_DIR}>
                                                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_compile_features(pybind11_headers INTERFACE cxx_inheriting_constructors cxx_user_literals
                                                    cxx_right_angle_brackets)
 
 if(PYBIND11_INSTALL)
-  install(DIRECTORY ${PYBIND11_INCLUDE_DIR}/pybind11 DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(DIRECTORY ${pybind11_INCLUDE_DIR}/pybind11 DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
   set(PYBIND11_CMAKECONFIG_INSTALL_DIR
       "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME}"
       CACHE STRING "install path for pybind11Config.cmake")
@@ -259,8 +266,5 @@ endif()
 if(NOT PYBIND11_MASTER_PROJECT)
   set(pybind11_FOUND
       TRUE
-      CACHE INTERNAL "true if pybind11 and all required components found on the system")
-  set(pybind11_INCLUDE_DIR
-      "${PYBIND11_INCLUDE_DIR}"
-      CACHE INTERNAL "Directory where pybind11 headers are located")
+      CACHE INTERNAL "True if pybind11 and all required components found on the system")
 endif()

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -36,6 +36,12 @@ if(NOT is_config)
   set(optional_global GLOBAL)
 endif()
 
+# If not run in Python mode, we still would like this to at least
+# include pybind11's include directory:
+set(pybind11_INCLUDE_DIRS
+    "${pybind11_INCLUDE_DIR}"
+    CACHE INTERNAL "Include directory for pybind11 (Python not requested)")
+
 # --------------------- Shared targets ----------------------------
 
 # Build an interface library target:

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -130,6 +130,9 @@ if(DEFINED ${_Python}_INCLUDE_DIRS)
     TARGET pybind11::pybind11
     APPEND
     PROPERTY INTERFACE_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${${_Python}_INCLUDE_DIRS}>)
+  set(pybind11_INCLUDE_DIRS
+      "${pybind11_INCLUDE_DIR}" "${${_Python}_INCLUDE_DIRS}"
+      CACHE INTERNAL "Directories where pybind11 and possibly Python headers are located")
 endif()
 
 if(DEFINED ${_Python}_VERSION AND ${_Python}_VERSION VERSION_LESS 3)

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -87,6 +87,10 @@ set_property(
   APPEND
   PROPERTY INTERFACE_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${PYTHON_INCLUDE_DIRS}>)
 
+set(pybind11_INCLUDE_DIRS
+    "${pybind11_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
+    CACHE INTERNAL "Directories where pybind11 and possibly Python headers are located")
+
 # Python debug libraries expose slightly different objects before 3.8
 # https://docs.python.org/3.6/c-api/intro.html#debugging-builds
 # https://stackoverflow.com/questions/39161202/how-to-work-around-missing-pymodule-create2-in-amd64-win-python35-d-lib


### PR DESCRIPTION
## Description

The `PYBIND11_INCLUDE_DIRS` variable was not being set up correctly. Closes #2632.

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

```rst
* ``pybind11_INCLUDE_DIRS`` was incorrect, potentially causing a regression if
  it was expected to include ``PYTHON_INCLUDE_DIRS`` (please use targets instead)
```

<!-- If the upgrade guide needs updating, note that here too -->
