### PR TITLE
Add argument names to enum_ methods

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1628,7 +1628,7 @@ struct enum_base {
                         strict_behavior;                                               \
                     return expr;                                                       \
                 },                                                                     \
-                name(op), is_method(m_base))
+                name(op), is_method(m_base), arg("other"))
 
         #define PYBIND11_ENUM_OP_CONV(op, expr)                                        \
             m_base.attr(op) = cpp_function(                                            \
@@ -1636,7 +1636,7 @@ struct enum_base {
                     int_ a(a_), b(b_);                                                 \
                     return expr;                                                       \
                 },                                                                     \
-                name(op), is_method(m_base))
+                name(op), is_method(m_base), arg("other"))
 
         #define PYBIND11_ENUM_OP_CONV_LHS(op, expr)                                    \
             m_base.attr(op) = cpp_function(                                            \
@@ -1644,7 +1644,7 @@ struct enum_base {
                     int_ a(a_);                                                        \
                     return expr;                                                       \
                 },                                                                     \
-                name(op), is_method(m_base))
+                name(op), is_method(m_base), arg("other"))
 
         if (is_convertible) {
             PYBIND11_ENUM_OP_CONV_LHS("__eq__", !b.is_none() &&  a.equal(b));
@@ -1730,7 +1730,7 @@ public:
         constexpr bool is_convertible = std::is_convertible<Type, Scalar>::value;
         m_base.init(is_arithmetic, is_convertible);
 
-        def(init([](Scalar i) { return static_cast<Type>(i); }));
+        def(init([](Scalar i) { return static_cast<Type>(i); }), arg("value"));
         def("__int__", [](Type value) { return (Scalar) value; });
         #if PY_MAJOR_VERSION < 3
             def("__long__", [](Type value) { return (Scalar) value; });
@@ -1744,7 +1744,7 @@ public:
                 detail::initimpl::setstate<Base>(v_h, static_cast<Type>(arg),
                         Py_TYPE(v_h.inst) != v_h.type->type); },
             detail::is_new_style_constructor(),
-            pybind11::name("__setstate__"), is_method(*this));
+            pybind11::name("__setstate__"), is_method(*this), arg("state"));
     }
 
     /// Export enumeration entries into the parent scope

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -218,3 +218,10 @@ def test_duplicate_enum_name():
     with pytest.raises(ValueError) as excinfo:
         m.register_bad_enum()
     assert str(excinfo.value) == 'SimpleEnum: element "ONE" already exists!'
+
+
+def test_docstring_signatures():
+    for enum_type in [m.ScopedEnum, m.UnscopedEnum]:
+        for attr in enum_type.__dict__.values():
+            # Issue #2623/PR #2637: Add argument names to enum_ methods
+            assert "arg0" not in (attr.__doc__ or "")


### PR DESCRIPTION
## Description

Add generic names to the methods added by `enum_`, to avoid autogenerated `arg0`, etc. names.

This is not a full solution to #2623, but I think it's the best we can easily do? Taking extra parameters seems reasonably over the top, and I can't immediately come up with a better solution. Suggestions welcome, though.

Closes #2623


## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

```rst
Added parameter names to the ``py::enum_`` constructor and methods, avoiding ``arg0`` in the generated docstrings.
```
