### PR TITLE
fix: match new extension discovery with changes to classic discovery

### DIFF
--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -115,7 +115,7 @@ print('.'.join(str(v) for v in sys.version_info));
 print(sys.prefix);
 print(s.get_python_inc(plat_specific=True));
 print(s.get_python_lib(plat_specific=True));
-print(s.get_config_var('SO') or s.get_config_var('EXT_SUFFIX'));
+print(s.get_config_var('EXT_SUFFIX') or s.get_config_var('SO'));
 print(hasattr(sys, 'gettotalrefcount')+0);
 print(struct.calcsize('@P'));
 print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -97,7 +97,7 @@ if(NOT DEFINED PYTHON_MODULE_EXTENSION)
   execute_process(
     COMMAND
       "${${_Python}_EXECUTABLE}" "-c"
-      "from distutils import sysconfig as s;print(s.get_config_var('SO') or s.get_config_var('EXT_SUFFIX'))"
+      "from distutils import sysconfig as s;print(s.get_config_var('EXT_SUFFIX') or s.get_config_var('SO'))"
     OUTPUT_VARIABLE _PYTHON_MODULE_EXTENSION
     ERROR_VARIABLE _PYTHON_MODULE_EXTENSION_ERR
     OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -95,8 +95,9 @@ endif()
 # required for PyPy3 (as of 7.3.1)
 if(NOT DEFINED PYTHON_MODULE_EXTENSION)
   execute_process(
-    COMMAND "${${_Python}_EXECUTABLE}" "-c"
-            "from distutils import sysconfig; print(sysconfig.get_config_var('SO'))"
+    COMMAND
+      "${${_Python}_EXECUTABLE}" "-c"
+      "from distutils import sysconfig as s;print(s.get_config_var('SO') or s.get_config_var('EXT_SUFFIX'))"
     OUTPUT_VARIABLE _PYTHON_MODULE_EXTENSION
     ERROR_VARIABLE _PYTHON_MODULE_EXTENSION_ERR
     OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
## Description

Followup to #2638 - this was fixed in 2.6.0, but only for classic Python




## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

None needed, too small.

<!-- If the upgrade guide needs updating, note that here too -->
