### PR TITLE
Feature/local exception translator

### DIFF
--- a/docs/advanced/exceptions.rst
+++ b/docs/advanced/exceptions.rst
@@ -75,9 +75,10 @@ Registering custom translators
 
 If the default exception conversion policy described above is insufficient,
 pybind11 also provides support for registering custom exception translators.
-To register a simple exception conversion that translates a C++ exception into
-a new Python exception using the C++ exception's ``what()`` method, a helper
-function is available:
+Similar to pybind11 classes, exception translators can be local to the module
+they are defined in or global to the entire python session.  To register a simple
+exception conversion that translates a C++ exception into a new Python exception
+using the C++ exception's ``what()`` method, a helper function is available:
 
 .. code-block:: cpp
 
@@ -87,12 +88,20 @@ This call creates a Python exception class with the name ``PyExp`` in the given
 module and automatically converts any encountered exceptions of type ``CppExp``
 into Python exceptions of type ``PyExp``.
 
+A matching function is available for registering a local exception translator:
+
+.. code-block:: cpp
+
+    py::register_local_exception<CppExp>(module, "PyExp");
+
+
 It is possible to specify base class for the exception using the third
 parameter, a `handle`:
 
 .. code-block:: cpp
 
     py::register_exception<CppExp>(module, "PyExp", PyExc_RuntimeError);
+    py::register_local_exception<CppExp>(module, "PyExp", PyExc_RuntimeError);
 
 Then `PyExp` can be caught both as `PyExp` and `RuntimeError`.
 
@@ -100,16 +109,18 @@ The class objects of the built-in Python exceptions are listed in the Python
 documentation on `Standard Exceptions <https://docs.python.org/3/c-api/exceptions.html#standard-exceptions>`_.
 The default base class is `PyExc_Exception`.
 
-When more advanced exception translation is needed, the function
-``py::register_exception_translator(translator)`` can be used to register
+When more advanced exception translation is needed, the functions
+``py::register_exception_translator(translator)`` and
+``py::register_local_exception_translator(translator)`` can be used to register
 functions that can translate arbitrary exception types (and which may include
-additional logic to do so).  The function takes a stateless callable (e.g.  a
+additional logic to do so).  The functions takes a stateless callable (e.g. a
 function pointer or a lambda function without captured variables) with the call
 signature ``void(std::exception_ptr)``.
 
 When a C++ exception is thrown, the registered exception translators are tried
 in reverse order of registration (i.e. the last registered translator gets the
-first shot at handling the exception).
+first shot at handling the exception). All local translators will be tried
+before a global translator is tried.
 
 Inside the translator, ``std::rethrow_exception`` should be used within
 a try block to re-throw the exception.  One or more catch clauses to catch
@@ -167,6 +178,56 @@ section.
     Note that ``libc++`` and ``libstdc++`` `behave differently <https://stackoverflow.com/questions/19496643/using-clang-fvisibility-hidden-and-typeinfo-and-type-erasure/28827430>`_
     with ``-fvisibility=hidden``. Therefore exceptions that are used across ABI boundaries need to be explicitly exported, as exercised in ``tests/test_exceptions.h``.
     See also: "Problems with C++ exceptions" under `GCC Wiki <https://gcc.gnu.org/wiki/Visibility>`_.
+
+
+Local vs Global Exception Translators
+=====================================
+
+Similar to how the ``py::module_local`` flag allows uesrs to limit a bound class
+to a single compiled module to prevent name collisions. When a global exception
+translator is registered, it will be applied across all modules in the reverse
+order of registration. This can create behavior where the order of module import
+influences how exceptions are translated.
+
+If module1 has the following translator:
+
+.. code-block:: cpp
+
+      py::register_exception_translator([](std::exception_ptr p) {
+        try {
+            if (p) std::rethrow_exception(p);
+        } catch (const std::invalid_argument &e) {
+            PyErr_SetString("module1 handled this")
+        }
+      }
+
+and module2 has the following similar translator:
+
+.. code-block:: cpp
+
+      py::register_exception_translator([](std::exception_ptr p) {
+        try {
+            if (p) std::rethrow_exception(p);
+        } catch (const std::invalid_argument &e) {
+            PyErr_SetString("module2 handled this")
+        }
+      }
+
+then which translator handles the invalid_argument will be determined by the
+order that module1 and module2 are imported. Since exception translators are
+applied in the reverse order of registration, which ever module was imported
+last will "win" and that translator will be applied.
+
+If there are multiple pybind11 modules that share exception types (either
+standard built-in or custom) loaded into a single python instance and
+consistent error handling behavior is needed, then local translators should be
+used.
+
+Changing the previous example to use register_local_exception_translator would
+mean that when invalid_argument is thrown in the module2 code, the module2
+translator will always handle it, while in module1, the module1 translator will
+do the same.
+>>>>>>> 854aa95a (Update documentation for new local exception feature)
 
 .. _handling_python_exceptions_cpp:
 

--- a/docs/advanced/exceptions.rst
+++ b/docs/advanced/exceptions.rst
@@ -183,11 +183,9 @@ section.
 Local vs Global Exception Translators
 =====================================
 
-Similar to how the ``py::module_local`` flag allows uesrs to limit a bound class
-to a single compiled module to prevent name collisions. When a global exception
-translator is registered, it will be applied across all modules in the reverse
-order of registration. This can create behavior where the order of module import
-influences how exceptions are translated.
+When a global exception translator is registered, it will be applied across all
+modules in the reverse order of registration. This can create behavior where the
+order of module import influences how exceptions are translated.
 
 If module1 has the following translator:
 
@@ -223,11 +221,10 @@ standard built-in or custom) loaded into a single python instance and
 consistent error handling behavior is needed, then local translators should be
 used.
 
-Changing the previous example to use register_local_exception_translator would
-mean that when invalid_argument is thrown in the module2 code, the module2
-translator will always handle it, while in module1, the module1 translator will
-do the same.
->>>>>>> 854aa95a (Update documentation for new local exception feature)
+Changing the previous example to use ``register_local_exception_translator``
+would mean that when invalid_argument is thrown in the module2 code, the
+module2 translator will always handle it, while in module1, the module1
+translator will do the same.
 
 .. _handling_python_exceptions_cpp:
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -209,7 +209,7 @@ extern "C" inline void pybind11_meta_dealloc(PyObject *obj) {
         internals.direct_conversions.erase(tindex);
 
         if (tinfo->module_local)
-            registered_local_types_cpp().erase(tindex);
+            get_registered_local_types_cpp().erase(tindex);
         else
             internals.registered_types_cpp.erase(tindex);
         internals.registered_types_py.erase(tinfo->type);

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -209,7 +209,7 @@ extern "C" inline void pybind11_meta_dealloc(PyObject *obj) {
         internals.direct_conversions.erase(tindex);
 
         if (tinfo->module_local)
-            get_local_internals().registered_local_types_cpp.erase(tindex);
+            get_local_internals().registered_types_cpp.erase(tindex);
         else
             internals.registered_types_cpp.erase(tindex);
         internals.registered_types_py.erase(tinfo->type);

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -209,7 +209,7 @@ extern "C" inline void pybind11_meta_dealloc(PyObject *obj) {
         internals.direct_conversions.erase(tindex);
 
         if (tinfo->module_local)
-            get_registered_local_types_cpp().erase(tindex);
+            get_local_internals().registered_local_types_cpp.erase(tindex);
         else
             internals.registered_types_cpp.erase(tindex);
         internals.registered_types_py.erase(tinfo->type);

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -325,7 +325,7 @@ inline module_internals &get_module_internals() {
 }
 
 /// Works like `internals.registered_types_cpp`, but for module-local registered types:
-inline type_map<type_info *> &registered_local_types_cpp() {
+inline type_map<type_info *> &get_registered_local_types_cpp() {
     return get_module_internals().registered_local_types_cpp;
 }
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -320,7 +320,7 @@ PYBIND11_NOINLINE inline internals &get_internals() {
 
 // the internals struct (above) is shared between all the modules. local_internals are only
 // for a single module. Any changes made to internals may require an update to
-// PYBIND11_INTERNALS_VERSION, breaking backwards compatiblity. local_internals is, by design,
+// PYBIND11_INTERNALS_VERSION, breaking backwards compatibility. local_internals is, by design,
 // restricted to a single module. Whether a module has local internals or not should not
 // impact any other modules, because the only things accessing the local internals is the
 // module that contains them.

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -12,7 +12,11 @@
 #include "../pytypes.h"
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+
+using ExceptionTranslator = void (*)(std::exception_ptr);
+
 PYBIND11_NAMESPACE_BEGIN(detail)
+
 // Forward declarations
 inline PyTypeObject *make_static_property_type();
 inline PyTypeObject *make_default_metaclass();
@@ -100,7 +104,7 @@ struct internals {
     std::unordered_set<std::pair<const PyObject *, const char *>, override_hash> inactive_override_cache;
     type_map<std::vector<bool (*)(PyObject *, void *&)>> direct_conversions;
     std::unordered_map<const PyObject *, std::vector<PyObject *>> patients;
-    std::forward_list<void (*) (std::exception_ptr)> registered_exception_translators;
+    std::forward_list<ExceptionTranslator> registered_exception_translators;
     std::unordered_map<std::string, void *> shared_data; // Custom data to be shared across extensions
     std::vector<PyObject *> loader_patient_stack; // Used by `loader_life_support`
     std::forward_list<std::string> static_strings; // Stores the std::strings backing detail::c_str()
@@ -316,7 +320,7 @@ PYBIND11_NOINLINE inline internals &get_internals() {
 
 struct local_internals {
   type_map<type_info *> registered_local_types_cpp;
-  std::forward_list<void (*) (std::exception_ptr)> registered_local_exception_translators;
+  std::forward_list<ExceptionTranslator> registered_local_exception_translators;
 };
 
 /// Works like `get_internals`, but for things which are locally registered.

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -314,19 +314,15 @@ PYBIND11_NOINLINE inline internals &get_internals() {
 }
 
 
-struct module_internals {
+struct local_internals {
   type_map<type_info *> registered_local_types_cpp;
   std::forward_list<void (*) (std::exception_ptr)> registered_local_exception_translators;
 };
 
-inline module_internals &get_module_internals() {
-  static module_internals locals;
+/// Works like `get_internals`, but for things which are locally registered.
+inline local_internals &get_local_internals() {
+  static local_internals locals;
   return locals;
-}
-
-/// Works like `internals.registered_types_cpp`, but for module-local registered types:
-inline type_map<type_info *> &get_registered_local_types_cpp() {
-    return get_module_internals().registered_local_types_cpp;
 }
 
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -313,11 +313,22 @@ PYBIND11_NOINLINE inline internals &get_internals() {
     return **internals_pp;
 }
 
+
+struct module_internals {
+  type_map<type_info *> registered_local_types_cpp;
+  std::forward_list<void (*) (std::exception_ptr)> registered_local_exception_translators;
+};
+
+inline module_internals &get_module_internals() {
+  static module_internals locals;
+  return locals;
+}
+
 /// Works like `internals.registered_types_cpp`, but for module-local registered types:
 inline type_map<type_info *> &registered_local_types_cpp() {
-    static type_map<type_info *> locals{};
-    return locals;
+    return get_module_internals().registered_local_types_cpp;
 }
+
 
 /// Constructs a std::string with the given arguments, stores it in `internals`, and returns its
 /// `c_str()`.  Such strings objects have a long storage duration -- the internal strings are only

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -318,6 +318,12 @@ PYBIND11_NOINLINE inline internals &get_internals() {
 }
 
 
+// the internals struct (above) is shared between all the modules. local_internals are only
+// for a single module. Any changes made to internals may require an update to
+// PYBIND11_INTERNALS_VERSION, breaking backwards compatiblity. local_internals is, by design,
+// restricted to a single module. Whether a module has local internals or not should not
+// impact any other modules, because the only things accessing the local internals is the
+// module that contains them.
 struct local_internals {
   type_map<type_info *> registered_types_cpp;
   std::forward_list<ExceptionTranslator> registered_exception_translators;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -319,8 +319,8 @@ PYBIND11_NOINLINE inline internals &get_internals() {
 
 
 struct local_internals {
-  type_map<type_info *> registered_local_types_cpp;
-  std::forward_list<ExceptionTranslator> registered_local_exception_translators;
+  type_map<type_info *> registered_types_cpp;
+  std::forward_list<ExceptionTranslator> registered_exception_translators;
 };
 
 /// Works like `get_internals`, but for things which are locally registered.

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -160,7 +160,7 @@ PYBIND11_NOINLINE inline detail::type_info* get_type_info(PyTypeObject *type) {
 }
 
 inline detail::type_info *get_local_type_info(const std::type_index &tp) {
-    auto &locals = registered_local_types_cpp();
+    auto &locals = get_local_internals().registered_local_types_cpp;
     auto it = locals.find(tp);
     if (it != locals.end())
         return it->second;

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -160,7 +160,7 @@ PYBIND11_NOINLINE inline detail::type_info* get_type_info(PyTypeObject *type) {
 }
 
 inline detail::type_info *get_local_type_info(const std::type_index &tp) {
-    auto &locals = get_local_internals().registered_local_types_cpp;
+    auto &locals = get_local_internals().registered_types_cpp;
     auto it = locals.find(tp);
     if (it != locals.end())
         return it->second;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1146,7 +1146,7 @@ protected:
         auto tindex = std::type_index(*rec.type);
         tinfo->direct_conversions = &internals.direct_conversions[tindex];
         if (rec.module_local)
-            registered_local_types_cpp()[tindex] = tinfo;
+            get_registered_local_types_cpp()[tindex] = tinfo;
         else
             internals.registered_types_cpp[tindex] = tinfo;
         internals.registered_types_py[(PyTypeObject *) m_ptr] = { tinfo };
@@ -1332,7 +1332,7 @@ public:
         generic_type::initialize(record);
 
         if (has_alias) {
-            auto &instances = record.module_local ? registered_local_types_cpp() : get_internals().registered_types_cpp;
+            auto &instances = record.module_local ? get_registered_local_types_cpp() : get_internals().registered_types_cpp;
             instances[std::type_index(typeid(type_alias))] = instances[std::type_index(typeid(type))];
         }
     }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -856,7 +856,7 @@ protected:
 
             auto last_exception = std::current_exception();
 
-            auto & registered_local_exception_translators = get_module_internals().registered_local_exception_translators;
+            auto & registered_local_exception_translators = get_local_internals().registered_local_exception_translators;
             for (auto& translator : registered_local_exception_translators) {
                 try {
                     translator(last_exception);
@@ -1150,7 +1150,7 @@ protected:
         auto tindex = std::type_index(*rec.type);
         tinfo->direct_conversions = &internals.direct_conversions[tindex];
         if (rec.module_local)
-            get_registered_local_types_cpp()[tindex] = tinfo;
+            get_local_internals().registered_local_types_cpp[tindex] = tinfo;
         else
             internals.registered_types_cpp[tindex] = tinfo;
         internals.registered_types_py[(PyTypeObject *) m_ptr] = { tinfo };
@@ -1336,7 +1336,7 @@ public:
         generic_type::initialize(record);
 
         if (has_alias) {
-            auto &instances = record.module_local ? get_registered_local_types_cpp() : get_internals().registered_types_cpp;
+            auto &instances = record.module_local ? get_local_internals().registered_local_types_cpp : get_internals().registered_types_cpp;
             instances[std::type_index(typeid(type_alias))] = instances[std::type_index(typeid(type))];
         }
     }
@@ -2051,7 +2051,7 @@ void register_exception_translator(ExceptionTranslator&& translator) {
   */
 template <typename ExceptionTranslator>
 void register_local_exception_translator(ExceptionTranslator&& translator) {
-    detail::get_module_internals().registered_local_exception_translators.push_front(
+    detail::get_local_internals().registered_local_exception_translators.push_front(
         std::forward<ExceptionTranslator>(translator));
 }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -840,8 +840,12 @@ protected:
 #endif
         } catch (...) {
             /* When an exception is caught, give each registered exception
-               translator a chance to translate it to a Python exception
-               in reverse order of registration.
+               translator a chance to translate it to a Python exception. First
+               all module-local translators will be tried in reverse order of
+               registration. If none of the module-locale translators handle
+               the exception (or there are no module-locale translators) then
+               the global translators will be tried, also in reverse order of
+               registration.
 
                A translator may choose to do one of the following:
 
@@ -2040,9 +2044,10 @@ void register_exception_translator(ExceptionTranslator&& translator) {
 
 
 /**
-  * Add a new module-local exception translator. This function will be applied
-  * before any globally registered exception translators, which will only be
-  * invoked if the moduke-local handlers do not deal with the exception.
+  * Add a new module-local exception translator. Locally registered functions
+  * will be tried before any globally registered exception translators, which
+  * will only be invoked if the moduke-local handlers do not deal with
+  * the exception.
   */
 template <typename ExceptionTranslator>
 void register_local_exception_translator(ExceptionTranslator&& translator) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -76,7 +76,7 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 inline bool apply_exception_translators(std::forward_list<void (*) (std::exception_ptr)>& translators) {
     auto last_exception = std::current_exception();
 
-    for (auto& translator : translators) {
+    for (auto &translator : translators) {
         try {
             translator(last_exception);
             return true;
@@ -881,11 +881,11 @@ protected:
 
             auto &local_exception_translators = get_local_internals().registered_local_exception_translators;
             if (detail::apply_exception_translators(local_exception_translators)) {
-              return nullptr;
+                return nullptr;
             }
             auto &exception_translators = get_internals().registered_exception_translators;
             if (detail::apply_exception_translators(exception_translators)) {
-              return nullptr;
+                return nullptr;
             }
 
             PyErr_SetString(PyExc_SystemError, "Exception escaped from default exception translator!");
@@ -2050,7 +2050,7 @@ template <typename InputType, typename OutputType> void implicitly_convertible()
 
 
 template <typename ExceptionTranslator>
-void register_exception_translator(ExceptionTranslator&& translator) {
+void register_exception_translator(ExceptionTranslator &&translator) {
     detail::get_internals().registered_exception_translators.push_front(
         std::forward<ExceptionTranslator>(translator));
 }
@@ -2063,7 +2063,7 @@ void register_exception_translator(ExceptionTranslator&& translator) {
   * the exception.
   */
 template <typename ExceptionTranslator>
-void register_local_exception_translator(ExceptionTranslator&& translator) {
+void register_local_exception_translator(ExceptionTranslator &&translator) {
     detail::get_local_internals().registered_local_exception_translators.push_front(
         std::forward<ExceptionTranslator>(translator));
 }
@@ -2102,7 +2102,7 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 template <typename CppException>
 exception<CppException> &get_exception_object() { static exception<CppException> ex; return ex; }
 
-using BasicTranslator = void(*)(std::exception_ptr);
+using BasicTranslator = void (*)(std::exception_ptr);
 
 // Helper function for register_exception and register_local_exception
 template <typename CppException>
@@ -2113,7 +2113,8 @@ exception<CppException> &register_exception_impl(handle scope,
     auto &ex = detail::get_exception_object<CppException>();
     if (!ex) ex = exception<CppException>(scope, name, base);
 
-    auto register_func = isLocal ? &register_local_exception_translator<BasicTranslator> : &register_exception_translator<BasicTranslator>;
+    auto register_func = isLocal ? &register_local_exception_translator<BasicTranslator>
+                                 : &register_exception_translator<BasicTranslator>;
 
     register_func([](std::exception_ptr p) {
         if (!p) return;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -878,7 +878,7 @@ protected:
                 - do nothing and let the exception fall through to the next translator, or
                 - delegate translation to the next translator by throwing a new type of exception. */
 
-            auto &local_exception_translators = get_local_internals().registered_local_exception_translators;
+            auto &local_exception_translators = get_local_internals().registered_exception_translators;
             if (detail::apply_exception_translators(local_exception_translators)) {
                 return nullptr;
             }
@@ -1161,7 +1161,7 @@ protected:
         auto tindex = std::type_index(*rec.type);
         tinfo->direct_conversions = &internals.direct_conversions[tindex];
         if (rec.module_local)
-            get_local_internals().registered_local_types_cpp[tindex] = tinfo;
+            get_local_internals().registered_types_cpp[tindex] = tinfo;
         else
             internals.registered_types_cpp[tindex] = tinfo;
         internals.registered_types_py[(PyTypeObject *) m_ptr] = { tinfo };
@@ -1347,7 +1347,7 @@ public:
         generic_type::initialize(record);
 
         if (has_alias) {
-            auto &instances = record.module_local ? get_local_internals().registered_local_types_cpp : get_internals().registered_types_cpp;
+            auto &instances = record.module_local ? get_local_internals().registered_types_cpp : get_internals().registered_types_cpp;
             instances[std::type_index(typeid(type_alias))] = instances[std::type_index(typeid(type))];
         }
     }
@@ -2061,7 +2061,7 @@ inline void register_exception_translator(ExceptionTranslator &&translator) {
   * the exception.
   */
 inline void register_local_exception_translator(ExceptionTranslator &&translator) {
-    detail::get_local_internals().registered_local_exception_translators.push_front(
+    detail::get_local_internals().registered_exception_translators.push_front(
         std::forward<ExceptionTranslator>(translator));
 }
 

--- a/tests/local_bindings.h
+++ b/tests/local_bindings.h
@@ -35,6 +35,17 @@ using NonLocalVec2 = std::vector<NonLocal2>;
 using NonLocalMap = std::unordered_map<std::string, NonLocalType>;
 using NonLocalMap2 = std::unordered_map<std::string, uint8_t>;
 
+
+// Exception that will be caught via the module local translator.
+class LocalException : public std::exception {
+public:
+    explicit LocalException(const char * m) : message{m} {}
+    const char * what() const noexcept override {return message.c_str();}
+private:
+    std::string message = "";
+};
+
+
 PYBIND11_MAKE_OPAQUE(LocalVec);
 PYBIND11_MAKE_OPAQUE(LocalVec2);
 PYBIND11_MAKE_OPAQUE(LocalMap);

--- a/tests/local_bindings.h
+++ b/tests/local_bindings.h
@@ -45,6 +45,14 @@ private:
     std::string message = "";
 };
 
+// Exception that will be registered with register_local_exception_translator
+class LocalSimpleException : public std::exception {
+public:
+    explicit LocalSimpleException(const char * m) : message{m} {}
+    const char * what() const noexcept override {return message.c_str();}
+private:
+    std::string message = "";
+};
 
 PYBIND11_MAKE_OPAQUE(LocalVec);
 PYBIND11_MAKE_OPAQUE(LocalVec2);

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -108,7 +108,7 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.def("get_mixed_lg", [](int i) { return MixedLocalGlobal(i); });
 
     // test_internal_locals_differ
-    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::get_registered_local_types_cpp(); });
+    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::get_local_internals().registered_local_types_cpp; });
 
     // test_stl_caster_vs_stl_bind
     py::bind_vector<std::vector<int>>(m, "VectorInt");

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -108,7 +108,7 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.def("get_mixed_lg", [](int i) { return MixedLocalGlobal(i); });
 
     // test_internal_locals_differ
-    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::get_local_internals().registered_local_types_cpp; });
+    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::get_local_internals().registered_types_cpp; });
 
     // test_stl_caster_vs_stl_bind
     py::bind_vector<std::vector<int>>(m, "VectorInt");

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -106,7 +106,7 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.def("get_mixed_lg", [](int i) { return MixedLocalGlobal(i); });
 
     // test_internal_locals_differ
-    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::registered_local_types_cpp(); });
+    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::get_registered_local_types_cpp(); });
 
     // test_stl_caster_vs_stl_bind
     py::bind_vector<std::vector<int>>(m, "VectorInt");

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -34,11 +34,23 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.def("throw_pybind_value_error", []() { throw py::value_error("pybind11 value error"); });
     m.def("throw_pybind_type_error", []() { throw py::type_error("pybind11 type error"); });
     m.def("throw_stop_iteration", []() { throw py::stop_iteration(); });
+    m.def("throw_local_error", []() { throw LocalException("just local"); });
     py::register_exception_translator([](std::exception_ptr p) {
       try {
           if (p) std::rethrow_exception(p);
       } catch (const shared_exception &e) {
           PyErr_SetString(PyExc_KeyError, e.what());
+      }
+    });
+
+    // translate the local exception into a key error but only in this module
+    py::register_local_exception_translator([](std::exception_ptr p) {
+      try {
+          if (p) {
+            std::rethrow_exception(p);
+          }
+      } catch (const LocalException &e) {
+        PyErr_SetString(PyExc_KeyError, e.what());
       }
     });
 

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -29,12 +29,14 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     bind_local<ExternalType2>(m, "ExternalType2", py::module_local());
 
     // test_exceptions.py
+    py::register_local_exception<LocalSimpleException>(m, "LocalSimpleException");
     m.def("raise_runtime_error", []() { PyErr_SetString(PyExc_RuntimeError, "My runtime error"); throw py::error_already_set(); });
     m.def("raise_value_error", []() { PyErr_SetString(PyExc_ValueError, "My value error"); throw py::error_already_set(); });
     m.def("throw_pybind_value_error", []() { throw py::value_error("pybind11 value error"); });
     m.def("throw_pybind_type_error", []() { throw py::type_error("pybind11 type error"); });
     m.def("throw_stop_iteration", []() { throw py::stop_iteration(); });
     m.def("throw_local_error", []() { throw LocalException("just local"); });
+    m.def("throw_local_simple_error", []() { throw LocalSimpleException("external mod"); });
     py::register_exception_translator([](std::exception_ptr p) {
       try {
           if (p) std::rethrow_exception(p);

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -149,6 +149,8 @@ TEST_SUBMODULE(exceptions, m) {
     // A slightly more complicated one that declares MyException5_1 as a subclass of MyException5
     py::register_exception<MyException5_1>(m, "MyException5_1", ex5.ptr());
 
+    //py::register_local_exception<LocalSimpleException>(m, "LocalSimpleException")
+
     py::register_local_exception_translator([](std::exception_ptr p) {
       try {
           if (p) {
@@ -169,6 +171,7 @@ TEST_SUBMODULE(exceptions, m) {
     m.def("throws_logic_error", []() { throw std::logic_error("this error should fall through to the standard handler"); });
     m.def("throws_overflow_error", []() { throw std::overflow_error(""); });
     m.def("throws_local_error", []() { throw LocalException("never caught"); });
+    m.def("throws_local_simple_error", []() { throw LocalSimpleException("this mod"); });
     m.def("exception_matches", []() {
         py::dict foo;
         try {

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -6,8 +6,8 @@
     All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file.
 */
-
 #include "test_exceptions.h"
+#include "local_bindings.h"
 
 #include "pybind11_tests.h"
 #include <utility>
@@ -67,6 +67,17 @@ public:
 class MyException5_1 : public MyException5 {
     using MyException5::MyException5;
 };
+
+
+// Exception that will be caught via the module local translator.
+class MyException6 : public std::exception {
+public:
+    explicit MyException6(const char * m) : message{m} {}
+    const char * what() const noexcept override {return message.c_str();}
+private:
+    std::string message = "";
+};
+
 
 struct PythonCallInDestructor {
     PythonCallInDestructor(const py::dict &d) : d(d) {}
@@ -138,14 +149,26 @@ TEST_SUBMODULE(exceptions, m) {
     // A slightly more complicated one that declares MyException5_1 as a subclass of MyException5
     py::register_exception<MyException5_1>(m, "MyException5_1", ex5.ptr());
 
+    py::register_local_exception_translator([](std::exception_ptr p) {
+      try {
+          if (p) {
+            std::rethrow_exception(p);
+          }
+      } catch (const MyException6 &e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    });
+
     m.def("throws1", []() { throw MyException("this error should go to a custom type"); });
     m.def("throws2", []() { throw MyException2("this error should go to a standard Python exception"); });
     m.def("throws3", []() { throw MyException3("this error cannot be translated"); });
     m.def("throws4", []() { throw MyException4("this error is rethrown"); });
     m.def("throws5", []() { throw MyException5("this is a helper-defined translated exception"); });
     m.def("throws5_1", []() { throw MyException5_1("MyException5 subclass"); });
+    m.def("throws6", []() { throw MyException6("MyException6 only handled in this module"); });
     m.def("throws_logic_error", []() { throw std::logic_error("this error should fall through to the standard handler"); });
-    m.def("throws_overflow_error", []() {throw std::overflow_error(""); });
+    m.def("throws_overflow_error", []() { throw std::overflow_error(""); });
+    m.def("throws_local_error", []() { throw LocalException("never caught"); });
     m.def("exception_matches", []() {
         py::dict foo;
         try {

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -7,6 +7,7 @@
     BSD-style license that can be found in the LICENSE file.
 */
 #include "test_exceptions.h"
+
 #include "local_bindings.h"
 
 #include "pybind11_tests.h"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -232,7 +232,7 @@ def test_local_translator(msg):
     """Tests that a local translator works and that the local translator from
     the cross module is not applied"""
     with pytest.raises(RuntimeError) as excinfo:
-       m.throws6()
+        m.throws6()
     assert msg(excinfo.value) == "MyException6 only handled in this module"
 
     with pytest.raises(RuntimeError) as excinfo:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -25,7 +25,7 @@ def test_error_already_set(msg):
     assert msg(excinfo.value) == "foo"
 
 
-def test_cross_module_exceptions():
+def test_cross_module_exceptions(msg):
     with pytest.raises(RuntimeError) as excinfo:
         cm.raise_runtime_error()
     assert str(excinfo.value) == "My runtime error"
@@ -44,6 +44,10 @@ def test_cross_module_exceptions():
 
     with pytest.raises(StopIteration) as excinfo:
         cm.throw_stop_iteration()
+
+    with pytest.raises(KeyError) as excinfo:
+        cm.throw_local_error()
+    assert msg(excinfo.value) == "just local"
 
 
 # TODO: FIXME
@@ -221,3 +225,16 @@ def test_invalid_repr():
 
     with pytest.raises(TypeError):
         m.simple_bool_passthrough(MyRepr())
+
+
+def test_local_translator(msg):
+    """Tests that a local translator works and that the local translator from
+    the cross module is not applied"""
+    with pytest.raises(RuntimeError) as excinfo:
+       m.throws6()
+    assert msg(excinfo.value) == "MyException6 only handled in this module"
+
+    with pytest.raises(RuntimeError) as excinfo:
+        m.throws_local_error()
+    assert type(excinfo) != KeyError
+    assert msg(excinfo.value) == "never caught"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -25,7 +25,7 @@ def test_error_already_set(msg):
     assert msg(excinfo.value) == "foo"
 
 
-def test_cross_module_exceptions(msg):
+def test_cross_module_exceptions():
     with pytest.raises(RuntimeError) as excinfo:
         cm.raise_runtime_error()
     assert str(excinfo.value) == "My runtime error"
@@ -47,7 +47,8 @@ def test_cross_module_exceptions(msg):
 
     with pytest.raises(KeyError) as excinfo:
         cm.throw_local_error()
-    assert msg(excinfo.value) == "just local"
+    # KeyError adds an extra set of quotes to the str value.
+    assert str(excinfo.value) == "'just local'"
 
 
 # TODO: FIXME

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -25,7 +25,7 @@ def test_error_already_set(msg):
     assert msg(excinfo.value) == "foo"
 
 
-def test_cross_module_exceptions():
+def test_cross_module_exceptions(msg):
     with pytest.raises(RuntimeError) as excinfo:
         cm.raise_runtime_error()
     assert str(excinfo.value) == "My runtime error"
@@ -45,9 +45,13 @@ def test_cross_module_exceptions():
     with pytest.raises(StopIteration) as excinfo:
         cm.throw_stop_iteration()
 
+    with pytest.raises(cm.LocalSimpleException) as excinfo:
+        cm.throw_local_simple_error()
+    assert msg(excinfo.value) == "external mod"
+
     with pytest.raises(KeyError) as excinfo:
         cm.throw_local_error()
-    # KeyError adds an extra set of quotes to the str value.
+    # KeyError is a repr of the key, so it has an extra set of quotes
     assert str(excinfo.value) == "'just local'"
 
 
@@ -237,5 +241,10 @@ def test_local_translator(msg):
 
     with pytest.raises(RuntimeError) as excinfo:
         m.throws_local_error()
-    assert type(excinfo) != KeyError
+    assert not isinstance(excinfo.value, KeyError)
     assert msg(excinfo.value) == "never caught"
+
+    with pytest.raises(Exception) as excinfo:
+        m.throws_local_simple_error()
+    assert not isinstance(excinfo.value, cm.LocalSimpleException)
+    assert msg(excinfo.value) == "this mod"

--- a/tests/test_local_bindings.cpp
+++ b/tests/test_local_bindings.cpp
@@ -78,7 +78,7 @@ TEST_SUBMODULE(local_bindings, m) {
     m.def("get_mixed_lg", [](int i) { return MixedLocalGlobal(i); });
 
     // test_internal_locals_differ
-    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::get_registered_local_types_cpp(); });
+    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::get_local_internals().registered_local_types_cpp; });
 
     // test_stl_caster_vs_stl_bind
     m.def("load_vector_via_caster", [](std::vector<int> v) {

--- a/tests/test_local_bindings.cpp
+++ b/tests/test_local_bindings.cpp
@@ -78,7 +78,7 @@ TEST_SUBMODULE(local_bindings, m) {
     m.def("get_mixed_lg", [](int i) { return MixedLocalGlobal(i); });
 
     // test_internal_locals_differ
-    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::registered_local_types_cpp(); });
+    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::get_registered_local_types_cpp(); });
 
     // test_stl_caster_vs_stl_bind
     m.def("load_vector_via_caster", [](std::vector<int> v) {

--- a/tests/test_local_bindings.cpp
+++ b/tests/test_local_bindings.cpp
@@ -78,7 +78,7 @@ TEST_SUBMODULE(local_bindings, m) {
     m.def("get_mixed_lg", [](int i) { return MixedLocalGlobal(i); });
 
     // test_internal_locals_differ
-    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::get_local_internals().registered_local_types_cpp; });
+    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::get_local_internals().registered_types_cpp; });
 
     // test_stl_caster_vs_stl_bind
     m.def("load_vector_via_caster", [](std::vector<int> v) {


### PR DESCRIPTION
## Description

Allow exception translators to be optionally registered local to a module instead of applying globally across all pybind11 modules.

This is useful in a situation where there are more than one compiled modules (e.g., clients for different micro-services) that share a lot of the same core code on the c++ side, including exceptions. Shared classes can be handled via the py::module_local() tag on the classes, but there is currently no way to deal with exception remapping.

So in code like:
```
    py::register_exception_translator([](std::exception_ptr p) {
      try {
        if (p) {
          std::rethrow_exception(p);
        }
      }
      catch (const ::vasg::exceptions::VasgException& e) {
        auto err = py::cast(e);
        auto errType = err.get_type().ptr();
        PyErr_SetObject(errType, err.ptr());
      }
```
The exception translator is global, so which module's exception you get back is determined by import order.

As an example, if you did something like
```
import tempo # compiled lib 

tempo.resolveKey(badPath)
```
you get back an exception from the tempo module.

However, if you were to do
```
import rhapsody # compiled lib
import tempo # compiled lib

tempo.resolveKey(badPath)
```
you'd get back an exception from the rhapsody module. Since those are different types in python (but the same type in c++), it means catch statements which are expecting the exception to come from the same module as the call are failing.


## Suggested changelog entry:

```rst

Allow exception translators to be optionally registered local to a module instead of applying globally across all pybind11 modules.
Use 
register_local_exception_translator(ExceptionTranslator&& translator)
instead of 
register_exception_translator(ExceptionTranslator&& translator)
to keep your exception remapping code local to the module.
```

### Why does this not require an Internals Version bump?
The internals struct in pybind11 is shared between all the modules. Any changes to that definitely requires a lot of careful thought about whether backwards compatibility is being broken. The local_internals that are added here should, by design, be segregated to a single module. Whether a module has local internals or not should not impact any other modules, because the only things accessing the local internals is the module that contains them.
