### PR TITLE
fix: make FindPython2 and FindPython3 work

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -144,11 +144,11 @@ if(DEFINED ${_Python}_VERSION AND ${_Python}_VERSION VERSION_LESS 3)
 endif()
 
 # In CMake 3.18+, you can find these separately, so include an if
-if(TARGET ${_Python}::${_Python})
+if(TARGET ${_Python}::Python)
   set_property(
     TARGET pybind11::embed
     APPEND
-    PROPERTY INTERFACE_LINK_LIBRARIES ${_Python}::${_Python})
+    PROPERTY INTERFACE_LINK_LIBRARIES ${_Python}::Python)
 endif()
 
 # CMake 3.15+ has this


### PR DESCRIPTION
## Description

When using FindPython3 (or FindPython2) from outside for a project that embeds the Python interpreter (with `pybind11:embed`), pybind11 isn't detecting Python correctly. This results in a working cmake execution, but with linking errors after building. FindPython is working though.
This is due to wrong target names (e.g. `Python3::Python3` instead of `Python3::Python`) used in `pybind11NewTools.cmake`.

This was tested under Debian testing with an actual pybind11 git clone, cmake 3.16.3 and Python 3.8.5

## Suggested changelog entry:

```rst
fix: make FindPython2 and FindPython3 work
```

Close #2664 