### PR TITLE
Fix an issue where the pybind::embedd target would link to an incorrect python lib

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -144,11 +144,11 @@ if(DEFINED ${_Python}_VERSION AND ${_Python}_VERSION VERSION_LESS 3)
 endif()
 
 # In CMake 3.18+, you can find these separately, so include an if
-if(TARGET ${_Python}::${_Python})
+if(TARGET ${_Python}::Python)
   set_property(
     TARGET pybind11::embed
     APPEND
-    PROPERTY INTERFACE_LINK_LIBRARIES ${_Python}::${_Python})
+    PROPERTY INTERFACE_LINK_LIBRARIES ${_Python}::Python)
 endif()
 
 # CMake 3.15+ has this


### PR DESCRIPTION
Fix an issue where the pybind::embedd target would link to an incorrect python lib
* with find_package(Python3) it would link the wrong Python3::Pyhton3 instead of the correct Python3::Pyhton
* with find_package(Python2) it would link the wrong Python2::Pyhton2 instead of the correct Python3::Pyhton

Fix #2664

## Description
Fix an issue where the pybind::embedd target would link to an incorrect python lib
* with find_package(Python3) it would link the wrong Python3::Pyhton3 instead of the correct Python3::Pyhton
* with find_package(Python2) it would link the wrong Python2::Pyhton2 instead of the correct Python3::Pyhton

Changed the target `${_Python}::${_Python}` to `${_Python}::Python`

## Suggested changelog entry:

```rst
Fix an issue where the pybind::embedd target would link to an incorrect python lib
```