### PR TITLE
Compose literals for argument values in docstring

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,7 @@ set(PYBIND11_TEST_FILES
     test_copy_move.cpp
     test_custom_type_casters.cpp
     test_docstring_options.cpp
+    test_docstring_function_signature.cpp
     test_eigen.cpp
     test_enum.cpp
     test_eval.cpp

--- a/tests/test_docstring_function_signature.cpp
+++ b/tests/test_docstring_function_signature.cpp
@@ -1,0 +1,23 @@
+/*
+    tests/test_docstring_options.cpp -- generation of docstrings function signatures
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#include "pybind11_tests.h"
+#include "pybind11/stl.h"
+
+enum class Color {Red};
+
+TEST_SUBMODULE(docstring_function_signature, m) {
+    // test_docstring_function_signatures
+    pybind11::enum_<Color> (m, "Color").value("Red", Color::Red);
+    m.def("a", [](Color) {}, pybind11::arg("a") = Color::Red);
+    m.def("b", [](int) {}, pybind11::arg("a") = 1);
+    m.def("c", [](std::vector<int>) {}, pybind11::arg("a") = std::vector<int> {{1, 2, 3, 4}});
+    m.def("d", [](UserType) {}, pybind11::arg("a") = UserType {});
+    m.def("e", [](std::pair<UserType, int>) {}, pybind11::arg("a") = std::make_pair<UserType, int>(UserType(), 4));
+    m.def("f", [](std::vector<Color>) {}, pybind11::arg("a") = std::vector<Color> {Color::Red});
+    m.def("g", [](std::tuple<int, Color, double>) {}, pybind11::arg("a") = std::make_tuple(4, Color::Red, 1.9));
+}

--- a/tests/test_docstring_function_signature.py
+++ b/tests/test_docstring_function_signature.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from pybind11_tests import docstring_function_signature as m
+import sys
+
+
+def test_docstring_function_signature():
+    def syntactically_valid(sig):
+        try:
+            complete_fnsig = "def " + sig + ": pass"
+            ast.parse(complete_fnsig)
+            return True
+        except SyntaxError:
+            return False
+
+    pass
+
+    methods = ["a", "b", "c", "d", "e", "f", "g"]
+    root_module = "pybind11_tests"
+    module = "{}.{}".format(root_module, "docstring_function_signature")
+    expected_signatures = [
+        "a(a: {0}.Color = {0}.Color.Red) -> None".format(module),
+        "b(a: int = 1) -> None",
+        "c(a: List[int] = [1, 2, 3, 4]) -> None",
+        "d(a: {}.UserType = ...) -> None".format(root_module),
+        "e(a: Tuple[{}.UserType, int] = (..., 4)) -> None".format(root_module),
+        "f(a: List[{0}.Color] = [{0}.Color.Red]) -> None".format(module),
+        "g(a: Tuple[int, {0}.Color, float] = (4, {0}.Color.Red, 1.9)) -> None".format(
+            module
+        ),
+    ]
+
+    for method, signature in zip(methods, expected_signatures):
+        docstring = getattr(m, method).__doc__.strip("\n")
+        assert docstring == signature
+
+    if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
+        import ast
+
+        for method in methods:
+            docstring = getattr(m, method).__doc__.strip("\n")
+            assert syntactically_valid(docstring)


### PR DESCRIPTION
## Description
Closes #2667 by addition of a `compose_literal` function that attempts to handle the generation of valid Python literals for default arguments in docstrings. Can handle built-in data structure nesting by recursion. Generates literals for bound enums, replaces non-enum bound class instances with an ellipsis.

## Suggested changelog entry:

```rst
Attempt to generate syntactically valid literals for default function arguments in docstrings
```