### PR TITLE
Remove workaround code in gil_scoped_acquire that is not needed since #1211

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2089,15 +2089,7 @@ public:
         }
 
         if (release) {
-            /* Work around an annoying assertion in PyThreadState_Swap */
-            #if defined(Py_DEBUG)
-                PyInterpreterState *interp = tstate->interp;
-                tstate->interp = nullptr;
-            #endif
             PyEval_AcquireThread(tstate);
-            #if defined(Py_DEBUG)
-                tstate->interp = interp;
-            #endif
         }
 
         inc_ref();


### PR DESCRIPTION
## Description

Remove code that is not needed since #1211 that causes CPython 3.9 debug build to fail with #2681

I tested this with the following python debug builds:
- python 3.6:
  - master: no crash
  - with this fix: no crash
- python 3.8: 
  - master: fails with https://github.com/pybind/pybind11/issues/2682
  - with this fix: fails with https://github.com/pybind/pybind11/issues/2682
  - with this fix and proposed fix for #2682: no crash
- python 3.9:
  - master: fails in gil_scoped_acquire as described in #2681
  - with this fix: fails with https://github.com/pybind/pybind11/issues/2682
  - with this fix and proposed fix for #2682: no crash

Let me know if you want me to do other tests.

## Suggested changelog entry:

Not sure if this should be added or not. Let me know if it needs updating.

```rst
Fix py::gil_scoped_acquire assert with CPython 3.9 debug build
```

