### PR TITLE
Workaround for #2682 and #2422 by simply clearing the TypeError

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1870,7 +1870,14 @@ private:
 #if !defined(NDEBUG)
         , type(type_id<T>())
 #endif
-    { }
+    {
+        // Workaround! See:
+        // https://github.com/pybind/pybind11/issues/2336
+        // https://github.com/pybind/pybind11/pull/2685#issuecomment-731286700
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+        }
+    }
 
 public:
     /// Direct construction with name, default, and description


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

As proposed in https://github.com/pybind/pybind11/issues/2422#issuecomment-724136788, this PR is a possible solution for the assertion error in cpython debug mode.

Fixes #2682 
Fixes #2422 

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

```rst
Fixed assertion error related to unhandled (later overwritten) exception in CPython 3.8 and 3.9 debug builds"
```

<!-- If the upgrade guide needs updating, note that here too -->
