### PR TITLE
Towards a solution to move holder pointers from Python to C++

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1587,9 +1587,6 @@ public:
 
     template <typename T> using cast_op_type = detail::movable_cast_op_type<T>;
 
-    explicit operator type*() { return this->value; }
-    explicit operator type&() { return *(this->value); }
-
     // Workaround for Intel compiler bug
     // see pybind11 issue 94
     #if !defined(__ICC) && !defined(__INTEL_COMPILER)

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -2061,6 +2061,8 @@ private:
         if ((... || !std::get<Is>(argcasters).load(call.args[Is], call.args_convert[Is])))
             return false;
 #else
+        // BUG: When loading the arguments, the actual argument type (pointer, lvalue reference, rvalue reference)
+        // is already lost (argcasters only know the intrinsic type), while the behaviour should differ for them, e.g. for rvalue references.
         for (bool r : {std::get<Is>(argcasters).load(call.args[Is], call.args_convert[Is])...})
             if (!r)
                 return false;


### PR DESCRIPTION
This PR is reopening #2046, which was closed by @wjakob due to security objections moving objects from Python to C++.
However, recently there was new interest in this topic, see e.g. #2583, #2672 and issue summary in #2646. 
I still believe moving can be safely done with some precautions. @rwgk, please feel free to augment this PR.