### PR TITLE
docs: add warning about FindPython's Development component when libraries don't exist (e.g. on manylinux)

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -438,8 +438,8 @@ Python version more often than the old system did).
     When the Python libraries (i.e. ``libpythonXX.a`` and ``libpythonXX.so``
     on Unix) are not available, as is the case on a manylinux image, the
     ``Development`` component will not be resolved by ``FindPython``. When not
-    using the embedding functionality, CMake 3.18+ allows to specify
-    ``Development.Module`` instead of ``Development``, to resolve this issue.
+    using the embedding functionality, CMake 3.18+ allows you to specify
+    ``Development.Module`` instead of ``Development`` to resolve this issue.
 
 .. versionadded:: 2.6
 

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -433,6 +433,14 @@ setting ``Python_ROOT_DIR`` may be the most common one (though with
 virtualenv/venv support, and Conda support, this tends to find the correct
 Python version more often than the old system did).
 
+.. warning::
+
+    When the Python libraries (i.e. ``libpythonXX.a`` and ``libpythonXX.so``
+    on Unix) are not available, as is the case on a manylinux image, the
+    ``Development`` component will not be resolved by ``FindPython``. When not
+    using the embedding functionality, CMake 3.18+ allows to specify
+    ``Development.Module`` instead of ``Development``, to resolve this issue.
+
 .. versionadded:: 2.6
 
 Advanced: interface library targets


### PR DESCRIPTION
## Description

To reproduce, try building a project with FindPython on [a random manylinux image](https://quay.io/repository/pypa/manylinux2010_x86_64).

See also https://gitlab.kitware.com/cmake/cmake/-/issues/20425 and https://github.com/pypa/manylinux/issues/484.

## Suggested changelog entry:

Just some docs, so not necessary.
