### PR TITLE
Update installing.rst

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -16,7 +16,7 @@ as a submodule. From your git repository, use:
 
 .. code-block:: bash
 
-    git submodule add ../../pybind/pybind11 extern/pybind11 -b stable
+    git submodule add -b stable ../../pybind/pybind11 extern/pybind11
     git submodule update --init
 
 This assumes you are placing your dependencies in ``extern/``, and that you are


### PR DESCRIPTION
`git submodule add` needs the branch before the repository or else it is ignored. The previous code checked out the `master` branch, not the `stable` branch.