### PR TITLE
Only allow integer type_caster to call __int__ method when conversion is allowed; always call __index__

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1027,6 +1027,8 @@ public:
                 return false;
         } else if (PyFloat_Check(src.ptr())) {
             return false;
+        } else if (!convert && !PyLong_Check(src.ptr())) {
+            return false;
         } else if (std::is_unsigned<py_type>::value) {
             py_value = as_unsigned<py_type>(src.ptr());
         } else { // signed integer:

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1027,7 +1027,7 @@ public:
                 return false;
         } else if (PyFloat_Check(src.ptr())) {
             return false;
-        } else if (!convert && !PYBIND11_LONG_CHECK(src.ptr()) && !PyIndex_Check(src.ptr())) {
+        } else if (!convert && !PyIndex_Check(src.ptr()) && !PYBIND11_LONG_CHECK(src.ptr())) {
             return false;
         } else if (std::is_unsigned<py_type>::value) {
             py_value = as_unsigned<py_type>(src.ptr());

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1027,7 +1027,7 @@ public:
                 return false;
         } else if (PyFloat_Check(src.ptr())) {
             return false;
-        } else if (!convert && !PyLong_Check(src.ptr())) {
+        } else if (!convert && !PYBIND11_LONG_CHECK(src.ptr())) {
             return false;
         } else if (std::is_unsigned<py_type>::value) {
             py_value = as_unsigned<py_type>(src.ptr());

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1027,7 +1027,7 @@ public:
                 return false;
         } else if (PyFloat_Check(src.ptr())) {
             return false;
-        } else if (!convert && !PYBIND11_LONG_CHECK(src.ptr())) {
+        } else if (!convert && !PYBIND11_LONG_CHECK(src.ptr()) && !PyIndex_Check(src.ptr())) {
             return false;
         } else if (std::is_unsigned<py_type>::value) {
             py_value = as_unsigned<py_type>(src.ptr());

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -98,6 +98,10 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("i64_str", [](std::int64_t v) { return std::to_string(v); });
     m.def("u64_str", [](std::uint64_t v) { return std::to_string(v); });
 
+    // test_int_convert
+    m.def("int_passthrough", [](int arg) { return arg; });
+    m.def("int_passthrough_noconvert", [](int arg) { return arg; }, py::arg().noconvert());
+
     // test_tuple
     m.def("pair_passthrough", [](std::pair<bool, std::string> input) {
         return std::make_pair(input.second, input.first);

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -100,7 +100,7 @@ TEST_SUBMODULE(builtin_casters, m) {
 
     // test_int_convert
     m.def("int_passthrough", [](int arg) { return arg; });
-    m.def("int_passthrough_noconvert", [](int arg) { return arg; }, py::arg().noconvert());
+    m.def("int_passthrough_noconvert", [](int arg) { return arg; }, py::arg{}.noconvert());
 
     // test_tuple
     m.def("pair_passthrough", [](std::pair<bool, std::string> input) {

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -263,6 +263,17 @@ def test_int_convert():
         def __float__(self):
             return 41.99999
 
+    class IndexedThought(object):
+        def __index__(self):
+            return 42
+
+    class RaisingThought(object):
+        def __index__(self):
+            raise ValueError
+
+        def __int__(self):
+            return 42
+
     convert, noconvert = m.int_passthrough, m.int_passthrough_noconvert
 
     def require_implicit(v):
@@ -278,6 +289,11 @@ def test_int_convert():
     require_implicit(DeepThought())
     cant_convert(ShallowThought())
     cant_convert(FuzzyThought())
+    if not env.PY2:
+        # I have no clue why __index__ is not picked up by Python 2's PyIndex_check
+        assert convert(IndexedThought()) == 42
+        assert noconvert(IndexedThought()) == 42
+        cant_convert(RaisingThought())  # no fall-back to `__int__`if `__index__` raises
 
 
 def test_numpy_int_convert():

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -252,14 +252,14 @@ def test_integer_casting():
 
 
 def test_int_convert():
-    class DeepThought:
+    class DeepThought(object):
         def __int__(self):
             return 42
 
-    class ShallowThought:
+    class ShallowThought(object):
         pass
 
-    class FuzzyThought:
+    class FuzzyThought(object):
         def __float__(self):
             return 41.99999
 

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -289,8 +289,8 @@ def test_int_convert():
     require_implicit(DeepThought())
     cant_convert(ShallowThought())
     cant_convert(FuzzyThought())
-    if not env.PY2:
-        # I have no clue why __index__ is not picked up by Python 2's PyIndex_check
+    if env.PY >= (3, 8):
+        # Before Python 3.8, `int(obj)` does not pick up on `obj.__index__`
         assert convert(IndexedThought()) == 42
         assert noconvert(IndexedThought()) == 42
         cant_convert(RaisingThought())  # no fall-back to `__int__`if `__index__` raises

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -308,7 +308,8 @@ def test_numpy_int_convert():
     assert convert(np.intc(42)) == 42
     assert noconvert(np.intc(42)) == 42
 
-    assert convert(np.float32(3.14159)) == 3  # This might be wrong/unwanted?
+    # The implicit conversion from np.float32 is undesirable but currently accepted.
+    assert convert(np.float32(3.14159)) == 3
     require_implicit(np.float32(3.14159))
 
 

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -259,10 +259,6 @@ def test_int_convert():
     class ShallowThought:
         pass
 
-    class AlternativeThought:
-        def __index__(self):
-            return 54
-
     class FuzzyThought:
         def __float__(self):
             return 41.99999
@@ -281,8 +277,6 @@ def test_int_convert():
     assert convert(DeepThought()) == 42
     require_implicit(DeepThought())
     cant_convert(ShallowThought())
-    assert convert(AlternativeThought()) == 54
-    require_implicit(AlternativeThought())
     cant_convert(FuzzyThought())
 
 

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -251,6 +251,41 @@ def test_integer_casting():
         assert "incompatible function arguments" in str(excinfo.value)
 
 
+def test_int_convert():
+    class DeepThought:
+        def __int__(self):
+            return 42
+
+    class ShallowThought:
+        pass
+
+    class AlternativeThought:
+        def __index__(self):
+            return 54
+
+    class FuzzyThought:
+        def __float__(self):
+            return 41.99999
+
+    convert, noconvert = m.int_passthrough, m.int_passthrough_noconvert
+
+    def require_implicit(v):
+        pytest.raises(TypeError, noconvert, v)
+
+    def cant_convert(v):
+        pytest.raises(TypeError, convert, v)
+
+    assert convert(7) == 7
+    assert noconvert(7) == 7
+    cant_convert(3.14159)
+    assert convert(DeepThought()) == 42
+    require_implicit(DeepThought())
+    cant_convert(ShallowThought())
+    assert convert(AlternativeThought()) == 54
+    require_implicit(AlternativeThought())
+    cant_convert(FuzzyThought())
+
+
 def test_tuple(doc):
     """std::pair <-> tuple & std::tuple <-> tuple"""
     assert m.pair_passthrough((True, "test")) == ("test", True)

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -280,6 +280,22 @@ def test_int_convert():
     cant_convert(FuzzyThought())
 
 
+def test_numpy_int_convert():
+    np = pytest.importorskip("numpy")
+
+    convert, noconvert = m.int_passthrough, m.int_passthrough_noconvert
+
+    def require_implicit(v):
+        pytest.raises(TypeError, noconvert, v)
+
+    # `np.intc` is an alias that corresponds to a C++ `int`
+    assert convert(np.intc(42)) == 42
+    assert noconvert(np.intc(42)) == 42
+
+    assert convert(np.float32(3.14159)) == 3  # This might be wrong/unwanted?
+    require_implicit(np.float32(3.14159))
+
+
 def test_tuple(doc):
     """std::pair <-> tuple & std::tuple <-> tuple"""
     assert m.pair_passthrough((True, "test")) == ("test", True)


### PR DESCRIPTION
## Description

As the title says and the patch shows: currently, `PyLong_AsLong`/`PyLong_AsLongLong` gets called independently of `convert` in the `type_caster` for integral types. This seems inconsistent with other type casters.

## Suggested changelog entry:

```rst
The ``type_caster`` for integers does not convert Python objects with ``__int__`` anymore with ``noconvert`` or during the first round of trying overloads.
```
