### PR TITLE
fix: regression with installed pybind11 overriding local one

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -127,10 +127,20 @@ endif()
 # Check on every access - since Python2 and Python3 could have been used - do nothing in that case.
 
 if(DEFINED ${_Python}_INCLUDE_DIRS)
+  # Only add Python for build - must be added during the import for config
+  # since it has to be re-discovered.
+  #
+  # This needs to be an target to it is included after the local pybind11
+  # directory, just in case there are multiple versions of pybind11, we want
+  # the one we expect.
+  add_library(pybind11::python_headers INTERFACE IMPORTED)
+  set_property(
+    TARGET pybind11::python_headers PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                                             "$<BUILD_INTERFACE:${${_Python}_INCLUDE_DIRS}>")
   set_property(
     TARGET pybind11::pybind11
     APPEND
-    PROPERTY INTERFACE_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${${_Python}_INCLUDE_DIRS}>)
+    PROPERTY INTERFACE_LINK_LIBRARIES pybind11::python_headers)
   set(pybind11_INCLUDE_DIRS
       "${pybind11_INCLUDE_DIR}" "${${_Python}_INCLUDE_DIRS}"
       CACHE INTERNAL "Directories where pybind11 and possibly Python headers are located")

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -130,9 +130,9 @@ if(DEFINED ${_Python}_INCLUDE_DIRS)
   # Only add Python for build - must be added during the import for config
   # since it has to be re-discovered.
   #
-  # This needs to be an target to it is included after the local pybind11
-  # directory, just in case there are multiple versions of pybind11, we want
-  # the one we expect.
+  # This needs to be a target to be included after the local pybind11
+  # directory, just in case there there is an installed pybind11 sitting
+  # next to Python's includes. It also ensures Python is a SYSTEM library.
   add_library(pybind11::python_headers INTERFACE IMPORTED)
   set_property(
     TARGET pybind11::python_headers PROPERTY INTERFACE_INCLUDE_DIRECTORIES

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -81,11 +81,19 @@ if(PYBIND11_MASTER_PROJECT)
   endif()
 endif()
 
-# Only add Python for build - must be added during the import for config since it has to be re-discovered.
+# Only add Python for build - must be added during the import for config since
+# it has to be re-discovered.
+#
+# This needs to be an target to it is included after the local pybind11
+# directory, just in case there are multiple versions of pybind11, we want the
+# one we expect.
+add_library(pybind11::python_headers INTERFACE IMPORTED)
+set_property(TARGET pybind11::python_headers PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                                                      "$<BUILD_INTERFACE:${PYTHON_INCLUDE_DIRS}>")
 set_property(
   TARGET pybind11::pybind11
   APPEND
-  PROPERTY INTERFACE_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${PYTHON_INCLUDE_DIRS}>)
+  PROPERTY INTERFACE_LINK_LIBRARIES pybind11::python_headers)
 
 set(pybind11_INCLUDE_DIRS
     "${pybind11_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"


### PR DESCRIPTION

## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

This was not always including the discovered pybind11 first. Closes #2709.


## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

```rst
* CMake: mixing local and installed pybind11's would prioritize the installed one over the local one (regression in 2.6.0)
```

<!-- If the upgrade guide needs updating, note that here too -->
