### PR TITLE
Use default arguments in create_extension_module

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -980,8 +980,12 @@ public:
         For Python 3, ``def`` should point to a staticly allocated module_def.
         For Python 2, ``def`` can be a nullptr and is completely ignored.
     \endrst */
-    static module_ create_extension_module(const char *name, const char *doc, module_def *def) {
+    static module_ create_extension_module(const char *name, const char *doc = nullptr, module_def *def = nullptr) {
 #if PY_MAJOR_VERSION >= 3
+        if (!def) {
+            def = new module_def;
+        }
+
         // module_def is PyModuleDef
         def = new (def) PyModuleDef {  // Placement new (not an allocation).
             /* m_base */     PyModuleDef_HEAD_INIT,

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -63,7 +63,7 @@ TEST_SUBMODULE(modules, m) {
         class DupeException { };
 
         // Go ahead and leak, until we have a non-leaking py::module_ constructor
-        auto dm = py::module_::create_extension_module("dummy", nullptr, new py::module_::module_def);
+        auto dm = py::module_::create_extension_module("dummy");
         auto failures = py::list();
 
         py::class_<Dupe1>(dm, "Dupe1");


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
We used to be able to create a module with a simple
```cpp
py::module my_module("module");
```

having to write the following to create a module is more verbose, less clean visually.
```cpp
py::module my_module = py::module_::create_extension_module("module", nullptr, new py::module_::module_def);
```

This PR allows to write the following instead:

```cpp
py::module my_module = py::module_::create_extension_module("module");
```