### PR TITLE
Remove redundant instance->owned = true

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -340,8 +340,6 @@ inline PyObject *make_new_instance(PyTypeObject *type) {
     // Allocate the value/holder internals:
     inst->allocate_layout();
 
-    inst->owned = true;
-
     return self;
 }
 


### PR DESCRIPTION
That's a minor improvement I stumbled over. `instance->owned` is set to true twice in a row: In `instance::allocate_layout()`:
https://github.com/pybind/pybind11/blob/91a697203c80b52086244bb385f4d477ffaac787/include/pybind11/cast.h#L395
and here in `make_new_instance`:
https://github.com/pybind/pybind11/blob/91a697203c80b52086244bb385f4d477ffaac787/include/pybind11/detail/class.h#L341-L343

This PR just removes the second one.