### PR TITLE
Implementing keep_alive with placement

### DIFF
--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -212,6 +212,28 @@ ties the lifetime of the constructor element to the constructed object:
     Patient != 0) and ``with_custodian_and_ward_postcall`` (if Nurse/Patient ==
     0) policies from Boost.Python.
 
+Keep alive with placement
+-------------------------
+
+When ``keep_alive<Nurse, Patient>`` is supplied in a method binding, the Patient
+object is kept alive unconditionally until the Nurse is destroyed. This implies
+that every call of the method adds a possibly new Patient. If the method is called
+in a loop, the number of Patients keeps growing and their underlying resources are
+not freed until the Nurse object is garbage-collected.
+
+``keep_alive<Nurse, Patient, Placement>`` adds a Patient and attributes a positive
+integer index to it (Placement). Whenever a method is called for the same Nurse and
+Placement, the reference to a previously hold Patient is removed (which causes its
+destruction if it is not referred elsewhere), and newly passed Patient takes its
+place.
+
+The same Placement index may be used across multiple methods. It is allowed to pass
+``None`` as patients to explicitly clear the Placement.
+
+This technique is convenient for binding regular setter methods that replace a
+referred resource with another resource and allows to keep the reference records
+up-to-date.
+
 Call guard
 ----------
 

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -66,7 +66,7 @@ struct base {
 };
 
 /// Keep patient alive while nurse lives
-template <size_t Nurse, size_t Patient>
+template <size_t Nurse, size_t Patient, size_t Placement = detail::KEEP_ALIVE_NO_PLACEMENT>
 struct keep_alive {};
 
 /// Annotation indicating that a class is involved in a multiple inheritance relationship
@@ -169,7 +169,7 @@ enum op_type : int;
 struct undefined_t;
 template <op_id id, op_type ot, typename L = undefined_t, typename R = undefined_t>
 struct op_;
-void keep_alive_impl(size_t Nurse, size_t Patient, function_call &call, handle ret);
+void keep_alive_impl(size_t Nurse, size_t Patient, size_t Placement, function_call &call, handle ret);
 
 /// Internal data structure which holds metadata about a keyword argument
 struct argument_record {
@@ -609,12 +609,13 @@ struct process_attribute<call_guard<Ts...>> : process_attribute_default<call_gua
  * pre-call handler if both Nurse, Patient != 0 and use the post-call handler
  * otherwise
  */
-template <size_t Nurse, size_t Patient>
-struct process_attribute<keep_alive<Nurse, Patient>>
-    : public process_attribute_default<keep_alive<Nurse, Patient>> {
+template <size_t Nurse, size_t Patient, size_t Placement>
+struct process_attribute<keep_alive<Nurse, Patient, Placement>>
+    : public process_attribute_default<keep_alive<Nurse, Patient, Placement>>
+{
     template <size_t N = Nurse, size_t P = Patient, enable_if_t<N != 0 && P != 0, int> = 0>
     static void precall(function_call &call) {
-        keep_alive_impl(Nurse, Patient, call, handle());
+        keep_alive_impl(Nurse, Patient, Placement, call, handle());
     }
     template <size_t N = Nurse, size_t P = Patient, enable_if_t<N != 0 && P != 0, int> = 0>
     static void postcall(function_call &, handle) {}
@@ -622,7 +623,7 @@ struct process_attribute<keep_alive<Nurse, Patient>>
     static void precall(function_call &) {}
     template <size_t N = Nurse, size_t P = Patient, enable_if_t<N == 0 || P == 0, int> = 0>
     static void postcall(function_call &call, handle ret) {
-        keep_alive_impl(Nurse, Patient, call, ret);
+        keep_alive_impl(Nurse, Patient, Placement, call, ret);
     }
 };
 

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -169,7 +169,8 @@ enum op_type : int;
 struct undefined_t;
 template <op_id id, op_type ot, typename L = undefined_t, typename R = undefined_t>
 struct op_;
-void keep_alive_impl(size_t Nurse, size_t Patient, size_t Placement, function_call &call, handle ret);
+void keep_alive_impl(
+    size_t Nurse, size_t Patient, size_t Placement, function_call &call, handle ret);
 
 /// Internal data structure which holds metadata about a keyword argument
 struct argument_record {
@@ -611,8 +612,7 @@ struct process_attribute<call_guard<Ts...>> : process_attribute_default<call_gua
  */
 template <size_t Nurse, size_t Patient, size_t Placement>
 struct process_attribute<keep_alive<Nurse, Patient, Placement>>
-    : public process_attribute_default<keep_alive<Nurse, Patient, Placement>>
-{
+    : public process_attribute_default<keep_alive<Nurse, Patient, Placement>> {
     template <size_t N = Nurse, size_t P = Patient, enable_if_t<N != 0 && P != 0, int> = 0>
     static void precall(function_call &call) {
         keep_alive_impl(Nurse, Patient, Placement, call, handle());

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -369,7 +369,9 @@ extern "C" inline int pybind11_object_init(PyObject *self, PyObject *, PyObject 
     return -1;
 }
 
-inline void add_patient(PyObject *nurse, PyObject *patient, size_t placement = detail::KEEP_ALIVE_NO_PLACEMENT) {
+inline void add_patient(PyObject *nurse,
+                        PyObject *patient,
+                        size_t placement = detail::KEEP_ALIVE_NO_PLACEMENT) {
     auto &internals = get_internals();
     auto *instance = reinterpret_cast<detail::instance *>(nurse);
 
@@ -383,7 +385,7 @@ inline void add_patient(PyObject *nurse, PyObject *patient, size_t placement = d
     // add patient with placement
     else {
         // check if the placement is already taken
-        auto& patients_with_placements = internals.patients_with_placements[nurse];
+        auto &patients_with_placements = internals.patients_with_placements[nurse];
         auto existing = patients_with_placements.find(placement);
         if (existing == patients_with_placements.end()) {
             // no patient at a given placement: put the new one
@@ -392,8 +394,7 @@ inline void add_patient(PyObject *nurse, PyObject *patient, size_t placement = d
                 Py_XINCREF(patient);
                 instance->has_patients = true;
             }
-        }
-        else if (existing->second != patient) {
+        } else if (existing->second != patient) {
             // a patient is already there and differs from the new one; exchange
             auto previous_patient = existing->second;
             existing->second = patient;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -157,6 +157,7 @@ struct internals {
         inactive_override_cache;
     type_map<std::vector<bool (*)(PyObject *, void *&)>> direct_conversions;
     std::unordered_map<const PyObject *, std::vector<PyObject *>> patients;
+    std::unordered_map<const PyObject *, std::unordered_map<size_t, PyObject *>> patients_with_placements;
     std::forward_list<ExceptionTranslator> registered_exception_translators;
     std::unordered_map<std::string, void *> shared_data; // Custom data to be shared across
                                                          // extensions

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -157,7 +157,8 @@ struct internals {
         inactive_override_cache;
     type_map<std::vector<bool (*)(PyObject *, void *&)>> direct_conversions;
     std::unordered_map<const PyObject *, std::vector<PyObject *>> patients;
-    std::unordered_map<const PyObject *, std::unordered_map<size_t, PyObject *>> patients_with_placements;
+    std::unordered_map<const PyObject *, std::unordered_map<size_t, PyObject *>>
+        patients_with_placements;
     std::forward_list<ExceptionTranslator> registered_exception_translators;
     std::unordered_map<std::string, void *> shared_data; // Custom data to be shared across
                                                          // extensions

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -491,8 +491,11 @@ inline PyThreadState *get_thread_state_unchecked() {
 #endif
 }
 
+/// Default placement value for keep_alive. When passed, the patient is kept alive indefinitely.
+constexpr size_t KEEP_ALIVE_NO_PLACEMENT = (size_t)-1;
+
 // Forward declarations
-void keep_alive_impl(handle nurse, handle patient);
+void keep_alive_impl(handle nurse, handle patient, size_t placement = KEEP_ALIVE_NO_PLACEMENT);
 inline PyObject *make_new_instance(PyTypeObject *type);
 
 class type_caster_generic {

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -492,7 +492,7 @@ inline PyThreadState *get_thread_state_unchecked() {
 }
 
 /// Default placement value for keep_alive. When passed, the patient is kept alive indefinitely.
-constexpr size_t KEEP_ALIVE_NO_PLACEMENT = (size_t)-1;
+constexpr size_t KEEP_ALIVE_NO_PLACEMENT = (size_t) -1;
 
 // Forward declarations
 void keep_alive_impl(handle nurse, handle patient, size_t placement = KEEP_ALIVE_NO_PLACEMENT);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2185,7 +2185,6 @@ private:
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-
 PYBIND11_NOINLINE void keep_alive_impl(handle nurse, handle patient, size_t placement) {
     // Keeping alive without placement
     if (placement == KEEP_ALIVE_NO_PLACEMENT) {
@@ -2198,13 +2197,12 @@ PYBIND11_NOINLINE void keep_alive_impl(handle nurse, handle patient, size_t plac
         auto tinfo = all_type_info(Py_TYPE(nurse.ptr()));
         if (!tinfo.empty()) {
             /* It's a pybind-registered type, so we can store the patient in the
-            * internal list. */
+             * internal list. */
             add_patient(nurse.ptr(), patient.ptr());
-        }
-        else {    
+        } else {
             /* Fall back to clever approach based on weak references taken from
-            * Boost.Python. This is not used for pybind-registered types because
-            * the objects can be destroyed out-of-order in a GC pass. */
+             * Boost.Python. This is not used for pybind-registered types because
+             * the objects can be destroyed out-of-order in a GC pass. */
             cpp_function disable_lifesupport([patient](handle weakref) {
                 patient.dec_ref();
                 weakref.dec_ref();
@@ -2223,11 +2221,12 @@ PYBIND11_NOINLINE void keep_alive_impl(handle nurse, handle patient, size_t plac
         auto tinfo = all_type_info(Py_TYPE(nurse.ptr()));
         if (!tinfo.empty()) {
             /* It's a pybind-registered type, so we can store the patient in the
-            * internal list. */
-            add_patient(nurse.ptr(), patient && !patient.is_none() ? patient.ptr() : nullptr, placement);
-        }
-        else {
-            pybind11_fail("Could not activate keep_alive with placement and Nurse of a non pybind-registered type!");
+             * internal list. */
+            add_patient(
+                nurse.ptr(), patient && !patient.is_none() ? patient.ptr() : nullptr, placement);
+        } else {
+            pybind11_fail("Could not activate keep_alive with placement and Nurse of a non "
+                          "pybind-registered type!");
         }
     }
 }

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -47,7 +47,8 @@ TEST_SUBMODULE(call_policies, m) {
         Parent() { py::print("Allocating parent."); }
         Parent(const Parent &parent) = default;
         ~Parent() { py::print("Releasing parent."); }
-        void addChild(Child *) {}
+        void addChild(Child *) { }
+        void setChild(Child *) { }
         Child *returnChild() { return new Child(); }
         Child *returnNullChild() { return nullptr; }
         static Child *staticFunction(Parent *) { return new Child(); }
@@ -61,8 +62,8 @@ TEST_SUBMODULE(call_policies, m) {
         .def("returnChildKeepAlive", &Parent::returnChild, py::keep_alive<1, 0>())
         .def("returnNullChildKeepAliveChild", &Parent::returnNullChild, py::keep_alive<1, 0>())
         .def("returnNullChildKeepAliveParent", &Parent::returnNullChild, py::keep_alive<0, 1>())
+        .def("setChildKeepAliveWithPlacement", &Parent::setChild, py::keep_alive<1, 2, 1>())
         .def_static("staticFunction", &Parent::staticFunction, py::keep_alive<1, 0>());
-
     m.def(
         "free_function", [](Parent *, Child *) {}, py::keep_alive<1, 2>());
     m.def(

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -47,8 +47,8 @@ TEST_SUBMODULE(call_policies, m) {
         Parent() { py::print("Allocating parent."); }
         Parent(const Parent &parent) = default;
         ~Parent() { py::print("Releasing parent."); }
-        void addChild(Child *) { }
-        void setChild(Child *) { }
+        void addChild(Child *) {}
+        void setChild(Child *) {}
         Child *returnChild() { return new Child(); }
         Child *returnNullChild() { return nullptr; }
         static Child *staticFunction(Parent *) { return new Child(); }

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -58,6 +58,55 @@ def test_keep_alive_argument(capture):
     assert str(excinfo.value) == "Could not activate keep_alive!"
 
 
+def test_keep_alive_with_placement(capture):
+    n_inst = ConstructorStats.detail_reg_inst()
+    # allocate parent
+    with capture:
+        p = m.Parent()
+    assert capture == "Allocating parent."
+    # allocate child and set
+    with capture:
+        p.setChildKeepAliveWithPlacement(m.Child())
+        assert ConstructorStats.detail_reg_inst() == n_inst + 2
+    assert (
+        capture
+        == """
+        Allocating child.
+    """
+    )
+    # allocate another child and replace the existing
+    with capture:
+        p.setChildKeepAliveWithPlacement(m.Child())
+        assert ConstructorStats.detail_reg_inst() == n_inst + 2
+    assert (
+        capture
+        == """
+        Allocating child.
+        Releasing child.
+    """
+    )
+    # pass None
+    with capture:
+        p.setChildKeepAliveWithPlacement(None)
+        assert ConstructorStats.detail_reg_inst() == n_inst + 1
+    assert (
+        capture
+        == """
+        Releasing child.
+    """
+    )
+    # delete parent
+    with capture:
+        del p
+        assert ConstructorStats.detail_reg_inst() == n_inst
+    assert (
+        capture
+        == """
+        Releasing parent.
+    """
+    )
+
+
 def test_keep_alive_return_value(capture):
     n_inst = ConstructorStats.detail_reg_inst()
     with capture:


### PR DESCRIPTION
## Description

I am possibly doing things wrong or come up with an unnecessarily complex approach. If there is an existing simple solution to my problem, please point me out.

### Problem

Consider the following Python code using a pybind11 module `module` having `Processor` and `Source` classes in it.

```py
processor = module.Processor()

# load first source to process
processor.input = module.Source("large_file1.avi")
processor.process()

# load second source to process
processor.input = module.Source("large_file2.avi")
processor.process()
```

`processor.input` is a property with a usual setter and getter bound to it. A `Processor` instance makes use of `input` property value (a `Source` instance) to do some sophisticated processing in `process()` method (so the value needs to be protected against being garbage-collected). Then the property value changed with another `Source` instance for a second processing iteration.

The only easy solution I found to make this code running without segfaults is to decorate the property setter with `keep_alive<1, 2>()`, making sure the `Source` instance is not destroyed while the `Processor` instance is alive and might be using it.

The problem with this solution arises when the processing is done in a loop, and there are many more `Source` instances potentially taking large memory. As far as only one instance of `Source` is actually used at a time, it makes sense to free the previously hold `input` value as soon as it becomes unused.

### Suggested solution

I tried different things like implementing some wrappers or changing the backend code. I run into different troubles that I will not detail right away. Then I ended up with implementing the keep_alive with placement feature in pybind11 code  which worked and required minimal overall changes.

This feature consists in assigning a "placement index" parameter to a Nurse-Patient link in `keep_alive` attribute. When a bound method with this attribute is called, a new Patient is not added unconditionnally as with regular `keep_alive`, but it replaces a previously hold Patient at the same Placement (if there is such). The placement index is an arbitrary user-defined non-negative integer number.

An explanation is added in the docs. A unit test is included.

Changes overview.
 * `keep_alive<Nurse, Patient, Placement>` is introduced.
 * A map holding patients with placements is added internally. `add_patient` and `clear_patients` methods upgraded accordingly.

Other notes.
  - The original `keep_alive` without placement is indeed maintained.
  - I am not a big fan of having three integer indices passed as template arguments. I tried to implement something like `keep_alive<Nurse, Patient>(Placement)`, but this seems to require more changes of other internal entities.
  - Placement can in principle be inferred automatically for object-valued properties as in the example. However, I found useful the ability to have the same placement in different methods, for example, for overloaded setters that operate on the same backend property.

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

```rst
Introducing ``keep_alive<Nurse, Patient, Placement>`` attribute
```

<!-- If the upgrade guide needs updating, note that here too -->
