### PR TITLE
lower requirement for list_caster from sequence to iterable

### DIFF
--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -13,6 +13,7 @@ def test_vector(doc):
     lst.append(2)
     assert m.load_vector(lst)
     assert m.load_vector(tuple(lst))
+    assert m.load_vector(x for x in (1, 2))  # not a sequence, but iterable
 
     assert m.cast_bool_vector() == [True, False]
     assert m.load_bool_vector([True, False])


### PR DESCRIPTION
## Description

The list_caster requires at minimum a Python `Sequence`, while a Python `Iterable` also does nicely. I lowered the requirement, so now also generators can be converted and other collection types which do not implement the full Sequence protocol, notably `torch.Tensor`. If the iterable has a `__len__` method, it is used reserve space in a vector, so this implementation is as efficient as the old one.

I also simplified the TMP of reserve_maybe with modern TMP techniques.

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

```rst
The list_caster in ``pybind11/stl.h`` now accepts a Python ``Iterable`` (before it required a ``Sequence``). This allows casting Python generators and collection types that do not implement the Sequence protocol, like ``torch.Tensor``.
```