### PR TITLE
docs: update changelog and add script to help generate it

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,10 +6,35 @@ Changelog
 Starting with version 1.8.0, pybind11 releases use a `semantic versioning
 <http://semver.org>`_ policy.
 
+
 v2.6.2 (TBA, not yet released)
 ------------------------------
 
-* Details to follow here
+
+* Fixed segfault in multithreaded environments when using ``scoped_ostream_redirect``.
+  `#2675 <https://github.com/pybind/pybind11/pull/2675>`_
+
+* CMake: mixing local and installed pybind11's would prioritize the installed one over the local one (regression in 2.6.0).
+  `#2716 <https://github.com/pybind/pybind11/pull/2716>`_
+
+* Fix bug where the constructor of `object` subclasses would not throw on being passed a Python object of the wrong type.
+  `#2701 <https://github.com/pybind/pybind11/pull/2701>`_
+
+* Fixed assertion error related to unhandled (later overwritten) exception in CPython 3.8 and 3.9 debug builds.
+  `#2685 <https://github.com/pybind/pybind11/pull/2685>`_
+
+* Fix ``py::gil_scoped_acquire`` assert with CPython 3.9 debug build.
+  `#2683 <https://github.com/pybind/pybind11/pull/2683>`_
+
+* Fixes segfaults in multithreaded environments when using ``scoped_ostream_redirect``.
+  `#2675 <https://github.com/pybind/pybind11/pull/2675>`_
+
+* Fix issue with FindPython2/FindPython3 not working with ``pybind11::embed``.
+  `#2662 <https://github.com/pybind/pybind11/pull/2662>`_
+
+* Allow thread termination to be avoided during shutdown for CPython 3.7+ via ``.disarm``.
+  `#2657 <https://github.com/pybind/pybind11/pull/2657>`_
+
 
 
 v2.6.1 (Nov 11, 2020)

--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import re
+
+import ghapi.core
+
+
+ENTRY = re.compile(
+    r"""
+    Suggested \s changelog \s entry:
+    .*
+    ```rst
+    \s*
+    (.*?)
+    \s*
+    ```
+""",
+    re.DOTALL | re.VERBOSE,
+)
+
+
+api = ghapi.core.GhApi(owner="pybind", repo="pybind11")
+
+issues = api.issues.list_for_repo(labels="needs changelog", state="closed")
+missing = []
+
+for issue in issues:
+    changelog = ENTRY.findall(issue.body)
+    if changelog:
+        (msg,) = changelog
+        if not msg.startswith("* "):
+            msg = "* " + msg
+        if not msg.endswith("."):
+            msg += "."
+
+        print(msg)
+        print(f"  `#{issue.number} <{issue.html_url}>`_\n")
+
+    else:
+        missing.append(issue)
+
+if missing:
+    print()
+    print("-" * 30)
+    print()
+
+    for issue in missing:
+        print(f"Missing: {issue.title}")
+        print(f"  {issue.html_url}")


### PR DESCRIPTION
## Description

Update changelog, and add script that produces a nice starting point for doing this in the future.

Example output:

```
./tools/make_changelog.py
* CMake: mixing local and installed pybind11's would prioritize the installed one over the local one (regression in 2.6.0).
  `#2716 <https://github.com/pybind/pybind11/pull/2716>`_

* Fix bug where the constructor of `object` subclasses would not throw on being passed a Python object of the wrong type.
  `#2701 <https://github.com/pybind/pybind11/pull/2701>`_

* Fixed assertion error related to unhandled (later overwritten) exception in CPython 3.8 and 3.9 debug builds".
  `#2685 <https://github.com/pybind/pybind11/pull/2685>`_

* Fix py::gil_scoped_acquire assert with CPython 3.9 debug build.
  `#2683 <https://github.com/pybind/pybind11/pull/2683>`_

* Fixes segfaults in multithreaded environments when using scoped_ostream_redirect.
  `#2675 <https://github.com/pybind/pybind11/pull/2675>`_

* fix: make FindPython2 and FindPython3 work.
  `#2662 <https://github.com/pybind/pybind11/pull/2662>`_

* Avoid unwanted termination if `gil_scoped_release()` is destroyed while Python runtime is finalizing.
  `#2657 <https://github.com/pybind/pybind11/pull/2657>`_

------------------------------

Missing: minor cleanup: fixing or silencing flake8 errors
  https://github.com/pybind/pybind11/pull/2731
Missing: ci: drop pypy2 linux, PGI 20.7, add Python 10 dev
  https://github.com/pybind/pybind11/pull/2724
Missing: Remove redundant instance->owned = true
  https://github.com/pybind/pybind11/pull/2723
Missing: pybind11/numpy.h does not require numpy at build time.
  https://github.com/pybind/pybind11/pull/2720
Missing: docs: Update warning about Python 3.9.0 UB, now that 3.9.1 has been released
  https://github.com/pybind/pybind11/pull/2719
Missing: Update installing.rst
  https://github.com/pybind/pybind11/pull/2691
Missing: docs: add warning about FindPython's Development component when libraries don't exist (e.g. on manylinux)
  https://github.com/pybind/pybind11/pull/2689
Missing: fix: define PYBIND11_CPP14 for recent intel compilers
  https://github.com/pybind/pybind11/pull/2679
```

