### PR TITLE
ci: update cmake action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,7 @@ jobs:
       run: echo "BOOST_ROOT=$BOOST_ROOT_1_72_0" >> $GITHUB_ENV
 
     - name: Update CMake
-      uses: jwlawson/actions-setup-cmake@v1.4
-      with:
-        cmake-version: 3.19.1
+      uses: jwlawson/actions-setup-cmake@v1.5
 
     - name: Cache wheels
       if: runner.os == 'macOS'
@@ -364,7 +362,7 @@ jobs:
       run: python3 -m pip install --upgrade pip
 
     - name: Setup CMake 3.18
-      uses: jwlawson/actions-setup-cmake@v1.4
+      uses: jwlawson/actions-setup-cmake@v1.5
       with:
         cmake-version: 3.18
 
@@ -551,9 +549,7 @@ jobs:
         architecture: x86
 
     - name: Update CMake
-      uses: jwlawson/actions-setup-cmake@v1.4
-      with:
-        cmake-version: 3.19.1
+      uses: jwlawson/actions-setup-cmake@v1.5
 
     - name: Prepare MSVC
       uses: ilammy/msvc-dev-cmd@v1
@@ -599,9 +595,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Update CMake
-      uses: jwlawson/actions-setup-cmake@v1.4
-      with:
-        cmake-version: 3.19.1
+      uses: jwlawson/actions-setup-cmake@v1.5
 
     - name: Prepare MSVC
       uses: ilammy/msvc-dev-cmd@v1
@@ -655,9 +649,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Update CMake
-      uses: jwlawson/actions-setup-cmake@v1.4
-      with:
-        cmake-version: 3.19.1
+      uses: jwlawson/actions-setup-cmake@v1.5
 
     - name: Prepare env
       run: python -m pip install -r tests/requirements.txt --prefer-binary

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -55,7 +55,7 @@ jobs:
     # An action for adding a specific version of CMake:
     #   https://github.com/jwlawson/actions-setup-cmake
     - name: Setup CMake ${{ matrix.cmake }}
-      uses: jwlawson/actions-setup-cmake@v1.4
+      uses: jwlawson/actions-setup-cmake@v1.5
       with:
         cmake-version: ${{ matrix.cmake }}
 


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Manually updating this instead of waiting for dependabot because it fixes the issue with cmake 3.19.2 on macOS.


## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

None needed. CI.

<!-- If the upgrade guide needs updating, note that here too -->
