### PR TITLE
Don't trigger -Wunused-parameter in flagcheck.cpp.

### DIFF
--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -232,7 +232,8 @@ def has_flag(compiler, flag):
     with tmp_chdir():
         fname = "flagcheck.cpp"
         with open(fname, "w") as f:
-            f.write("int main (int argc, char **argv) { return 0; }")
+            # Don't trigger -Wunused-parameter.
+            f.write("int main (int, char **) { return 0; }")
 
         try:
             compiler.compile([fname], extra_postargs=[flag])


### PR DESCRIPTION
... by leaving the unused parameters anonymous.

(This can be checked e.g. by compiling python_example with -Wall
-Wextra.)

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

```rst
* Don't trigger unused parameter warning in setup_helpers.py.
```
