### PR TITLE
docs: add a note about compiling the example

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -140,9 +140,10 @@ On Linux, the above example can be compiled using the following command:
 
 .. note::
 
-    If you used :ref:`include_as_a_submodule` to install the pybind11 source,
-    then use ``$(python3-config --includes) -Iextern/pybind11/include``
-    instead of ``$(python3 -m pybind11 --includes)`` in the above compilation.
+    If you used :ref:`include_as_a_submodule` to get the pybind11 source, then
+    use ``$(python3-config --includes) -Iextern/pybind11/include`` instead of
+    ``$(python3 -m pybind11 --includes)`` in the above compilation, as
+    explained in :ref:`building_manually`.
 
 For more details on the required compiler flags on Linux and macOS, see
 :ref:`building_manually`. For complete cross-platform compilation instructions,

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -140,7 +140,7 @@ On Linux, the above example can be compiled using the following command:
 
 .. note::
 
-    If you used :ref:`include-as-a-submodule` to install the pybind11 source,
+    If you used :ref:`include_as_a_submodule` to install the pybind11 source,
     then use ``$(python3-config --includes) -Iextern/pybind11/include``
     instead of ``$(python3 -m pybind11 --includes)`` in the above compilation.
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -136,7 +136,13 @@ On Linux, the above example can be compiled using the following command:
 
 .. code-block:: bash
 
-    $ c++ -O3 -Wall -shared -std=c++11 -fPIC `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+    $ c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) example.cpp -o example$(python3-config --extension-suffix)
+
+.. note::
+
+    If you used :ref:`include-as-a-submodule` to install the pybind11 source,
+    then use ``$(python3-config --includes) -Iextern/pybind11/include``
+    instead of ``$(python3 -m pybind11 --includes)`` in the above compilation.
 
 For more details on the required compiler flags on Linux and macOS, see
 :ref:`building_manually`. For complete cross-platform compilation instructions,

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -565,7 +565,7 @@ On Linux, you can compile an example such as the one given in
 
 .. code-block:: bash
 
-    $ c++ -O3 -Wall -shared -std=c++11 -fPIC `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+    $ c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) example.cpp -o example$(python3-config --extension-suffix)
 
 The flags given here assume that you're using Python 3. For Python 2, just
 change the executable appropriately (to ``python`` or ``python2``).
@@ -577,7 +577,7 @@ using ``pip`` or ``conda``. If it hasn't, you can also manually specify
 ``python3-config --includes``.
 
 Note that Python 2.7 modules don't use a special suffix, so you should simply
-use ``example.so`` instead of ``example`python3-config --extension-suffix```.
+use ``example.so`` instead of ``example$(python3-config --extension-suffix)``.
 Besides, the ``--extension-suffix`` option may or may not be available, depending
 on the distribution; in the latter case, the module extension can be manually
 set to ``.so``.
@@ -588,7 +588,7 @@ building the module:
 
 .. code-block:: bash
 
-    $ c++ -O3 -Wall -shared -std=c++11 -undefined dynamic_lookup `python3 -m pybind11 --includes` example.cpp -o example`python3-config --extension-suffix`
+    $ c++ -O3 -Wall -shared -std=c++11 -undefined dynamic_lookup $(python3 -m pybind11 --includes) example.cpp -o example$(python3-config --extension-suffix)
 
 In general, it is advisable to include several additional build parameters
 that can considerably reduce the size of the created binary. Refer to section

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -28,10 +28,6 @@ From here, you can now include ``extern/pybind11/include``, or you can use
 the various integration tools (see :ref:`compiling`) pybind11 provides directly
 from the local folder.
 
-You may also need to ``export PYTHONPATH='PATH_TO/extern/pybind11'``. This
-updates your Python module search path, which is required for commands such as
-``python3 -m pybind11 --includes`` to find and use the pybind11 git submodule.
-
 Include with PyPI
 =================
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -28,6 +28,10 @@ From here, you can now include ``extern/pybind11/include``, or you can use
 the various integration tools (see :ref:`compiling`) pybind11 provides directly
 from the local folder.
 
+You may also need to ``export PYTHONPATH='PATH_TO/extern/pybind11'``. This
+updates your Python module search path, which is required for commands such as
+``python3 -m pybind11 --includes`` to find and use the pybind11 git submodule.
+
 Include with PyPI
 =================
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -8,6 +8,8 @@ There are several ways to get the pybind11 source, which lives at
 developers recommend one of the first three ways listed here, submodule, PyPI,
 or conda-forge, for obtaining pybind11.
 
+.. _include_as_a_submodule:
+
 Include as a submodule
 ======================
 


### PR DESCRIPTION
When pybind11 is included as a submodule, the user needs to update their
Python module search path.  Otherwise, the first c++ compilation command
in docs/basics.rst will fail.