### PR TITLE
enum: Add iteration and simple type-based check, towards PEP 435

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1719,7 +1719,6 @@ public:
     using Base = class_<Type>;
     using Base::def;
     using Base::attr;
-    using Base::def_property;
     using Base::def_property_readonly;
     using Base::def_property_readonly_static;
     using Scalar = typename std::underlying_type<Type>::type;
@@ -1732,7 +1731,7 @@ public:
         m_base.init(is_arithmetic, is_convertible);
 
         def(init([](Scalar i) { return static_cast<Type>(i); }), arg("value"));
-        def_property("value", [](Type value) { return (Scalar) value; }, nullptr);
+        def_property_readonly("value", [](Type value) { return (Scalar) value; });
         def("__int__", [](Type value) { return (Scalar) value; });
         #if PY_MAJOR_VERSION < 3
             def("__long__", [](Type value) { return (Scalar) value; });

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -46,7 +46,6 @@
 #include "options.h"
 #include "detail/class.h"
 #include "detail/init.h"
-#include "detail/typeid.h"
 
 #include <memory>
 #include <vector>
@@ -1570,23 +1569,6 @@ inline str enum_name(handle arg) {
     return "???";
 }
 
-template <typename Type, typename Scalar, bool is_convertible = true>
-struct enum_value {
-    static Scalar run(handle arg) {
-        Type value = pybind11::cast<Type>(arg);
-        return static_cast<Scalar>(value);
-    }
-};
-
-template <typename Type, typename Scalar>
-struct enum_value<Type, Scalar, false> {
-    static Scalar run(handle) {
-      throw pybind11::cast_error(
-            "Enum for " + type_id<Type>() + " is not convertible to " +
-            type_id<Scalar>());
-    }
-};
-
 struct enum_base {
     enum_base(handle base, handle parent) : m_base(base), m_parent(parent) { }
 
@@ -1737,6 +1719,7 @@ public:
     using Base = class_<Type>;
     using Base::def;
     using Base::attr;
+    using Base::def_property;
     using Base::def_property_readonly;
     using Base::def_property_readonly_static;
     using Scalar = typename std::underlying_type<Type>::type;
@@ -1746,15 +1729,10 @@ public:
       : class_<Type>(scope, name, extra...), m_base(*this, scope) {
         constexpr bool is_arithmetic = detail::any_of<std::is_same<arithmetic, Extra>...>::value;
         constexpr bool is_convertible = std::is_convertible<Type, Scalar>::value;
-        auto property = handle((PyObject *) &PyProperty_Type);
         m_base.init(is_arithmetic, is_convertible);
 
-        attr("value") = property(
-            cpp_function(
-                &detail::enum_value<Type, Scalar, is_convertible>::run,
-                pybind11::name("value"), is_method(*this)));
-
         def(init([](Scalar i) { return static_cast<Type>(i); }), arg("value"));
+        def_property("value", [](Type value) { return (Scalar) value; }, nullptr);
         def("__int__", [](Type value) { return (Scalar) value; });
         #if PY_MAJOR_VERSION < 3
             def("__long__", [](Type value) { return (Scalar) value; });

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,6 +1,43 @@
 # -*- coding: utf-8 -*-
 import pytest
+
+import env  # noqa: F401
+
 from pybind11_tests import enums as m
+
+if env.PY2:
+    enum = None
+else:
+    import enum
+
+
+def is_enum(cls):
+    """Example showing how to recognize a class as pybind11 enum or a
+    PEP 345 enum."""
+    if enum is not None:
+        if issubclass(cls, enum.Enum):
+            return True
+    return getattr(cls, "is_pybind11_enum", False)
+
+
+def test_pep435():
+    # See #2332.
+    cls = m.UnscopedEnum
+    names = ("EOne", "ETwo", "EThree")
+    values = (cls.EOne, cls.ETwo, cls.EThree)
+    raw_values = (1, 2, 3)
+
+    assert len(cls) == len(names)
+    assert list(cls) == list(values)
+    assert is_enum(cls)
+    if enum:
+        assert not issubclass(cls, enum.Enum)
+    for name, value, raw_value in zip(names, values, raw_values):
+        assert isinstance(value, cls)
+        if enum:
+            assert not isinstance(value, enum.Enum)
+        assert value.name == name
+        assert value.value == raw_value
 
 
 def test_unscoped_enum():

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -13,15 +13,24 @@ def test_unscoped_enum():
 
     # name property
     assert m.UnscopedEnum.EOne.name == "EOne"
+    assert m.UnscopedEnum.EOne.value == 1
     assert m.UnscopedEnum.ETwo.name == "ETwo"
-    assert m.EOne.name == "EOne"
-    # name readonly
+    assert m.UnscopedEnum.ETwo.value == 2
+    assert m.EOne is m.UnscopedEnum.EOne
+    # name, value readonly
     with pytest.raises(AttributeError):
         m.UnscopedEnum.EOne.name = ""
-    # name returns a copy
-    foo = m.UnscopedEnum.EOne.name
-    foo = "bar"
+    with pytest.raises(AttributeError):
+        m.UnscopedEnum.EOne.value = 10
+    # name, value returns a copy
+    # TODO: Neither the name nor value tests actually check against aliasing.
+    # Use a mutable type that has reference semantics.
+    nonaliased_name = m.UnscopedEnum.EOne.name
+    nonaliased_name = "bar"  # noqa: F841
     assert m.UnscopedEnum.EOne.name == "EOne"
+    nonaliased_value = m.UnscopedEnum.EOne.value
+    nonaliased_value = 10  # noqa: F841
+    assert m.UnscopedEnum.EOne.value == 1
 
     # __members__ property
     assert m.UnscopedEnum.__members__ == {
@@ -33,8 +42,8 @@ def test_unscoped_enum():
     with pytest.raises(AttributeError):
         m.UnscopedEnum.__members__ = {}
     # __members__ returns a copy
-    foo = m.UnscopedEnum.__members__
-    foo["bar"] = "baz"
+    nonaliased_members = m.UnscopedEnum.__members__
+    nonaliased_members["bar"] = "baz"
     assert m.UnscopedEnum.__members__ == {
         "EOne": m.UnscopedEnum.EOne,
         "ETwo": m.UnscopedEnum.ETwo,


### PR DESCRIPTION
## Description

(Currently draft)
Resolves #2332

Duck-type, but does not support `isinstance(pybind11_enum_value, enum.Enum)`.


## Suggested changelog entry:

```rst
enum: Add iteration and simple type-based check, towards PEP 435
```