### PR TITLE
Do not set docstring for function when it's empty

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -440,10 +440,8 @@ protected:
         /* Install docstring */
         auto *func = (PyCFunctionObject *) m_ptr;
         std::free(const_cast<char *>(func->m_ml->ml_doc));
-        func->m_ml->ml_doc = nullptr;
         // Install docstring if it's non-empty (when at least one option is enabled)
-        if (!signatures.empty())
-            func->m_ml->ml_doc = strdup(signatures.c_str());
+        func->m_ml->ml_doc = signatures.empty() ? nullptr : strdup(signatures.c_str());
 
         if (rec->is_method) {
             m_ptr = PYBIND11_INSTANCE_METHOD_NEW(m_ptr, rec->scope.ptr());

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -439,12 +439,9 @@ protected:
 
         /* Install docstring */
         auto *func = (PyCFunctionObject *) m_ptr;
-        // Free and reset previous docstring if it exists
-        if (func->m_ml->ml_doc) {
-            std::free(const_cast<char *>(func->m_ml->ml_doc));
-            func->m_ml->ml_doc = nullptr;
-        }
-        // Then install new one if it's non-empty (when at least one option is enabled)
+        std::free(const_cast<char *>(func->m_ml->ml_doc));
+        func->m_ml->ml_doc = nullptr;
+        // Install docstring if it's non-empty (when at least one option is enabled)
         if (!signatures.empty())
             func->m_ml->ml_doc = strdup(signatures.c_str());
 
@@ -477,9 +474,7 @@ protected:
                 arg.value.dec_ref();
             }
             if (rec->def) {
-                if (rec->def->ml_doc) {
-                    std::free(const_cast<char *>(rec->def->ml_doc));
-                }
+                std::free(const_cast<char *>(rec->def->ml_doc));
                 // Python 3.9.0 decref's these in the wrong order; rec->def
                 // If loaded on 3.9.0, let these leak (use Python 3.9.1 at runtime to fix)
                 // See https://github.com/python/cpython/pull/22670

--- a/tests/test_docstring_options.cpp
+++ b/tests/test_docstring_options.cpp
@@ -48,6 +48,14 @@ TEST_SUBMODULE(docstring_options, m) {
     {
         py::options options;
         options.disable_user_defined_docstrings();
+        options.disable_function_signatures();
+
+        m.def("test_function8", []() {});
+    }
+
+    {
+        py::options options;
+        options.disable_user_defined_docstrings();
 
         struct DocstringTestFoo {
             int value;

--- a/tests/test_docstring_options.py
+++ b/tests/test_docstring_options.py
@@ -34,6 +34,9 @@ def test_docstring_options():
     assert m.test_function7.__doc__.startswith("test_function7(a: int, b: int) -> None")
     assert m.test_function7.__doc__.endswith("A custom docstring\n")
 
+    # when all options are disabled, no docstring (instead of an empty one) should be generated
+    assert m.test_function8.__doc__ is None
+
     # Suppression of user-defined docstrings for non-function objects
     assert not m.DocstringTestFoo.__doc__
     assert not m.DocstringTestFoo.value_prop.__doc__


### PR DESCRIPTION
## Description

In pybind11, automatic docstring generated from function signature and user-provided documents can be suppressed by disabling all docstring-related options. However, this currently produces an empty docstring, which is unnecessary and interferes with situations where users want to manually add docstring to the bound function later directly through the Python C API (for example, [PyTorch currently does this to its manual C bindings](https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L221) and I find it difficult to extend this to work with pybind11-bound functions without touching pybind11's implementation details). This pull request modifies this behavior, such that when all docstring-related options are disabled and the resulting docstring is empty, no docstring is set on the function.

## Suggested changelog entry

```rst
When all docstring-related options are disabled and the resulting docstring is empty, no docstring is now set on the function. Previously, pybind11 sets an empty docstring.
```
