### PR TITLE
Add shortcut type::name()

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -923,6 +923,9 @@ public:
     /// See https://github.com/pybind/pybind11/issues/2486
     template<typename T>
     static type of() {return type(type::handle_of<T>(), borrowed_t{}); }
+
+    /// Return the type name
+    object name() const { return attr("__name__"); }
 };
 
 class iterable : public object {

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -160,6 +160,10 @@ TEST_SUBMODULE(class_, m) {
         return py::type(ob);
     });
 
+    m.def("get_instance_type_name", [](py::object ob) {
+        return py::type::of(ob).name();
+    });
+
     // test_mismatched_holder
     struct MismatchBase1 { };
     struct MismatchDerived1 : MismatchBase1 { };

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -68,6 +68,15 @@ def test_as_type_py():
         assert m.as_type(m.DerivedClass1()) == m.DerivedClass1
 
 
+def test_type_name():
+    class PurePythonClass(object):
+        pass
+
+    assert m.get_instance_type_name(1) == "int"
+    assert m.get_instance_type_name(PurePythonClass()) == "PurePythonClass"
+    assert m.get_instance_type_name(m.DerivedClass1()) == "DerivedClass1"
+
+
 def test_docstrings(doc):
     assert doc(UserType) == "A `py::class_` type for testing"
     assert UserType.__name__ == "UserType"


### PR DESCRIPTION
## Description
Add `type::name()` as a shortcut for getting the name of a type, like `cpp_function::name()`. I also feel that maybe we can move `cpp_function::name()` to `function::name()`, as all Python functions have names?

## Suggested changelog entry:
```rst
Add shortcut `type::name()` for getting the name of a type
```
