### PR TITLE
Plug leaking function_records in cpp_function initialization in case of exceptions (found by Valgrind in #2746)

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -256,6 +256,9 @@ protected:
     /// Register a function call with Python (generic non-templated code goes here)
     void initialize_generic(unique_function_record &&unique_rec, const char *text,
                             const std::type_info *const *types, size_t args) {
+        // Do NOT receive `unique_rec` by value. If this function fails to move out the unique_ptr,
+        // we do not want this to destuct the pointer. `initialize` (the caller) still relies on the
+        // pointee being alive after this call. Only move out if a `capsule` is going to keep it alive.
         auto rec = unique_rec.get();
 
         // Keep track of strdup'ed strings, and clean them up as long as the function's capsule

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -243,7 +243,7 @@ protected:
         }
         char *operator()(const char *s) {
             auto t = strdup(s);
-            strings.emplace_back(t);
+            strings.push_back(t);
             return t;
         }
         void release() {

--- a/tests/test_constants_and_functions.py
+++ b/tests/test_constants_and_functions.py
@@ -40,3 +40,14 @@ def test_exception_specifiers():
     assert m.f2(53) == 55
     assert m.f3(86) == 89
     assert m.f4(140) == 144
+
+
+def test_function_record_leaks():
+    class RaisingRepr:
+        def __repr__(self):
+            raise RuntimeError("Surprise!")
+
+    with pytest.raises(RuntimeError):
+        m.register_large_capture_with_invalid_arguments(m)
+    with pytest.raises(RuntimeError):
+        m.register_with_raising_repr(m, RaisingRepr())


### PR DESCRIPTION
## Description

Another leak fix taken out of #2746.

~~I am not entirely happy with this solution yet, mostly because we are not reusing `destruct(function_record *)`. I tried adding this as the `unique_ptr`'s deleter, but the issue is that the `char *`s only get copied along the way, and are not owned before those copies.~~ (kind of fixed that)
~~Also, `rec->data` can still leak as `rec->free_data` is not called after an exception.~~ (fixed that)

## Suggested changelog entry:

```rst
Resolved memory leak in cpp_function initialization when exceptions occured.
```
