### PR TITLE
Ignore deprecation warnings about old-style __init__/__setstate__ constructors in the tests (originally done in #2746)

### DIFF
--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <pybind11/pybind11.h>
+#include <pybind11/eval.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
 // We get some really long type names here which causes MSVC 2015 to emit warnings
@@ -70,16 +71,14 @@ public:
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(pybind11)
 
-/// Simplified ``with warnigns.catch_warnings()`` wrapper
 template <typename F>
 void ignoreOldStyleInitWarnings(F &&body) {
-    auto message = "pybind11-bound class '.+' is using an old-style placement-new '(?:__init__|__setstate__)' which has been deprecated";
-    auto category = py::reinterpret_borrow<py::object>(PyExc_FutureWarning);
-    auto warnings = py::module_::import("warnings");
-    auto context_mgr = warnings.attr("catch_warnings")();
-    context_mgr.attr("__enter__")();
-    warnings.attr("filterwarnings")("ignore", py::arg("message")=message, py::arg("category")=category);
-    body();
-    // Exceptions in `body` not handled; see PEP 343 when these would need to be added
-    context_mgr.attr("__exit__")(py::none(), py::none(), py::none());
+    py::exec(R"(
+    message = "pybind11-bound class '.+' is using an old-style placement-new '(?:__init__|__setstate__)' which has been deprecated"
+
+    import warnings
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=message, category=FutureWarning)
+        body()
+    )", py::dict(py::arg("body") = py::cpp_function(body)));
 }

--- a/tests/test_factory_constructors.cpp
+++ b/tests/test_factory_constructors.cpp
@@ -183,27 +183,28 @@ TEST_SUBMODULE(factory_constructors, m) {
     auto c4a = [c](pointer_tag, TF4_tag, int a) { (void) c; return new TestFactory4(a);};
 
     // test_init_factory_basic, test_init_factory_casting
-    ignoreOldStyleInitWarnings([&]() {
-        py::class_<TestFactory3, std::shared_ptr<TestFactory3>>(m, "TestFactory3")
-            .def(py::init([](pointer_tag, int v) { return TestFactoryHelper::construct3(v); }))
-            .def(py::init([](shared_ptr_tag) { return TestFactoryHelper::construct3(); }))
-            .def("__init__", [](TestFactory3 &self, std::string v) { new (&self) TestFactory3(v); }) // placement-new ctor
-
-            // factories returning a derived type:
-            .def(py::init(c4a)) // derived ptr
-            .def(py::init([](pointer_tag, TF5_tag, int a) { return new TestFactory5(a); }))
-            // derived shared ptr:
-            .def(py::init([](shared_ptr_tag, TF4_tag, int a) { return std::make_shared<TestFactory4>(a); }))
-            .def(py::init([](shared_ptr_tag, TF5_tag, int a) { return std::make_shared<TestFactory5>(a); }))
-
-            // Returns nullptr:
-            .def(py::init([](null_ptr_tag) { return (TestFactory3 *) nullptr; }))
-            .def(py::init([](null_unique_ptr_tag) { return std::unique_ptr<TestFactory3>(); }))
-            .def(py::init([](null_shared_ptr_tag) { return std::shared_ptr<TestFactory3>(); }))
-
-            .def_readwrite("value", &TestFactory3::value)
-            ;
+    py::class_<TestFactory3, std::shared_ptr<TestFactory3>> pyTestFactory3(m, "TestFactory3");
+    pyTestFactory3
+        .def(py::init([](pointer_tag, int v) { return TestFactoryHelper::construct3(v); }))
+        .def(py::init([](shared_ptr_tag) { return TestFactoryHelper::construct3(); }));
+    ignoreOldStyleInitWarnings([&pyTestFactory3]() {
+        pyTestFactory3.def("__init__", [](TestFactory3 &self, std::string v) { new (&self) TestFactory3(v); }); // placement-new ctor
     });
+    pyTestFactory3
+        // factories returning a derived type:
+        .def(py::init(c4a)) // derived ptr
+        .def(py::init([](pointer_tag, TF5_tag, int a) { return new TestFactory5(a); }))
+        // derived shared ptr:
+        .def(py::init([](shared_ptr_tag, TF4_tag, int a) { return std::make_shared<TestFactory4>(a); }))
+        .def(py::init([](shared_ptr_tag, TF5_tag, int a) { return std::make_shared<TestFactory5>(a); }))
+
+        // Returns nullptr:
+        .def(py::init([](null_ptr_tag) { return (TestFactory3 *) nullptr; }))
+        .def(py::init([](null_unique_ptr_tag) { return std::unique_ptr<TestFactory3>(); }))
+        .def(py::init([](null_shared_ptr_tag) { return std::shared_ptr<TestFactory3>(); }))
+
+        .def_readwrite("value", &TestFactory3::value)
+        ;
 
     // test_init_factory_casting
     py::class_<TestFactory4, TestFactory3, std::shared_ptr<TestFactory4>>(m, "TestFactory4")
@@ -307,25 +308,30 @@ TEST_SUBMODULE(factory_constructors, m) {
 #endif
     };
 
-    ignoreOldStyleInitWarnings([&]() {
-        py::class_<NoisyAlloc>(m, "NoisyAlloc")
-            // Since these overloads have the same number of arguments, the dispatcher will try each of
-            // them until the arguments convert.  Thus we can get a pre-allocation here when passing a
-            // single non-integer:
-            .def("__init__", [](NoisyAlloc *a, int i) { new (a) NoisyAlloc(i); }) // Regular constructor, runs first, requires preallocation
-            .def(py::init([](double d) { return new NoisyAlloc(d); }))
 
-            // The two-argument version: first the factory pointer overload.
-            .def(py::init([](int i, int) { return new NoisyAlloc(i); }))
-            // Return-by-value:
-            .def(py::init([](double d, int) { return NoisyAlloc(d); }))
-            // Old-style placement new init; requires preallocation
-            .def("__init__", [](NoisyAlloc &a, double d, double) { new (&a) NoisyAlloc(d); })
-            // Requires deallocation of previous overload preallocated value:
-            .def(py::init([](int i, double) { return new NoisyAlloc(i); }))
-            // Regular again: requires yet another preallocation
-            .def("__init__", [](NoisyAlloc &a, int i, std::string) { new (&a) NoisyAlloc(i); })
-            ;
+    py::class_<NoisyAlloc> pyNoisyAlloc(m, "NoisyAlloc");
+        // Since these overloads have the same number of arguments, the dispatcher will try each of
+        // them until the arguments convert.  Thus we can get a pre-allocation here when passing a
+        // single non-integer:
+    ignoreOldStyleInitWarnings([&pyNoisyAlloc]() {
+        pyNoisyAlloc.def("__init__", [](NoisyAlloc *a, int i) { new (a) NoisyAlloc(i); }); // Regular constructor, runs first, requires preallocation
+    });
+
+    pyNoisyAlloc.def(py::init([](double d) { return new NoisyAlloc(d); }));
+
+    // The two-argument version: first the factory pointer overload.
+    pyNoisyAlloc.def(py::init([](int i, int) { return new NoisyAlloc(i); }));
+    // Return-by-value:
+    pyNoisyAlloc.def(py::init([](double d, int) { return NoisyAlloc(d); }));
+    // Old-style placement new init; requires preallocation
+    ignoreOldStyleInitWarnings([&pyNoisyAlloc]() {
+        pyNoisyAlloc.def("__init__", [](NoisyAlloc &a, double d, double) { new (&a) NoisyAlloc(d); });
+    });
+    // Requires deallocation of previous overload preallocated value:
+    pyNoisyAlloc.def(py::init([](int i, double) { return new NoisyAlloc(i); }));
+    // Regular again: requires yet another preallocation
+    ignoreOldStyleInitWarnings([&pyNoisyAlloc]() {
+        pyNoisyAlloc.def("__init__", [](NoisyAlloc &a, int i, std::string) { new (&a) NoisyAlloc(i); });
     });
 
 

--- a/tests/test_pickling.cpp
+++ b/tests/test_pickling.cpp
@@ -31,20 +31,22 @@ TEST_SUBMODULE(pickling, m) {
         using Pickleable::Pickleable;
     };
 
-    ignoreOldStyleInitWarnings([&]() {
-        py::class_<Pickleable>(m, "Pickleable")
-            .def(py::init<std::string>())
-            .def("value", &Pickleable::value)
-            .def("extra1", &Pickleable::extra1)
-            .def("extra2", &Pickleable::extra2)
-            .def("setExtra1", &Pickleable::setExtra1)
-            .def("setExtra2", &Pickleable::setExtra2)
-            // For details on the methods below, refer to
-            // http://docs.python.org/3/library/pickle.html#pickling-class-instances
-            .def("__getstate__", [](const Pickleable &p) {
-                /* Return a tuple that fully encodes the state of the object */
-                return py::make_tuple(p.value(), p.extra1(), p.extra2());
-            })
+    py::class_<Pickleable> pyPickleable(m, "Pickleable");
+    pyPickleable
+        .def(py::init<std::string>())
+        .def("value", &Pickleable::value)
+        .def("extra1", &Pickleable::extra1)
+        .def("extra2", &Pickleable::extra2)
+        .def("setExtra1", &Pickleable::setExtra1)
+        .def("setExtra2", &Pickleable::setExtra2)
+        // For details on the methods below, refer to
+        // http://docs.python.org/3/library/pickle.html#pickling-class-instances
+        .def("__getstate__", [](const Pickleable &p) {
+            /* Return a tuple that fully encodes the state of the object */
+            return py::make_tuple(p.value(), p.extra1(), p.extra2());
+        });
+    ignoreOldStyleInitWarnings([&pyPickleable]() {
+        pyPickleable
             .def("__setstate__", [](Pickleable &p, py::tuple t) {
                 if (t.size() != 3)
                     throw std::runtime_error("Invalid state!");
@@ -89,15 +91,17 @@ TEST_SUBMODULE(pickling, m) {
         using PickleableWithDict::PickleableWithDict;
     };
 
-    ignoreOldStyleInitWarnings([&]() {
-        py::class_<PickleableWithDict>(m, "PickleableWithDict", py::dynamic_attr())
-            .def(py::init<std::string>())
-            .def_readwrite("value", &PickleableWithDict::value)
-            .def_readwrite("extra", &PickleableWithDict::extra)
-            .def("__getstate__", [](py::object self) {
-                /* Also include __dict__ in state */
-                return py::make_tuple(self.attr("value"), self.attr("extra"), self.attr("__dict__"));
-            })
+    py::class_<PickleableWithDict> pyPickleableWithDict(m, "PickleableWithDict", py::dynamic_attr());
+    pyPickleableWithDict
+        .def(py::init<std::string>())
+        .def_readwrite("value", &PickleableWithDict::value)
+        .def_readwrite("extra", &PickleableWithDict::extra)
+        .def("__getstate__", [](py::object self) {
+            /* Also include __dict__ in state */
+            return py::make_tuple(self.attr("value"), self.attr("extra"), self.attr("__dict__"));
+        });
+    ignoreOldStyleInitWarnings([&pyPickleableWithDict]() {
+        pyPickleableWithDict
             .def("__setstate__", [](py::object self, py::tuple t) {
                 if (t.size() != 3)
                     throw std::runtime_error("Invalid state!");


### PR DESCRIPTION
## Description

As the title says. The test suite contains a few tests to make sure the old-style `__init__` (with placement `new`s) still works and interacts correctly with the new, non-deprecated way of doing things. Using a debug build of Python (in #2746), pybind11 shows these deprecation warnings, so let's filter these out to remove some output clutter and make sure we have a higher chance of catching useful warnings.

## Suggested changelog entry:

```rst
Suppressed some deprecation warnings about old-style ``__init__``/``__setstate__`` in the tests.
```
