### PR TITLE
CI: Intel icx/icpx via oneAPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,30 +511,43 @@ jobs:
         -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
         -DCMAKE_VERBOSE_MAKEFILE=ON                    \
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
+
     - name: Build
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake --build build -j 2
+
     - name: Python tests
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         sudo service apport stop
-        cmake --build build --target check \
+        cmake --build build \
         -DCMAKE_CXX_COMPILER_ID="Clang"                \
         -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-        -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"
+        -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
+        --target check
+
     - name: C++ tests
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build --target cpptest
+        cmake --build build \
+        -DCMAKE_CXX_COMPILER_ID="Clang"                \
+        -DCMAKE_CXX_COMPILER_VERSION=12.0              \
+        -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
+        --target cpptest
+
     - name: Interface test
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build --target test_cmake_build
+        cmake --build build \
+        -DCMAKE_CXX_COMPILER_ID="Clang"                \
+        -DCMAKE_CXX_COMPILER_VERSION=12.0              \
+        -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
+        --target test_cmake_build
 
 
   # Testing on CentOS (manylinux uses a centos base, and this is an easy way

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,7 +521,10 @@ jobs:
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         sudo service apport stop
-        cmake --build build --target check
+        cmake --build build --target check \
+        -DCMAKE_CXX_COMPILER_ID="Clang"                \
+        -DCMAKE_CXX_COMPILER_VERSION=12.0              \
+        -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"
     - name: C++ tests
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,6 +465,78 @@ jobs:
       run: cmake --build build --target test_cmake_build
 
 
+  # Testing on ICC using the oneAPI apt repo
+  icc:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+
+    name: "🐍 3 • ICC latest • x64"
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Add apt repo
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+    - name: Add ICC & Python 3
+      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic cmake python3-dev python3-numpy python3-pytest python3-pip
+
+    - name: Update pip
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        python3 -m pip install --upgrade pip
+
+    - name: Install dependencies
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        python3 -m pip install -r tests/requirements.txt --prefer-binary
+
+    - name: Configure
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        cmake -S . -B build     \
+        -DPYBIND11_WERROR=ON    \
+        -DDOWNLOAD_CATCH=ON     \
+        -DDOWNLOAD_EIGEN=OFF    \
+        -DCMAKE_CXX_STANDARD=11             \
+        -DCMAKE_CXX_COMPILER=$(which icpc)  \
+        -DCMAKE_VERBOSE_MAKEFILE=ON         \
+        -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
+
+    - name: Build
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        cmake --build build -j 2
+
+    - name: Python tests
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        sudo service apport stop
+        cmake --build build --target check
+
+    - name: C++ tests
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        cmake --build build --target cpptest
+
+    - name: Interface test
+      shell: bash
+      run: |
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        cmake --build build --target test_cmake_build
+
+
   # Testing on ICX/ICPX, Intel's next-gen C/C++ compiler using the oneAPI apt repo
   icx:
     runs-on: ubuntu-20.04
@@ -491,6 +563,7 @@ jobs:
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         python3 -m pip install --upgrade pip
+
     - name: Install dependencies
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,13 +465,13 @@ jobs:
       run: cmake --build build --target test_cmake_build
 
 
-  # Testing on ICC using the oneAPI apt repo
-  icc:
+  # Testing on ICX/ICPX, Intel's next-gen C/C++ compiler using the oneAPI apt repo
+  icx:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
 
-    name: "🐍 3 • ICC latest • x64"
+    name: "🐍 3 • ICPX latest • x64"
 
     steps:
     - uses: actions/checkout@v1
@@ -483,18 +483,15 @@ jobs:
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-
     - name: Add ICC & Python 3
-      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic cmake python3-dev python3-numpy python3-pytest python3-pip
+      run: sudo apt-get update; sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp cmake python3-dev python3-numpy python3-pytest python3-pip
 
     - name: Update pip
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         python3 -m pip install --upgrade pip
-
     - name: Install dependencies
-      run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         python3 -m pip install -r tests/requirements.txt --prefer-binary
 
@@ -506,30 +503,29 @@ jobs:
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
-        -DCMAKE_CXX_STANDARD=11             \
-        -DCMAKE_CXX_COMPILER=$(which icpc)  \
-        -DCMAKE_VERBOSE_MAKEFILE=ON         \
+        -DCMAKE_CXX_STANDARD=14             \
+        -DCMAKE_CXX_COMPILER=$(which icpx)  \
+        -DCMAKE_CXX_COMPILER_ID="Clang"                \
+        -DCMAKE_CXX_COMPILER_VERSION=12.0              \
+        -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
+        -DCMAKE_VERBOSE_MAKEFILE=ON                    \
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
-
     - name: Build
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake --build build -j 2
-
     - name: Python tests
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         sudo service apport stop
         cmake --build build --target check
-
     - name: C++ tests
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake --build build --target cpptest
-
     - name: Interface test
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,6 +492,7 @@ jobs:
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         python3 -m pip install --upgrade pip
     - name: Install dependencies
+      run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         python3 -m pip install -r tests/requirements.txt --prefer-binary
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,8 @@ jobs:
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-    - name: Add ICC & Python 3
+
+    - name: Add ICPC & Python 3
       run: sudo apt-get update; sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp cmake python3-dev python3-numpy python3-pytest python3-pip
 
     - name: Update pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,31 +597,19 @@ jobs:
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         sudo service apport stop
-        cmake --build build \
-        -DCMAKE_CXX_COMPILER_ID="Clang"                \
-        -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-        -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
-        --target check
+        cmake --build build --target check
 
     - name: C++ tests
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build \
-        -DCMAKE_CXX_COMPILER_ID="Clang"                \
-        -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-        -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
-        --target cpptest
+        cmake --build build --target cpptest
 
     - name: Interface test
       shell: bash
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build \
-        -DCMAKE_CXX_COMPILER_ID="Clang"                \
-        -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-        -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"     \
-        --target test_cmake_build
+        cmake --build build --target test_cmake_build
 
 
   # Testing on CentOS (manylinux uses a centos base, and this is an easy way


### PR DESCRIPTION
Add testing for Intel icx/icpx via the oneAPI images.
This is Intel's next-gen compiler and new C++ support, e.g. C++17 bug fixes, first land here.

For the Intel "classic" compilers icc/icpc, please see #2573