### PR TITLE
Update 'inactive_override_cache' key

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -83,9 +83,9 @@ template <typename value_type>
 using type_map = std::unordered_map<std::type_index, value_type, type_hash, type_equal_to>;
 
 struct override_hash {
-    inline size_t operator()(const std::pair<const PyObject *, const char *>& v) const {
+    inline size_t operator()(const std::pair<const PyObject *, std::string>& v) const {
         size_t value = std::hash<const void *>()(v.first);
-        value ^= std::hash<const void *>()(v.second) + 0x9e3779b9 + (value<<6) + (value>>2);
+        value ^= std::hash<std::string>()(v.second);
         return value;
     }
 };
@@ -97,7 +97,7 @@ struct internals {
     type_map<type_info *> registered_types_cpp; // std::type_index -> pybind11's type information
     std::unordered_map<PyTypeObject *, std::vector<type_info *>> registered_types_py; // PyTypeObject* -> base type_info(s)
     std::unordered_multimap<const void *, instance*> registered_instances; // void * -> instance*
-    std::unordered_set<std::pair<const PyObject *, const char *>, override_hash> inactive_override_cache;
+    std::unordered_set<std::pair<const PyObject *, std::string>, override_hash> inactive_override_cache;
     type_map<std::vector<bool (*)(PyObject *, void *&)>> direct_conversions;
     std::unordered_map<const PyObject *, std::vector<PyObject *>> patients;
     std::forward_list<void (*) (std::exception_ptr)> registered_exception_translators;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -82,10 +82,16 @@ struct type_equal_to {
 template <typename value_type>
 using type_map = std::unordered_map<std::type_index, value_type, type_hash, type_equal_to>;
 
+// Adapted from boost::hash_combine(). See also:
+// https://stackoverflow.com/a/27952689/7829525.
+inline void hash_combine(size_t& lhs, size_t rhs ) {
+    lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
+}
+
 struct override_hash {
     inline size_t operator()(const std::pair<const PyObject *, std::string>& v) const {
         size_t value = std::hash<const void *>()(v.first);
-        value ^= std::hash<std::string>()(v.second);
+        hash_combine(value, std::hash<std::string>()(v.second));
         return value;
     }
 };
@@ -150,7 +156,7 @@ struct type_info {
 };
 
 /// Tracks the `internals` and `type_info` ABI version independent of the main library version
-#define PYBIND11_INTERNALS_VERSION 4
+#define PYBIND11_INTERNALS_VERSION 5
 
 /// On MSVC, debug and release builds are not ABI-compatible!
 #if defined(_MSC_VER) && defined(_DEBUG)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2221,7 +2221,8 @@ inline function get_type_override(const void *this_ptr, const type_info *this_ty
     if (!self)
         return function();
     handle type = type::handle_of(self);
-    auto key = std::make_pair(type.ptr(), name);
+    std::string full_name = type.attr("__qualname__").cast<std::string>() + "." + name;
+    auto key = std::make_pair(type.ptr(), full_name);
 
     /* Cache functions that aren't overridden in Python to avoid
        many costly Python dictionary lookups below */

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2221,7 +2221,7 @@ inline function get_type_override(const void *this_ptr, const type_info *this_ty
     if (!self)
         return function();
     handle type = type::handle_of(self);
-    std::string full_name = type.attr("__qualname__").cast<std::string>() + "." + name;
+    std::string full_name = get_fully_qualified_tp_name((PyTypeObject*) type.ptr()) + "." + name;
     auto key = std::make_pair(type.ptr(), full_name);
 
     /* Cache functions that aren't overridden in Python to avoid


### PR DESCRIPTION
## Description

Avoid false cache hits for virtual overrides by using `__qualname__` as the hashing key. Change storage to `std::string` to avoid memory management mishaps.

Supersedes #2092 - just merge conflict resolution; I'll address any further changes.
Resolves #1922

## Suggested changelog entry:

```rst
Avoid false cache hits for virtual overrides by using ``__qualname__`` as the hashing key. Change storage of key to use ``std::string`` to avoid memory management mishaps.
```

\cc @BetsyMcPhail 