### PR TITLE
Update attr.h: fix a warning found by static code analyzer

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -544,7 +544,7 @@ template <typename... Extra,
           size_t named = constexpr_sum(std::is_base_of<arg, Extra>::value...),
           size_t self  = constexpr_sum(std::is_same<is_method, Extra>::value...)>
 constexpr bool expected_num_args(size_t nargs, bool has_args, bool has_kwargs) {
-    return named == 0 || (self + named + has_args + has_kwargs) == nargs;
+    return named == 0 || (self + named + (has_args ? 1 : 0) + (has_kwargs ? 1 : 0)) == nargs;
 }
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -544,7 +544,7 @@ template <typename... Extra,
           size_t named = constexpr_sum(std::is_base_of<arg, Extra>::value...),
           size_t self  = constexpr_sum(std::is_same<is_method, Extra>::value...)>
 constexpr bool expected_num_args(size_t nargs, bool has_args, bool has_kwargs) {
-    return named == 0 || (self + named + (has_args ? 1 : 0) + (has_kwargs ? 1 : 0)) == nargs;
+    return named == 0 || (self + named + std::size_t(has_args) + std::size_t(has_kwargs)) == nargs;
 }
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -544,7 +544,7 @@ template <typename... Extra,
           size_t named = constexpr_sum(std::is_base_of<arg, Extra>::value...),
           size_t self  = constexpr_sum(std::is_same<is_method, Extra>::value...)>
 constexpr bool expected_num_args(size_t nargs, bool has_args, bool has_kwargs) {
-    return named == 0 || (self + named + std::size_t(has_args) + std::size_t(has_kwargs)) == nargs;
+    return named == 0 || (self + named + size_t(has_args) + size_t(has_kwargs)) == nargs;
 }
 
 PYBIND11_NAMESPACE_END(detail)


### PR DESCRIPTION


## Description


Update attr.h: fix a warning found by Visual Studio static code analyzer

Severity:Warning
Code:C6323
Description: Use of arithmetic operator on Boolean type(s).
Location:	C:\src\onnxruntime\debug\pybind11\src\pybind11\include\pybind11\attr.h:547

## Suggested changelog entry:

(nothing)