### PR TITLE
Disable builds for 3.10.0a4, and enable a nightly 3.10-dev build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,6 @@ jobs:
             python: 3.6
             args: >
               -DPYBIND11_FINDPYTHON=ON
-          - runs-on: ubuntu-latest
-            python: 3.10-dev
-            nightly: true
 
         # These items will be removed from the build matrix, keys must match.
         exclude:
@@ -58,21 +55,14 @@ jobs:
           - runs-on: ubuntu-latest
             python: pypy2
 
-    name: "🐍 ${{ matrix.python }} ${{ matrix.nightly && '(nightly)' || '' }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
+    name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Setup Python ${{ matrix.python }}
-      if: "!matrix.nightly"
       uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-
-    - name: Setup Python ${{ matrix.python }} (nightly)
-      if: matrix.nightly
-      uses: deadsnakes/action@v2.1.0
       with:
         python-version: ${{ matrix.python }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           - runs-on: ubuntu-latest
             python: pypy2
 
-    name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
+    name: "🐍 ${{ matrix.python }} ${{ matrix.nightly && '(nightly)' || '' }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,51 @@ jobs:
       run: pytest tests/extra_setuptools
 
 
+  deadsnakes:
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+        - version: 2.7
+          debug: true
+        - version: 3.9
+          debug: true
+        - version: 3.10-dev
+          debug: false
+
+    name: "🐍 ${{ matrix.python.version }}${{ matrix.python.debug && ' (debug)' || '' }} • deadsnakes • x64"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python ${{ matrix.python.version }}
+      uses: deadsnakes/action@v2.1.0
+      with:
+        python-version: ${{ matrix.python.version }}
+        debug: ${{ matrix.python.version.debug }}
+
+    - name: Prepare env
+      run: python -m pip install -r tests/requirements.txt --prefer-binary
+
+    - name: Configure
+      run: >
+        cmake -S . -B build
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DDOWNLOAD_EIGEN=ON
+        -DCMAKE_CXX_STANDARD=17
+
+    - name: Build
+      run: cmake --build build -j 2
+
+    - name: Python tests
+      run: cmake --build build --target pytest
+
+    - name: C++ tests
+      run: cmake --build build --target cpptest
+
+
   # Testing on clang using the excellent silkeh clang docker images
   clang:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Python ${{ matrix.python.version }} (deadsnakes)
-      uses: deadsnakes/action@v2.1.0
+      uses: YannickJadoul/deadsnakes-action@fix-input-boolean
       with:
         python-version: ${{ matrix.python.version }}
         debug: ${{ matrix.python.debug }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - version: 2.7
-          debug: true
         - version: 3.9
           debug: true
         - version: 3.10-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Python ${{ matrix.python.version }} (deadsnakes)
-      uses: YannickJadoul/deadsnakes-action@fix-input-boolean
+      uses: deadsnakes/action@v2.1.1
       with:
         python-version: ${{ matrix.python.version }}
         debug: ${{ matrix.python.debug }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         - 3.5
         - 3.6
         - 3.9
-        - 3.10-dev
+        # - 3.10-dev  # Re-enable once 3.10.0a5 is released
         - pypy2
         - pypy3
 
@@ -42,6 +42,9 @@ jobs:
             python: 3.6
             args: >
               -DPYBIND11_FINDPYTHON=ON
+          - runs-on: ubuntu-latest
+            python: 3.10-dev
+            nightly: true
 
         # These items will be removed from the build matrix, keys must match.
         exclude:
@@ -62,7 +65,14 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Python ${{ matrix.python }}
+      if: "!matrix.nightly"
       uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Setup Python ${{ matrix.python }} (nightly)
+      if: matrix.nightly
+      uses: deadsnakes/action@v2.1.0
       with:
         python-version: ${{ matrix.python }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,11 +181,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Python ${{ matrix.python.version }}
+    - name: Setup Python ${{ matrix.python.version }} (deadsnakes)
       uses: deadsnakes/action@v2.1.0
       with:
         python-version: ${{ matrix.python.version }}
-        debug: ${{ matrix.python.version.debug }}
+        debug: ${{ matrix.python.debug }}
 
     - name: Prepare env
       run: python -m pip install -r tests/requirements.txt --prefer-binary

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -31,7 +31,7 @@ endif()
 
 # A user can set versions manually too
 set(Python_ADDITIONAL_VERSIONS
-    "3.9;3.8;3.7;3.6;3.5;3.4"
+    "3.10;3.9;3.8;3.7;3.6;3.5;3.4"
     CACHE INTERNAL "")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")


### PR DESCRIPTION
## Description

Temporary fix for #2774. Meanwhile, this also adds 3.10-dev nightly builds from [deadsnakes](https://github.com/deadsnakes/action).