### PR TITLE
Revert workaround of test_virtual_functions.py from #2746

### DIFF
--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -251,7 +251,8 @@ def test_dispatch_issue(msg):
                 == 'Tried to call pure virtual function "Base::dispatch"'
             )
 
-            return m.dispatch_issue_go(PyClass1())
+            p = PyClass1()
+            return m.dispatch_issue_go(p)
 
     b = PyClass2()
     assert m.dispatch_issue_go(b) == "Yay.."


### PR DESCRIPTION
## Description

We made workaround in #2746 for an issue flagged by Valgrind we didn't understand/track down. So far it's unclear whether this is a real issue (a very tricky one, then, because this small change triggers it), or an issue with Valgrind. In any case, we'd like to revert this :-)