### PR TITLE
Factoring out make_constructor from type_caster_base (for reuse under PR #2672).

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -882,8 +882,7 @@ struct polymorphic_type_hook : public polymorphic_type_hook_base<itype> {};
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 /// Generic type caster for objects stored on the heap
-template <typename type> class type_caster_base : public type_caster_generic,
-                                                  protected make_constructor {
+template <typename type> class type_caster_base : public type_caster_generic {
     using itype = intrinsic_t<type>;
 
 public:
@@ -930,7 +929,8 @@ public:
         auto st = src_and_type(src);
         return type_caster_generic::cast(
             st.first, policy, parent, st.second,
-            make_copy_constructor(src), make_move_constructor(src));
+            make_constructor::make_copy_constructor(src),
+            make_constructor::make_move_constructor(src));
     }
 
     static handle cast_holder(const itype *src, const void *holder) {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -816,6 +816,30 @@ template <typename Container> struct is_copy_assignable<Container, enable_if_t<a
 template <typename T1, typename T2> struct is_copy_assignable<std::pair<T1, T2>>
     : all_of<is_copy_assignable<T1>, is_copy_assignable<T2>> {};
 
+// Helper for type_caster_base.
+struct make_constructor {
+    using Constructor = void *(*)(const void *);
+
+    /* Only enabled when the types are {copy,move}-constructible *and* when the type
+       does not have a private operator new implementation. */
+    template <typename T, typename = enable_if_t<is_copy_constructible<T>::value>>
+    static auto make_copy_constructor(const T *x) -> decltype(new T(*x), Constructor{}) {
+        return [](const void *arg) -> void * {
+            return new T(*reinterpret_cast<const T *>(arg));
+        };
+    }
+
+    template <typename T, typename = enable_if_t<std::is_move_constructible<T>::value>>
+    static auto make_move_constructor(const T *x) -> decltype(new T(std::move(*const_cast<T *>(x))), Constructor{}) {
+        return [](const void *arg) -> void * {
+            return new T(std::move(*const_cast<T *>(reinterpret_cast<const T *>(arg))));
+        };
+    }
+
+    static Constructor make_copy_constructor(...) { return nullptr; }
+    static Constructor make_move_constructor(...) { return nullptr; }
+};
+
 PYBIND11_NAMESPACE_END(detail)
 
 // polymorphic_type_hook<itype>::get(src, tinfo) determines whether the object pointed
@@ -858,7 +882,8 @@ struct polymorphic_type_hook : public polymorphic_type_hook_base<itype> {};
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 /// Generic type caster for objects stored on the heap
-template <typename type> class type_caster_base : public type_caster_generic {
+template <typename type> class type_caster_base : public type_caster_generic,
+                                                  protected make_constructor {
     using itype = intrinsic_t<type>;
 
 public:
@@ -919,28 +944,6 @@ public:
 
     operator itype*() { return (type *) value; }
     operator itype&() { if (!value) throw reference_cast_error(); return *((itype *) value); }
-
-protected:
-    using Constructor = void *(*)(const void *);
-
-    /* Only enabled when the types are {copy,move}-constructible *and* when the type
-       does not have a private operator new implementation. */
-    template <typename T, typename = enable_if_t<is_copy_constructible<T>::value>>
-    static auto make_copy_constructor(const T *x) -> decltype(new T(*x), Constructor{}) {
-        return [](const void *arg) -> void * {
-            return new T(*reinterpret_cast<const T *>(arg));
-        };
-    }
-
-    template <typename T, typename = enable_if_t<std::is_move_constructible<T>::value>>
-    static auto make_move_constructor(const T *x) -> decltype(new T(std::move(*const_cast<T *>(x))), Constructor{}) {
-        return [](const void *arg) -> void * {
-            return new T(std::move(*const_cast<T *>(reinterpret_cast<const T *>(arg))));
-        };
-    }
-
-    static Constructor make_copy_constructor(...) { return nullptr; }
-    static Constructor make_move_constructor(...) { return nullptr; }
 };
 
 template <typename type, typename SFINAE = void> class type_caster : public type_caster_base<type> { };


### PR DESCRIPTION
Pure, very small-scale refactoring of internals, to support reuse in new developments.

This PR enables removal of duplicate code here: https://github.com/pybind/pybind11/pull/2672/commits/df1360389f25ed3d63387e95984d70ae063e3574

In theory I could inherit from the existing `type_caster_base`, although I only need the `make_constructor functionality`, but that would muddy the waters considerably, i.e. it would be much less clear to readers of the new code what's actually needed.