### PR TITLE
Always call PyNumber_Index when casting from Python to a C++ integral type, also pre-3.8

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1044,17 +1044,12 @@ public:
             return false;
         } else {
             handle src_or_index = src;
+            py_value = (py_type) -1;
 #if PY_VERSION_HEX < 0x03080000
             object index;
-            if (index_check(src.ptr())) {
+            if (!PYBIND11_LONG_CHECK(src.ptr()) && index_check(src.ptr())) {
                 index = reinterpret_steal<object>(PyNumber_Index(src.ptr()));
-                if (!index) {
-                    src_or_index = handle();
-                    py_value = (py_type) -1;
-                }
-                else {
-                    src_or_index = index;
-                }
+                src_or_index = index ? index : handle();
             }
 #endif
             if (src_or_index) {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1046,10 +1046,11 @@ public:
             handle obj = src;
 #if PY_VERSION_HEX < 0x03080000
             bool do_decref = false;
-            if (PyIndex_Check(src.ptr())) {
+            if (index_check(src.ptr())) {
                 PyObject *tmp = PyNumber_Index(src.ptr());
                 if (!tmp) {
-                    py_value = (py_type) -1;
+                    PyErr_Clear();
+                    return false;
                 }
                 do_decref = true;
                 obj = tmp;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1049,18 +1049,22 @@ public:
             if (index_check(src.ptr())) {
                 index = reinterpret_steal<object>(PyNumber_Index(src.ptr()));
                 if (!index) {
-                    PyErr_Clear();
-                    return false;
+                    src_or_index = handle();
+                    py_value = (py_type) -1;
                 }
-                src_or_index = index;
+                else {
+                    src_or_index = index;
+                }
             }
 #endif
-            if (std::is_unsigned<py_type>::value) {
-                py_value = as_unsigned<py_type>(src_or_index.ptr());
-            } else { // signed integer:
-                py_value = sizeof(T) <= sizeof(long)
-                    ? (py_type) PyLong_AsLong(src_or_index.ptr())
-                    : (py_type) PYBIND11_LONG_AS_LONGLONG(src_or_index.ptr());
+            if (src_or_index) {
+                if (std::is_unsigned<py_type>::value) {
+                    py_value = as_unsigned<py_type>(src_or_index.ptr());
+                } else { // signed integer:
+                    py_value = sizeof(T) <= sizeof(long)
+                        ? (py_type) PyLong_AsLong(src_or_index.ptr())
+                        : (py_type) PYBIND11_LONG_AS_LONGLONG(src_or_index.ptr());
+                }
             }
         }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1040,26 +1040,30 @@ public:
                 return false;
         } else if (PyFloat_Check(src.ptr())) {
             return false;
-        } else if (!convert && !index_check(src.ptr()) && !PYBIND11_LONG_CHECK(src.ptr())) {
+        } else if (!convert && !PYBIND11_LONG_CHECK(src.ptr()) && !index_check(src.ptr())) {
             return false;
         } else {
             handle src_or_index = src;
-            py_value = (py_type) -1;
 #if PY_VERSION_HEX < 0x03080000
             object index;
-            if (!PYBIND11_LONG_CHECK(src.ptr()) && index_check(src.ptr())) {
+            if (!PYBIND11_LONG_CHECK(src.ptr())) {  // So: index_check(src.ptr())
                 index = reinterpret_steal<object>(PyNumber_Index(src.ptr()));
-                src_or_index = index ? index : handle();
+                if (!index) {
+                    PyErr_Clear();
+                    if (!convert)
+                        return false;
+                }
+                else {
+                    src_or_index = index;
+                }
             }
 #endif
-            if (src_or_index) {
-                if (std::is_unsigned<py_type>::value) {
-                    py_value = as_unsigned<py_type>(src_or_index.ptr());
-                } else { // signed integer:
-                    py_value = sizeof(T) <= sizeof(long)
-                        ? (py_type) PyLong_AsLong(src_or_index.ptr())
-                        : (py_type) PYBIND11_LONG_AS_LONGLONG(src_or_index.ptr());
-                }
+            if (std::is_unsigned<py_type>::value) {
+                py_value = as_unsigned<py_type>(src_or_index.ptr());
+            } else { // signed integer:
+                py_value = sizeof(T) <= sizeof(long)
+                    ? (py_type) PyLong_AsLong(src_or_index.ptr())
+                    : (py_type) PYBIND11_LONG_AS_LONGLONG(src_or_index.ptr());
             }
         }
 
@@ -1069,15 +1073,8 @@ public:
         // Check to see if the conversion is valid (integers should match exactly)
         // Signed/unsigned checks happen elsewhere
         if (py_err || (std::is_integral<T>::value && sizeof(py_type) != sizeof(T) && py_value != (py_type) (T) py_value)) {
-            bool type_error = py_err && PyErr_ExceptionMatches(
-#if PY_VERSION_HEX < 0x03000000 && !defined(PYPY_VERSION)
-                PyExc_SystemError
-#else
-                PyExc_TypeError
-#endif
-            );
             PyErr_Clear();
-            if (type_error && convert && PyNumber_Check(src.ptr())) {
+            if (py_err && convert && PyNumber_Check(src.ptr())) {
                 auto tmp = reinterpret_steal<object>(std::is_floating_point<T>::value
                                                      ? PyNumber_Float(src.ptr())
                                                      : PyNumber_Long(src.ptr()));

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -251,6 +251,7 @@ def test_integer_casting():
         assert "incompatible function arguments" in str(excinfo.value)
 
 
+@pytest.mark.filterwarnings("ignore:an integer is required:DeprecationWarning")
 def test_int_convert():
     class DeepThought(object):
         def __int__(self):
@@ -297,6 +298,7 @@ def test_int_convert():
     cant_convert(RaisingThought())  # no fall-back to `__int__`if `__index__` raises
 
 
+@pytest.mark.filterwarnings("ignore:an integer is required:DeprecationWarning")
 def test_numpy_int_convert():
     np = pytest.importorskip("numpy")
 

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -268,6 +268,13 @@ def test_int_convert():
         def __index__(self):
             return 42
 
+    class TypeErrorThought(object):
+        def __index__(self):
+            raise TypeError
+
+        def __int__(self):
+            return 42
+
     class RaisingThought(object):
         def __index__(self):
             raise ValueError
@@ -295,6 +302,8 @@ def test_int_convert():
     # "backports" this behavior.
     assert convert(IndexedThought()) == 42
     assert noconvert(IndexedThought()) == 42
+    assert convert(TypeErrorThought()) == 42
+    require_implicit(TypeErrorThought())
     cant_convert(RaisingThought())  # no fall-back to `__int__`if `__index__` raises
 
 

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -289,11 +289,12 @@ def test_int_convert():
     require_implicit(DeepThought())
     cant_convert(ShallowThought())
     cant_convert(FuzzyThought())
-    if env.PY >= (3, 8):
-        # Before Python 3.8, `int(obj)` does not pick up on `obj.__index__`
-        assert convert(IndexedThought()) == 42
-        assert noconvert(IndexedThought()) == 42
-        cant_convert(RaisingThought())  # no fall-back to `__int__`if `__index__` raises
+
+    # Before Python 3.8, `int(obj)` does not pick up on `obj.__index__`, but pybind11
+    # "backports" this behavior.
+    assert convert(IndexedThought()) == 42
+    assert noconvert(IndexedThought()) == 42
+    cant_convert(RaisingThought())  # no fall-back to `__int__`if `__index__` raises
 
 
 def test_numpy_int_convert():

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -252,36 +252,36 @@ def test_integer_casting():
 
 
 def test_int_convert():
-    class DeepThought(object):
+    class Int(object):
         def __int__(self):
             return 42
 
-    class DoubleThought(object):
+    class NotInt(object):
+        pass
+
+    class Float(object):
+        def __float__(self):
+            return 41.99999
+
+    class Index(object):
+        def __index__(self):
+            return 42
+
+    class IntAndIndex(object):
         def __int__(self):
             return 42
 
         def __index__(self):
             return 0
 
-    class ShallowThought(object):
-        pass
-
-    class FuzzyThought(object):
-        def __float__(self):
-            return 41.99999
-
-    class IndexedThought(object):
-        def __index__(self):
-            return 42
-
-    class TypeErrorThought(object):
+    class RaisingTypeErrorOnIndex(object):
         def __index__(self):
             raise TypeError
 
         def __int__(self):
             return 42
 
-    class RaisingThought(object):
+    class RaisingValueErrorOnIndex(object):
         def __index__(self):
             raise ValueError
 
@@ -299,21 +299,21 @@ def test_int_convert():
     assert convert(7) == 7
     assert noconvert(7) == 7
     cant_convert(3.14159)
-    assert convert(DeepThought()) == 42
-    requires_conversion(DeepThought())
-    assert convert(DoubleThought()) == 0  # Fishy; `int(DoubleThought)` == 42
-    assert noconvert(DoubleThought()) == 0
-    cant_convert(ShallowThought())
-    cant_convert(FuzzyThought())
+    assert convert(Int()) == 42
+    requires_conversion(Int())
+    cant_convert(NotInt())
+    cant_convert(Float())
 
     # Before Python 3.8, `PyLong_AsLong` does not pick up on `obj.__index__`,
     # but pybind11 "backports" this behavior.
-    assert convert(IndexedThought()) == 42
-    assert noconvert(IndexedThought()) == 42
-    assert convert(TypeErrorThought()) == 42
-    requires_conversion(TypeErrorThought())
-    assert convert(RaisingThought()) == 42
-    requires_conversion(RaisingThought())
+    assert convert(Index()) == 42
+    assert noconvert(Index()) == 42
+    assert convert(IntAndIndex()) == 0  # Fishy; `int(DoubleThought)` == 42
+    assert noconvert(IntAndIndex()) == 0
+    assert convert(RaisingTypeErrorOnIndex()) == 42
+    requires_conversion(RaisingTypeErrorOnIndex())
+    assert convert(RaisingValueErrorOnIndex()) == 42
+    requires_conversion(RaisingValueErrorOnIndex())
 
 
 def test_numpy_int_convert():


### PR DESCRIPTION
## Description

See the remaining decision to be made in #2698: https://github.com/pybind/pybind11/pull/2698#issuecomment-752218748

In one sentence, this makes the casting from Python objects to C++ integer types consistent across Python versions, "backporting" Python 3.8 behavior on handling `__index__` to pre-3.8 Pythons.

As @bstaletic pointed out to me, we have done this before, most often backporting Python 3 behavior to Python 2 (unicode, for example), but also in #2616, "backporting" 3.8 behavior.

Given the original issue fixed by #2698, and especially the discussion following that ("everything with `__index__` is an integer type"), I think this is the logical to minimize surprises when developing pybind11 libraries. See also the changed test demonstrating how things are more consistent across versions.

I'm cheekily adding this to 2.6.2, because in my eyes, it's still part of #2698, and I'd like to see a decision made ("no, because ..." is also fine, btw; then we close this PR! But it doesn't make sense to me to delay this simple decision on policy.). This PR mainly makes it easier to judge the changes (after soon merging #2698, at least).

## Suggested changelog entry:

```rst
When casting to a C++ integer, `__index__` is always called and not considered as conversion, consistent with Python 3.8+.
```