### PR TITLE
Make int_::operator T() (for integer types) behave the same as the caster for integers

### DIFF
--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -270,6 +270,7 @@ TEST_SUBMODULE(pytypes, m) {
         throw std::runtime_error("Invalid type");
     });
 
+    // test_implicit_casting
     m.def("get_implicit_casting", []() {
         py::dict d;
         d["char*_i1"] = "abc";
@@ -306,6 +307,10 @@ TEST_SUBMODULE(pytypes, m) {
             "l"_a=l
         );
     });
+
+    // (see also test_builtin_casters)
+    m.def("implicitly_cast_to_int32", [](py::int_ value) { return int32_t{value}; });
+    m.def("implicitly_cast_to_uint32", [](py::int_ value) { return uint32_t{value}; });
 
     // test_print
     m.def("print_function", []() {

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -331,6 +331,14 @@ def test_implicit_casting():
     }
     assert z["l"] == [3, 6, 9, 12, 15]
 
+    assert m.implicitly_cast_to_int32(42) == 42
+    assert m.implicitly_cast_to_int32(2 ** 31 - 1) == 2 ** 31 - 1
+    assert m.implicitly_cast_to_int32(2 ** 31)
+
+    assert m.implicitly_cast_to_uint32(42) == 42
+    assert m.implicitly_cast_to_uint32(2 ** 32 - 1) == 2 ** 32 - 1
+    assert m.implicitly_cast_to_uint32(2 ** 32)
+
 
 def test_print(capture):
     with capture:


### PR DESCRIPTION
## Description

Currently only demonstrates #2786, but soon hopefully fixes it.


## Suggested changelog entry:

```rst
Conversion errors are now correctly handled by `py::int_`'s integer conversion operator.
```