### PR TITLE
ci: update to setup-cmake v1.6

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -55,7 +55,7 @@ jobs:
     # An action for adding a specific version of CMake:
     #   https://github.com/jwlawson/actions-setup-cmake
     - name: Setup CMake ${{ matrix.cmake }}
-      uses: jwlawson/actions-setup-cmake@v1.5
+      uses: jwlawson/actions-setup-cmake@v1.6
       with:
         cmake-version: ${{ matrix.cmake }}
 


### PR DESCRIPTION
## Description

This has stopped finding older CMakes (3.18 is fine, but 3.4, 3.7, and 3.8 are printing out "Unable to find version matching"), first trying a version bump before bugging @jwlawson. :)

## Suggested changelog entry:

<!-- fill in the below block with the expected RestructuredText entry (delete if no entry needed) -->

None needed, CI.

<!-- If the upgrade guide needs updating, note that here too -->
