### PR TITLE
Force the builtin module key to be the correct type.

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -266,7 +266,7 @@ PYBIND11_NOINLINE inline internals &get_internals() {
         const PyGILState_STATE state;
     } gil;
 
-    constexpr auto *id = PYBIND11_INTERNALS_ID;
+    PYBIND11_STR_TYPE id(PYBIND11_INTERNALS_ID);
     auto builtins = handle(PyEval_GetBuiltins());
     if (builtins.contains(id) && isinstance<capsule>(builtins[id])) {
         internals_pp = static_cast<internals **>(capsule(builtins[id]));

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -75,3 +75,11 @@ def test_duplicate_registration():
     """Registering two things with the same name"""
 
     assert m.duplicate_registration() == []
+
+
+def test_builtinsKeyType():
+    """Test that all the keys in the builtin modules have type str.
+
+    Previous versions of pybind11 would add a unicode key in python 2.
+    """
+    assert {type(k) for k in __builtins__.keys()} == {str}

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -77,14 +77,14 @@ def test_duplicate_registration():
     assert m.duplicate_registration() == []
 
 
-def test_builtinsKeyType():
+def test_builtin_key_type():
     """Test that all the keys in the builtin modules have type str.
 
     Previous versions of pybind11 would add a unicode key in python 2.
     """
-    if hasattr(__builtins__, 'keys'):
+    if hasattr(__builtins__, "keys"):
         keys = __builtins__.keys()
-    else: # this is to make pypy happy since builtins is different there.
+    else:  # this is to make pypy happy since builtins is different there.
         keys = __builtins__.__dict__.keys()
 
     assert {type(k) for k in keys} == {str}

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -82,4 +82,9 @@ def test_builtinsKeyType():
 
     Previous versions of pybind11 would add a unicode key in python 2.
     """
-    assert {type(k) for k in __builtins__.keys()} == {str}
+    if hasattr(__builtins__, 'keys'):
+        keys = __builtins__.keys()
+    else: # this is to make pypy happy since builtins is different there.
+        keys = __builtins__.__dict__.keys()
+
+    assert {type(k) for k in keys} == {str}


### PR DESCRIPTION
Previously it was always going to be a std::string which converted into
unicode. Python 2 appears to want module keys to be normal str types, so
this was breaking code that expected plain string types in the
builtins.keys() data structure

## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

```rst
Change the type of the module key in builtins that pybind11 uses to store its internals from std::string to a python str type. This will have no effect in python 3, but will change the key type from unicode to str on python 2
```

<!-- If the upgrade guide needs updating, note that here too -->
