### PR TITLE
Enable -Wstrict-aliasing warning

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -162,11 +162,12 @@ protected:
 #  pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
             // UB without std::launder, but without breaking ABI and/or
-            // a significant refactoring it's "impossible" to solve'
+            // a significant refactoring it's "impossible" to solve.
             if (!std::is_trivially_destructible<Func>::value)
                 rec->free_data = [](function_record *r) {
-                    auto cap = PYBIND11_STD_LAUNDER((capture *) &r->data);
-                    cap->~capture();
+                    auto data = PYBIND11_STD_LAUNDER((capture *) &r->data);
+                    (void) data;
+                    data->~capture();
                 };
 #if defined(__GNUG__) && !PYBIND11_HAS_STD_LAUNDER
 #  pragma GCC diagnostic pop

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -157,7 +157,7 @@ protected:
 #if defined(__GNUG__) && !defined(__clang__) && __GNUC__ >= 6
 #  pragma GCC diagnostic pop
 #endif
-#if defined(__GNUG__) && !PYBIND11_HAS_STD_LAUNDER
+#if defined(__GNUG__) && !PYBIND11_HAS_STD_LAUNDER && !defined(__INTEL_COMPILER)
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
@@ -169,7 +169,7 @@ protected:
                     (void) data;
                     data->~capture();
                 };
-#if defined(__GNUG__) && !PYBIND11_HAS_STD_LAUNDER
+#if defined(__GNUG__) && !PYBIND11_HAS_STD_LAUNDER && !defined(__INTEL_COMPILER)
 #  pragma GCC diagnostic pop
 #endif
         } else {


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Even though our cmake uses `-fno-strict-aliasing`, not all extensions do. Since C++17, we can actually fix `-Wstrict-aliasing` errors. For now, let's just see how things fail in CI.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
