### PR TITLE
docs: prepare for 2.6.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
 # Standard hooks
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.4.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -46,7 +46,7 @@ repos:
 
 # Flake8 also supports pre-commit natively (same author)
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.3
+  rev: 3.8.4
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear, pep8-naming]
@@ -63,7 +63,7 @@ repos:
 
 # Check static types with mypy
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.790
+  rev: v0.800
   hooks:
   - id: mypy
     # The default Python type ignores .pyi files, so let's rerun if detected
@@ -74,7 +74,7 @@ repos:
 
 # Checks the manifest for missing files (native support)
 - repo: https://github.com/mgedmin/check-manifest
-  rev: "0.43"
+  rev: "0.46"
   hooks:
   - id: check-manifest
     # This is a slow hook, so only run this if --hook-stage manual is passed

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,8 +7,8 @@ Starting with version 1.8.0, pybind11 releases use a `semantic versioning
 <http://semver.org>`_ policy.
 
 
-v2.6.2 (TBA, not yet released)
-------------------------------
+v2.6.2 (Jan 26, 2021)
+---------------------
 
 
 Minor missing functionality added:
@@ -62,6 +62,10 @@ Bug fixes:
   overloads.
   `#2698 <https://github.com/pybind/pybind11/pull/2698>`_
 
+* When casting to a C++ integer, ``__index__`` is always called and not
+  considered as conversion, consistent with Python 3.8+.
+  `#2801 <https://github.com/pybind/pybind11/pull/2801>`_
+
 * Fix bug where the constructor of ``object`` subclasses would not throw on
   being passed a Python object of the wrong type.
   `#2701 <https://github.com/pybind/pybind11/pull/2701>`_
@@ -73,6 +77,11 @@ Bug fixes:
 * Leave docstring unset when all docstring-related options are disabled, rather
   than set an empty string.
   `#2745 <https://github.com/pybind/pybind11/pull/2745>`_
+
+* The module key in builtins that pybind11 uses to store its internals changed
+  from std::string to a python str type (more natural on Python 2, no change on
+  Python 3).
+  `#2814 <https://github.com/pybind/pybind11/pull/2814>`_
 
 * Fixed assertion error related to unhandled (later overwritten) exception in
   CPython 3.8 and 3.9 debug builds.


### PR DESCRIPTION
- docs: prepare for 2.6.2
- chore: pre-commit autoupdate

Preparing for tomorrow's release of 2.6.2.
