### PR TITLE
Fix confusing weakref constructor overload

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -819,6 +819,10 @@ PYBIND11_NAMESPACE_END(detail)
     : Parent(check_(o) ? o.release().ptr() : ConvertFun(o.ptr()), stolen_t{}) \
     { if (!m_ptr) throw error_already_set(); }
 
+#define PYBIND11_OBJECT_CVT_DEFAULT(Name, Parent, CheckFun, ConvertFun) \
+    PYBIND11_OBJECT_CVT(Name, Parent, CheckFun, ConvertFun) \
+    Name() : Parent() { }
+
 #define PYBIND11_OBJECT_CHECK_FAILED(Name, o_ptr) \
     ::pybind11::type_error("Object of type '" + \
                            ::pybind11::detail::get_fully_qualified_tp_name(Py_TYPE(o_ptr)) + \
@@ -1168,7 +1172,7 @@ public:
 
 class weakref : public object {
 public:
-    PYBIND11_OBJECT_CVT(weakref, object, PyWeakref_Check, raw_weakref)
+    PYBIND11_OBJECT_CVT_DEFAULT(weakref, object, PyWeakref_Check, raw_weakref)
     explicit weakref(handle obj, handle callback = {})
         : object(PyWeakref_NewRef(obj.ptr(), callback.ptr()), stolen_t{}) {
         if (!m_ptr) pybind11_fail("Could not allocate weak reference!");

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1168,10 +1168,15 @@ public:
 
 class weakref : public object {
 public:
-    PYBIND11_OBJECT_DEFAULT(weakref, object, PyWeakref_Check)
+    PYBIND11_OBJECT_CVT(weakref, object, PyWeakref_Check, raw_weakref)
     explicit weakref(handle obj, handle callback = {})
         : object(PyWeakref_NewRef(obj.ptr(), callback.ptr()), stolen_t{}) {
         if (!m_ptr) pybind11_fail("Could not allocate weak reference!");
+    }
+
+private:
+    static PyObject *raw_weakref(PyObject *o) {
+        return PyWeakref_NewRef(o, nullptr);
     }
 };
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -424,4 +424,14 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("pass_to_pybind11_bytes", [](py::bytes b) { return py::len(b); });
     m.def("pass_to_pybind11_str", [](py::str s) { return py::len(s); });
     m.def("pass_to_std_string", [](std::string s) { return s.size(); });
+
+    // test_weakref
+    m.def("weakref_from_handle",
+          [](py::handle h) { return py::weakref(h); });
+    m.def("weakref_from_handle_and_function",
+          [](py::handle h, py::function f) { return py::weakref(h, f); });
+    m.def("weakref_from_object",
+          [](py::object o) { return py::weakref(o); });
+    m.def("weakref_from_object_and_function",
+          [](py::object o, py::function f) { return py::weakref(o, f); });
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -550,11 +550,11 @@ def test_weakref():
     class WeaklyReferenced(object):
         pass
 
-    called = [0]
-
     def callback(wr):
         # No `nonlocal` in Python 2
-        called[0] += 1
+        callback.called += 1
+
+    callback.called = 0
 
     obj = WeaklyReferenced()
     assert getweakrefcount(obj) == 0
@@ -565,10 +565,10 @@ def test_weakref():
     assert getweakrefcount(obj) == 0
     wr = m.weakref_from_handle_and_function(obj, callback)  # noqa: F841
     assert getweakrefcount(obj) == 1
-    assert called[0] == 0
+    assert callback.called == 0
     del obj
     pytest.gc_collect()
-    assert called[0] == 1
+    assert callback.called == 1
 
     obj = WeaklyReferenced()
     assert getweakrefcount(obj) == 0
@@ -579,7 +579,7 @@ def test_weakref():
     assert getweakrefcount(obj) == 0
     wr = m.weakref_from_object_and_function(obj, callback)  # noqa: F841
     assert getweakrefcount(obj) == 1
-    assert called[0] == 1
+    assert callback.called == 1
     del obj
     pytest.gc_collect()
-    assert called[0] == 2
+    assert callback.called == 2


### PR DESCRIPTION
## Description

Fixes #2536, where the two `weakref` constructors from `handle` and `object` do different things.
Demonstrated by failing tests in the first commit, fixed in the second one.

## Suggested changelog entry:

```rst
Fix the ``weakref`` constructor from ``py::object`` to create a new ``weakref`` on conversion.
```
