### PR TITLE
Is it valid to have both class_ & custom type_caster?

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,7 @@ set(PYBIND11_TEST_FILES
     test_callbacks.cpp
     test_chrono.cpp
     test_class.cpp
+    test_class_custom_type_caster_mix.cpp
     test_constants_and_functions.cpp
     test_copy_move.cpp
     test_custom_type_casters.cpp

--- a/tests/test_class_custom_type_caster_mix.cpp
+++ b/tests/test_class_custom_type_caster_mix.cpp
@@ -1,0 +1,42 @@
+#include "pybind11_tests.h"
+
+namespace pybind11_tests {
+namespace class_custom_type_caster_mix {
+
+class NumberStore {
+private:
+    int stored;
+
+public:
+    explicit NumberStore(int num) : stored{num} {}
+    int Get() const { return stored; }
+};
+
+} // namespace class_custom_type_caster_mix
+} // namespace pybind11_tests
+
+namespace pybind11 {
+namespace detail {
+
+using namespace pybind11_tests::class_custom_type_caster_mix;
+
+template <>
+struct type_caster<NumberStore> {
+public:
+    PYBIND11_TYPE_CASTER(NumberStore,
+                         _("pybind11_tests::class_custom_type_caster_mix::NumberStore"));
+
+    bool load(handle /*handle*/, bool /*convert*/) {
+        value = NumberStore(5);
+        return true;
+    }
+};
+
+} // namespace detail
+} // namespace pybind11
+
+TEST_SUBMODULE(class_custom_type_caster_mix, m) {
+    using namespace pybind11_tests::class_custom_type_caster_mix;
+
+    py::class_<NumberStore>(m, "NumberStore").def(py::init<int>()).def("Get", &NumberStore::Get);
+}

--- a/tests/test_class_custom_type_caster_mix.py
+++ b/tests/test_class_custom_type_caster_mix.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from pybind11_tests import class_custom_type_caster_mix as m
+
+
+def test_make_unique_pointee():
+    obj = m.NumberStore()
+    assert obj.Get() == 5 # custom type_caster wins.


### PR DESCRIPTION
Minimal reproducer of a situation I found in the wild. Is this valid?
We could add a `static_assert` to make this impossible. Good or bad idea?