### PR TITLE
chore: get PyPy 3.7 wheels using NumPy 1.20

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,8 @@
 --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010/
 numpy==1.16.6; python_version<"3.6" and sys_platform!="win32"
 numpy==1.18.0; platform_python_implementation=="PyPy" and sys_platform=="darwin" and python_version>="3.6"
-numpy==1.19.3; (platform_python_implementation!="PyPy" or sys_platform=="linux") and python_version>="3.6" and python_version<"3.10"
+numpy==1.19.3; (platform_python_implementation!="PyPy" or sys_platform=="linux") and python_version=="3.6"
+numpy==1.20.0; (platform_python_implementation!="PyPy" or sys_platform=="linux") and python_version>="3.7" and python_version<"3.10"
 pytest==4.6.9; python_version<"3.5"
 pytest==6.1.2; python_version=="3.5"
 pytest==6.2.1; python_version>="3.6"

--- a/tests/valgrind-numpy-scipy.supp
+++ b/tests/valgrind-numpy-scipy.supp
@@ -1,4 +1,8 @@
 # Valgrind suppression file for NumPy & SciPy errors and leaks in pybind11 tests
+#
+# On updating a dependency, to get a list of "default" leaks in e.g. NumPy, run
+# `PYTHONMALLOC=malloc valgrind --leak-check=full --show-leak-kinds=definite,indirect python3.9-dbg -c "import numpy"`
+# To use theses suppression files, add e.g. `--suppressions=valgrind-numpy-scipy.supp`
 
 {
    Leaks when importing NumPy
@@ -29,7 +33,7 @@
 }
 
 {
-   Leaks when importing NumPy (tris)
+   Leaks when importing NumPy (ter)
    Memcheck:Leak
    fun:malloc
    fun:_PyMem_RawMalloc
@@ -59,6 +63,24 @@
    fun:_PyObject_GC_Malloc
    fun:_PyObject_GC_NewVar
    fun:tuple_alloc
+   fun:_PyTuple_FromArray
+   fun:_PyObject_MakeTpCall
+   fun:_PyObject_VectorcallTstate
+   fun:_PyObject_CallFunctionVa
+   fun:PyObject_CallFunction
+   fun:PyImport_Import
+}
+
+{
+   Leaks when importing NumPy (quinquies)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:tuple_alloc
    fun:PyTuple_New
    fun:r_object
    fun:r_object
@@ -67,7 +89,7 @@
 }
 
 {
-   Leaks when importing NumPy (quinquies)
+   Leaks when importing NumPy (sexies)
    Memcheck:Leak
    fun:malloc
    fun:_PyMem_RawMalloc

--- a/tests/valgrind-python.supp
+++ b/tests/valgrind-python.supp
@@ -115,21 +115,3 @@
    fun:_PyImport_FindSharedFuncptr
    fun:_PyImport_LoadDynamicModuleWithSpec
 }
-
-# Not really CPython-specific, see link
-{
-   dlopen leak (https://stackoverflow.com/questions/1542457/memory-leak-reported-by-valgrind-in-dlopen)
-   Memcheck:Leak
-   fun:malloc
-   ...
-   fun:dl_open_worker
-   fun:_dl_catch_exception
-   fun:_dl_open
-   fun:dlopen_doit
-   fun:_dl_catch_exception
-   fun:_dl_catch_error
-   fun:_dlerror_run
-   fun:dlopen@@GLIBC_2.2.5
-   fun:_PyImport_FindSharedFuncptr
-   fun:_PyImport_LoadDynamicModuleWithSpec
-}


### PR DESCRIPTION
## Description

PyPy 3.7 wheels are included with NumPy 1.20. But not 3.6 since they've dropped 3.6 support.


## Suggested changelog entry:

Just tests.
