### PR TITLE
Make sure all warnings in pytest get turned into errors

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -7,11 +7,11 @@ addopts =
     -rs
     # capture only Python print and C++ py::print, but not C output (low-level Python errors)
     --capture=sys
-    # enable all warnings
-    -Wa
 filterwarnings =
     # make warnings into errors but ignore certain third-party extension issues
     error
+    # somehow, some DeprecationWarnings do not get turned into errors
+    always::DeprecationWarning
     # importing scipy submodules on some version of Python
     ignore::ImportWarning
     # bogus numpy ABI warning (see numpy/#432)

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -299,7 +299,9 @@ def test_int_convert():
     assert convert(7) == 7
     assert noconvert(7) == 7
     cant_convert(3.14159)
-    assert convert(Int()) == 42
+    # TODO: Avoid DeprecationWarning in `PyLong_AsLong` (and similar)
+    with pytest.deprecated_call():
+        assert convert(Int()) == 42
     requires_conversion(Int())
     cant_convert(NotInt())
     cant_convert(Float())
@@ -329,7 +331,9 @@ def test_numpy_int_convert():
     assert noconvert(np.intc(42)) == 42
 
     # The implicit conversion from np.float32 is undesirable but currently accepted.
-    assert convert(np.float32(3.14159)) == 3
+    # TODO: Avoid DeprecationWarning in `PyLong_AsLong` (and similar)
+    with pytest.deprecated_call():
+        assert convert(np.float32(3.14159)) == 3
     require_implicit(np.float32(3.14159))
 
 

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -300,7 +300,7 @@ def test_int_convert():
     assert noconvert(7) == 7
     cant_convert(3.14159)
     # TODO: Avoid DeprecationWarning in `PyLong_AsLong` (and similar)
-    if env.PY >= (3, 8):
+    if (3, 8) <= env.PY < (3, 10):
         with pytest.deprecated_call():
             assert convert(Int()) == 42
     else:
@@ -335,7 +335,7 @@ def test_numpy_int_convert():
 
     # The implicit conversion from np.float32 is undesirable but currently accepted.
     # TODO: Avoid DeprecationWarning in `PyLong_AsLong` (and similar)
-    if env.PY >= (3, 8):
+    if (3, 8) <= env.PY < (3, 10):
         with pytest.deprecated_call():
             assert convert(np.float32(3.14159)) == 3
     else:

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -300,7 +300,10 @@ def test_int_convert():
     assert noconvert(7) == 7
     cant_convert(3.14159)
     # TODO: Avoid DeprecationWarning in `PyLong_AsLong` (and similar)
-    with pytest.deprecated_call():
+    if env.PY >= (3, 8):
+        with pytest.deprecated_call():
+            assert convert(Int()) == 42
+    else:
         assert convert(Int()) == 42
     requires_conversion(Int())
     cant_convert(NotInt())
@@ -332,7 +335,10 @@ def test_numpy_int_convert():
 
     # The implicit conversion from np.float32 is undesirable but currently accepted.
     # TODO: Avoid DeprecationWarning in `PyLong_AsLong` (and similar)
-    with pytest.deprecated_call():
+    if env.PY >= (3, 8):
+        with pytest.deprecated_call():
+            assert convert(np.float32(3.14159)) == 3
+    else:
         assert convert(np.float32(3.14159)) == 3
     require_implicit(np.float32(3.14159))
 

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -434,8 +434,7 @@ TEST_SUBMODULE(class_, m) {
     struct SamePointer {};
     static SamePointer samePointer;
     py::class_<SamePointer, std::unique_ptr<SamePointer, py::nodelete>>(m, "SamePointer")
-        .def(py::init([]() { return &samePointer; }))
-        .def("__del__", [](SamePointer&) { py::print("__del__ called"); });
+        .def(py::init([]() { return &samePointer; }));
 
     struct Empty {};
     py::class_<Empty>(m, "Empty")


### PR DESCRIPTION
## Description

Follow-up on #2837.

There's a weird thing going on where `filterwarnings=error` starts ignoring the `DeprecationWarning` from https://github.com/python/cpython/blob/3c8d6934436e20163be802f5239c5b4e4925eeec/Objects/longobject.c#L226.

I have no clue why. Apart from that, the `-Wa` flag seemed to take precedence, so no warning was actually an error.

## Suggested changelog entry:

None, just some tests.
