### PR TITLE
Fix CMake status for DOWNLOAD_EIGEN

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -225,7 +225,8 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
     message(STATUS "Building tests with Eigen v${EIGEN3_VERSION}")
   else()
     list(REMOVE_AT PYBIND11_TEST_FILES ${PYBIND11_TEST_FILES_EIGEN_I})
-    message(STATUS "Building tests WITHOUT Eigen, use -DDOWNLOAD_EIGEN on CMake 3.11+ to download")
+    message(
+      STATUS "Building tests WITHOUT Eigen, use -DDOWNLOAD_EIGEN=ON on CMake 3.11+ to download")
   endif()
 endif()
 


### PR DESCRIPTION
## Description

Fixes documentation for CMake: user is instructed to enable `cmake -DDOWNLOAD_EIGEN` but `-D` requires a key=value pair: `cmake -DDOWNLOAD_EIGEN=ON`
