### PR TITLE
Use correct duration representation when casting from datetime.timdelta to std::chrono::duration

### DIFF
--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -35,7 +35,7 @@ public:
     using rep = typename type::rep;
     using period = typename type::period;
 
-    using days = std::chrono::duration<uint_fast32_t, std::ratio<86400>>;
+    using days = std::chrono::duration<int_least32_t, std::ratio<86400>>; // signed 25 bits required by the standard.
 
     bool load(handle src, bool) {
         using namespace std::chrono;

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -39,9 +39,7 @@ def test_chrono_system_clock_roundtrip():
 
     # They should be identical (no information lost on roundtrip)
     diff = abs(date1 - date2)
-    assert diff.days == 0
-    assert diff.seconds == 0
-    assert diff.microseconds == 0
+    assert diff == datetime.timedelta(0)
 
 
 def test_chrono_system_clock_roundtrip_date():
@@ -64,9 +62,7 @@ def test_chrono_system_clock_roundtrip_date():
     assert diff.microseconds == 0
 
     # Year, Month & Day should be the same after the round trip
-    assert date1.year == date2.year
-    assert date1.month == date2.month
-    assert date1.day == date2.day
+    assert date1 == date2
 
     # There should be no time information
     assert time2.hour == 0
@@ -117,10 +113,7 @@ def test_chrono_system_clock_roundtrip_time(time1, tz, monkeypatch):
     assert isinstance(time2, datetime.time)
 
     # Hour, Minute, Second & Microsecond should be the same after the round trip
-    assert time1.hour == time2.hour
-    assert time1.minute == time2.minute
-    assert time1.second == time2.second
-    assert time1.microsecond == time2.microsecond
+    assert time1 == time2
 
     # There should be no date information (i.e. date = python base date)
     assert date2.year == 1970
@@ -157,9 +150,7 @@ def test_chrono_duration_subtraction_equivalence():
     diff = date2 - date1
     cpp_diff = m.test_chrono4(date2, date1)
 
-    assert cpp_diff.days == diff.days
-    assert cpp_diff.seconds == diff.seconds
-    assert cpp_diff.microseconds == diff.microseconds
+    assert cpp_diff == diff
 
 
 def test_chrono_duration_subtraction_equivalence_date():
@@ -170,9 +161,7 @@ def test_chrono_duration_subtraction_equivalence_date():
     diff = date2 - date1
     cpp_diff = m.test_chrono4(date2, date1)
 
-    assert cpp_diff.days == diff.days
-    assert cpp_diff.seconds == diff.seconds
-    assert cpp_diff.microseconds == diff.microseconds
+    assert cpp_diff == diff
 
 
 def test_chrono_steady_clock():
@@ -187,9 +176,7 @@ def test_chrono_steady_clock_roundtrip():
     assert isinstance(time2, datetime.timedelta)
 
     # They should be identical (no information lost on roundtrip)
-    assert time1.days == time2.days
-    assert time1.seconds == time2.seconds
-    assert time1.microseconds == time2.microseconds
+    assert time1 == time2
 
 
 def test_floating_point_duration():

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -140,9 +140,13 @@ def test_chrono_duration_roundtrip():
 
     cpp_diff = m.test_chrono3(diff)
 
-    assert cpp_diff.days == diff.days
-    assert cpp_diff.seconds == diff.seconds
-    assert cpp_diff.microseconds == diff.microseconds
+    assert cpp_diff == diff
+
+    # Negative timedelta roundtrip
+    diff = datetime.timedelta(microseconds=-1)
+    cpp_diff = m.test_chrono3(diff)
+
+    assert cpp_diff == diff
 
 
 def test_chrono_duration_subtraction_equivalence():


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

this is an attempt to fix #2861 

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Allow negative timedelta values to roundtrip.
```

<!-- If the upgrade guide needs updating, note that here too -->
