### PR TITLE
Shuffling code in test_smart_ptr.cpp to separate struct/class definitions from bindings code.

### DIFF
--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -15,23 +15,7 @@
 #include "pybind11_tests.h"
 #include "object.h"
 
-// Make pybind aware of the ref-counted wrapper type (s):
-
-// ref<T> is a wrapper for 'Object' which uses intrusive reference counting
-// It is always possible to construct a ref<T> from an Object* pointer without
-// possible inconsistencies, hence the 'true' argument at the end.
-PYBIND11_DECLARE_HOLDER_TYPE(T, ref<T>, true);
-// Make pybind11 aware of the non-standard getter member function
-namespace pybind11 { namespace detail {
-    template <typename T>
-    struct holder_helper<ref<T>> {
-        static const T *get(const ref<T> &p) { return p.get_ptr(); }
-    };
-} // namespace detail
-} // namespace pybind11
-
-// The following is not required anymore for std::shared_ptr, but it should compile without error:
-PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
+namespace {
 
 // This is just a wrapper around unique_ptr, but with extra fields to deliberately bloat up the
 // holder size to trigger the non-simple-layout internal instance layout for single inheritance with
@@ -43,7 +27,6 @@ public:
     huge_unique_ptr(T *p) : ptr(p) {};
     T *get() { return ptr.get(); }
 };
-PYBIND11_DECLARE_HOLDER_TYPE(T, huge_unique_ptr<T>);
 
 // Simple custom holder that works like unique_ptr
 template <typename T>
@@ -54,7 +37,6 @@ public:
     T* get() const { return impl.get(); }
     T* release_ptr() { return impl.release(); }
 };
-PYBIND11_DECLARE_HOLDER_TYPE(T, custom_unique_ptr<T>);
 
 // Simple custom holder that works like shared_ptr and has operator& overload
 // To obtain address of an instance of this holder pybind should use std::addressof
@@ -68,7 +50,6 @@ public:
     T* get() const { return impl.get(); }
     T** operator&() { throw std::logic_error("Call of overloaded operator& is not expected"); }
 };
-PYBIND11_DECLARE_HOLDER_TYPE(T, shared_ptr_with_addressof_operator<T>);
 
 // Simple custom holder that works like unique_ptr and has operator& overload
 // To obtain address of an instance of this holder pybind should use std::addressof
@@ -83,10 +64,218 @@ public:
     T* release_ptr() { return impl.release(); }
     T** operator&() { throw std::logic_error("Call of overloaded operator& is not expected"); }
 };
+
+// Custom object with builtin reference counting (see 'object.h' for the implementation)
+class MyObject1 : public Object {
+public:
+    MyObject1(int value) : value(value) { print_created(this, toString()); }
+    std::string toString() const override { return "MyObject1[" + std::to_string(value) + "]"; }
+protected:
+    ~MyObject1() override { print_destroyed(this); }
+private:
+    int value;
+};
+
+// Object managed by a std::shared_ptr<>
+class MyObject2 {
+public:
+    MyObject2(const MyObject2 &) = default;
+    MyObject2(int value) : value(value) { print_created(this, toString()); }
+    std::string toString() const { return "MyObject2[" + std::to_string(value) + "]"; }
+    virtual ~MyObject2() { print_destroyed(this); }
+private:
+    int value;
+};
+
+// Object managed by a std::shared_ptr<>, additionally derives from std::enable_shared_from_this<>
+class MyObject3 : public std::enable_shared_from_this<MyObject3> {
+public:
+    MyObject3(const MyObject3 &) = default;
+    MyObject3(int value) : value(value) { print_created(this, toString()); }
+    std::string toString() const { return "MyObject3[" + std::to_string(value) + "]"; }
+    virtual ~MyObject3() { print_destroyed(this); }
+private:
+    int value;
+};
+
+// test_unique_nodelete
+// Object with a private destructor
+class MyObject4;
+static std::unordered_set<MyObject4 *> myobject4_instances;
+class MyObject4 {
+public:
+    MyObject4(int value) : value{value} {
+        print_created(this);
+        myobject4_instances.insert(this);
+    }
+    int value;
+
+    static void cleanupAllInstances() {
+        auto tmp = std::move(myobject4_instances);
+        myobject4_instances.clear();
+        for (auto o : tmp)
+            delete o;
+    }
+private:
+    ~MyObject4() {
+        myobject4_instances.erase(this);
+        print_destroyed(this);
+    }
+};
+
+// test_unique_deleter
+// Object with std::unique_ptr<T, D> where D is not matching the base class
+// Object with a protected destructor
+class MyObject4a;
+static std::unordered_set<MyObject4a *> myobject4a_instances;
+class MyObject4a {
+public:
+    MyObject4a(int i) {
+        value = i;
+        print_created(this);
+        myobject4a_instances.insert(this);
+    };
+    int value;
+
+    static void cleanupAllInstances() {
+        auto tmp = std::move(myobject4a_instances);
+        myobject4a_instances.clear();
+        for (auto o : tmp)
+            delete o;
+    }
+protected:
+    virtual ~MyObject4a() {
+        myobject4a_instances.erase(this);
+        print_destroyed(this);
+    }
+};
+
+// Object derived but with public destructor and no Deleter in default holder
+class MyObject4b : public MyObject4a {
+public:
+    MyObject4b(int i) : MyObject4a(i) { print_created(this); }
+    ~MyObject4b() override { print_destroyed(this); }
+};
+
+// test_large_holder
+class MyObject5 { // managed by huge_unique_ptr
+public:
+    MyObject5(int value) : value{value} { print_created(this); }
+    ~MyObject5() { print_destroyed(this); }
+    int value;
+};
+
+// test_shared_ptr_and_references
+struct SharedPtrRef {
+    struct A {
+        A() { print_created(this); }
+        A(const A &) { print_copy_created(this); }
+        A(A &&) { print_move_created(this); }
+        ~A() { print_destroyed(this); }
+    };
+
+    A value = {};
+    std::shared_ptr<A> shared = std::make_shared<A>();
+};
+
+// test_shared_ptr_from_this_and_references
+struct SharedFromThisRef {
+    struct B : std::enable_shared_from_this<B> {
+        B() { print_created(this); }
+        B(const B &) : std::enable_shared_from_this<B>() { print_copy_created(this); }
+        B(B &&) : std::enable_shared_from_this<B>() { print_move_created(this); }
+        ~B() { print_destroyed(this); }
+    };
+
+    B value = {};
+    std::shared_ptr<B> shared = std::make_shared<B>();
+};
+
+// Issue #865: shared_from_this doesn't work with virtual inheritance
+struct SharedFromThisVBase : std::enable_shared_from_this<SharedFromThisVBase> {
+    SharedFromThisVBase() = default;
+    SharedFromThisVBase(const SharedFromThisVBase &) = default;
+    virtual ~SharedFromThisVBase() = default;
+};
+struct SharedFromThisVirt : virtual SharedFromThisVBase {};
+
+// test_move_only_holder
+struct C {
+    C() { print_created(this); }
+    ~C() { print_destroyed(this); }
+};
+
+// test_holder_with_addressof_operator
+struct TypeForHolderWithAddressOf {
+    TypeForHolderWithAddressOf() { print_created(this); }
+    TypeForHolderWithAddressOf(const TypeForHolderWithAddressOf &) { print_copy_created(this); }
+    TypeForHolderWithAddressOf(TypeForHolderWithAddressOf &&) { print_move_created(this); }
+    ~TypeForHolderWithAddressOf() { print_destroyed(this); }
+    std::string toString() const {
+        return "TypeForHolderWithAddressOf[" + std::to_string(value) + "]";
+    }
+    int value = 42;
+};
+
+// test_move_only_holder_with_addressof_operator
+struct TypeForMoveOnlyHolderWithAddressOf {
+    TypeForMoveOnlyHolderWithAddressOf(int value) : value{value} { print_created(this); }
+    ~TypeForMoveOnlyHolderWithAddressOf() { print_destroyed(this); }
+    std::string toString() const {
+        return "MoveOnlyHolderWithAddressOf[" + std::to_string(value) + "]";
+    }
+    int value;
+};
+
+// test_smart_ptr_from_default
+struct HeldByDefaultHolder { };
+
+// test_shared_ptr_gc
+// #187: issue involving std::shared_ptr<> return value policy & garbage collection
+struct ElementBase {
+    virtual ~ElementBase() = default; /* Force creation of virtual table */
+    ElementBase() = default;
+    ElementBase(const ElementBase&) = delete;
+};
+
+struct ElementA : ElementBase {
+    ElementA(int v) : v(v) { }
+    int value() { return v; }
+    int v;
+};
+
+struct ElementList {
+    void add(std::shared_ptr<ElementBase> e) { l.push_back(e); }
+    std::vector<std::shared_ptr<ElementBase>> l;
+};
+
+} // namespace
+
+// ref<T> is a wrapper for 'Object' which uses intrusive reference counting
+// It is always possible to construct a ref<T> from an Object* pointer without
+// possible inconsistencies, hence the 'true' argument at the end.
+// Make pybind11 aware of the non-standard getter member function
+namespace pybind11 { namespace detail {
+    template <typename T>
+    struct holder_helper<ref<T>> {
+        static const T *get(const ref<T> &p) { return p.get_ptr(); }
+    };
+} // namespace detail
+} // namespace pybind11
+
+// Make pybind aware of the ref-counted wrapper type (s):
+PYBIND11_DECLARE_HOLDER_TYPE(T, ref<T>, true);
+// The following is not required anymore for std::shared_ptr, but it should compile without error:
+PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
+PYBIND11_DECLARE_HOLDER_TYPE(T, huge_unique_ptr<T>);
+PYBIND11_DECLARE_HOLDER_TYPE(T, custom_unique_ptr<T>);
+PYBIND11_DECLARE_HOLDER_TYPE(T, shared_ptr_with_addressof_operator<T>);
 PYBIND11_DECLARE_HOLDER_TYPE(T, unique_ptr_with_addressof_operator<T>);
 
-
 TEST_SUBMODULE(smart_ptr, m) {
+    // Please do not interleave `struct` and `class` definitions with bindings code,
+    // but implement `struct`s and `class`es in the anonymous namespace above.
+    // This helps keeping the smart_holder branch in sync with master.
 
     // test_smart_ptr
 
@@ -94,16 +283,6 @@ TEST_SUBMODULE(smart_ptr, m) {
     py::class_<Object, ref<Object>> obj(m, "Object");
     obj.def("getRefCount", &Object::getRefCount);
 
-    // Custom object with builtin reference counting (see 'object.h' for the implementation)
-    class MyObject1 : public Object {
-    public:
-        MyObject1(int value) : value(value) { print_created(this, toString()); }
-        std::string toString() const override { return "MyObject1[" + std::to_string(value) + "]"; }
-    protected:
-        ~MyObject1() override { print_destroyed(this); }
-    private:
-        int value;
-    };
     py::class_<MyObject1, ref<MyObject1>>(m, "MyObject1", obj)
         .def(py::init<int>());
     py::implicitly_convertible<py::int_, MyObject1>();
@@ -124,17 +303,6 @@ TEST_SUBMODULE(smart_ptr, m) {
     // Expose constructor stats for the ref type
     m.def("cstats_ref", &ConstructorStats::get<ref_tag>);
 
-
-    // Object managed by a std::shared_ptr<>
-    class MyObject2 {
-    public:
-        MyObject2(const MyObject2 &) = default;
-        MyObject2(int value) : value(value) { print_created(this, toString()); }
-        std::string toString() const { return "MyObject2[" + std::to_string(value) + "]"; }
-        virtual ~MyObject2() { print_destroyed(this); }
-    private:
-        int value;
-    };
     py::class_<MyObject2, std::shared_ptr<MyObject2>>(m, "MyObject2")
         .def(py::init<int>());
     m.def("make_myobject2_1", []() { return new MyObject2(6); });
@@ -144,16 +312,6 @@ TEST_SUBMODULE(smart_ptr, m) {
     m.def("print_myobject2_3", [](const std::shared_ptr<MyObject2> &obj) { py::print(obj->toString()); });
     m.def("print_myobject2_4", [](const std::shared_ptr<MyObject2> *obj) { py::print((*obj)->toString()); });
 
-    // Object managed by a std::shared_ptr<>, additionally derives from std::enable_shared_from_this<>
-    class MyObject3 : public std::enable_shared_from_this<MyObject3> {
-    public:
-        MyObject3(const MyObject3 &) = default;
-        MyObject3(int value) : value(value) { print_created(this, toString()); }
-        std::string toString() const { return "MyObject3[" + std::to_string(value) + "]"; }
-        virtual ~MyObject3() { print_destroyed(this); }
-    private:
-        int value;
-    };
     py::class_<MyObject3, std::shared_ptr<MyObject3>>(m, "MyObject3")
         .def(py::init<int>());
     m.def("make_myobject3_1", []() { return new MyObject3(8); });
@@ -175,100 +333,29 @@ TEST_SUBMODULE(smart_ptr, m) {
     });
 
     // test_unique_nodelete
-    // Object with a private destructor
-    class MyObject4;
-    static std::unordered_set<MyObject4 *> myobject4_instances;
-    class MyObject4 {
-    public:
-        MyObject4(int value) : value{value} {
-            print_created(this);
-            myobject4_instances.insert(this);
-        }
-        int value;
-
-        static void cleanupAllInstances() {
-            auto tmp = std::move(myobject4_instances);
-            myobject4_instances.clear();
-            for (auto o : tmp)
-                delete o;
-        }
-    private:
-        ~MyObject4() {
-            myobject4_instances.erase(this);
-            print_destroyed(this);
-        }
-    };
     py::class_<MyObject4, std::unique_ptr<MyObject4, py::nodelete>>(m, "MyObject4")
         .def(py::init<int>())
         .def_readwrite("value", &MyObject4::value)
         .def_static("cleanup_all_instances", &MyObject4::cleanupAllInstances);
 
     // test_unique_deleter
-    // Object with std::unique_ptr<T, D> where D is not matching the base class
-    // Object with a protected destructor
-    class MyObject4a;
-    static std::unordered_set<MyObject4a *> myobject4a_instances;
-    class MyObject4a {
-    public:
-        MyObject4a(int i) {
-            value = i;
-            print_created(this);
-            myobject4a_instances.insert(this);
-        };
-        int value;
-
-        static void cleanupAllInstances() {
-            auto tmp = std::move(myobject4a_instances);
-            myobject4a_instances.clear();
-            for (auto o : tmp)
-                delete o;
-        }
-    protected:
-        virtual ~MyObject4a() {
-            myobject4a_instances.erase(this);
-            print_destroyed(this);
-        }
-    };
     py::class_<MyObject4a, std::unique_ptr<MyObject4a, py::nodelete>>(m, "MyObject4a")
         .def(py::init<int>())
         .def_readwrite("value", &MyObject4a::value)
         .def_static("cleanup_all_instances", &MyObject4a::cleanupAllInstances);
 
-    // Object derived but with public destructor and no Deleter in default holder
-    class MyObject4b : public MyObject4a {
-    public:
-        MyObject4b(int i) : MyObject4a(i) { print_created(this); }
-        ~MyObject4b() override { print_destroyed(this); }
-    };
-    py::class_<MyObject4b, MyObject4a>(m, "MyObject4b")
+    py::class_<MyObject4b, MyObject4a, std::unique_ptr<MyObject4b>>(m, "MyObject4b")
         .def(py::init<int>());
 
     // test_large_holder
-    class MyObject5 { // managed by huge_unique_ptr
-    public:
-        MyObject5(int value) : value{value} { print_created(this); }
-        ~MyObject5() { print_destroyed(this); }
-        int value;
-    };
     py::class_<MyObject5, huge_unique_ptr<MyObject5>>(m, "MyObject5")
         .def(py::init<int>())
         .def_readwrite("value", &MyObject5::value);
 
     // test_shared_ptr_and_references
-    struct SharedPtrRef {
-        struct A {
-            A() { print_created(this); }
-            A(const A &) { print_copy_created(this); }
-            A(A &&) { print_move_created(this); }
-            ~A() { print_destroyed(this); }
-        };
-
-        A value = {};
-        std::shared_ptr<A> shared = std::make_shared<A>();
-    };
     using A = SharedPtrRef::A;
     py::class_<A, std::shared_ptr<A>>(m, "A");
-    py::class_<SharedPtrRef>(m, "SharedPtrRef")
+    py::class_<SharedPtrRef, std::unique_ptr<SharedPtrRef>>(m, "SharedPtrRef")
         .def(py::init<>())
         .def_readonly("ref", &SharedPtrRef::value)
         .def_property_readonly("copy", [](const SharedPtrRef &s) { return s.value; },
@@ -280,20 +367,9 @@ TEST_SUBMODULE(smart_ptr, m) {
         .def("set_holder", [](SharedPtrRef &, std::shared_ptr<A>) { return true; });
 
     // test_shared_ptr_from_this_and_references
-    struct SharedFromThisRef {
-        struct B : std::enable_shared_from_this<B> {
-            B() { print_created(this); }
-            B(const B &) : std::enable_shared_from_this<B>() { print_copy_created(this); }
-            B(B &&) : std::enable_shared_from_this<B>() { print_move_created(this); }
-            ~B() { print_destroyed(this); }
-        };
-
-        B value = {};
-        std::shared_ptr<B> shared = std::make_shared<B>();
-    };
     using B = SharedFromThisRef::B;
     py::class_<B, std::shared_ptr<B>>(m, "B");
-    py::class_<SharedFromThisRef>(m, "SharedFromThisRef")
+    py::class_<SharedFromThisRef, std::unique_ptr<SharedFromThisRef>>(m, "SharedFromThisRef")
         .def(py::init<>())
         .def_readonly("bad_wp", &SharedFromThisRef::value)
         .def_property_readonly("ref", [](const SharedFromThisRef &s) -> const B & { return *s.shared; })
@@ -306,36 +382,16 @@ TEST_SUBMODULE(smart_ptr, m) {
         .def("set_holder", [](SharedFromThisRef &, std::shared_ptr<B>) { return true; });
 
     // Issue #865: shared_from_this doesn't work with virtual inheritance
-    struct SharedFromThisVBase : std::enable_shared_from_this<SharedFromThisVBase> {
-        SharedFromThisVBase() = default;
-        SharedFromThisVBase(const SharedFromThisVBase &) = default;
-        virtual ~SharedFromThisVBase() = default;
-    };
-    struct SharedFromThisVirt : virtual SharedFromThisVBase {};
     static std::shared_ptr<SharedFromThisVirt> sft(new SharedFromThisVirt());
     py::class_<SharedFromThisVirt, std::shared_ptr<SharedFromThisVirt>>(m, "SharedFromThisVirt")
         .def_static("get", []() { return sft.get(); });
 
     // test_move_only_holder
-    struct C {
-        C() { print_created(this); }
-        ~C() { print_destroyed(this); }
-    };
     py::class_<C, custom_unique_ptr<C>>(m, "TypeWithMoveOnlyHolder")
         .def_static("make", []() { return custom_unique_ptr<C>(new C); })
         .def_static("make_as_object", []() { return py::cast(custom_unique_ptr<C>(new C)); });
 
     // test_holder_with_addressof_operator
-    struct TypeForHolderWithAddressOf {
-        TypeForHolderWithAddressOf() { print_created(this); }
-        TypeForHolderWithAddressOf(const TypeForHolderWithAddressOf &) { print_copy_created(this); }
-        TypeForHolderWithAddressOf(TypeForHolderWithAddressOf &&) { print_move_created(this); }
-        ~TypeForHolderWithAddressOf() { print_destroyed(this); }
-        std::string toString() const {
-            return "TypeForHolderWithAddressOf[" + std::to_string(value) + "]";
-        }
-        int value = 42;
-    };
     using HolderWithAddressOf = shared_ptr_with_addressof_operator<TypeForHolderWithAddressOf>;
     py::class_<TypeForHolderWithAddressOf, HolderWithAddressOf>(m, "TypeForHolderWithAddressOf")
         .def_static("make", []() { return HolderWithAddressOf(new TypeForHolderWithAddressOf); })
@@ -346,14 +402,6 @@ TEST_SUBMODULE(smart_ptr, m) {
         .def("print_object_4", [](const HolderWithAddressOf *obj) { py::print((*obj).get()->toString()); });
 
     // test_move_only_holder_with_addressof_operator
-    struct TypeForMoveOnlyHolderWithAddressOf {
-        TypeForMoveOnlyHolderWithAddressOf(int value) : value{value} { print_created(this); }
-        ~TypeForMoveOnlyHolderWithAddressOf() { print_destroyed(this); }
-        std::string toString() const {
-            return "MoveOnlyHolderWithAddressOf[" + std::to_string(value) + "]";
-        }
-        int value;
-    };
     using MoveOnlyHolderWithAddressOf = unique_ptr_with_addressof_operator<TypeForMoveOnlyHolderWithAddressOf>;
     py::class_<TypeForMoveOnlyHolderWithAddressOf, MoveOnlyHolderWithAddressOf>(m, "TypeForMoveOnlyHolderWithAddressOf")
         .def_static("make", []() { return MoveOnlyHolderWithAddressOf(new TypeForMoveOnlyHolderWithAddressOf(0)); })
@@ -361,33 +409,18 @@ TEST_SUBMODULE(smart_ptr, m) {
         .def("print_object", [](const TypeForMoveOnlyHolderWithAddressOf *obj) { py::print(obj->toString()); });
 
     // test_smart_ptr_from_default
-    struct HeldByDefaultHolder { };
-    py::class_<HeldByDefaultHolder>(m, "HeldByDefaultHolder")
+    py::class_<HeldByDefaultHolder, std::unique_ptr<HeldByDefaultHolder>>(m, "HeldByDefaultHolder")
         .def(py::init<>())
         .def_static("load_shared_ptr", [](std::shared_ptr<HeldByDefaultHolder>) {});
 
     // test_shared_ptr_gc
     // #187: issue involving std::shared_ptr<> return value policy & garbage collection
-    struct ElementBase {
-        virtual ~ElementBase() = default; /* Force creation of virtual table */
-        ElementBase() = default;
-        ElementBase(const ElementBase&) = delete;
-    };
     py::class_<ElementBase, std::shared_ptr<ElementBase>>(m, "ElementBase");
 
-    struct ElementA : ElementBase {
-        ElementA(int v) : v(v) { }
-        int value() { return v; }
-        int v;
-    };
     py::class_<ElementA, ElementBase, std::shared_ptr<ElementA>>(m, "ElementA")
         .def(py::init<int>())
         .def("value", &ElementA::value);
 
-    struct ElementList {
-        void add(std::shared_ptr<ElementBase> e) { l.push_back(e); }
-        std::vector<std::shared_ptr<ElementBase>> l;
-    };
     py::class_<ElementList, std::shared_ptr<ElementList>>(m, "ElementList")
         .def(py::init<>())
         .def("add", &ElementList::add)


### PR DESCRIPTION
* Back-porting from `smart_holder` branch, to minimize diffs and the potential for merge conflicts. 
* Mostly code is just shuffled (see below for proof that nothing got lost).
* All code outside `TEST_MODULE` moved to the anonymous `namespace`. This isn't strictly necessary for the `smart_holder` work, but best practice. All `PYBIND11_DECLARE_HOLDER_TYPE` were grouped together right after the anonymous `namespace` (to not have to close-reopen the `namespace` N times).
* In 4 cases, `std::unique_ptr` is explicitly specified as holder (see diff below). On current `master` this is redundant, because `std::unique_ptr` is the default holder, but it enables testing against the `smart_holder` branch with `-DPYBIND11_USE_SMART_HOLDER_AS_DEFAULT`.
* A few comments were duplicated for clarity, to appear both in the anonymous `namespace` and in `TEST_MODULE`. See diff below.

Changelog not needed.

Simple proof that nothing got lost:
```
cd pybind11/tests
git checkout master
cat test_smart_ptr.cpp | sed 's/^ *//' | grep -v '^$' | sort > zmaster
git checkout test_smart_ptr_non_interleaved
cat test_smart_ptr.cpp | sed 's/^ *//' | grep -v '^$' | sort > zpr
diff zmaster zpr
rm zmaster zpr
```

The full output from the `diff` command above:
```
37a38
> // #187: issue involving std::shared_ptr<> return value policy & garbage collection
54a56
> // but implement `struct`s and `class`es in the anonymous namespace above.
146a149
> // Issue #865: shared_from_this doesn't work with virtual inheritance
196a200,201
> } // namespace
> namespace {
207a213
> // Please do not interleave `struct` and `class` definitions with bindings code,
243c249
< py::class_<HeldByDefaultHolder>(m, "HeldByDefaultHolder")
---
> py::class_<HeldByDefaultHolder, std::unique_ptr<HeldByDefaultHolder>>(m, "HeldByDefaultHolder")
248c254
< py::class_<MyObject4b, MyObject4a>(m, "MyObject4b")
---
> py::class_<MyObject4b, MyObject4a, std::unique_ptr<MyObject4b>>(m, "MyObject4b")
252c258
< py::class_<SharedFromThisRef>(m, "SharedFromThisRef")
---
> py::class_<SharedFromThisRef, std::unique_ptr<SharedFromThisRef>>(m, "SharedFromThisRef")
254c260
< py::class_<SharedPtrRef>(m, "SharedPtrRef")
---
> py::class_<SharedPtrRef, std::unique_ptr<SharedPtrRef>>(m, "SharedPtrRef")
315a322,323
> // test_holder_with_addressof_operator
> // test_large_holder
317a326,327
> // test_move_only_holder
> // test_move_only_holder_with_addressof_operator
319a330
> // test_shared_ptr_and_references
320a332,333
> // test_shared_ptr_from_this_and_references
> // test_shared_ptr_gc
323a337
> // test_smart_ptr_from_default
327a342,343
> // test_unique_deleter
> // test_unique_nodelete
333a350
> // This helps keeping the smart_holder branch in sync with master.
```