### PR TITLE
Changing cast_error("... Python instance was disowned.") to value_error.

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -388,8 +388,8 @@ private:
                           " Python instance is uninitialized.");
         }
         if (!holder().has_pointee()) {
-            throw cast_error("Missing value for wrapped C++ type:"
-                             " Python instance was disowned.");
+            throw value_error("Missing value for wrapped C++ type:"
+                              " Python instance was disowned.");
         }
     }
 

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -78,7 +78,7 @@ def test_load_with_rtrn_f(pass_f, rtrn_f, expected):
 def test_pass_unique_ptr_disowns(pass_f, rtrn_f, expected):
     obj = rtrn_f()
     assert pass_f(obj) == expected
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(ValueError) as exc_info:
         pass_f(obj)
     assert str(exc_info.value) == (
         "Missing value for wrapped C++ type: Python instance was disowned."

--- a/tests/test_class_sh_unique_ptr_member.py
+++ b/tests/test_class_sh_unique_ptr_member.py
@@ -17,7 +17,7 @@ def test_pointee_and_ptr_owner(give_up_ownership_via):
     obj = m.pointee()
     assert obj.get_int() == 213
     owner = m.ptr_owner(obj)
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(ValueError) as exc_info:
         obj.get_int()
     assert (
         str(exc_info.value)


### PR DESCRIPTION
Changes `RuntimeError` to `ValueError` in the Python interpreter.

`ValueError` is deemed more fitting and intuitive, and is compatible with established PyCLIF behavior.