### PR TITLE
docs: document loading related modules

### DIFF
--- a/docs/advanced/pycpp/object.rst
+++ b/docs/advanced/pycpp/object.rst
@@ -70,7 +70,7 @@ This example obtains a reference to the Python ``Decimal`` class.
 Loading related native modules
 ==============================
 
-You can use an import of the form `py::module::import("some_other_module");`
+You can use an import of the form ``py::module::import("some_other_module");``
 to import a native module that defines types you use in the current module.
 
 This will remove Python run-time errors of the form

--- a/docs/advanced/pycpp/object.rst
+++ b/docs/advanced/pycpp/object.rst
@@ -75,7 +75,7 @@ to import a native module that defines types you use in the current module.
 
 This will remove Python run-time errors of the form
 
-.. code-block:: Python
+::
 
     TypeError: Unable to convert function return value to a Python type! The signature was
             (arg0: some_module.Cat) -> some_other_module.Name

--- a/docs/advanced/pycpp/object.rst
+++ b/docs/advanced/pycpp/object.rst
@@ -56,12 +56,12 @@ This example obtains a reference to the Python ``Decimal`` class.
 .. code-block:: cpp
 
     // Equivalent to "from decimal import Decimal"
-    py::object Decimal = py::module::import("decimal").attr("Decimal");
+    py::object Decimal = py::module_::import("decimal").attr("Decimal");
 
 .. code-block:: cpp
 
     // Try to import scipy
-    py::object scipy = py::module::import("scipy");
+    py::object scipy = py::module_::import("scipy");
     return scipy.attr("__version__");
 
 
@@ -78,13 +78,14 @@ This will remove Python run-time errors of the form
 .. code-block:: Python
 
     TypeError: Unable to convert function return value to a Python type! The signature was
-            (arg0: some_module.Cat) -> some_other_module::Name
+            (arg0: some_module.Cat) -> some_other_module.Name
 
 where the user of ``some_module`` forgot to include ``some_other_module`` and thus
 a type in ``some_other_module`` was not known to the Python interpreter.
 
 
 .. _calling_python_functions:
+
 
 Calling Python functions
 ========================
@@ -100,7 +101,7 @@ via ``operator()``.
 .. code-block:: cpp
 
     // Use Python to make our directories
-    py::object os = py::module::import("os");
+    py::object os = py::module_::import("os");
     py::object makedirs = os.attr("makedirs");
     makedirs("/tmp/path/to/somewhere");
 
@@ -215,9 +216,9 @@ C++ functions that require a specific subtype rather than a generic :class:`obje
     #include <pybind11/numpy.h>
     using namespace pybind11::literals;
 
-    py::module os = py::module::import("os");
-    py::module path = py::module::import("os.path");  // like 'import os.path as path'
-    py::module np = py::module::import("numpy");  // like 'import numpy as np'
+    py::module_ os = py::module_::import("os");
+    py::module_ path = py::module_::import("os.path");  // like 'import os.path as path'
+    py::module_ np = py::module_::import("numpy");  // like 'import numpy as np'
 
     py::str curdir_abs = path.attr("abspath")(path.attr("curdir"));
     py::print(py::str("Current directory: ") + curdir_abs);

--- a/docs/advanced/pycpp/object.rst
+++ b/docs/advanced/pycpp/object.rst
@@ -56,13 +56,32 @@ This example obtains a reference to the Python ``Decimal`` class.
 .. code-block:: cpp
 
     // Equivalent to "from decimal import Decimal"
-    py::object Decimal = py::module_::import("decimal").attr("Decimal");
+    py::object Decimal = py::module::import("decimal").attr("Decimal");
 
 .. code-block:: cpp
 
     // Try to import scipy
-    py::object scipy = py::module_::import("scipy");
+    py::object scipy = py::module::import("scipy");
     return scipy.attr("__version__");
+
+
+.. _loading_related_native_modules:
+
+Loading related native modules
+==============================
+
+You can use an import of the form `py::module::import("some_other_module");`
+to import a native module that defines types you use in the current module.
+
+This will remove Python run-time errors of the form
+
+.. code-block:: Python
+
+    TypeError: Unable to convert function return value to a Python type! The signature was
+            (arg0: some_module.Cat) -> some_other_module::Name
+
+where the user of ``some_module`` forgot to include ``some_other_module`` and thus
+a type in ``some_other_module`` was not known to the Python interpreter.
 
 
 .. _calling_python_functions:
@@ -81,7 +100,7 @@ via ``operator()``.
 .. code-block:: cpp
 
     // Use Python to make our directories
-    py::object os = py::module_::import("os");
+    py::object os = py::module::import("os");
     py::object makedirs = os.attr("makedirs");
     makedirs("/tmp/path/to/somewhere");
 
@@ -196,9 +215,9 @@ C++ functions that require a specific subtype rather than a generic :class:`obje
     #include <pybind11/numpy.h>
     using namespace pybind11::literals;
 
-    py::module_ os = py::module_::import("os");
-    py::module_ path = py::module_::import("os.path");  // like 'import os.path as path'
-    py::module_ np = py::module_::import("numpy");  // like 'import numpy as np'
+    py::module os = py::module::import("os");
+    py::module path = py::module::import("os.path");  // like 'import os.path as path'
+    py::module np = py::module::import("numpy");  // like 'import numpy as np'
 
     py::str curdir_abs = path.attr("abspath")(path.attr("curdir"));
     py::print(py::str("Current directory: ") + curdir_abs);


### PR DESCRIPTION
## Description

`py::module_` is not known to my `pybind11` but `py::module` is.  Also I've added a use-case which was not mentioned in the documentation before.


