### PR TITLE
Changing all but one std::runtime_error to std::invalid_argument.

### DIFF
--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace pybind11_tests {
 namespace class_sh_basic {
@@ -57,11 +58,16 @@ std::string pass_udcp(std::unique_ptr<atyp const, sddc> obj) { return "pass_udcp
 // Helpers for testing.
 std::string get_mtxt(atyp const &obj) { return obj.mtxt; }
 std::unique_ptr<atyp> unique_ptr_roundtrip(std::unique_ptr<atyp> obj) { return obj; }
+struct SharedPtrStash {
+    std::vector<std::shared_ptr<const atyp>> stash;
+    void Add(std::shared_ptr<const atyp> obj) { stash.push_back(obj); }
+};
 
 } // namespace class_sh_basic
 } // namespace pybind11_tests
 
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_basic::atyp)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_basic::SharedPtrStash)
 
 namespace pybind11_tests {
 namespace class_sh_basic {
@@ -110,6 +116,9 @@ TEST_SUBMODULE(class_sh_basic, m) {
     // These require selected functions above to work first, as indicated:
     m.def("get_mtxt", get_mtxt);                         // pass_cref
     m.def("unique_ptr_roundtrip", unique_ptr_roundtrip); // pass_uqmp, rtrn_uqmp
+    py::classh<SharedPtrStash>(m, "SharedPtrStash")
+        .def(py::init<>())
+        .def("Add", &SharedPtrStash::Add, py::arg("obj"));
 
     m.def("py_type_handle_of_atyp", []() {
         return py::type::handle_of<atyp>(); // Exercises static_cast in this function.

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -85,6 +85,26 @@ def test_pass_unique_ptr_disowns(pass_f, rtrn_f, expected):
     )
 
 
+@pytest.mark.parametrize(
+    "pass_f, rtrn_f",
+    [
+        (m.pass_uqmp, m.rtrn_uqmp),
+        (m.pass_uqcp, m.rtrn_uqcp),
+        (m.pass_udmp, m.rtrn_udmp),
+        (m.pass_udcp, m.rtrn_udcp),
+    ],
+)
+def test_cannot_disown_use_count_ne_1(pass_f, rtrn_f):
+    obj = rtrn_f()
+    stash = m.SharedPtrStash()
+    stash.Add(obj)
+    with pytest.raises(ValueError) as exc_info:
+        pass_f(obj)
+    assert str(exc_info.value) == (
+        "Cannot disown use_count != 1 (loaded_as_unique_ptr)."
+    )
+
+
 def test_unique_ptr_roundtrip(num_round_trips=1000):
     # Multiple roundtrips to stress-test instance registration/deregistration.
     recycled = m.atyp("passenger")


### PR DESCRIPTION
`std::invalid_argument` appears as `ValueError` in the Python interpreter, which is more intuitive than `RuntimeError`, and compatible with existing PyCLIF behavior.