### PR TITLE
Shuffling code in test_multiple_inheritance.cpp to separate struct/class definitions from bindings code.

### DIFF
--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -11,6 +11,8 @@
 #include "pybind11_tests.h"
 #include "constructor_stats.h"
 
+namespace {
+
 // Many bases for testing that multiple inheritance from many classes (i.e. requiring extra
 // space for holder constructed flags) works.
 template <int N> struct BaseN {
@@ -43,7 +45,34 @@ int WithStatic2::static_value2 = 2;
 int VanillaStaticMix1::static_value = 12;
 int VanillaStaticMix2::static_value = 12;
 
+// test_multiple_inheritance_virtbase
+struct Base1a {
+    Base1a(int i) : i(i) { }
+    int foo() { return i; }
+    int i;
+};
+struct Base2a {
+    Base2a(int i) : i(i) { }
+    int bar() { return i; }
+    int i;
+};
+struct Base12a : Base1a, Base2a {
+    Base12a(int i, int j) : Base1a(i), Base2a(j) { }
+};
+
+// test_mi_unaligned_base
+// test_mi_base_return
+struct I801B1 { int a = 1; I801B1() = default; I801B1(const I801B1 &) = default; virtual ~I801B1() = default; };
+struct I801B2 { int b = 2; I801B2() = default; I801B2(const I801B2 &) = default; virtual ~I801B2() = default; };
+struct I801C : I801B1, I801B2 {};
+struct I801D : I801C {}; // Indirect MI
+
+} // namespace
+
 TEST_SUBMODULE(multiple_inheritance, m) {
+    // Please do not interleave `struct` and `class` definitions with bindings code,
+    // but implement `struct`s and `class`es in the anonymous namespace above.
+    // This helps keeping the smart_holder branch in sync with master.
 
     // test_multiple_inheritance_mix1
     // test_multiple_inheritance_mix2
@@ -99,27 +128,14 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     // test_multiple_inheritance_virtbase
     // Test the case where not all base classes are specified, and where pybind11 requires the
     // py::multiple_inheritance flag to perform proper casting between types.
-    struct Base1a {
-        Base1a(int i) : i(i) { }
-        int foo() { return i; }
-        int i;
-    };
     py::class_<Base1a, std::shared_ptr<Base1a>>(m, "Base1a")
         .def(py::init<int>())
         .def("foo", &Base1a::foo);
 
-    struct Base2a {
-        Base2a(int i) : i(i) { }
-        int bar() { return i; }
-        int i;
-    };
     py::class_<Base2a, std::shared_ptr<Base2a>>(m, "Base2a")
         .def(py::init<int>())
         .def("bar", &Base2a::bar);
 
-    struct Base12a : Base1a, Base2a {
-        Base12a(int i, int j) : Base1a(i), Base2a(j) { }
-    };
     py::class_<Base12a, /* Base1 missing */ Base2a,
                std::shared_ptr<Base12a>>(m, "Base12a", py::multiple_inheritance())
         .def(py::init<int, int>());
@@ -130,10 +146,6 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     // test_mi_unaligned_base
     // test_mi_base_return
     // Issue #801: invalid casting to derived type with MI bases
-    struct I801B1 { int a = 1; I801B1() = default; I801B1(const I801B1 &) = default; virtual ~I801B1() = default; };
-    struct I801B2 { int b = 2; I801B2() = default; I801B2(const I801B2 &) = default; virtual ~I801B2() = default; };
-    struct I801C : I801B1, I801B2 {};
-    struct I801D : I801C {}; // Indirect MI
     // Unregistered classes:
     struct I801B3 { int c = 3; virtual ~I801B3() = default; };
     struct I801E : I801B3, I801D {};


### PR DESCRIPTION
Similar to #2875 but significantly simpler.

* Back-porting from `smart_holder` branch, to minimize diffs and the potential for merge conflicts. In particular, this PR is to help merge the `smart_holder` branch into the https://github.com/RobotLocomotion/pybind11 `drake` branch.
* Mostly code is just shuffled (see below for proof that nothing got lost).
* All code outside `TEST_MODULE` moved to the anonymous `namespace`. This isn't strictly necessary for the `smart_holder` work, but best practice.
* A few comments were duplicated for clarity, to appear both in the anonymous `namespace` and in `TEST_MODULE`. See diff below.

Changelog not needed.

Simple proof that nothing got lost:
```
cd pybind11/tests
git checkout master
cat test_multiple_inheritance.cpp | sed 's/^ *//' | grep -v '^$' | sort > zmaster
git checkout test_multiple_inheritance_non_interleaved
cat test_multiple_inheritance.cpp | sed 's/^ *//' | grep -v '^$' | sort > zpr
diff zmaster zpr
rm zmaster zpr
```

The full output from the `diff` command above:
```diff
30a31
> // but implement `struct`s and `class`es in the anonymous namespace above.
97a99,101
> } // namespace
> namespace {
> // Please do not interleave `struct` and `class` definitions with bindings code,
172a177
> // test_mi_base_return
175a181
> // test_mi_unaligned_base
180a187
> // test_multiple_inheritance_virtbase
183a191
> // This helps keeping the smart_holder branch in sync with master.
```
