### PR TITLE
Generalizing suppression for pypocketfft.

### DIFF
--- a/tests/valgrind-numpy-scipy.supp
+++ b/tests/valgrind-numpy-scipy.supp
@@ -138,3 +138,22 @@
    fun:__Pyx__PyObject_CallOneArg
    fun:__pyx_pw_5numpy_6random_13bit_generator_12BitGenerator_1__init__
 }
+
+{
+   pypocketfft leaks on import
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znwm
+   fun:PyInit_pypocketfft
+   fun:_PyImport_LoadDynamicModuleWithSpec
+   fun:_imp_create_dynamic_impl.constprop.0
+   fun:_imp_create_dynamic
+   fun:cfunction_vectorcall_FASTCALL
+   fun:PyVectorcall_Call
+   fun:_PyObject_Call
+   fun:PyObject_Call
+   fun:do_call_core
+   fun:_PyEval_EvalFrameDefault
+   fun:_PyEval_EvalFrame
+   fun:_PyEval_EvalCode
+}

--- a/tests/valgrind-numpy-scipy.supp
+++ b/tests/valgrind-numpy-scipy.supp
@@ -111,7 +111,7 @@
    fun:_Znwm
    fun:PyInit_pypocketfft
    fun:_PyImport_LoadDynamicModuleWithSpec
-   fun:_imp_create_dynamic_impl.constprop.3
+   fun:_imp_create_dynamic_impl.constprop.*
    fun:_imp_create_dynamic
    fun:cfunction_vectorcall_FASTCALL
    fun:PyVectorcall_Call
@@ -137,23 +137,4 @@
    fun:type_call
    fun:__Pyx__PyObject_CallOneArg
    fun:__pyx_pw_5numpy_6random_13bit_generator_12BitGenerator_1__init__
-}
-
-{
-   pypocketfft leaks on import
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:_Znwm
-   fun:PyInit_pypocketfft
-   fun:_PyImport_LoadDynamicModuleWithSpec
-   fun:_imp_create_dynamic_impl.constprop.0
-   fun:_imp_create_dynamic
-   fun:cfunction_vectorcall_FASTCALL
-   fun:PyVectorcall_Call
-   fun:_PyObject_Call
-   fun:PyObject_Call
-   fun:do_call_core
-   fun:_PyEval_EvalFrameDefault
-   fun:_PyEval_EvalFrame
-   fun:_PyEval_EvalCode
 }


### PR DESCRIPTION
This valgrind error started appearing today, for completely unrelated changes. E.g.:

https://github.com/pybind/pybind11/pull/2895/checks?check_run_id=2061696834

```
==9513== 104 bytes in 1 blocks are definitely lost in loss record 6,250 of 8,539
==9513==    at 0x4A3852A: operator new(unsigned long) (vg_replace_malloc.c:342)
==9513==    by 0x153EFF33: PyInit_pypocketfft (in /home/runner/venv-3.9/lib/python3.9/site-packages/scipy/fft/_pocketfft/pypocketfft.cpython-39-x86_64-linux-gnu.so)
==9513==    by 0x4F5016: _PyImport_LoadDynamicModuleWithSpec (importdl.c:164)
==9513==    by 0x4F454A: _imp_create_dynamic_impl.constprop.0 (import.c:2297)
==9513==    by 0x4F44AD: _imp_create_dynamic (import.c.h:330)
==9513==    by 0x62546B: cfunction_vectorcall_FASTCALL (methodobject.c:426)
==9513==    by 0x4318A2: PyVectorcall_Call (call.c:231)
==9513==    by 0x431596: _PyObject_Call (call.c:266)
==9513==    by 0x4314E3: PyObject_Call (call.c:293)
==9513==    by 0x4D49C1: do_call_core (ceval.c:5092)
==9513==    by 0x4D32F7: _PyEval_EvalFrameDefault (ceval.c:3580)
==9513==    by 0x4C9161: _PyEval_EvalFrame (pycore_ceval.h:40)
==9513==    by 0x4C9161: _PyEval_EvalCode (ceval.c:4327)
==9513== 
```