### PR TITLE
Adding virtual_overrider_self_life_support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ set(PYBIND11_HEADERS
     include/pybind11/detail/smart_holder_type_casters.h
     include/pybind11/detail/type_caster_base.h
     include/pybind11/detail/typeid.h
+    include/pybind11/detail/virtual_overrider_self_life_support.h
     include/pybind11/attr.h
     include/pybind11/buffer_info.h
     include/pybind11/cast.h

--- a/include/pybind11/detail/smart_holder_poc.h
+++ b/include/pybind11/detail/smart_holder_poc.h
@@ -234,26 +234,26 @@ struct smart_holder {
         return hld;
     }
 
-    // Caller is responsible for ensuring preconditions (TODO: details).
+    // Caller is responsible for ensuring preconditions (SMART_HOLDER_WIP: details).
     void disown() {
         *vptr_deleter_armed_flag_ptr = false;
         was_disowned                 = true;
     }
 
-    // Caller is responsible for ensuring preconditions (TODO: details).
+    // Caller is responsible for ensuring preconditions (SMART_HOLDER_WIP: details).
     void release_disowned() {
         vptr.reset();
         vptr_deleter_armed_flag_ptr.reset();
     }
 
-    // TODO: review this function.
+    // SMART_HOLDER_WIP: review this function.
     void ensure_can_release_ownership(const char *context = "ensure_can_release_ownership") {
         ensure_was_not_disowned(context);
         ensure_vptr_is_using_builtin_delete(context);
         ensure_use_count_1(context);
     }
 
-    // Caller is responsible for ensuring preconditions (TODO: details).
+    // Caller is responsible for ensuring preconditions (SMART_HOLDER_WIP: details).
     void release_ownership() {
         *vptr_deleter_armed_flag_ptr = false;
         release_disowned();

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -56,6 +56,7 @@ struct virtual_overrider_self_life_support {
     }
 
     // Some compilers complain about implicitly defined versions of some of the following:
+    virtual_overrider_self_life_support()                                            = default;
     virtual_overrider_self_life_support(const virtual_overrider_self_life_support &) = default;
     virtual_overrider_self_life_support(virtual_overrider_self_life_support &&)      = default;
     virtual_overrider_self_life_support &operator=(const virtual_overrider_self_life_support &)

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -13,6 +13,7 @@
 #include "smart_holder_sfinae_hooks_only.h"
 #include "type_caster_base.h"
 #include "typeid.h"
+#include "virtual_overrider_self_life_support.h"
 
 #include <cstddef>
 #include <memory>
@@ -34,48 +35,6 @@ struct is_smart_holder_type<smart_holder> : std::true_type {};
 // SMART_HOLDER_WIP: Needs refactoring of existing pybind11 code.
 inline void register_instance(instance *self, void *valptr, const type_info *tinfo);
 inline bool deregister_instance(instance *self, void *valptr, const type_info *tinfo);
-
-// The original core idea for this struct goes back to PyCLIF:
-// https://github.com/google/clif/blob/07f95d7e69dca2fcf7022978a55ef3acff506c19/clif/python/runtime.cc#L37
-// URL provided here mainly to give proper credit. To fully explain the `HoldPyObj` feature, more
-// context is needed (SMART_HOLDER_WIP).
-struct virtual_overrider_self_life_support {
-    value_and_holder loaded_v_h;
-    ~virtual_overrider_self_life_support() {
-        if (loaded_v_h.inst != nullptr && loaded_v_h.vh != nullptr) {
-            void *value_void_ptr = loaded_v_h.value_ptr();
-            if (value_void_ptr != nullptr) {
-                PyGILState_STATE threadstate = PyGILState_Ensure();
-                Py_DECREF((PyObject *) loaded_v_h.inst);
-                loaded_v_h.value_ptr() = nullptr;
-                loaded_v_h.holder<smart_holder>().release_disowned();
-                deregister_instance(loaded_v_h.inst, value_void_ptr, loaded_v_h.type);
-                PyGILState_Release(threadstate);
-            }
-        }
-    }
-
-    // Some compilers complain about implicitly defined versions of some of the following:
-    virtual_overrider_self_life_support()                                            = default;
-    virtual_overrider_self_life_support(const virtual_overrider_self_life_support &) = default;
-    virtual_overrider_self_life_support(virtual_overrider_self_life_support &&)      = default;
-    virtual_overrider_self_life_support &operator=(const virtual_overrider_self_life_support &)
-        = default;
-    virtual_overrider_self_life_support &operator=(virtual_overrider_self_life_support &&)
-        = default;
-};
-
-template <typename T, detail::enable_if_t<!std::is_polymorphic<T>::value, int> = 0>
-virtual_overrider_self_life_support *
-dynamic_cast_virtual_overrider_self_life_support_ptr(T * /*raw_type_ptr*/) {
-    return nullptr;
-}
-
-template <typename T, detail::enable_if_t<std::is_polymorphic<T>::value, int> = 0>
-virtual_overrider_self_life_support *
-dynamic_cast_virtual_overrider_self_life_support_ptr(T *raw_type_ptr) {
-    return dynamic_cast<virtual_overrider_self_life_support *>(raw_type_ptr);
-}
 
 // The modified_type_caster_generic_load_impl could replace type_caster_generic::load_impl but not
 // vice versa. The main difference is that the original code only propagates a reference to the

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -54,6 +54,14 @@ struct virtual_overrider_self_life_support {
             }
         }
     }
+
+    // Some compilers complain about implicitly defined versions of some of the following:
+    virtual_overrider_self_life_support(const virtual_overrider_self_life_support &) = default;
+    virtual_overrider_self_life_support(virtual_overrider_self_life_support &&)      = default;
+    virtual_overrider_self_life_support &operator=(const virtual_overrider_self_life_support &)
+        = default;
+    virtual_overrider_self_life_support &operator=(virtual_overrider_self_life_support &&)
+        = default;
 };
 
 template <typename T, detail::enable_if_t<!std::is_polymorphic<T>::value, int> = 0>

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -394,6 +394,7 @@ struct smart_holder_type_caster_load {
         if (!have_holder())
             return nullptr;
         throw_if_uninitialized_or_disowned_holder();
+        holder().ensure_was_not_disowned("loaded_as_shared_ptr");
         auto void_raw_ptr = holder().template as_raw_ptr_unowned<void>();
         auto type_raw_ptr = convert_type(void_raw_ptr);
         if (holder().pointee_depends_on_holder_owner) {
@@ -415,6 +416,7 @@ struct smart_holder_type_caster_load {
         if (!have_holder())
             return nullptr;
         throw_if_uninitialized_or_disowned_holder();
+        holder().ensure_was_not_disowned(context);
         holder().template ensure_compatible_rtti_uqp_del<T, D>(context);
         holder().ensure_use_count_1(context);
         auto raw_void_ptr = holder().template as_raw_ptr_unowned<void>();

--- a/include/pybind11/detail/virtual_overrider_self_life_support.h
+++ b/include/pybind11/detail/virtual_overrider_self_life_support.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 The Pybind Development Team.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "common.h"
+#include "smart_holder_poc.h"
+#include "type_caster_base.h"
+
+#include <type_traits>
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+// SMART_HOLDER_WIP: Needs refactoring of existing pybind11 code.
+inline bool deregister_instance(instance *self, void *valptr, const type_info *tinfo);
+
+// The original core idea for this struct goes back to PyCLIF:
+// https://github.com/google/clif/blob/07f95d7e69dca2fcf7022978a55ef3acff506c19/clif/python/runtime.cc#L37
+// URL provided here mainly to give proper credit. To fully explain the `HoldPyObj` feature, more
+// context is needed (SMART_HOLDER_WIP).
+struct virtual_overrider_self_life_support {
+    value_and_holder loaded_v_h;
+    ~virtual_overrider_self_life_support() {
+        if (loaded_v_h.inst != nullptr && loaded_v_h.vh != nullptr) {
+            void *value_void_ptr = loaded_v_h.value_ptr();
+            if (value_void_ptr != nullptr) {
+                PyGILState_STATE threadstate = PyGILState_Ensure();
+                Py_DECREF((PyObject *) loaded_v_h.inst);
+                loaded_v_h.value_ptr() = nullptr;
+                loaded_v_h.holder<pybindit::memory::smart_holder>().release_disowned();
+                deregister_instance(loaded_v_h.inst, value_void_ptr, loaded_v_h.type);
+                PyGILState_Release(threadstate);
+            }
+        }
+    }
+
+    // Some compilers complain about implicitly defined versions of some of the following:
+    virtual_overrider_self_life_support()                                            = default;
+    virtual_overrider_self_life_support(const virtual_overrider_self_life_support &) = default;
+    virtual_overrider_self_life_support(virtual_overrider_self_life_support &&)      = default;
+    virtual_overrider_self_life_support &operator=(const virtual_overrider_self_life_support &)
+        = default;
+    virtual_overrider_self_life_support &operator=(virtual_overrider_self_life_support &&)
+        = default;
+};
+
+template <typename T, detail::enable_if_t<!std::is_polymorphic<T>::value, int> = 0>
+virtual_overrider_self_life_support *
+dynamic_cast_virtual_overrider_self_life_support_ptr(T * /*raw_type_ptr*/) {
+    return nullptr;
+}
+
+template <typename T, detail::enable_if_t<std::is_polymorphic<T>::value, int> = 0>
+virtual_overrider_self_life_support *
+dynamic_cast_virtual_overrider_self_life_support_ptr(T *raw_type_ptr) {
+    return dynamic_cast<virtual_overrider_self_life_support *>(raw_type_ptr);
+}
+
+PYBIND11_NAMESPACE_END(detail)
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -48,6 +48,7 @@ detail_headers = {
     "include/pybind11/detail/smart_holder_type_casters.h",
     "include/pybind11/detail/type_caster_base.h",
     "include/pybind11/detail/typeid.h",
+    "include/pybind11/detail/virtual_overrider_self_life_support.h",
 }
 
 cmake_files = {

--- a/tests/test_class_sh_with_alias.cpp
+++ b/tests/test_class_sh_with_alias.cpp
@@ -7,6 +7,7 @@
 namespace pybind11_tests {
 namespace test_class_sh_with_alias {
 
+template <int SerNo> // Using int as a trick to easily generate a series of types.
 struct Abase {
     int val          = 0;
     virtual ~Abase() = default;
@@ -21,41 +22,65 @@ struct Abase {
     Abase &operator=(Abase &&) = default;
 };
 
-struct AbaseAlias : Abase, py::detail::virtual_overrider_self_life_support {
-    using Abase::Abase;
+template <int SerNo>
+struct AbaseAlias : Abase<SerNo> {
+    using Abase<SerNo>::Abase;
 
     int Add(int other_val) const override {
-        PYBIND11_OVERRIDE_PURE(int,   /* Return type */
-                               Abase, /* Parent class */
-                               Add,   /* Name of function in C++ (must match Python name) */
+        PYBIND11_OVERRIDE_PURE(int,          /* Return type */
+                               Abase<SerNo>, /* Parent class */
+                               Add,          /* Name of function in C++ (must match Python name) */
                                other_val);
     }
 };
 
-int AddInCppRawPtr(const Abase *obj, int other_val) { return obj->Add(other_val) * 10 + 7; }
+template <>
+struct AbaseAlias<1> : Abase<1>, py::detail::virtual_overrider_self_life_support {
+    using Abase<1>::Abase;
 
-int AddInCppSharedPtr(std::shared_ptr<Abase> obj, int other_val) {
+    int Add(int other_val) const override {
+        PYBIND11_OVERRIDE_PURE(int,      /* Return type */
+                               Abase<1>, /* Parent class */
+                               Add,      /* Name of function in C++ (must match Python name) */
+                               other_val);
+    }
+};
+
+template <int SerNo>
+int AddInCppRawPtr(const Abase<SerNo> *obj, int other_val) {
+    return obj->Add(other_val) * 10 + 7;
+}
+
+template <int SerNo>
+int AddInCppSharedPtr(std::shared_ptr<Abase<SerNo>> obj, int other_val) {
     return obj->Add(other_val) * 100 + 11;
 }
 
-int AddInCppUniquePtr(std::unique_ptr<Abase> obj, int other_val) {
+template <int SerNo>
+int AddInCppUniquePtr(std::unique_ptr<Abase<SerNo>> obj, int other_val) {
     return obj->Add(other_val) * 100 + 13;
+}
+
+template <int SerNo>
+void wrap(py::module_ m, const char *py_class_name) {
+    py::classh<Abase<SerNo>, AbaseAlias<SerNo>>(m, py_class_name)
+        .def(py::init<int>(), py::arg("val"))
+        .def("Get", &Abase<SerNo>::Get)
+        .def("Add", &Abase<SerNo>::Add, py::arg("other_val"));
+
+    m.def("AddInCppRawPtr", AddInCppRawPtr<SerNo>, py::arg("obj"), py::arg("other_val"));
+    m.def("AddInCppSharedPtr", AddInCppSharedPtr<SerNo>, py::arg("obj"), py::arg("other_val"));
+    m.def("AddInCppUniquePtr", AddInCppUniquePtr<SerNo>, py::arg("obj"), py::arg("other_val"));
 }
 
 } // namespace test_class_sh_with_alias
 } // namespace pybind11_tests
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_with_alias::Abase)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_with_alias::Abase<0>)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_with_alias::Abase<1>)
 
 TEST_SUBMODULE(class_sh_with_alias, m) {
     using namespace pybind11_tests::test_class_sh_with_alias;
-
-    py::classh<Abase, AbaseAlias>(m, "Abase")
-        .def(py::init<int>(), py::arg("val"))
-        .def("Get", &Abase::Get)
-        .def("Add", &Abase::Add, py::arg("other_val"));
-
-    m.def("AddInCppRawPtr", AddInCppRawPtr, py::arg("obj"), py::arg("other_val"));
-    m.def("AddInCppSharedPtr", AddInCppSharedPtr, py::arg("obj"), py::arg("other_val"));
-    m.def("AddInCppUniquePtr", AddInCppUniquePtr, py::arg("obj"), py::arg("other_val"));
+    wrap<0>(m, "Abase0");
+    wrap<1>(m, "Abase1");
 }

--- a/tests/test_class_sh_with_alias.cpp
+++ b/tests/test_class_sh_with_alias.cpp
@@ -21,7 +21,7 @@ struct Abase {
     Abase &operator=(Abase &&) = default;
 };
 
-struct AbaseAlias : Abase {
+struct AbaseAlias : Abase, py::detail::virtual_overrider_self_life_support {
     using Abase::Abase;
 
     int Add(int other_val) const override {

--- a/tests/test_class_sh_with_alias.py
+++ b/tests/test_class_sh_with_alias.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import pytest
 
 from pybind11_tests import class_sh_with_alias as m
 
@@ -23,15 +22,14 @@ def test_add_in_cpp_raw_ptr():
 
 
 def test_add_in_cpp_shared_ptr():
-    drvd = PyDrvd(36)
-    assert m.AddInCppSharedPtr(drvd, 56) == ((36 * 10 + 3) * 100 + 56) * 100 + 11
+    while True:
+        drvd = PyDrvd(36)
+        assert m.AddInCppSharedPtr(drvd, 56) == ((36 * 10 + 3) * 100 + 56) * 100 + 11
+        return  # Comment out for manual leak checking (use `top` command).
 
 
 def test_add_in_cpp_unique_ptr():
-    drvd = PyDrvd(0)
-    with pytest.raises(ValueError) as exc_info:
-        m.AddInCppUniquePtr(drvd, 0)
-    assert (
-        str(exc_info.value)
-        == "Ownership of instance with virtual overrides in Python cannot be transferred to C++."
-    )
+    while True:
+        drvd = PyDrvd(25)
+        assert m.AddInCppUniquePtr(drvd, 83) == ((25 * 10 + 3) * 100 + 83) * 100 + 13
+        return  # Comment out for manual leak checking (use `top` command).

--- a/tests/test_class_sh_with_alias.py
+++ b/tests/test_class_sh_with_alias.py
@@ -1,35 +1,57 @@
 # -*- coding: utf-8 -*-
+import pytest
 
 from pybind11_tests import class_sh_with_alias as m
 
 
-class PyDrvd(m.Abase):
+class PyDrvd0(m.Abase0):
     def __init__(self, val):
-        super(PyDrvd, self).__init__(val)
+        super(PyDrvd0, self).__init__(val)
 
     def Add(self, other_val):  # noqa:  N802
         return self.Get() * 100 + other_val
 
 
-def test_drvd_add():
-    drvd = PyDrvd(74)
+class PyDrvd1(m.Abase1):
+    def __init__(self, val):
+        super(PyDrvd1, self).__init__(val)
+
+    def Add(self, other_val):  # noqa:  N802
+        return self.Get() * 200 + other_val
+
+
+def test_drvd0_add():
+    drvd = PyDrvd0(74)
     assert drvd.Add(38) == (74 * 10 + 3) * 100 + 38
 
 
-def test_add_in_cpp_raw_ptr():
-    drvd = PyDrvd(52)
+def test_drvd0_add_in_cpp_raw_ptr():
+    drvd = PyDrvd0(52)
     assert m.AddInCppRawPtr(drvd, 27) == ((52 * 10 + 3) * 100 + 27) * 10 + 7
 
 
-def test_add_in_cpp_shared_ptr():
+def test_drvd0_add_in_cpp_shared_ptr():
     while True:
-        drvd = PyDrvd(36)
+        drvd = PyDrvd0(36)
         assert m.AddInCppSharedPtr(drvd, 56) == ((36 * 10 + 3) * 100 + 56) * 100 + 11
         return  # Comment out for manual leak checking (use `top` command).
 
 
-def test_add_in_cpp_unique_ptr():
+def test_drvd0_add_in_cpp_unique_ptr():
     while True:
-        drvd = PyDrvd(25)
-        assert m.AddInCppUniquePtr(drvd, 83) == ((25 * 10 + 3) * 100 + 83) * 100 + 13
+        drvd = PyDrvd0(0)
+        with pytest.raises(ValueError) as exc_info:
+            m.AddInCppUniquePtr(drvd, 0)
+        assert (
+            str(exc_info.value)
+            == "Ownership of instance with virtual overrides in Python"
+            " cannot be transferred to C++."
+        )
+        return  # Comment out for manual leak checking (use `top` command).
+
+
+def test_drvd1_add_in_cpp_unique_ptr():
+    while True:
+        drvd = PyDrvd1(25)
+        assert m.AddInCppUniquePtr(drvd, 83) == ((25 * 10 + 3) * 200 + 83) * 100 + 13
         return  # Comment out for manual leak checking (use `top` command).


### PR DESCRIPTION
Enables safely passing `unique_ptr` from Python to C++, even for trampolines.

A disowned trampoline Python object is kept it alive until the  `unique_ptr` pointee is destroyed. The critical small trick needed was found in PyCLIF (probably invented by @mrovner):

https://github.com/google/clif/commit/acacae6728810dd67df57157c337963297a2e1eb

The critical part of the trick is: the `Py_INCREF` is triggered only when the trampoline Python object is in the process of being disowned.

This PR goes beyond PyCLIF, in that the disowned Python object still maintains a pointer that is only reset and deregistered when the `unique_ptr` pointee is deleted, which means methods of the pointee can still be safely accessed from Python. This could be viewed as "lazy disowning".