### PR TITLE
Raise codec errors when casting to std::string

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -973,7 +973,7 @@ public:
         if (PyUnicode_Check(m_ptr)) {
             temp = reinterpret_steal<object>(PyUnicode_AsUTF8String(m_ptr));
             if (!temp)
-                pybind11_fail("Unable to extract string contents! (encoding issue)");
+                throw error_already_set();
         }
         char *buffer;
         ssize_t length;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -81,6 +81,9 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("str_from_object", [](const py::object& obj) { return py::str(obj); });
     m.def("repr_from_object", [](const py::object& obj) { return py::repr(obj); });
     m.def("str_from_handle", [](py::handle h) { return py::str(h); });
+    m.def("str_from_string_from_str", [](const py::str& obj) {
+        return py::str(static_cast<std::string>(obj));
+    });
 
     m.def("str_format", []() {
         auto s1 = "{} + {} = {}"_s.format(1, 2, 3);

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -134,9 +134,9 @@ def test_str(doc):
         assert m.str_from_handle(malformed_utf8) == "b'\\x80'"
 
     assert m.str_from_string_from_str("this is a str") == "this is a str"
-    ucs_surrogates_str = u"\udcc3"
+    ucs_surrogates_str = "\udcc3"
     if env.PY2:
-        assert u"\udcc3" == m.str_from_string_from_str(ucs_surrogates_str)
+        assert "\udcc3" == m.str_from_string_from_str(ucs_surrogates_str)
     else:
         with pytest.raises(UnicodeEncodeError):
             m.str_from_string_from_str(ucs_surrogates_str)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -133,6 +133,14 @@ def test_str(doc):
     else:
         assert m.str_from_handle(malformed_utf8) == "b'\\x80'"
 
+    assert m.str_from_string_from_str("this is a str") == "this is a str"
+    ucs_surrogates_str = "\udcc3"
+    if env.PY2:
+        assert u"\udcc3" == m.str_from_string_from_str(ucs_surrogates_str)
+    else:
+        with pytest.raises(UnicodeEncodeError):
+            m.str_from_string_from_str(ucs_surrogates_str)
+
 
 def test_bytes(doc):
     assert m.bytes_from_string().decode() == "foo"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -134,9 +134,9 @@ def test_str(doc):
         assert m.str_from_handle(malformed_utf8) == "b'\\x80'"
 
     assert m.str_from_string_from_str("this is a str") == "this is a str"
-    ucs_surrogates_str = "\udcc3"
+    ucs_surrogates_str = u"\udcc3"
     if env.PY2:
-        assert "\udcc3" == m.str_from_string_from_str(ucs_surrogates_str)
+        assert u"\udcc3" == m.str_from_string_from_str(ucs_surrogates_str)
     else:
         with pytest.raises(UnicodeEncodeError):
             m.str_from_string_from_str(ucs_surrogates_str)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -134,7 +134,7 @@ def test_str(doc):
         assert m.str_from_handle(malformed_utf8) == "b'\\x80'"
 
     assert m.str_from_string_from_str("this is a str") == "this is a str"
-    ucs_surrogates_str = "\udcc3"
+    ucs_surrogates_str = u"\udcc3"
     if env.PY2:
         assert u"\udcc3" == m.str_from_string_from_str(ucs_surrogates_str)
     else:


### PR DESCRIPTION
## Description

This allows [the codec's exception](https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF8String) to be raised instead of `RuntimeError` when casting from `py::str` to `std::string`. I ran into this when porting a CPython extention to pybind11 with an existing test that expected a `UnicodeEncodeError` when given a string with [UCS surrogate characters](https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Surrogates).

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Allow the codec's exception to be raised instead of :code:`RuntimeError` when casting from :code:`py::str` to :code:`std::string`.
```

<!-- If the upgrade guide needs updating, note that here too -->
