### PR TITLE
Missing cast from const unique_ptr&

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -716,6 +716,15 @@ struct smart_holder_type_caster<std::unique_ptr<T, D>> : smart_holder_type_caste
 
         return inst.release();
     }
+    static handle cast(const std::unique_ptr<T, D> &src, return_value_policy policy, handle parent) {
+        if (!src)
+            return none().release();
+        if (policy == return_value_policy::automatic)
+            policy = return_value_policy::reference_internal;
+        if (policy != return_value_policy::reference_internal)
+            throw cast_error("Invalid return_value_policy for unique_ptr&");
+        return smart_holder_type_caster<T>::cast(src.get(), policy, parent);
+    }
 
     template <typename>
     using cast_op_type = std::unique_ptr<T, D>;


### PR DESCRIPTION
The issue mentioned in #2901 (the compiler complaining about impossible casting from `const unique_ptr&` to `unique_ptr&&`) originates from a missing cast implementation. I added a dummy implementation (69769a9) and the compiler errors are gone.

IMO, casting from a `const unique_ptr&` should distinguish the following two cases:
1. If the instance is already registered, it should be returned with an increased refcount.
2. Otherwise, a new instance should be created (which holder?), which must not be deleted or moved. Is that possible at all?