### PR TITLE
Adding clang-format to pre-commit checks.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -180,9 +180,13 @@ pre-commit install
 
 As of v2.6.2, pybind11 ships with a [`clang-format`][clang-format]
 configuration file at the top level of the repo (the filename is
-`.clang-format`). Currently, formatting is NOT applied automatically, but
-manually using `clang-format` for newly developed files is highly encouraged.
-To check if a file needs formatting:
+`.clang-format`). Formatting is checked automatically as part of
+`pre-commit run`, but many source files were grandfathered in by adding
+`// clang-format off` at the top. Please consider `clang-format`ing these
+files before starting with major changes, ideally in a separate commit, or even
+a separate PR, to keep development changes separate from `clang-format` cleanup.
+
+To quickly check if a certain file needs formatting:
 
 ```bash
 clang-format -style=file --dry-run some.cpp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,3 +98,15 @@ repos:
     types:
     - c++
     entry: ./tools/check-style.sh
+
+- repo: local
+  hooks:
+  - id: docker-clang-format
+    name: Docker Clang Format
+    language: docker_image
+    types:
+    - c++
+    entry: unibeautify/clang-format:latest
+    args:
+    - -style=file
+    - -i

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,12 @@
 #
 # See https://github.com/pre-commit/pre-commit
 
+# If we enable pre-commit.ci, this will be useful:
+ci:
+  skip:
+  - docker-clang-format
+  # check-style maybe too?
+
 repos:
 # Standard hooks
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/attr.h: Infrastructure for processing custom
     type and function attributes

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/buffer_info.h: Python buffer object interface
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/cast.h: Partial template specializations to cast between
     C++ and Python types

--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/chrono.h: Transparent conversion between std::chrono and python's datetime
 

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -1,2 +1,6 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 #include "detail/common.h"
 #warning "Including 'common.h' is deprecated. It will be removed in v3.0. Use 'pybind11.h'."

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/complex.h: Complex number support
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/detail/class.h: Python C API implementation details for py::class_
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/detail/common.h -- Basic macros
 

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/detail/descr.h: Helper type for concatenating type signatures at compile time
 

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/detail/init.h: init factory function implementation and support code.
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/detail/internals.h: Internal data structure and related functions
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/detail/type_caster_base.h (originally first part of pybind11/cast.h)
 

--- a/include/pybind11/detail/typeid.h
+++ b/include/pybind11/detail/typeid.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/detail/typeid.h: Compiler-independent access to type identifiers
 

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/eigen.h: Transparent conversion for dense and sparse Eigen matrices
 

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/embed.h: Support for embedding the interpreter
 

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/exec.h: Support for evaluating Python expressions and statements
     from strings and files

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/functional.h: std::function<> support
 

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/gil.h: RAII helpers for managing the GIL
 

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/iostream.h -- Tools to assist with redirecting cout and cerr to Python
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/numpy.h: Basic NumPy support, vectorize() wrapper
 

--- a/include/pybind11/operators.h
+++ b/include/pybind11/operators.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/operator.h: Metatemplates for operator overloading
 

--- a/include/pybind11/options.h
+++ b/include/pybind11/options.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/options.h: global settings that are configurable at runtime.
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/pybind11.h: Main header file of the C++11 python
     binding generator library

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/pytypes.h: Convenience wrapper classes for basic Python types
 

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/stl.h: Transparent conversion for STL data types
 

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     pybind11/std_bind.h: Binding generators for STL data types
 

--- a/tests/constructor_stats.h
+++ b/tests/constructor_stats.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 #pragma once
 /*
     tests/constructor_stats.h -- framework for printing and tracking object

--- a/tests/cross_module_gil_utils.cpp
+++ b/tests/cross_module_gil_utils.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/cross_module_gil_utils.cpp -- tools for acquiring GIL from a different module
 

--- a/tests/local_bindings.h
+++ b/tests/local_bindings.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 #pragma once
 #include "pybind11_tests.h"
 

--- a/tests/object.h
+++ b/tests/object.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 #if !defined(__OBJECT_H)
 #define __OBJECT_H
 

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/pybind11_cross_module_tests.cpp -- contains tests that require multiple modules
 

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/pybind11_tests.cpp -- pybind example plugin
 

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 #pragma once
 #include <pybind11/pybind11.h>
 #include <pybind11/eval.h>

--- a/tests/test_async.cpp
+++ b/tests/test_async.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_async.cpp -- __await__ support
 

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_buffers.cpp -- supporting Pythons' buffer protocol
 

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_builtin_casters.cpp -- Casters available without any additional headers
 

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_call_policies.cpp -- keep_alive and call_guard
 

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_callbacks.cpp -- callbacks
 

--- a/tests/test_chrono.cpp
+++ b/tests/test_chrono.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_chrono.cpp -- test conversions to/from std::chrono types
 

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_class.cpp -- test py::class_ definitions and basic functionality
 

--- a/tests/test_cmake_build/embed.cpp
+++ b/tests/test_cmake_build/embed.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 #include <pybind11/embed.h>
 namespace py = pybind11;
 

--- a/tests/test_cmake_build/main.cpp
+++ b/tests/test_cmake_build/main.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
 

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_constants_and_functions.cpp -- global constants and functions, enumerations, raw byte strings
 

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_copy_move_policies.cpp -- 'copy' and 'move' return value policies
                                          and related tests

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_custom_type_casters.cpp -- tests type_caster<T>
 

--- a/tests/test_docstring_options.cpp
+++ b/tests/test_docstring_options.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_docstring_options.cpp -- generation of docstrings and signatures
 

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/eigen.cpp -- automatic conversion of Eigen types
 

--- a/tests/test_embed/catch.cpp
+++ b/tests/test_embed/catch.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 // The Catch implementation is compiled here. This is a standalone
 // translation unit to avoid recompiling it for every test change.
 

--- a/tests/test_embed/external_module.cpp
+++ b/tests/test_embed/external_module.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 #include <pybind11/embed.h>
 
 #ifdef _MSC_VER

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_enums.cpp -- enumerations
 

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_eval.cpp -- Usage of eval() and eval_file()
 

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_custom-exceptions.cpp -- exception translation
 

--- a/tests/test_factory_constructors.cpp
+++ b/tests/test_factory_constructors.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_factory_constructors.cpp -- tests construction from a factory function
                                            via py::init_factory()

--- a/tests/test_gil_scoped.cpp
+++ b/tests/test_gil_scoped.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_gil_scoped.cpp -- acquire and release gil
 

--- a/tests/test_iostream.cpp
+++ b/tests/test_iostream.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_iostream.cpp -- Usage of scoped_output_redirect
 

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_kwargs_and_defaults.cpp -- keyword arguments and default values
 

--- a/tests/test_local_bindings.cpp
+++ b/tests/test_local_bindings.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_local_bindings.cpp -- tests the py::module_local class feature which makes a class
                                      binding local to the module in which it is defined.

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_methods_and_attributes.cpp -- constructors, deconstructors, attribute access,
     __str__, argument and return value conventions

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_modules.cpp -- nested modules, importing modules, and
                             internal references

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_multiple_inheritance.cpp -- multiple inheritance,
     implicit MI casts

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_numpy_array.cpp -- test core array functionality
 

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
   tests/test_numpy_dtypes.cpp -- Structured and compound NumPy dtypes
 

--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_numpy_vectorize.cpp -- auto-vectorize functions over NumPy array
     arguments

--- a/tests/test_opaque_types.cpp
+++ b/tests/test_opaque_types.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_opaque_types.cpp -- opaque types, passing void pointers
 

--- a/tests/test_operator_overloading.cpp
+++ b/tests/test_operator_overloading.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_operator_overloading.cpp -- operator overloading
 

--- a/tests/test_pickling.cpp
+++ b/tests/test_pickling.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_pickling.cpp -- pickle support
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_pytypes.cpp -- Python type casters
 

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_sequences_and_iterators.cpp -- supporting Pythons' sequence protocol, iterators,
     etc.

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_smart_ptr.cpp -- binding classes with custom reference counting,
     implicit conversions between types

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_stl.cpp -- STL type casters
 

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_stl_binders.cpp -- Usage of stl_binders functions
 

--- a/tests/test_tagbased_polymorphic.cpp
+++ b/tests/test_tagbased_polymorphic.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_tagbased_polymorphic.cpp -- test of polymorphic_type_hook
 

--- a/tests/test_union.cpp
+++ b/tests/test_union.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_class.cpp -- test py::class_ definitions and basic functionality
 

--- a/tests/test_virtual_functions.cpp
+++ b/tests/test_virtual_functions.cpp
@@ -1,3 +1,7 @@
+// clang-format off
+// Please consider `clang-format`ting this file before starting with significant
+// changes, ideally in a separate commit. See also: .github/CONTRIBUTING.md
+
 /*
     tests/test_virtual_functions.cpp -- overriding virtual functions from Python
 


### PR DESCRIPTION
Adding `clang-format-lint` to Format workflow, and updating clang-format section in .github/CONTRIBUTING.md.

This PR has two commits, PLEASE DO NOT SQUASH when merging.

The first commit was generated automatically to systematically insert `//clang-format off` in all 75 files that currently generate clang-format errors. Please review only one file. Requests for changes will be systematically reapplied.

The second commit is for manual changes to .pre-commit-config.yaml and .github/CONTRIBUTING.md.

