### PR TITLE
Fix argument passing from trampoline methods

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -434,7 +434,11 @@ enum class return_value_policy : uint8_t {
         collected while Python is still using the child. More advanced
         variations of this scheme are also possible using combinations of
         return_value_policy::reference and the keep_alive call policy */
-    reference_internal
+    reference_internal,
+
+    /*  This internally-only used policy applies to C++ arguments passed
+        to virtual methods overridden in Python to allow reference passing. */
+    automatic_override
 };
 
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -731,6 +731,9 @@ struct smart_holder_type_caster<std::unique_ptr<T, D>> : smart_holder_type_caste
     template <typename>
     using cast_op_type = std::unique_ptr<T, D>;
 
+    // TODO: This always returns a new, moving unique_ptr instance to the raw pointer,
+    // even if argument should be passed as reference.
+    // See test_class_sh_basic.py::test_unique_ptr_cref_roundtrip
     operator std::unique_ptr<T, D>() { return this->template loaded_as_unique_ptr<D>(); }
 };
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -899,6 +899,8 @@ public:
     }
 
     static handle cast(const itype *src, return_value_policy policy, handle parent) {
+        if (policy == return_value_policy::automatic_override)
+            policy = return_value_policy::reference;
         auto st = src_and_type(src);
         return type_caster_generic::cast(
             st.first, policy, parent, st.second,

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -105,9 +105,9 @@ public:
         function will throw a `cast_error` exception. When the Python function
         call fails, a `error_already_set` exception is thrown.
     \endrst */
-    template <return_value_policy policy = return_value_policy::automatic_reference, typename... Args>
+    template <return_value_policy policy = return_value_policy::automatic_override, typename... Args>
     object operator()(Args &&...args) const;
-    template <return_value_policy policy = return_value_policy::automatic_reference, typename... Args>
+    template <return_value_policy policy = return_value_policy::automatic_override, typename... Args>
     PYBIND11_DEPRECATED("call(...) was deprecated in favor of operator()(...)")
         object call(Args&&... args) const;
 

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -17,7 +17,7 @@ struct atyp { // Short for "any type".
     atyp(atyp &&other) { mtxt = other.mtxt + "_MvCtor"; }
 };
 
-struct uconsumer { // unique_ptr consumer
+struct consumer { // unique_ptr consumer
     std::unique_ptr<atyp> held;
     bool valid() const { return static_cast<bool>(held); }
 
@@ -90,7 +90,7 @@ struct SharedPtrStash {
 } // namespace pybind11_tests
 
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_basic::atyp)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_basic::uconsumer)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_basic::consumer)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_basic::SharedPtrStash)
 
 namespace pybind11_tests {
@@ -136,19 +136,19 @@ TEST_SUBMODULE(class_sh_basic, m) {
     m.def("pass_udmp", pass_udmp);
     m.def("pass_udcp", pass_udcp);
 
-    py::classh<uconsumer>(m, "uconsumer")
+    py::classh<consumer>(m, "consumer")
         .def(py::init<>())
-        .def("valid", &uconsumer::valid)
-        .def("pass_uq_valu", &uconsumer::pass_uq_valu)
-        .def("pass_uq_rref", &uconsumer::pass_uq_rref)
-        .def("pass_uq_cref", &uconsumer::pass_uq_cref)
-        .def("pass_cptr", &uconsumer::pass_cptr)
-        .def("pass_cref", &uconsumer::pass_cref)
-        .def("rtrn_uq_valu", &uconsumer::rtrn_uq_valu)
-        .def("rtrn_uq_lref", &uconsumer::rtrn_uq_lref)
-        .def("rtrn_uq_cref", &uconsumer::rtrn_uq_cref)
-        .def("rtrn_cptr", &uconsumer::rtrn_cptr, py::return_value_policy::reference_internal)
-        .def("rtrn_cref", &uconsumer::rtrn_cref, py::return_value_policy::reference_internal);
+        .def("valid", &consumer::valid)
+        .def("pass_uq_valu", &consumer::pass_uq_valu)
+        .def("pass_uq_rref", &consumer::pass_uq_rref)
+        .def("pass_uq_cref", &consumer::pass_uq_cref)
+        .def("pass_cptr", &consumer::pass_cptr)
+        .def("pass_cref", &consumer::pass_cref)
+        .def("rtrn_uq_valu", &consumer::rtrn_uq_valu)
+        .def("rtrn_uq_lref", &consumer::rtrn_uq_lref)
+        .def("rtrn_uq_cref", &consumer::rtrn_uq_cref)
+        .def("rtrn_cptr", &consumer::rtrn_cptr, py::return_value_policy::reference_internal)
+        .def("rtrn_cref", &consumer::rtrn_cref, py::return_value_policy::reference_internal);
 
         // Helpers for testing.
         // These require selected functions above to work first, as indicated:

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -102,7 +102,7 @@ TEST_SUBMODULE(class_sh_basic, m) {
     m.def("rtrn_valu", rtrn_valu);
     m.def("rtrn_rref", rtrn_rref);
     m.def("rtrn_cref", rtrn_cref);
-    m.def("rtrn_mref", rtrn_mref);
+    m.def("rtrn_mref", rtrn_mref, py::return_value_policy::reference);
     m.def("rtrn_cptr", rtrn_cptr);
     m.def("rtrn_mptr", rtrn_mptr);
 

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -121,14 +121,14 @@ def test_unique_ptr_roundtrip(num_round_trips=1000):
 @pytest.mark.parametrize(
     "pass_f, rtrn_f, moved_out, moved_in",
     [
-        (m.uconsumer.pass_uq_valu, m.uconsumer.rtrn_uq_valu, True, True),
-        (m.uconsumer.pass_uq_rref, m.uconsumer.rtrn_uq_valu, True, True),
-        (m.uconsumer.pass_uq_valu, m.uconsumer.rtrn_uq_lref, True, False),
-        (m.uconsumer.pass_uq_valu, m.uconsumer.rtrn_uq_cref, True, False),
+        (m.consumer.pass_uq_valu, m.consumer.rtrn_uq_valu, True, True),
+        (m.consumer.pass_uq_rref, m.consumer.rtrn_uq_valu, True, True),
+        (m.consumer.pass_uq_valu, m.consumer.rtrn_uq_lref, True, False),
+        (m.consumer.pass_uq_valu, m.consumer.rtrn_uq_cref, True, False),
     ],
 )
 def test_unique_ptr_consumer_roundtrip(pass_f, rtrn_f, moved_out, moved_in):
-    c = m.uconsumer()
+    c = m.consumer()
     recycled = m.atyp("passenger")
     mtxt_orig = m.get_mtxt(recycled)
     ptr_orig = m.get_ptr(recycled)
@@ -148,7 +148,7 @@ def test_unique_ptr_consumer_roundtrip(pass_f, rtrn_f, moved_out, moved_in):
 
 @pytest.mark.parametrize(
     "rtrn_f",
-    [m.uconsumer.rtrn_uq_cref, m.uconsumer.rtrn_cref, m.uconsumer.rtrn_cptr],
+    [m.consumer.rtrn_uq_cref, m.consumer.rtrn_cref, m.consumer.rtrn_cptr],
 )
 @pytest.mark.parametrize(
     "pass_f",
@@ -160,13 +160,13 @@ def test_unique_ptr_consumer_roundtrip(pass_f, rtrn_f, moved_out, moved_in):
         # and is thus (correctly) suppressed.
         # To fix this, smart_holder would need to store the (original) unique_ptr reference,
         # e.g. using a union of unique_ptr + shared_ptr.
-        pytest.param(m.uconsumer.pass_uq_cref, marks=pytest.mark.xfail),
-        m.uconsumer.pass_cptr,
-        m.uconsumer.pass_cref,
+        pytest.param(m.consumer.pass_uq_cref, marks=pytest.mark.xfail),
+        m.consumer.pass_cptr,
+        m.consumer.pass_cref,
     ],
 )
 def test_unique_ptr_cref_consumer_roundtrip(rtrn_f, pass_f):
-    c = m.uconsumer()
+    c = m.consumer()
     passenger = m.atyp("passenger")
     mtxt_orig = m.get_mtxt(passenger)
     ptr_orig = m.get_ptr(passenger)

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -22,7 +22,7 @@ def test_atyp_constructors():
         (m.rtrn_valu, "rtrn_valu(_MvCtor)*_MvCtor"),
         (m.rtrn_rref, "rtrn_rref(_MvCtor)*_MvCtor"),
         (m.rtrn_cref, "rtrn_cref(_MvCtor)*_CpCtor"),
-        (m.rtrn_mref, "rtrn_mref(_MvCtor)*_CpCtor"),
+        (m.rtrn_mref, "rtrn_mref"),
         (m.rtrn_cptr, "rtrn_cptr"),
         (m.rtrn_mptr, "rtrn_mptr"),
         (m.rtrn_shmp, "rtrn_shmp"),

--- a/tests/test_class_sh_with_alias.cpp
+++ b/tests/test_class_sh_with_alias.cpp
@@ -2,6 +2,7 @@
 
 #include <pybind11/smart_holder.h>
 
+#include <cstdint>
 #include <memory>
 
 namespace pybind11_tests {
@@ -73,14 +74,92 @@ void wrap(py::module_ m, const char *py_class_name) {
     m.def("AddInCppUniquePtr", AddInCppUniquePtr<SerNo>, py::arg("obj"), py::arg("other_val"));
 }
 
+struct Passenger {
+    std::string mtxt;
+    // on construction: store pointer as an id
+    Passenger() : mtxt(id() + "_") {}
+    Passenger(const Passenger &other) { mtxt = other.mtxt + "Copy->" + id(); }
+    Passenger(Passenger &&other) { mtxt = other.mtxt + "Move->" + id(); }
+    std::string id() const { return std::to_string(reinterpret_cast<uintptr_t>(this)); }
+};
+struct ConsumerBase {
+    ConsumerBase()                     = default;
+    ConsumerBase(const ConsumerBase &) = default;
+    ConsumerBase(ConsumerBase &&)      = default;
+    virtual ~ConsumerBase()            = default;
+    virtual void pass_uq_cref(const std::unique_ptr<Passenger> &obj) { modify(*obj); };
+    virtual void pass_valu(Passenger obj) { modify(obj); };
+    virtual void pass_lref(Passenger &obj) { modify(obj); };
+    virtual void pass_cref(const Passenger &obj) { modify(const_cast<Passenger &>(obj)); };
+    void modify(Passenger &obj) {
+        // when base virtual method is called: append obj pointer again (should be same as before)
+        obj.mtxt.append("_");
+        obj.mtxt.append(std::to_string(reinterpret_cast<uintptr_t>(&obj)));
+    }
+};
+struct ConsumerBaseAlias : ConsumerBase {
+    using ConsumerBase::ConsumerBase;
+    void pass_uq_cref(const std::unique_ptr<Passenger> &obj) override {
+        PYBIND11_OVERRIDE(void, ConsumerBase, pass_uq_cref, obj);
+    }
+    void pass_valu(Passenger obj) override {
+        PYBIND11_OVERRIDE(void, ConsumerBase, pass_valu, obj);
+    }
+    void pass_lref(Passenger &obj) override {
+        PYBIND11_OVERRIDE(void, ConsumerBase, pass_lref, obj);
+    }
+    void pass_cref(const Passenger &obj) override {
+        PYBIND11_OVERRIDE(void, ConsumerBase, pass_cref, obj);
+    }
+};
+
+// check roundtrip of Passenger send to ConsumerBaseAlias
+// TODO: Find template magic to avoid code duplication
+std::string check_roundtrip_uq_cref(ConsumerBase &consumer) {
+    std::unique_ptr<Passenger> obj(new Passenger());
+    consumer.pass_uq_cref(obj);
+    return obj->mtxt;
+}
+std::string check_roundtrip_valu(ConsumerBase &consumer) {
+    Passenger obj;
+    consumer.pass_valu(obj);
+    return obj.mtxt;
+}
+std::string check_roundtrip_lref(ConsumerBase &consumer) {
+    Passenger obj;
+    consumer.pass_lref(obj);
+    return obj.mtxt;
+}
+std::string check_roundtrip_cref(ConsumerBase &consumer) {
+    Passenger obj;
+    consumer.pass_cref(obj);
+    return obj.mtxt;
+}
+
 } // namespace test_class_sh_with_alias
 } // namespace pybind11_tests
 
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_with_alias::Abase<0>)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_with_alias::Abase<1>)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_with_alias::Passenger)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_with_alias::ConsumerBase)
 
 TEST_SUBMODULE(class_sh_with_alias, m) {
     using namespace pybind11_tests::test_class_sh_with_alias;
     wrap<0>(m, "Abase0");
     wrap<1>(m, "Abase1");
+
+    py::classh<Passenger>(m, "Passenger").def_readwrite("mtxt", &Passenger::mtxt);
+
+    py::classh<ConsumerBase, ConsumerBaseAlias>(m, "ConsumerBase")
+        .def(py::init<>())
+        .def("pass_uq_cref", &ConsumerBase::pass_uq_cref)
+        .def("pass_valu", &ConsumerBase::pass_valu)
+        .def("pass_lref", &ConsumerBase::pass_lref)
+        .def("pass_cref", &ConsumerBase::pass_cref);
+
+    m.def("check_roundtrip_uq_cref", check_roundtrip_uq_cref);
+    m.def("check_roundtrip_valu", check_roundtrip_valu);
+    m.def("check_roundtrip_lref", check_roundtrip_lref);
+    m.def("check_roundtrip_cref", check_roundtrip_cref);
 }


### PR DESCRIPTION
This adds some more `smart_holder` tests that mimic some of my (currently failing) application use cases. 
Particularly, they consider _roundtrip_ situations where an object is passed around as a reference: 
- Python -> C++ -> Python
- C++ -> Python -> C++

The single failing test in [`test_unique_ptr_cref_consumer_roundtrip`](https://github.com/rhaschke/pybind11/blob/315625340a9dfcf25363faf1b4cac48dfc7222e5/tests/test_class_sh_basic.py#L165-L173) and [`test_unique_ptr_cref_roundtrip`](https://github.com/rhaschke/pybind11/blob/315625340a9dfcf25363faf1b4cac48dfc7222e5/tests/test_class_sh_basic.py#L184-L185) aren't important. I added them just for completeness. However, [`test_unique_ptr_consumer_roundtrip`](https://github.com/rhaschke/pybind11/blob/bbe45d15bfd1e2446a1f6efcf7be28982c0476e6/tests/test_class_sh_with_alias.py#L86-L88) is. For this latter test, I didn't look into the reason yet. Will continue tomorrow...