### PR TITLE
Adding tests to exercise corner cases involving disowning.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,7 @@ set(PYBIND11_TEST_FILES
     test_chrono.cpp
     test_class.cpp
     test_class_sh_basic.cpp
+    test_class_sh_disowning.cpp
     test_class_sh_factory_constructors.cpp
     test_class_sh_inheritance.cpp
     test_class_sh_trampoline_shared_ptr_cpp_arg.cpp

--- a/tests/test_class_sh_disowning.cpp
+++ b/tests/test_class_sh_disowning.cpp
@@ -41,6 +41,6 @@ TEST_SUBMODULE(class_sh_disowning, m) {
 
     m.def("mixed", mixed);
 
-    m.def("overloaded", py::overload_cast<std::unique_ptr<Atype<1>>, int>(&overloaded));
-    m.def("overloaded", py::overload_cast<std::unique_ptr<Atype<2>>, int>(&overloaded));
+    m.def("overloaded", (int (*)(std::unique_ptr<Atype<1>>, int)) & overloaded);
+    m.def("overloaded", (int (*)(std::unique_ptr<Atype<2>>, int)) & overloaded);
 }

--- a/tests/test_class_sh_disowning.cpp
+++ b/tests/test_class_sh_disowning.cpp
@@ -1,0 +1,46 @@
+#include "pybind11_tests.h"
+
+#include <pybind11/smart_holder.h>
+
+#include <memory>
+
+namespace pybind11_tests {
+namespace class_sh_disowning {
+
+template <int SerNo> // Using int as a trick to easily generate a series of types.
+struct Atype {
+    int val = 0;
+    Atype(int val_) : val{val_} {}
+    int get() const { return val * 10 + SerNo; }
+};
+
+int same_twice(std::unique_ptr<Atype<1>> at1a, std::unique_ptr<Atype<1>> at1b) {
+    return at1a->get() * 100 + at1b->get() * 10;
+}
+
+int mixed(std::unique_ptr<Atype<1>> at1, std::unique_ptr<Atype<2>> at2) {
+    return at1->get() * 200 + at2->get() * 20;
+}
+
+int overloaded(std::unique_ptr<Atype<1>> at1, int i) { return at1->get() * 30 + i; }
+int overloaded(std::unique_ptr<Atype<2>> at2, int i) { return at2->get() * 40 + i; }
+
+} // namespace class_sh_disowning
+} // namespace pybind11_tests
+
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_disowning::Atype<1>)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_disowning::Atype<2>)
+
+TEST_SUBMODULE(class_sh_disowning, m) {
+    using namespace pybind11_tests::class_sh_disowning;
+
+    py::classh<Atype<1>>(m, "Atype1").def(py::init<int>()).def("get", &Atype<1>::get);
+    py::classh<Atype<2>>(m, "Atype2").def(py::init<int>()).def("get", &Atype<2>::get);
+
+    m.def("same_twice", same_twice);
+
+    m.def("mixed", mixed);
+
+    m.def("overloaded", py::overload_cast<std::unique_ptr<Atype<1>>, int>(&overloaded));
+    m.def("overloaded", py::overload_cast<std::unique_ptr<Atype<2>>, int>(&overloaded));
+}

--- a/tests/test_class_sh_disowning.py
+++ b/tests/test_class_sh_disowning.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from pybind11_tests import class_sh_disowning as m
+
+
+def test_same_twice():
+    while True:
+        obj1a = m.Atype1(57)
+        obj1b = m.Atype1(62)
+        assert m.same_twice(obj1a, obj1b) == (57 * 10 + 1) * 100 + (62 * 10 + 1) * 10
+        obj1c = m.Atype1(0)
+        with pytest.raises(ValueError):
+            m.same_twice(obj1c, obj1c)  # 1st disowning works, 2nd fails.
+        with pytest.raises(ValueError):
+            obj1c.get()
+        return  # Comment out for manual leak checking (use `top` command).
+
+
+def test_mixed():
+    while True:
+        obj1a = m.Atype1(90)
+        obj2a = m.Atype2(25)
+        assert m.mixed(obj1a, obj2a) == (90 * 10 + 1) * 200 + (25 * 10 + 2) * 20
+        obj1b = m.Atype1(0)
+        with pytest.raises(ValueError):
+            m.mixed(obj1b, obj2a)
+        with pytest.raises(ValueError):
+            obj1b.get()  # obj1b was disowned even though m.mixed(obj1b, obj2a) failed.
+        return  # Comment out for manual leak checking (use `top` command).
+
+
+def test_overloaded():
+    while True:
+        obj1 = m.Atype1(81)
+        obj2 = m.Atype2(60)
+        with pytest.raises(TypeError):
+            m.overloaded(obj1, "NotInt")
+        assert obj1.get() == 81 * 10 + 1  # Not disowned.
+        assert m.overloaded(obj1, 3) == (81 * 10 + 1) * 30 + 3
+        with pytest.raises(TypeError):
+            m.overloaded(obj2, "NotInt")
+        assert obj2.get() == 60 * 10 + 2  # Not disowned.
+        assert m.overloaded(obj2, 2) == (60 * 10 + 2) * 40 + 2
+        return  # Comment out for manual leak checking (use `top` command).

--- a/tests/test_class_sh_factory_constructors.cpp
+++ b/tests/test_class_sh_factory_constructors.cpp
@@ -6,7 +6,7 @@
 #include <string>
 
 namespace pybind11_tests {
-namespace test_class_sh_factory_constructors {
+namespace class_sh_factory_constructors {
 
 template <int> // Using int as a trick to easily generate a series of types.
 struct atyp {  // Short for "any type".
@@ -69,25 +69,25 @@ struct with_alias {
 struct with_alias_alias : with_alias {};
 struct sddwaa : std::default_delete<with_alias_alias> {};
 
-} // namespace test_class_sh_factory_constructors
+} // namespace class_sh_factory_constructors
 } // namespace pybind11_tests
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_valu)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_rref)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_cref)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_mref)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_cptr)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_mptr)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_shmp)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_shcp)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_uqmp)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_uqcp)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_udmp)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::atyp_udcp)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_factory_constructors::with_alias)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_valu)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_rref)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_cref)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_mref)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_cptr)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_mptr)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_shmp)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_shcp)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_uqmp)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_uqcp)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_udmp)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::atyp_udcp)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::with_alias)
 
 TEST_SUBMODULE(class_sh_factory_constructors, m) {
-    using namespace pybind11_tests::test_class_sh_factory_constructors;
+    using namespace pybind11_tests::class_sh_factory_constructors;
 
     py::classh<atyp_valu>(m, "atyp_valu")
         .def(py::init(&rtrn_valu))

--- a/tests/test_class_sh_virtual_py_cpp_mix.cpp
+++ b/tests/test_class_sh_virtual_py_cpp_mix.cpp
@@ -5,7 +5,7 @@
 #include <memory>
 
 namespace pybind11_tests {
-namespace test_class_sh_virtual_py_cpp_mix {
+namespace class_sh_virtual_py_cpp_mix {
 
 class Base {
 public:
@@ -43,16 +43,15 @@ struct CppDerivedVirtualOverrider : CppDerived, py::virtual_overrider_self_life_
     int get() const override { PYBIND11_OVERRIDE(int, CppDerived, get); }
 };
 
-} // namespace test_class_sh_virtual_py_cpp_mix
+} // namespace class_sh_virtual_py_cpp_mix
 } // namespace pybind11_tests
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_virtual_py_cpp_mix::Base)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(
-    pybind11_tests::test_class_sh_virtual_py_cpp_mix::CppDerivedPlain)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_virtual_py_cpp_mix::CppDerived)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_virtual_py_cpp_mix::Base)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_virtual_py_cpp_mix::CppDerivedPlain)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_virtual_py_cpp_mix::CppDerived)
 
 TEST_SUBMODULE(class_sh_virtual_py_cpp_mix, m) {
-    using namespace pybind11_tests::test_class_sh_virtual_py_cpp_mix;
+    using namespace pybind11_tests::class_sh_virtual_py_cpp_mix;
 
     py::classh<Base, BaseVirtualOverrider>(m, "Base").def(py::init<>()).def("get", &Base::get);
 

--- a/tests/test_class_sh_with_alias.cpp
+++ b/tests/test_class_sh_with_alias.cpp
@@ -5,7 +5,7 @@
 #include <memory>
 
 namespace pybind11_tests {
-namespace test_class_sh_with_alias {
+namespace class_sh_with_alias {
 
 template <int SerNo> // Using int as a trick to easily generate a series of types.
 struct Abase {
@@ -73,14 +73,14 @@ void wrap(py::module_ m, const char *py_class_name) {
     m.def("AddInCppUniquePtr", AddInCppUniquePtr<SerNo>, py::arg("obj"), py::arg("other_val"));
 }
 
-} // namespace test_class_sh_with_alias
+} // namespace class_sh_with_alias
 } // namespace pybind11_tests
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_with_alias::Abase<0>)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::test_class_sh_with_alias::Abase<1>)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_with_alias::Abase<0>)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_with_alias::Abase<1>)
 
 TEST_SUBMODULE(class_sh_with_alias, m) {
-    using namespace pybind11_tests::test_class_sh_with_alias;
+    using namespace pybind11_tests::class_sh_with_alias;
     wrap<0>(m, "Abase0");
     wrap<1>(m, "Abase1");
 }


### PR DESCRIPTION
The most interesting corner case is in test_class_sh_disowning.py `test_mixed`. See comments there. A "maybe later" idea:

* For each overloaded function considered, in the first pass keep track if the call will raise `ValueError` "disowned" for one or more arguments. If this is true for the winning overload, raise a special exception before actually converting any arguments, to make the behavior predictable/portable (no arguments will be disowned).

This PR also fixing minor namespace naming inconsistencies across test_class_sh_*.cpp files.