### PR TITLE
Adding PyGILState_Check() in object_api<>::operator().

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1348,7 +1348,7 @@ unpacking_collector<policy> collect_arguments(Args &&...args) {
 template <typename Derived>
 template <return_value_policy policy, typename... Args>
 object object_api<Derived>::operator()(Args &&...args) const {
-#if defined(NDEBUG) && PY_VERSION_HEX >= 0x03060000
+#if !defined(NDEBUG) && PY_VERSION_HEX >= 0x03060000
     if (!PyGILState_Check()) {
         pybind11_fail("pybind11::object_api<>::operator() PyGILState_Check() failure.");
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1348,7 +1348,7 @@ unpacking_collector<policy> collect_arguments(Args &&...args) {
 template <typename Derived>
 template <return_value_policy policy, typename... Args>
 object object_api<Derived>::operator()(Args &&...args) const {
-#if PY_VERSION_HEX >= 0x03060000
+#if defined(NDEBUG) && PY_VERSION_HEX >= 0x03060000
     if (!PyGILState_Check()) {
         pybind11_fail("pybind11::object_api<>::operator() PyGILState_Check() failure.");
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1348,7 +1348,7 @@ unpacking_collector<policy> collect_arguments(Args &&...args) {
 template <typename Derived>
 template <return_value_policy policy, typename... Args>
 object object_api<Derived>::operator()(Args &&...args) const {
-#if PY_VERSION_HEX >= 0x03040000
+#if PY_VERSION_HEX >= 0x03060000
     if (!PyGILState_Check()) {
         pybind11_fail("pybind11::object_api<>::operator() PyGILState_Check() failure.");
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1348,6 +1348,11 @@ unpacking_collector<policy> collect_arguments(Args &&...args) {
 template <typename Derived>
 template <return_value_policy policy, typename... Args>
 object object_api<Derived>::operator()(Args &&...args) const {
+#if PY_VERSION_HEX >= 0x03040000
+    if (!PyGILState_Check()) {
+        pybind11_fail("pybind11::object_api<>::operator() PyGILState_Check() failure.");
+    }
+#endif
     return detail::collect_arguments<policy>(std::forward<Args>(args)...).call(derived().ptr());
 }
 

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -172,4 +172,10 @@ TEST_SUBMODULE(callbacks, m) {
         for (auto i : work)
             start_f(py::cast<int>(i));
     });
+
+    m.def("callback_num_times", [](py::function f, std::size_t num) {
+        for (std::size_t i = 0; i < num; i++) {
+            f();
+        }
+    });
 }

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -151,6 +151,9 @@ def test_async_async_callbacks():
 
 def test_callback_num_times(capsys):
     # Super-simple micro-benchmarking related to PR #2919.
+    # Example runtimes (Intel Xeon 2.2GHz, fully optimized):
+    #   num_millions  1, repeats  2:  0.1 secs
+    #   num_millions 20, repeats 10: 11.5 secs
     one_million = 1000000
     num_millions = 1  # Try 20 for actual micro-benchmarking.
     repeats = 2  # Try 10.

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -159,9 +159,9 @@ def test_callback_num_times(capsys):
         t0 = time.time()
         m.callback_num_times(lambda: None, num_millions * one_million)
         td = time.time() - t0
+        rate = num_millions / td if td else 0
+        rates.append(rate)
         with capsys.disabled():
-            rate = num_millions / td if td else 0
-            rates.append(rate)
             if not rep:
                 print()
             print(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -152,8 +152,8 @@ def test_async_async_callbacks():
 def test_callback_num_times(capsys):
     # Super-simple micro-benchmarking related to PR #2919.
     one_million = 1000000
-    num_millions = 20  # Try 20 for actual micro-benchmarking.
-    repeats = 10  # Try 10.
+    num_millions = 1  # Try 20 for actual micro-benchmarking.
+    repeats = 2  # Try 10.
     rates = []
     for rep in range(repeats):
         t0 = time.time()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -149,7 +149,7 @@ def test_async_async_callbacks():
     t.join()
 
 
-def test_callback_num_times(capsys):
+def test_callback_num_times():
     # Super-simple micro-benchmarking related to PR #2919.
     # Example runtimes (Intel Xeon 2.2GHz, fully optimized):
     #   num_millions  1, repeats  2:  0.1 secs
@@ -164,16 +164,17 @@ def test_callback_num_times(capsys):
         td = time.time() - t0
         rate = num_millions / td if td else 0
         rates.append(rate)
-        with capsys.disabled():
-            if not rep:
-                print()
-            print(
-                "callback_num_times: %d million / %.3f seconds = %.3f million / second"
-                % (num_millions, td, rate)
+        if not rep:
+            print()
+        print(
+            "callback_num_times: {:d} million / {:.3f} seconds = {:.3f} million / second".format(
+                num_millions, td, rate
             )
+        )
     if len(rates) > 1:
-        with capsys.disabled():
-            print("Min    Mean   Max")
-            print(
-                "%6.3f %6.3f %6.3f" % (min(rates), sum(rates) / len(rates), max(rates))
+        print("Min    Mean   Max")
+        print(
+            "{:6.3f} {:6.3f} {:6.3f}".format(
+                min(rates), sum(rates) / len(rates), max(rates)
             )
+        )


### PR DESCRIPTION
Keywords: callbacks, Python Global Interpreter Lock (GIL)

Problem addressed: GIL not held when C++ calls back into Python. This is a fairly common accident, easily overlooked, and notoriously difficult/time-consuming to diagnose.

This PR adds a safety guard in one strategic location, guarded by `NDEBUG`.

* If `NDEBUG` **is not defined** the guard ensures that the Python GIL is held when C++ calls back into Python via `object_api<>::operator()` (e.g. `py::function` `__call__`). The worst-case runtime overhead (for a callback that returns immediately without doing any work) is ~10%. See detailed timings under https://github.com/pybind/pybind11/pull/2919#issuecomment-812176639. The typical runtime overhead (callback doing work) is probably much smaller. 
* If `NDEBUG` **is defined**, the guard is disabled, there is no protection, and zero runtime overhead.

This PR was tested in the Google internal environment, which lead to the discovery of a few GIL-related issues and their cleanup. (The Google internal testing currently covers a couple hundred pybind11 extensions, including many imported or exported OSS packages.)

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
PR #2919 adds a safety guard to ensure that the Python GIL is held when C++ calls back into Python via `object_api<>::operator()` (e.g. `py::function` `__call__`).
```