### PR TITLE
Fix Pybind11Extension on Mingw64

### DIFF
--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -47,6 +47,7 @@ import tempfile
 import threading
 import platform
 import warnings
+import sysconfig
 
 try:
     from setuptools.command.build_ext import build_ext as _build_ext
@@ -59,7 +60,7 @@ import distutils.errors
 import distutils.ccompiler
 
 
-WIN = sys.platform.startswith("win32")
+WIN = sys.platform.startswith("win32") and sysconfig.get_platform() != "mingw"
 PY2 = sys.version_info[0] < 3
 MACOS = sys.platform.startswith("darwin")
 STD_TMPL = "/std:c++{}" if WIN else "-std=c++{}"


### PR DESCRIPTION
## Description

* `Pybind11Extension` add the `/EHsc /bigobj /std:c++14` flags on Windows.
  This is good for Visual C++ but not for Mingw.
* According
  https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-python2/0410-MINGW-build-extensions-with-GCC.patch
  sysconfig.get_platform() is the way to check for a Mingw64

## Suggested changelog entry:

```rst
-  Fix the default ``Pybind11Extension`` compilation flags with a Mingw64 python
```
