### PR TITLE
env: Add surrogate for pytest.deprecated_call for ptyest<3.9

### DIFF
--- a/tests/env.py
+++ b/tests/env.py
@@ -24,6 +24,7 @@ def deprecated_call():
     This is a narrowed reimplementation of the following PR :(
     https://github.com/pytest-dev/pytest/pull/4104
     """
+    # TODO: Remove this when testing requires pytest>=3.9.
     pieces = pytest.__version__.split(".")
     pytest_major_minor = (int(pieces[0]), int(pieces[1]))
     if pytest_major_minor < (3, 9):

--- a/tests/env.py
+++ b/tests/env.py
@@ -2,6 +2,8 @@
 import platform
 import sys
 
+import pytest
+
 LINUX = sys.platform.startswith("linux")
 MACOS = sys.platform.startswith("darwin")
 WIN = sys.platform.startswith("win32") or sys.platform.startswith("cygwin")
@@ -12,3 +14,19 @@ PYPY = platform.python_implementation() == "PyPy"
 PY2 = sys.version_info.major == 2
 
 PY = sys.version_info
+
+
+def deprecated_call():
+    """
+    pytest.deprecated_call() seems broken in pytest<3.9.x; concretely, it
+    doesn't work on CPython 3.8.0 with pytest==3.3.2 on Ubuntu 18.04 (#2922).
+
+    This is a narrowed reimplementation of the following PR :(
+    https://github.com/pytest-dev/pytest/pull/4104
+    """
+    pieces = pytest.__version__.split(".")
+    pytest_major_minor = (int(pieces[0]), int(pieces[1]))
+    if pytest_major_minor < (3, 9):
+        return pytest.warns((DeprecationWarning, PendingDeprecationWarning))
+    else:
+        return pytest.deprecated_call()

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -301,7 +301,7 @@ def test_int_convert():
     cant_convert(3.14159)
     # TODO: Avoid DeprecationWarning in `PyLong_AsLong` (and similar)
     if (3, 8) <= env.PY < (3, 10):
-        with pytest.deprecated_call():
+        with env.deprecated_call():
             assert convert(Int()) == 42
     else:
         assert convert(Int()) == 42
@@ -336,7 +336,7 @@ def test_numpy_int_convert():
     # The implicit conversion from np.float32 is undesirable but currently accepted.
     # TODO: Avoid DeprecationWarning in `PyLong_AsLong` (and similar)
     if (3, 8) <= env.PY < (3, 10):
-        with pytest.deprecated_call():
+        with env.deprecated_call():
             assert convert(np.float32(3.14159)) == 3
     else:
         assert convert(np.float32(3.14159)) == 3


### PR DESCRIPTION
## Description

Resolves #2922

## Suggested changelog entry:

Testing only; doesn't merit a change?