### PR TITLE
enum docstrings for sphinx

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1644,7 +1644,7 @@ struct enum_base {
             }, name("name"), is_method(m_base)
         );
 
-        m_base.attr("__doc__") = static_property(cpp_function(
+        m_base.attr("__doc__") = pybind11::str(static_property(cpp_function(
             [](handle arg) -> std::string {
                 std::string docstring;
                 dict entries = arg.attr("__entries");
@@ -1660,7 +1660,7 @@ struct enum_base {
                 }
                 return docstring;
             }, name("__doc__")
-        ), none(), none(), "");
+        ), none(), none(), ""));
 
         m_base.attr("__members__") = static_property(cpp_function(
             [](handle arg) -> dict {


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
I get errors like:
```
  File "/home/psilocaluser/toolchainconda/envs/ghadocs3/lib/python3.8/site-packages/sphinx/util/docstrings.py", line 62, in prepare_docstring
    lines = s.expandtabs(tabsize).splitlines()
AttributeError: 'pybind11_static_property' object has no attribute 'expandtabs'
```
for bindings like:
```
    py::enum_<Molecule::GeometryUnits>(m, "GeometryUnits", "The units used to define the geometry")
        .value("Angstrom", Molecule::Angstrom)
        .value("Bohr", Molecule::Bohr)
        .export_values();
```
unless this patch is applied in pybind11 or the result is stringified, `str(s).expandtabs(tabsize).splitlines()`, upstream in Sphinx https://github.com/sphinx-doc/sphinx/pull/9037

These bindings were fine for years with Sphinx <2. The proposed solution was modeled on https://github.com/pybind/pybind11/blob/master/include/pybind11/pybind11.h#L986 , but I don't know how you want to handle the issue. Or even if I perhaps missed an upgrade step.

I'd be glad to hear where you think the change should happen: my project, pybind11, or sphinx.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Fixed bug where enum docstrings errored in processing by Sphinx.
```

<!-- If the upgrade guide needs updating, note that here too -->
