### PR TITLE
Fix the enabling of default extension handling

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -230,7 +230,7 @@ function(pybind11_add_module target_name)
   endif()
 
   # If we don't pass a WITH_SOABI or WITHOUT_SOABI, use our own default handling of extensions
-  if(NOT ARG_WITHOUT_SOABI OR NOT "WITH_SOABI" IN_LIST ARG_UNPARSED_ARGUMENTS)
+  if(NOT ARG_WITHOUT_SOABI AND NOT "WITH_SOABI" IN_LIST ARG_UNPARSED_ARGUMENTS)
     pybind11_extension(${target_name})
   endif()
 


### PR DESCRIPTION
pybind11_extension() is bypassed when ARG_WITHOUT_SOABI is set or "WITH_SOABI" is specified.

## Description

This PR closes #2937 


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Fix bug not respecting ``WITH_SOABI`` or ``WITHOUT_SOABI`` to CMake
```

<!-- If the upgrade guide needs updating, note that here too -->
