### PR TITLE
Allow function pointer extraction from overloaded functions

### DIFF
--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -46,11 +46,17 @@ public:
             auto c = reinterpret_borrow<capsule>(PyCFunction_GET_SELF(cfunc.ptr()));
             auto rec = (function_record *) c;
 
-            if (rec && rec->is_stateless &&
-                    same_type(typeid(function_type), *reinterpret_cast<const std::type_info *>(rec->data[1]))) {
-                struct capture { function_type f; };
-                value = ((capture *) &rec->data)->f;
-                return true;
+            while (rec != nullptr) {
+                if (rec->is_stateless
+                    && same_type(typeid(function_type),
+                                 *reinterpret_cast<const std::type_info *>(rec->data[1]))) {
+                    struct capture {
+                        function_type f;
+                    };
+                    value = ((capture *) &rec->data)->f;
+                    return true;
+                }
+                rec = rec->next;
             }
         }
 

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -97,6 +97,8 @@ TEST_SUBMODULE(callbacks, m) {
     // test_cpp_function_roundtrip
     /* Test if passing a function pointer from C++ -> Python -> C++ yields the original pointer */
     m.def("dummy_function", &dummy_function);
+    m.def("dummy_function_overloaded", [](int i, int j) { return i + j; });
+    m.def("dummy_function_overloaded", &dummy_function);
     m.def("dummy_function2", [](int i, int j) { return i + j; });
     m.def("roundtrip", [](std::function<int(int)> f, bool expect_none = false) {
         if (expect_none && f)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -93,6 +93,10 @@ def test_cpp_function_roundtrip():
         m.test_dummy_function(m.roundtrip(m.dummy_function))
         == "matches dummy_function: eval(1) = 2"
     )
+    assert (
+        m.test_dummy_function(m.dummy_function_overloaded)
+        == "matches dummy_function: eval(1) = 2"
+    )
     assert m.roundtrip(None, expect_none=True) is None
     assert (
         m.test_dummy_function(lambda x: x + 2)


### PR DESCRIPTION
## Description

When I try to avoid  C++ -> Python -> C++ roundtrip for overloaded functions, it only works for the first overloaded function.
This PR allows function pointer extraction from all overloaded functions.

I added a [failure test case](https://github.com/pybind/pybind11/commit/10a1c967fa6d28f286831d2dd58724e39a172658). Without the fix in this PR, it fails as follows:
```python
>       assert (
            m.test_dummy_function(m.dummy_function_overloaded)
            == "matches dummy_function: eval(1) = 2"
        )
E       assert "can't conver...: eval(1) = 2" == 'matches dumm...: eval(1) = 2'
E         - matches dummy_function: eval(1) = 2
E         + can't convert to function pointer: eval(1) = 2
```

I applied clang-format to only the related code block so the style was changed a bit.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Allow function pointer extraction from overloaded functions
```

<!-- If the upgrade guide needs updating, note that here too -->
