### PR TITLE
docs: remove recommonmark

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,4 @@
 breathe==4.26.1
-commonmark==0.9.1
-recommonmark==0.7.1
 sphinx==3.3.1
 sphinx_rtd_theme==0.5.0
 sphinxcontrib-moderncmakedomain==3.17


### PR DESCRIPTION
First checking to see if we still use it.  CC https://github.com/readthedocs/recommonmark/issues/221 I believe we no longer to, since we converted the README and a few other files to RST.