### PR TITLE
tests: Skip/enable tests more explicitly (in lieu of `hasattr`)

### DIFF
--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -82,6 +82,7 @@ TEST_SUBMODULE(builtin_casters, m) {
     // Under Python 2.7, invalid unicode UTF-32 characters don't appear to trigger UnicodeDecodeError
     if (PY_MAJOR_VERSION >= 3)
         m.def("bad_utf32_string", [=]() { return std::u32string({ a32, char32_t(0xd800), z32 }); });
+    m.attr("wchar_t_size") = (sizeof(wchar_t) == 2);
     if (PY_MAJOR_VERSION >= 3 || sizeof(wchar_t) == 2)
         m.def("bad_wchar_string", [=]() { return std::wstring({ wchar_t(0x61), wchar_t(0xd800) }); });
     m.def("u8_Z", []() -> char { return 'Z'; });
@@ -113,6 +114,8 @@ TEST_SUBMODULE(builtin_casters, m) {
     // test_single_char_arguments
     m.def("ord_char8", [](char8_t c) -> int { return static_cast<unsigned char>(c); });
     m.def("ord_char8_lv", [](char8_t &c) -> int { return static_cast<unsigned char>(c); });
+#else  // PYBIND11_HAS_U8STRING
+    m.attr("has_u8string") = false;
 #endif
 
     // test_string_view
@@ -133,6 +136,8 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("string_view8_chars",  [](std::u8string_view s) { py::list l; for (auto c : s) l.append((std::uint8_t) c); return l; });
     m.def("string_view8_return", []() { return std::u8string_view(u8"utf8 secret \U0001f382"); });
 #   endif
+#else   // PYBIND11_HAS_STRING_VIEW
+    m.attr("has_string_view") = false;
 #endif
 
     // test_integer_casting

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -17,7 +17,7 @@ def test_unicode_conversion():
     assert m.good_utf16_string() == u"b‽🎂𝐀z"
     assert m.good_utf32_string() == u"a𝐀🎂‽z"
     assert m.good_wchar_string() == u"a⸘𝐀z"
-    if hasattr(m, "has_u8string"):
+    if m.has_u8string:
         assert m.good_utf8_u8string() == u"Say utf8‽ 🎂 𝐀"
 
     with pytest.raises(UnicodeDecodeError):
@@ -27,13 +27,13 @@ def test_unicode_conversion():
         m.bad_utf16_string()
 
     # These are provided only if they actually fail (they don't when 32-bit and under Python 2.7)
-    if hasattr(m, "bad_utf32_string"):
+    if not env.PY2:
         with pytest.raises(UnicodeDecodeError):
             m.bad_utf32_string()
-    if hasattr(m, "bad_wchar_string"):
+    if not env.PY2 and m.wchar_t_size == 2:
         with pytest.raises(UnicodeDecodeError):
             m.bad_wchar_string()
-    if hasattr(m, "has_u8string"):
+    if m.has_u8string:
         with pytest.raises(UnicodeDecodeError):
             m.bad_utf8_u8string()
 
@@ -42,7 +42,7 @@ def test_unicode_conversion():
     assert m.u16_ibang() == u"‽"
     assert m.u32_mathbfA() == u"𝐀"
     assert m.wchar_heart() == u"♥"
-    if hasattr(m, "has_u8string"):
+    if m.has_u8string:
         assert m.u8_char8_Z() == "Z"
 
 
@@ -105,7 +105,7 @@ def test_single_char_arguments():
         assert m.ord_wchar(u"aa")
     assert str(excinfo.value) == toolong_message
 
-    if hasattr(m, "has_u8string"):
+    if m.has_u8string:
         assert m.ord_char8(u"a") == 0x61  # simple ASCII
         assert m.ord_char8_lv(u"b") == 0x62
         assert (
@@ -138,21 +138,21 @@ def test_bytes_to_string():
     assert m.string_length(u"💩".encode("utf8")) == 4
 
 
-@pytest.mark.skipif(not hasattr(m, "has_string_view"), reason="no <string_view>")
+@pytest.mark.skipif(not m.has_string_view, reason="no <string_view>")
 def test_string_view(capture):
     """Tests support for C++17 string_view arguments and return values"""
     assert m.string_view_chars("Hi") == [72, 105]
     assert m.string_view_chars("Hi 🎂") == [72, 105, 32, 0xF0, 0x9F, 0x8E, 0x82]
     assert m.string_view16_chars(u"Hi 🎂") == [72, 105, 32, 0xD83C, 0xDF82]
     assert m.string_view32_chars(u"Hi 🎂") == [72, 105, 32, 127874]
-    if hasattr(m, "has_u8string"):
+    if m.has_u8string:
         assert m.string_view8_chars("Hi") == [72, 105]
         assert m.string_view8_chars(u"Hi 🎂") == [72, 105, 32, 0xF0, 0x9F, 0x8E, 0x82]
 
     assert m.string_view_return() == u"utf8 secret 🎂"
     assert m.string_view16_return() == u"utf16 secret 🎂"
     assert m.string_view32_return() == u"utf32 secret 🎂"
-    if hasattr(m, "has_u8string"):
+    if m.has_u8string:
         assert m.string_view8_return() == u"utf8 secret 🎂"
 
     with capture:
@@ -169,7 +169,7 @@ def test_string_view(capture):
         utf32 🎂 7
     """
     )
-    if hasattr(m, "has_u8string"):
+    if m.has_u8string:
         with capture:
             m.string_view8_print("Hi")
             m.string_view8_print(u"utf8 🎂")
@@ -195,7 +195,7 @@ def test_string_view(capture):
         Hi, utf32 🎂 11
     """
     )
-    if hasattr(m, "has_u8string"):
+    if m.has_u8string:
         with capture:
             m.string_view8_print("Hi, ascii")
             m.string_view8_print(u"Hi, utf8 🎂")

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -85,6 +85,7 @@ TEST_SUBMODULE(call_policies, m) {
     }, py::call_guard<DependentGuard, CustomGuard>());
 
 #if defined(WITH_THREAD) && !defined(PYPY_VERSION)
+    m.attr("should_test_gil") = true;
     // `py::call_guard<py::gil_scoped_release>()` should work in PyPy as well,
     // but it's unclear how to test it without `PyGILState_GetThisThreadState`.
     auto report_gil_status = []() {
@@ -97,5 +98,7 @@ TEST_SUBMODULE(call_policies, m) {
 
     m.def("with_gil", report_gil_status);
     m.def("without_gil", report_gil_status, py::call_guard<py::gil_scoped_release>());
+#else
+    m.attr("should_test_gil") = false;
 #endif
 }

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -214,6 +214,6 @@ def test_call_guard():
     assert m.multiple_guards_correct_order() == "guarded & guarded"
     assert m.multiple_guards_wrong_order() == "unguarded & guarded"
 
-    if hasattr(m, "with_gil"):
+    if m.should_test_gil:
         assert m.with_gil() == "GIL held"
         assert m.without_gil() == "GIL released"

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -402,12 +402,15 @@ TEST_SUBMODULE(class_, m) {
     py::implicitly_convertible<std::string, StringWrapper>();
 
     #if defined(PYBIND11_CPP17)
+        m.attr("is_cpp17") = true;
         struct alignas(1024) Aligned {
             std::uintptr_t ptr() const { return (uintptr_t) this; }
         };
         py::class_<Aligned>(m, "Aligned")
             .def(py::init<>())
             .def("ptr", &Aligned::ptr);
+    #else
+        m.attr("is_cpp17") = false;
     #endif
 
     // test_final

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -378,7 +378,7 @@ def test_error_after_conversions():
 
 
 def test_aligned():
-    if hasattr(m, "Aligned"):
+    if m.is_cpp17:
         p = m.Aligned().ptr()
         assert p % 1024 == 0
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1,3 +1,4 @@
+
 /*
     tests/test_pytypes.cpp -- Python type casters
 
@@ -422,7 +423,9 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("get_len", [](py::handle h) { return py::len(h); });
 
 #ifdef PYBIND11_STR_LEGACY_PERMISSIVE
-    m.attr("PYBIND11_STR_LEGACY_PERMISSIVE") = true;
+    m.attr("has_str_legacy_permissive") = true;
+#else
+    m.attr("has_str_legacy_permissive") = false;
 #endif
 
     m.def("isinstance_pybind11_bytes", [](py::object o) { return py::isinstance<py::bytes>(o); });

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -120,7 +120,7 @@ def test_str(doc):
     assert s1 == s2
 
     malformed_utf8 = b"\x80"
-    if hasattr(m, "PYBIND11_STR_LEGACY_PERMISSIVE"):
+    if m.has_str_legacy_permissive:
         assert m.str_from_object(malformed_utf8) is malformed_utf8
     elif env.PY2:
         with pytest.raises(UnicodeDecodeError):
@@ -312,7 +312,7 @@ def test_pybind11_str_raw_str():
     valid_orig = u"Ǳ"
     valid_utf8 = valid_orig.encode("utf-8")
     valid_cvt = cvt(valid_utf8)
-    if hasattr(m, "PYBIND11_STR_LEGACY_PERMISSIVE"):
+    if m.has_str_legacy_permissive:
         assert valid_cvt is valid_utf8
     else:
         assert type(valid_cvt) is unicode if env.PY2 else str  # noqa: F821
@@ -322,7 +322,7 @@ def test_pybind11_str_raw_str():
             assert valid_cvt == "b'\\xc7\\xb1'"
 
     malformed_utf8 = b"\x80"
-    if hasattr(m, "PYBIND11_STR_LEGACY_PERMISSIVE"):
+    if m.has_str_legacy_permissive:
         assert cvt(malformed_utf8) is malformed_utf8
     else:
         if env.PY2:
@@ -517,7 +517,7 @@ def test_isinstance_string_types():
     assert not m.isinstance_pybind11_bytes(u"")
 
     assert m.isinstance_pybind11_str(u"")
-    if hasattr(m, "PYBIND11_STR_LEGACY_PERMISSIVE"):
+    if m.has_str_legacy_permissive:
         assert m.isinstance_pybind11_str(b"")
     else:
         assert not m.isinstance_pybind11_str(b"")
@@ -528,7 +528,7 @@ def test_pass_bytes_or_unicode_to_string_types():
     with pytest.raises(TypeError):
         m.pass_to_pybind11_bytes(u"Str")
 
-    if hasattr(m, "PYBIND11_STR_LEGACY_PERMISSIVE") or env.PY2:
+    if m.has_str_legacy_permissive or env.PY2:
         assert m.pass_to_pybind11_str(b"Bytes") == 5
     else:
         with pytest.raises(TypeError):
@@ -539,7 +539,7 @@ def test_pass_bytes_or_unicode_to_string_types():
     assert m.pass_to_std_string(u"Str") == 3
 
     malformed_utf8 = b"\x80"
-    if hasattr(m, "PYBIND11_STR_LEGACY_PERMISSIVE"):
+    if m.has_str_legacy_permissive:
         assert m.pass_to_pybind11_str(malformed_utf8) == 1
     elif env.PY2:
         with pytest.raises(UnicodeDecodeError):

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -34,7 +34,7 @@ struct visit_helper<boost::variant> {
     }
 };
 }} // namespace pybind11::detail
-#endif
+#endif  //  defined(PYBIND11_HAS_VARIANT)
 
 PYBIND11_MAKE_OPAQUE(std::vector<std::string, std::allocator<std::string>>);
 
@@ -209,6 +209,8 @@ TEST_SUBMODULE(stl, m) {
         .def(py::init<>())
         .def_readonly("member", &opt_holder::member)
         .def("member_initialized", &opt_holder::member_initialized);
+#else
+    m.attr("has_optional") = false;
 #endif
 
 #ifdef PYBIND11_HAS_EXP_OPTIONAL
@@ -235,9 +237,12 @@ TEST_SUBMODULE(stl, m) {
         .def(py::init<>())
         .def_readonly("member", &opt_exp_holder::member)
         .def("member_initialized", &opt_exp_holder::member_initialized);
+#else
+    m.attr("has_exp_optional") = false;
 #endif
 
 #ifdef PYBIND11_HAS_VARIANT
+    m.attr("has_variant") = true;
     static_assert(std::is_same<py::detail::variant_caster_visitor::result_type, py::handle>::value,
                   "visitor::result_type is required by boost::variant in C++11 mode");
 
@@ -261,6 +266,8 @@ TEST_SUBMODULE(stl, m) {
         using V = variant<int, std::string>;
         return py::make_tuple(V(5), V("Hello"));
     });
+#else
+    m.attr("has_variant") = false;
 #endif
 
     // #528: templated constructor

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -106,7 +106,7 @@ def test_move_out_container():
     assert [x.value for x in moved_out_list] == [0, 1, 2]
 
 
-@pytest.mark.skipif(not hasattr(m, "has_optional"), reason="no <optional>")
+@pytest.mark.skipif(not m.has_optional, reason="no <optional>")
 def test_optional():
     assert m.double_or_zero(None) == 0
     assert m.double_or_zero(42) == 84
@@ -134,9 +134,7 @@ def test_optional():
     assert holder.member_initialized()
 
 
-@pytest.mark.skipif(
-    not hasattr(m, "has_exp_optional"), reason="no <experimental/optional>"
-)
+@pytest.mark.skipif(not m.has_exp_optional, reason="no <experimental/optional>")
 def test_exp_optional():
     assert m.double_or_zero_exp(None) == 0
     assert m.double_or_zero_exp(42) == 84
@@ -162,7 +160,7 @@ def test_exp_optional():
     assert holder.member_initialized()
 
 
-@pytest.mark.skipif(not hasattr(m, "load_variant"), reason="no <variant>")
+@pytest.mark.skipif(not m.has_variant, reason="no <variant>")
 def test_variant(doc):
     assert m.load_variant(1) == "int"
     assert m.load_variant("1") == "std::string"


### PR DESCRIPTION
## Description

Minor test cleanup per @anntzer's suggestion in https://github.com/pybind/pybind11/pull/2730#discussion_r615405935

## Suggested changelog entry:

N/A. Testing only.