### PR TITLE
Extra any_container constructor

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -857,6 +857,9 @@ public:
     template <typename TIn, typename = enable_if_t<std::is_convertible<TIn, T>::value>>
     any_container(const std::initializer_list<TIn> &c) : any_container(c.begin(), c.end()) { }
 
+    // So it knows which type to use in mixed cases { 2L, 3 }
+    any_container(const std::initializer_list<T> &c) : any_container(c.begin(), c.end()) { }
+
     // Avoid copying if given an rvalue vector of the correct type.
     any_container(std::vector<T> &&v) : v(std::move(v)) { }
 

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -183,7 +183,7 @@ TEST_SUBMODULE(numpy_array, sm) {
     def_index_fn(mutate_at_t, arr_t&);
 
     // test_make_c_f_array
-    sm.def("make_f_array", [] { return py::array_t<float>({ 2, 2 }, { 4, 8 }); });
+    sm.def("make_f_array", [] { return py::array_t<float>({ (short) 2, 2 }, { 4, 8 }); });
     sm.def("make_c_array", [] { return py::array_t<float>({ 2, 2 }, { 8, 4 }); });
 
     // test_empty_shaped_array


### PR DESCRIPTION
## Description

This lets us construct an array with
```c++
py::array_t<double>({ 2L, 3 });
```
without needing to first cast everything to the same type. Note that it will not allow mixed types if narrowing conversions are involved, but that's not what I am aiming for right now.

It is similar to #885, but that PR was replacing the template constructor with this one, while I am adding it as a complement. This avoids introducing narrowing errors, since those cases can keep using the old constructor.