### PR TITLE
Fix Unicode support for ostream redirects

### DIFF
--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -41,7 +41,7 @@ private:
         return sync() == 0 ? traits_type::not_eof(c) : traits_type::eof();
     }
 
-    // Computes how many bytes at the end of the buffer are part of an 
+    // Computes how many bytes at the end of the buffer are part of an
     // incomplete sequence of UTF-8 bytes.
     // Precondition: pbase() < pptr()
     size_t utf8_remainder() const {
@@ -71,7 +71,7 @@ private:
         const auto dist    = static_cast<size_t>(leading - rpptr);
         size_t remainder   = 0;
 
-        if (dist == 0)  
+        if (dist == 0)
             remainder = 1; // 1-byte code point is impossible
         else if (dist == 1)
             remainder = is_leading_2b(*leading) ? 0 : dist + 1;
@@ -79,7 +79,7 @@ private:
             remainder = is_leading_3b(*leading) ? 0 : dist + 1;
         // else if (dist >= 3), at least 4 bytes before encountering an UTF-8
         // leading byte, either no remainder or invalid UTF-8.
-        // Invalid UTF-8 will cause an exception later when converting 
+        // Invalid UTF-8 will cause an exception later when converting
         // to a Python string, so that's not handled here.
         return remainder;
     }

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -66,6 +66,8 @@ private:
         // UTF-8 leading byte
         const auto rpend   = rbase - rpptr >= 3 ? rpptr + 3 : rbase;
         const auto leading = std::find_if(rpptr, rpend, is_leading);
+        if (leading == rbase)
+            return 0;
         const auto dist    = static_cast<size_t>(leading - rpptr);
         size_t remainder   = 0;
 

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -16,6 +16,9 @@
 #include <string>
 #include <memory>
 #include <iostream>
+#include <cstring>
+#include <iterator>
+#include <algorithm>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
@@ -38,6 +41,47 @@ private:
         return sync() == 0 ? traits_type::not_eof(c) : traits_type::eof();
     }
 
+    // Computes how many bytes at the end of the buffer are part of an 
+    // incomplete sequence of UTF-8 bytes.
+    // Precondition: pbase() < pptr()
+    size_t utf8_remainder() const {
+        const auto rbase = std::reverse_iterator<char *>(pbase());
+        const auto rpptr = std::reverse_iterator<char *>(pptr());
+        auto is_ascii = [](char c) {
+            return (static_cast<unsigned char>(c) & 0x80) == 0x00;
+        };
+        auto is_leading = [](char c) {
+            return (static_cast<unsigned char>(c) & 0xC0) == 0xC0;
+        };
+        auto is_leading_2b = [](char c) {
+            return static_cast<unsigned char>(c) <= 0xDF;
+        };
+        auto is_leading_3b = [](char c) {
+            return static_cast<unsigned char>(c) <= 0xEF;
+        };
+        // If the last character is ASCII, there are no incomplete code points
+        if (is_ascii(*rpptr))
+            return 0;
+        // Otherwise, work back from the end of the buffer and find the first
+        // UTF-8 leading byte
+        const auto rpend   = rbase - rpptr >= 3 ? rpptr + 3 : rbase;
+        const auto leading = std::find_if(rpptr, rpend, is_leading);
+        const auto dist    = static_cast<size_t>(leading - rpptr);
+        size_t remainder   = 0;
+
+        if (dist == 0)  
+            remainder = 1; // 1-byte code point is impossible
+        else if (dist == 1)
+            remainder = is_leading_2b(*leading) ? 0 : dist + 1;
+        else if (dist == 2)
+            remainder = is_leading_3b(*leading) ? 0 : dist + 1;
+        // else if (dist >= 3), at least 4 bytes before encountering an UTF-8
+        // leading byte, either no remainder or invalid UTF-8.
+        // Invalid UTF-8 will cause an exception later when converting 
+        // to a Python string, so that's not handled here.
+        return remainder;
+    }
+
     // This function must be non-virtual to be called in a destructor. If the
     // rare MSVC test failure shows up with this version, then this should be
     // simplified to a fully qualified call.
@@ -48,13 +92,22 @@ private:
                 gil_scoped_acquire tmp;
 
                 // This subtraction cannot be negative, so dropping the sign.
-                str line(pbase(), static_cast<size_t>(pptr() - pbase()));
+                auto size        = static_cast<size_t>(pptr() - pbase());
+                size_t remainder = utf8_remainder();
 
-                pywrite(line);
-                pyflush();
+                if (size > remainder) {
+                    str line(pbase(), size - remainder);
+                    pywrite(line);
+                    pyflush();
+                }
 
-                // Placed inside gil_scoped_aquire as a mutex to avoid a race
+                // Placed inside gil_scoped_aquire as a mutex to avoid a race.
+
+                // Copy the remainder at the end of the buffer to the beginning:
+                if (remainder > 0)
+                    std::memmove(pbase(), pptr() - remainder, remainder);
                 setp(pbase(), epptr());
+                pbump(static_cast<int>(remainder));
             }
 
         }

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -68,6 +68,86 @@ def test_captured_large_string(capsys):
     assert stdout == msg
     assert stderr == ""
 
+def test_captured_utf8_2byte_offset0(capsys):
+    msg = "\u07FF"
+    msg = "" + msg * (1024 // len(msg) + 1)
+
+    m.captured_output_default(msg)
+    stdout, stderr = capsys.readouterr()
+    assert stdout == msg
+    assert stderr == ""
+
+def test_captured_utf8_2byte_offset1(capsys):
+    msg = "\u07FF"
+    msg = "1" + msg * (1024 // len(msg) + 1)
+
+    m.captured_output_default(msg)
+    stdout, stderr = capsys.readouterr()
+    assert stdout == msg
+    assert stderr == ""
+
+def test_captured_utf8_3byte_offset0(capsys):
+    msg = "\uFFFF"
+    msg = "" + msg * (1024 // len(msg) + 1)
+
+    m.captured_output_default(msg)
+    stdout, stderr = capsys.readouterr()
+    assert stdout == msg
+    assert stderr == ""
+
+def test_captured_utf8_3byte_offset1(capsys):
+    msg = "\uFFFF"
+    msg = "1" + msg * (1024 // len(msg) + 1)
+
+    m.captured_output_default(msg)
+    stdout, stderr = capsys.readouterr()
+    assert stdout == msg
+    assert stderr == ""
+
+def test_captured_utf8_3byte_offset2(capsys):
+    msg = "\uFFFF"
+    msg = "12" + msg * (1024 // len(msg) + 1)
+
+    m.captured_output_default(msg)
+    stdout, stderr = capsys.readouterr()
+    assert stdout == msg
+    assert stderr == ""
+
+def test_captured_utf8_4byte_offset0(capsys):
+    msg = "\U0010FFFF"
+    msg = "" + msg * (1024 // len(msg) + 1)
+
+    m.captured_output_default(msg)
+    stdout, stderr = capsys.readouterr()
+    assert stdout == msg
+    assert stderr == ""
+
+def test_captured_utf8_4byte_offset1(capsys):
+    msg = "\U0010FFFF"
+    msg = "1" + msg * (1024 // len(msg) + 1)
+
+    m.captured_output_default(msg)
+    stdout, stderr = capsys.readouterr()
+    assert stdout == msg
+    assert stderr == ""
+
+def test_captured_utf8_4byte_offset2(capsys):
+    msg = "\U0010FFFF"
+    msg = "12" + msg * (1024 // len(msg) + 1)
+
+    m.captured_output_default(msg)
+    stdout, stderr = capsys.readouterr()
+    assert stdout == msg
+    assert stderr == ""
+
+def test_captured_utf8_4byte_offset3(capsys):
+    msg = "\U0010FFFF"
+    msg = "123" + msg * (1024 // len(msg) + 1)
+
+    m.captured_output_default(msg)
+    stdout, stderr = capsys.readouterr()
+    assert stdout == msg
+    assert stderr == ""
 
 def test_guard_capture(capsys):
     msg = "I've been redirected to Python, I hope!"

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -68,6 +68,7 @@ def test_captured_large_string(capsys):
     assert stdout == msg
     assert stderr == ""
 
+
 def test_captured_utf8_2byte_offset0(capsys):
     msg = "\u07FF"
     msg = "" + msg * (1024 // len(msg) + 1)
@@ -76,6 +77,7 @@ def test_captured_utf8_2byte_offset0(capsys):
     stdout, stderr = capsys.readouterr()
     assert stdout == msg
     assert stderr == ""
+
 
 def test_captured_utf8_2byte_offset1(capsys):
     msg = "\u07FF"
@@ -86,6 +88,7 @@ def test_captured_utf8_2byte_offset1(capsys):
     assert stdout == msg
     assert stderr == ""
 
+
 def test_captured_utf8_3byte_offset0(capsys):
     msg = "\uFFFF"
     msg = "" + msg * (1024 // len(msg) + 1)
@@ -94,6 +97,7 @@ def test_captured_utf8_3byte_offset0(capsys):
     stdout, stderr = capsys.readouterr()
     assert stdout == msg
     assert stderr == ""
+
 
 def test_captured_utf8_3byte_offset1(capsys):
     msg = "\uFFFF"
@@ -104,6 +108,7 @@ def test_captured_utf8_3byte_offset1(capsys):
     assert stdout == msg
     assert stderr == ""
 
+
 def test_captured_utf8_3byte_offset2(capsys):
     msg = "\uFFFF"
     msg = "12" + msg * (1024 // len(msg) + 1)
@@ -112,6 +117,7 @@ def test_captured_utf8_3byte_offset2(capsys):
     stdout, stderr = capsys.readouterr()
     assert stdout == msg
     assert stderr == ""
+
 
 def test_captured_utf8_4byte_offset0(capsys):
     msg = "\U0010FFFF"
@@ -122,6 +128,7 @@ def test_captured_utf8_4byte_offset0(capsys):
     assert stdout == msg
     assert stderr == ""
 
+
 def test_captured_utf8_4byte_offset1(capsys):
     msg = "\U0010FFFF"
     msg = "1" + msg * (1024 // len(msg) + 1)
@@ -130,6 +137,7 @@ def test_captured_utf8_4byte_offset1(capsys):
     stdout, stderr = capsys.readouterr()
     assert stdout == msg
     assert stderr == ""
+
 
 def test_captured_utf8_4byte_offset2(capsys):
     msg = "\U0010FFFF"
@@ -140,6 +148,7 @@ def test_captured_utf8_4byte_offset2(capsys):
     assert stdout == msg
     assert stderr == ""
 
+
 def test_captured_utf8_4byte_offset3(capsys):
     msg = "\U0010FFFF"
     msg = "123" + msg * (1024 // len(msg) + 1)
@@ -148,6 +157,7 @@ def test_captured_utf8_4byte_offset3(capsys):
     stdout, stderr = capsys.readouterr()
     assert stdout == msg
     assert stderr == ""
+
 
 def test_guard_capture(capsys):
     msg = "I've been redirected to Python, I hope!"


### PR DESCRIPTION
## Description

When printing UTF-8 data to a redirected ostream (using `pybind11::scoped_ostream_redirect`), Python randomly crashes.  
This happens because the `pybind11::pythonbuf` class is not Unicode aware: it only sees bytes and converts them to a Python string directly. When there is an unfinished multibyte UTF-8 sequenced at the end of the buffer, the `PyUnicode_FromStringAndSize` function detects that it is not a valid Unicode string and returns `NULL`, resulting in `pybind11_fail("Could not allocate string object!")` being called in the `pybind11::str` constructor, raising an uncaught exception that takes down the entire application.

The first commit (bf96760e8f9c886cafe465bc4f6d2d9333c915f7) adds some failing test cases to demonstrate the problem. For instance:
```py
def test_captured_utf8_2byte_offset1(capsys):
    msg = "\u07FF"
    msg = "1" + msg * (1024 // len(msg) + 1)

    m.captured_output_default(msg)
    stdout, stderr = capsys.readouterr()
    assert stdout == msg
    assert stderr == ""
```
This results in the test being aborted entirely:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Could not allocate string object!
Fatal Python error: Aborted
Aborted (core dumped)
FAILED: tests/CMakeFiles/pytest 
```

## Solution

The second commit (4d655b0c1ba99f7f69a117233fce7ceaf27dba08) fixes this issue by inspecting (up to) the last 3 bytes of the buffer to check whether they are part of an unfinished multibyte UTF-8 sequence. If they are, they are not included in the string forwarded to Python, and these bytes are then moved to the beginning of the buffer so they can be completed after the buffer is flushed.  
If the last byte is a normal ASCII character, there is no difference.

If the buffer contains invalid Unicode, this is not handled by my fix, and it still triggers the same error in the `pybind11::str` constructor. Maybe this can be improved upon as well, crashing the entire program because of a Unicode error in the output seems a bit excessive to me. Maybe the error message can be made more specific as well? `Could not allocate string object!` is not a clear error message for a Unicode problem, I spent considerably more time debugging why my Python program was randomly aborted than I'd like to admit ...

## Further improvements and considerations

This solution was tested on Linux only. I'm not familiar with the intricacies of how `std::cout` is used with Unicode strings on Windows (since Windows uses UTF-16 and `wchar_t` for most strings).  
I didn't test this on Python 2.7 either, I imagine a different strategy might be needed since Python 2 handles Unicode differently. 

## Suggested changelog entry:

```rst
Fixed exception when printing UTF-8 to a ``scoped_ostream_redirect``.
```
