### PR TITLE
Splitting out include/pybind11/detail/pragma_warning_block.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ set(PYBIND11_HEADERS
     include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h
     include/pybind11/detail/init.h
     include/pybind11/detail/internals.h
-    include/pybind11/detail/detail/pragma_warning_block.h
+    include/pybind11/detail/pragma_warning_block.h
     include/pybind11/detail/smart_holder_poc.h
     include/pybind11/detail/smart_holder_sfinae_hooks_only.h
     include/pybind11/detail/smart_holder_type_casters.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(PYBIND11_HEADERS
     include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h
     include/pybind11/detail/init.h
     include/pybind11/detail/internals.h
+    include/pybind11/detail/detail/pragma_warning_block.h
     include/pybind11/detail/smart_holder_poc.h
     include/pybind11/detail/smart_holder_sfinae_hooks_only.h
     include/pybind11/detail/smart_holder_type_casters.h

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -13,38 +13,6 @@
 #define PYBIND11_VERSION_MINOR 6
 #define PYBIND11_VERSION_PATCH 3.dev1
 
-#if defined(__INTEL_COMPILER)
-#  pragma warning push
-#  pragma warning disable 68    // integer conversion resulted in a change of sign
-#  pragma warning disable 186   // pointless comparison of unsigned integer with zero
-#  pragma warning disable 878   // incompatible exception specifications
-#  pragma warning disable 1334  // the "template" keyword used for syntactic disambiguation may only be used within a template
-#  pragma warning disable 1682  // implicit conversion of a 64-bit integral type to a smaller integral type (potential portability problem)
-#  pragma warning disable 1786  // function "strdup" was declared deprecated
-#  pragma warning disable 1875  // offsetof applied to non-POD (Plain Old Data) types is nonstandard
-#  pragma warning disable 2196  // warning #2196: routine is both "inline" and "noinline"
-#elif defined(_MSC_VER)
-#  pragma warning(push)
-#  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
-#  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
-#  pragma warning(disable: 4512) // warning C4512: Assignment operator was implicitly defined as deleted
-#  pragma warning(disable: 4800) // warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
-#  pragma warning(disable: 4996) // warning C4996: The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name
-#  pragma warning(disable: 4702) // warning C4702: unreachable code
-#  pragma warning(disable: 4522) // warning C4522: multiple assignment operators specified
-#  pragma warning(disable: 4505) // warning C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
-#elif defined(__GNUG__) && !defined(__clang__)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
-#  pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#  pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#  pragma GCC diagnostic ignored "-Wattributes"
-#  if __GNUC__ >= 7
-#    pragma GCC diagnostic ignored "-Wnoexcept-type"
-#  endif
-#endif
-
 #define PYBIND11_NAMESPACE_BEGIN(name) namespace name {
 #define PYBIND11_NAMESPACE_END(name) }
 

--- a/include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h
+++ b/include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "pragma_warning_block.h"
+
 #include "common.h"
 
 #include <type_traits>

--- a/include/pybind11/detail/pragma_warning_block.h
+++ b/include/pybind11/detail/pragma_warning_block.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#if defined(__INTEL_COMPILER)
+#  pragma warning push
+#  pragma warning disable 68    // integer conversion resulted in a change of sign
+#  pragma warning disable 186   // pointless comparison of unsigned integer with zero
+#  pragma warning disable 878   // incompatible exception specifications
+#  pragma warning disable 1334  // the "template" keyword used for syntactic disambiguation may only be used within a template
+#  pragma warning disable 1682  // implicit conversion of a 64-bit integral type to a smaller integral type (potential portability problem)
+#  pragma warning disable 1786  // function "strdup" was declared deprecated
+#  pragma warning disable 1875  // offsetof applied to non-POD (Plain Old Data) types is nonstandard
+#  pragma warning disable 2196  // warning #2196: routine is both "inline" and "noinline"
+#elif defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
+#  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
+#  pragma warning(disable: 4512) // warning C4512: Assignment operator was implicitly defined as deleted
+#  pragma warning(disable: 4800) // warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
+#  pragma warning(disable: 4996) // warning C4996: The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name
+#  pragma warning(disable: 4702) // warning C4702: unreachable code
+#  pragma warning(disable: 4522) // warning C4522: multiple assignment operators specified
+#  pragma warning(disable: 4505) // warning C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
+#elif defined(__GNUG__) && !defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
+#  pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#  pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#  pragma GCC diagnostic ignored "-Wattributes"
+#  if __GNUC__ >= 7
+#    pragma GCC diagnostic ignored "-Wnoexcept-type"
+#  endif
+#endif

--- a/include/pybind11/detail/smart_holder_sfinae_hooks_only.h
+++ b/include/pybind11/detail/smart_holder_sfinae_hooks_only.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "pragma_warning_block.h"
+
 #include "common.h"
 
 #include <type_traits>

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "pragma_warning_block.h"
+
 #include "../gil.h"
 #include "../pytypes.h"
 #include "../trampoline_self_life_support.h"

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -11,6 +11,10 @@
 
 #pragma once
 
+// Legacy pragma warning block moved to separate file, to enable iwyu cleanup of newly developed
+// code, without having to open up this can of worms. #HelpAppreciated cleaning this up.
+#include "detail/pragma_warning_block.h"
+
 #include "attr.h"
 #include "gil.h"
 #include "options.h"

--- a/include/pybind11/smart_holder.h
+++ b/include/pybind11/smart_holder.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "detail/pragma_warning_block.h"
+
 #include "detail/common.h"
 #include "detail/smart_holder_type_casters.h"
 #include "pybind11.h"

--- a/include/pybind11/trampoline_self_life_support.h
+++ b/include/pybind11/trampoline_self_life_support.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "detail/pragma_warning_block.h"
+
 #include "detail/common.h"
 #include "detail/smart_holder_poc.h"
 #include "detail/type_caster_base.h"

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -45,7 +45,7 @@ detail_headers = {
     "include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h",
     "include/pybind11/detail/init.h",
     "include/pybind11/detail/internals.h",
-    "include/pybind11/detail/detail/pragma_warning_block.h",
+    "include/pybind11/detail/pragma_warning_block.h",
     "include/pybind11/detail/smart_holder_poc.h",
     "include/pybind11/detail/smart_holder_sfinae_hooks_only.h",
     "include/pybind11/detail/smart_holder_type_casters.h",

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -45,6 +45,7 @@ detail_headers = {
     "include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h",
     "include/pybind11/detail/init.h",
     "include/pybind11/detail/internals.h",
+    "include/pybind11/detail/detail/pragma_warning_block.h",
     "include/pybind11/detail/smart_holder_poc.h",
     "include/pybind11/detail/smart_holder_sfinae_hooks_only.h",
     "include/pybind11/detail/smart_holder_type_casters.h",


### PR DESCRIPTION
Alternative to moving the pragma block to common.h. This way the code organization on master can stay exactly the same.