### PR TITLE
Adding iostream.h thread-safety documentation.

### DIFF
--- a/docs/advanced/pycpp/utilities.rst
+++ b/docs/advanced/pycpp/utilities.rst
@@ -47,6 +47,18 @@ redirects output to the corresponding Python streams:
         call_noisy_func();
     });
 
+.. warning::
+
+    The implementation in ``pybind11/iostream.h`` is NOT thread safe. Multiple
+    threads writing to a redirected ostream concurrently cause data races
+    and potentially buffer overflows. Therefore it is a requirement that
+    all (possibly) concurrent redirected ostream writes are locked. Note
+    that this is not expected to be an actual limitation, because without
+    synchronization output will be randomly interleaved and most likely
+    unreadable. Well-written C++ code is likely to use locking regardless of
+    this pybind11 requirement. — For more background see the discussion under
+    `PR #2982 <https://github.com/pybind/pybind11/pull/2982>`_.
+
 This method respects flushes on the output streams and will flush if needed
 when the scoped guard is destroyed. This allows the output to be redirected in
 real time, such as to a Jupyter notebook. The two arguments, the C++ stream and

--- a/docs/advanced/pycpp/utilities.rst
+++ b/docs/advanced/pycpp/utilities.rst
@@ -51,13 +51,12 @@ redirects output to the corresponding Python streams:
 
     The implementation in ``pybind11/iostream.h`` is NOT thread safe. Multiple
     threads writing to a redirected ostream concurrently cause data races
-    and potentially buffer overflows. Therefore it is a requirement that
-    all (possibly) concurrent redirected ostream writes are locked. Note
-    that this is not expected to be an actual limitation, because without
-    synchronization output will be randomly interleaved and most likely
-    unreadable. Well-written C++ code is likely to use locking regardless of
-    this pybind11 requirement. — For more background see the discussion under
-    `PR #2982 <https://github.com/pybind/pybind11/pull/2982>`_.
+    and potentially buffer overflows. Therefore it is currrently a requirement
+    that all (possibly) concurrent redirected ostream writes are protected by
+    a mutex. #HelpAppreciated: Work on iostream.h thread safety. For more
+    background see the discussions under
+    `PR #2982 <https://github.com/pybind/pybind11/pull/2982>`_ and
+    `PR #2995 <https://github.com/pybind/pybind11/pull/2995>`_.
 
 This method respects flushes on the output streams and will flush if needed
 when the scoped guard is destroyed. This allows the output to be redirected in

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -5,6 +5,13 @@
 
     All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file.
+
+    WARNING: The implementation in this file is NOT thread safe. Multiple
+    threads writing to a redirected ostream concurrently cause data races and
+    potentially buffer overflows. Therefore it is a REQUIREMENT that all
+    (possibly) concurrent redirected ostream writes are locked. For more
+    background see the discussion under
+    https://github.com/pybind/pybind11/pull/2982.
 */
 
 #pragma once
@@ -85,30 +92,25 @@ private:
         return remainder;
     }
 
-    // This function must be non-virtual to be called in a destructor. If the
-    // rare MSVC test failure shows up with this version, then this should be
-    // simplified to a fully qualified call.
+    // This function must be non-virtual to be called in a destructor.
     int _sync() {
         if (pbase() != pptr()) { // If buffer is not empty
             gil_scoped_acquire tmp;
-            // Placed inside gil_scoped_acquire as a mutex to avoid a race.
-            if (pbase() != pptr()) { // Check again under the lock
-                // This subtraction cannot be negative, so dropping the sign.
-                auto size        = static_cast<size_t>(pptr() - pbase());
-                size_t remainder = utf8_remainder();
+            // This subtraction cannot be negative, so dropping the sign.
+            auto size        = static_cast<size_t>(pptr() - pbase());
+            size_t remainder = utf8_remainder();
 
-                if (size > remainder) {
-                    str line(pbase(), size - remainder);
-                    pywrite(line);
-                    pyflush();
-                }
-
-                // Copy the remainder at the end of the buffer to the beginning:
-                if (remainder > 0)
-                    std::memmove(pbase(), pptr() - remainder, remainder);
-                setp(pbase(), epptr());
-                pbump(static_cast<int>(remainder));
+            if (size > remainder) {
+                str line(pbase(), size - remainder);
+                pywrite(line);
+                pyflush();
             }
+
+            // Copy the remainder at the end of the buffer to the beginning:
+            if (remainder > 0)
+                std::memmove(pbase(), pptr() - remainder, remainder);
+            setp(pbase(), epptr());
+            pbump(static_cast<int>(remainder));
         }
         return 0;
     }

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -7,11 +7,14 @@
     BSD-style license that can be found in the LICENSE file.
 
     WARNING: The implementation in this file is NOT thread safe. Multiple
-    threads writing to a redirected ostream concurrently cause data races and
-    potentially buffer overflows. Therefore it is a REQUIREMENT that all
-    (possibly) concurrent redirected ostream writes are locked. For more
-    background see the discussion under
-    https://github.com/pybind/pybind11/pull/2982.
+    threads writing to a redirected ostream concurrently cause data races
+    and potentially buffer overflows. Therefore it is currrently a requirement
+    that all (possibly) concurrent redirected ostream writes are protected by
+    a mutex.
+    #HelpAppreciated: Work on iostream.h thread safety.
+    For more background see the discussions under
+    https://github.com/pybind/pybind11/pull/2982 and
+    https://github.com/pybind/pybind11/pull/2995.
 */
 
 #pragma once

--- a/tests/test_iostream.cpp
+++ b/tests/test_iostream.cpp
@@ -40,6 +40,12 @@ struct TestThread {
             static std::mutex cout_mutex;
             while (!stop_) {
                 {
+                    // #HelpAppreciated: Work on iostream.h thread safety.
+                    // Without this lock, the clang ThreadSanitizer (tsan) reliably reports a
+                    // data race, and this test is predictably flakey on Windows.
+                    // For more background see the discussion under
+                    // https://github.com/pybind/pybind11/pull/2982 and
+                    // https://github.com/pybind/pybind11/pull/2995.
                     const std::lock_guard<std::mutex> lock(cout_mutex);
                     std::cout << "x" << std::flush;
                 }

--- a/tests/test_iostream.cpp
+++ b/tests/test_iostream.cpp
@@ -35,7 +35,7 @@ void noisy_funct_dual(const std::string &msg, const std::string &emsg) {
 // simply repeatedly write to std::cerr until stopped
 // redirect is called at some point to test the safety of scoped_estream_redirect
 struct TestThread {
-    TestThread() : t_{nullptr}, stop_{false} {
+    TestThread() : stop_{false} {
         auto thread_f = [this] {
             static std::mutex cout_mutex;
             while (!stop_) {
@@ -60,7 +60,7 @@ struct TestThread {
 
     void stop() { stop_ = true; }
 
-    void join() {
+    void join() const {
         py::gil_scoped_release gil_lock;
         t_->join();
     }
@@ -70,7 +70,7 @@ struct TestThread {
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 
-    std::thread * t_;
+    std::thread *t_{nullptr};
     std::atomic<bool> stop_;
 };
 

--- a/tests/test_iostream.cpp
+++ b/tests/test_iostream.cpp
@@ -13,9 +13,8 @@
 
 #include <pybind11/iostream.h>
 #include "pybind11_tests.h"
-#include <atomic>
 #include <iostream>
-#include <thread>
+#include <string>
 
 void noisy_function(const std::string &msg, bool flush) {
 
@@ -28,40 +27,6 @@ void noisy_funct_dual(const std::string &msg, const std::string &emsg) {
     std::cout << msg;
     std::cerr << emsg;
 }
-
-// object to manage C++ thread
-// simply repeatedly write to std::cerr until stopped
-// redirect is called at some point to test the safety of scoped_estream_redirect
-struct TestThread {
-    TestThread() : stop_{false} {
-        auto thread_f = [this] {
-            while (!stop_) {
-                std::cout << "x" << std::flush;
-                std::this_thread::sleep_for(std::chrono::microseconds(50));
-            } };
-        t_ = new std::thread(std::move(thread_f));
-    }
-
-    ~TestThread() {
-        delete t_;
-    }
-
-    void stop() { stop_ = true; }
-
-    void join() const {
-        py::gil_scoped_release gil_lock;
-        t_->join();
-    }
-
-    void sleep() {
-        py::gil_scoped_release gil_lock;
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    }
-
-    std::thread *t_{nullptr};
-    std::atomic<bool> stop_;
-};
-
 
 TEST_SUBMODULE(iostream, m) {
 
@@ -104,10 +69,4 @@ TEST_SUBMODULE(iostream, m) {
         std::cout << msg << std::flush;
         std::cerr << emsg << std::flush;
     });
-
-    py::class_<TestThread>(m, "TestThread")
-        .def(py::init<>())
-        .def("stop", &TestThread::stop)
-        .def("join", &TestThread::join)
-        .def("sleep", &TestThread::sleep);
 }

--- a/tests/test_iostream.cpp
+++ b/tests/test_iostream.cpp
@@ -13,8 +13,11 @@
 
 #include <pybind11/iostream.h>
 #include "pybind11_tests.h"
+#include <atomic>
 #include <iostream>
+#include <mutex>
 #include <string>
+#include <thread>
 
 void noisy_function(const std::string &msg, bool flush) {
 
@@ -27,6 +30,44 @@ void noisy_funct_dual(const std::string &msg, const std::string &emsg) {
     std::cout << msg;
     std::cerr << emsg;
 }
+
+// object to manage C++ thread
+// simply repeatedly write to std::cerr until stopped
+// redirect is called at some point to test the safety of scoped_estream_redirect
+struct TestThread {
+    TestThread() : t_{nullptr}, stop_{false} {
+        auto thread_f = [this] {
+            static std::mutex cout_mutex;
+            while (!stop_) {
+                {
+                    const std::lock_guard<std::mutex> lock(cout_mutex);
+                    std::cout << "x" << std::flush;
+                }
+                std::this_thread::sleep_for(std::chrono::microseconds(50));
+            } };
+        t_ = new std::thread(std::move(thread_f));
+    }
+
+    ~TestThread() {
+        delete t_;
+    }
+
+    void stop() { stop_ = true; }
+
+    void join() {
+        py::gil_scoped_release gil_lock;
+        t_->join();
+    }
+
+    void sleep() {
+        py::gil_scoped_release gil_lock;
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    std::thread * t_;
+    std::atomic<bool> stop_;
+};
+
 
 TEST_SUBMODULE(iostream, m) {
 
@@ -69,4 +110,10 @@ TEST_SUBMODULE(iostream, m) {
         std::cout << msg << std::flush;
         std::cerr << emsg << std::flush;
     });
+
+    py::class_<TestThread>(m, "TestThread")
+        .def(py::init<>())
+        .def("stop", &TestThread::stop)
+        .def("join", &TestThread::join)
+        .def("sleep", &TestThread::sleep);
 }

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -306,3 +306,26 @@ def test_redirect_both(capfd):
     assert stderr == ""
     assert stream.getvalue() == msg
     assert stream2.getvalue() == msg2
+
+
+def test_threading():
+    with m.ostream_redirect(stdout=True, stderr=False):
+        # start some threads
+        threads = []
+
+        # start some threads
+        for _j in range(20):
+            threads.append(m.TestThread())
+
+        # give the threads some time to fail
+        threads[0].sleep()
+
+        # stop all the threads
+        for t in threads:
+            t.stop()
+
+        for t in threads:
+            t.join()
+
+        # if a thread segfaults, we don't get here
+        assert True

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -306,26 +306,3 @@ def test_redirect_both(capfd):
     assert stderr == ""
     assert stream.getvalue() == msg
     assert stream2.getvalue() == msg2
-
-
-def test_threading():
-    with m.ostream_redirect(stdout=True, stderr=False):
-        # start some threads
-        threads = []
-
-        # start some threads
-        for _j in range(20):
-            threads.append(m.TestThread())
-
-        # give the threads some time to fail
-        threads[0].sleep()
-
-        # stop all the threads
-        for t in threads:
-            t.stop()
-
-        for t in threads:
-            t.join()
-
-        # if a thread segfaults, we don't get here
-        assert True


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

For full background see the discussions under PR #2982 and this PR.

This PR resolves the clang ThreadSanitizer (tsan) error reported under #2754, but only in stop-gap fashion.

#HelpAppreciated: Work on iostream.h thread safety.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
An important warning about thread safety was added to the iostream.h documentation.
```

<!-- If the upgrade guide needs updating, note that here too -->
