### PR TITLE
Explicitly export exception types.

### DIFF
--- a/docs/advanced/exceptions.rst
+++ b/docs/advanced/exceptions.rst
@@ -164,9 +164,9 @@ section.
     may be explicitly (re-)thrown to delegate it to the other,
     previously-declared existing exception translators.
 
-    Libc++ `behaves differently <https://stackoverflow.com/questions/19496643/using-clang-fvisibility-hidden-and-typeinfo-and-type-erasure/28827430>`_
-    with ``-fvisibility=hidden``. So you'll need to explicitly export exceptions who'll be used across ABI boundaries as ``tests/test_exceptions.h``.
-    See also section "Problems with C++ exceptions" in `GCC Wiki <https://gcc.gnu.org/wiki/Visibility>`_.
+    Note that ``libc++`` and ``libstdc++`` `behave differently <https://stackoverflow.com/questions/19496643/using-clang-fvisibility-hidden-and-typeinfo-and-type-erasure/28827430>`_
+    with ``-fvisibility=hidden``. Therefore exceptions that are used across ABI boundaries need to be explicitly exported, as exercised in ``tests/test_exceptions.h``.
+    See also: "Problems with C++ exceptions" under `GCC Wiki <https://gcc.gnu.org/wiki/Visibility>`_.
 
 .. _handling_python_exceptions_cpp:
 

--- a/docs/advanced/exceptions.rst
+++ b/docs/advanced/exceptions.rst
@@ -164,6 +164,9 @@ section.
     may be explicitly (re-)thrown to delegate it to the other,
     previously-declared existing exception translators.
 
+    Libc++ `behaves differently <https://stackoverflow.com/questions/19496643/using-clang-fvisibility-hidden-and-typeinfo-and-type-erasure/28827430>`_
+    with ``-fvisibility=hidden``. So you'll need to explicitly export exceptions who'll be used across ABI boundaries as ``tests/test_exceptions.h``.
+
 .. _handling_python_exceptions_cpp:
 
 Handling exceptions from Python in C++

--- a/docs/advanced/exceptions.rst
+++ b/docs/advanced/exceptions.rst
@@ -166,6 +166,7 @@ section.
 
     Libc++ `behaves differently <https://stackoverflow.com/questions/19496643/using-clang-fvisibility-hidden-and-typeinfo-and-type-erasure/28827430>`_
     with ``-fvisibility=hidden``. So you'll need to explicitly export exceptions who'll be used across ABI boundaries as ``tests/test_exceptions.h``.
+    See also section "Problems with C++ exceptions" in `GCC Wiki <https://gcc.gnu.org/wiki/Visibility>`_.
 
 .. _handling_python_exceptions_cpp:
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -723,16 +723,23 @@ using expand_side_effects = bool[];
 
 PYBIND11_NAMESPACE_END(detail)
 
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable: 4275) // warning C4275: An exported class was derived from a class that wasn't exported. Can be ignored when derived from a STL class.
+#endif
 /// C++ bindings of builtin Python exceptions
-class builtin_exception : public std::runtime_error {
+class PYBIND11_EXPORT builtin_exception : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
     /// Set the error using the Python C API
     virtual void set_error() const = 0;
 };
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 
 #define PYBIND11_RUNTIME_EXCEPTION(name, type) \
-    class name : public builtin_exception { public: \
+    class PYBIND11_EXPORT name : public builtin_exception { public: \
         using builtin_exception::builtin_exception; \
         name() : name("") { } \
         void set_error() const override { PyErr_SetString(type, what()); } \

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -242,16 +242,6 @@ inline void translate_exception(std::exception_ptr p) {
     }
 }
 
-#if !defined(__GLIBCXX__)
-inline void translate_local_exception(std::exception_ptr p) {
-    try {
-        if (p) std::rethrow_exception(p);
-    } catch (error_already_set &e)       { e.restore();   return;
-    } catch (const builtin_exception &e) { e.set_error(); return;
-    }
-}
-#endif
-
 /// Return a reference to the current `internals` data
 PYBIND11_NOINLINE inline internals &get_internals() {
     auto **&internals_pp = get_internals_pp();
@@ -270,15 +260,6 @@ PYBIND11_NOINLINE inline internals &get_internals() {
     auto builtins = handle(PyEval_GetBuiltins());
     if (builtins.contains(id) && isinstance<capsule>(builtins[id])) {
         internals_pp = static_cast<internals **>(capsule(builtins[id]));
-
-        // We loaded builtins through python's builtins, which means that our `error_already_set`
-        // and `builtin_exception` may be different local classes than the ones set up in the
-        // initial exception translator, below, so add another for our local exception classes.
-        //
-        // libstdc++ doesn't require this (types there are identified only by name)
-#if !defined(__GLIBCXX__)
-        (*internals_pp)->registered_exception_translators.push_front(&translate_local_exception);
-#endif
     } else {
         if (!internals_pp) internals_pp = new internals*();
         auto *&internals_ptr = *internals_pp;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -319,11 +319,15 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 inline std::string error_string();
 PYBIND11_NAMESPACE_END(detail)
 
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable: 4275 4251) // warning C4275: An exported class was derived from a class that wasn't exported. Can be ignored when derived from a STL class.
+#endif
 /// Fetch and hold an error which was already set in Python.  An instance of this is typically
 /// thrown to propagate python-side errors back through C++ which can either be caught manually or
 /// else falls back to the function dispatcher (which then raises the captured error back to
 /// python).
-class error_already_set : public std::runtime_error {
+class PYBIND11_EXPORT error_already_set : public std::runtime_error {
 public:
     /// Constructs a new exception from the current Python error indicator, if any.  The current
     /// Python error indicator will be cleared.
@@ -371,6 +375,9 @@ public:
 private:
     object m_type, m_value, m_trace;
 };
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 
 /** \defgroup python_builtins _
     Unless stated otherwise, the following C++ functions behave the same

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -34,7 +34,7 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     py::register_exception_translator([](std::exception_ptr p) {
       try {
           if (p) std::rethrow_exception(p);
-      } catch (const tmp_e &e) {
+      } catch (const shared_exception &e) {
           PyErr_SetString(PyExc_KeyError, e.what());
       }
     });

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -9,6 +9,7 @@
 
 #include "pybind11_tests.h"
 #include "local_bindings.h"
+#include "test_exceptions.h"
 #include <pybind11/stl_bind.h>
 #include <numeric>
 
@@ -30,6 +31,13 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.def("throw_pybind_value_error", []() { throw py::value_error("pybind11 value error"); });
     m.def("throw_pybind_type_error", []() { throw py::type_error("pybind11 type error"); });
     m.def("throw_stop_iteration", []() { throw py::stop_iteration(); });
+    py::register_exception_translator([](std::exception_ptr p) {
+      try {
+          if (p) std::rethrow_exception(p);
+      } catch (const tmp_e &e) {
+          PyErr_SetString(PyExc_KeyError, e.what());
+      }
+    });
 
     // test_local_bindings.py
     // Local to both:

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -229,5 +229,5 @@ TEST_SUBMODULE(exceptions, m) {
     // Test repr that cannot be displayed
     m.def("simple_bool_passthrough", [](bool x) {return x;});
 
-    m.def("throw_", []() { throw tmp_e(); });
+    m.def("throw_should_be_translated_to_key_error", []() { throw shared_exception(); });
 }

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -7,6 +7,7 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
+#include "test_exceptions.h"
 #include "pybind11_tests.h"
 
 // A type that should be raised as an exception in Python
@@ -228,4 +229,5 @@ TEST_SUBMODULE(exceptions, m) {
     // Test repr that cannot be displayed
     m.def("simple_bool_passthrough", [](bool x) {return x;});
 
+    m.def("throw_", []() { throw tmp_e(); });
 }

--- a/tests/test_exceptions.h
+++ b/tests/test_exceptions.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "pybind11_tests.h"
+#include <stdexcept>
+
+// shared exceptions for cross_module_tests
+
+class PYBIND11_EXPORT tmp_e : public pybind11::builtin_exception {
+public:
+    using builtin_exception::builtin_exception;
+    explicit tmp_e() : tmp_e("") {}
+    void set_error() const override { PyErr_SetString(PyExc_RuntimeError, what()); }
+};

--- a/tests/test_exceptions.h
+++ b/tests/test_exceptions.h
@@ -4,9 +4,9 @@
 
 // shared exceptions for cross_module_tests
 
-class PYBIND11_EXPORT tmp_e : public pybind11::builtin_exception {
+class PYBIND11_EXPORT shared_exception : public pybind11::builtin_exception {
 public:
     using builtin_exception::builtin_exception;
-    explicit tmp_e() : tmp_e("") {}
+    explicit shared_exception() : shared_exception("") {}
     void set_error() const override { PyErr_SetString(PyExc_RuntimeError, what()); }
 };

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,6 +3,8 @@ import sys
 
 import pytest
 
+import env  # noqa: F401
+
 from pybind11_tests import exceptions as m
 import pybind11_cross_module_tests as cm
 
@@ -43,7 +45,14 @@ def test_cross_module_exceptions():
     with pytest.raises(StopIteration) as excinfo:
         cm.throw_stop_iteration()
 
-    with pytest.raises(KeyError) as excinfo:
+
+# TODO: FIXME
+@pytest.mark.skipif(
+    "env.PYPY and env.MACOS",
+    reason="Known failure with PyPy and libc++ (Issue #2847 & PR #2999)",
+)
+def test_cross_module_exception_translator():
+    with pytest.raises(KeyError) as _:
         # translator registered in cross_module_tests
         m.throw_should_be_translated_to_key_error()
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -50,10 +50,10 @@ def test_cross_module_exceptions():
 @pytest.mark.xfail(
     "env.PYPY and env.MACOS",
     raises=RuntimeError,
-    reason="Known failure with PyPy and libc++ (Issue #2847 & PR #2999)",
+    reason="Expected failure with PyPy and libc++ (Issue #2847 & PR #2999)",
 )
 def test_cross_module_exception_translator():
-    with pytest.raises(KeyError) as _:
+    with pytest.raises(KeyError):
         # translator registered in cross_module_tests
         m.throw_should_be_translated_to_key_error()
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -43,6 +43,9 @@ def test_cross_module_exceptions():
     with pytest.raises(StopIteration) as excinfo:
         cm.throw_stop_iteration()
 
+    with pytest.raises(KeyError) as excinfo:
+        m.throw_()
+
 
 def test_python_call_in_catch():
     d = {}

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -47,8 +47,9 @@ def test_cross_module_exceptions():
 
 
 # TODO: FIXME
-@pytest.mark.skipif(
+@pytest.mark.xfail(
     "env.PYPY and env.MACOS",
+    raises=RuntimeError,
     reason="Known failure with PyPy and libc++ (Issue #2847 & PR #2999)",
 )
 def test_cross_module_exception_translator():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -44,7 +44,8 @@ def test_cross_module_exceptions():
         cm.throw_stop_iteration()
 
     with pytest.raises(KeyError) as excinfo:
-        m.throw_()
+        # translator registered in cross_module_tests
+        m.throw_should_be_translated_to_key_error()
 
 
 def test_python_call_in_catch():


### PR DESCRIPTION
## Description

closes #2847 by setting visibility of exceptions to default. cc @XZiar
closes #3016

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
``pybind11::builtin_exception`` is now explicitly exported, which means the types included/defined in different modules are identical, and exceptions raised in different modules can be caught correctly. The documentation was updated to explain that custom exceptions that are used across module boundaries need to be explicitly exported as well.
```

<!-- If the upgrade guide needs updating, note that here too -->
