### PR TITLE
use CMAKE_INSTALL_FULL_INCLUDEDIR

### DIFF
--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -201,7 +201,7 @@ Using ``find_package`` with version info is not recommended except for release v
 @PACKAGE_INIT@
 
 # Location of pybind11/pybind11.h
-set(pybind11_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
+set(pybind11_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
 
 set(pybind11_LIBRARY "")
 set(pybind11_DEFINITIONS USING_pybind11)


### PR DESCRIPTION
## Description
see https://github.com/jtojnar/cmake-snips#assuming-cmake_install_dir-is-relative-path


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
fix pybind11_INCLUDE_DIR in case CMAKE_INSTALL_INCLUDEDIR is absolute
```

<!-- If the upgrade guide needs updating, note that here too -->
