### PR TITLE
Docs: CMake LTO honor global flag

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -500,7 +500,10 @@ You can use these targets to build complex applications. For example, the
 
     add_library(example MODULE main.cpp)
 
-    target_link_libraries(example PRIVATE pybind11::module pybind11::lto pybind11::windows_extras)
+    target_link_libraries(example PRIVATE pybind11::module pybind11::windows_extras)
+    if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_link_libraries(example PRIVATE pybind11::lto)
+    endif()
 
     pybind11_extension(example)
     pybind11_strip(example)


### PR DESCRIPTION
## Description

In this example, the IPO/LTO flags should not be added if the general property is already set for all targets via `CMAKE_INTERPROCEDURAL_OPTIMIZATION`.

Also, if `CMAKE_INTERPROCEDURAL_OPTIMIZATION` is set to `OFF`, LTO flags should also not be added. This is sometimes needed when working around compiler bugs with IPO/LTO, e.g. on ppc64le with some
toolchains.


## Suggested changelog entry:

```rst
- documentation: improve manual LTO CMake example
```

<!-- If the upgrade guide needs updating, note that here too -->
