### PR TITLE
Add const T to docstring generation.

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1029,7 +1029,10 @@ struct npy_format_descriptor_name<T, enable_if_t<std::is_integral<T>::value>> {
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_floating_point<T>::value>> {
-    static constexpr auto name = _<std::is_same<T, float>::value || std::is_same<T, double>::value>(
+    static constexpr auto name = _<std::is_same<T, float>::value
+                                   || std::is_same<T, const float>::value
+                                   || std::is_same<T, const double>::value
+                                   || std::is_same<T, double>::value>(
         _("numpy.float") + _<sizeof(T)*8>(), _("numpy.longdouble")
     );
 };
@@ -1037,7 +1040,9 @@ struct npy_format_descriptor_name<T, enable_if_t<std::is_floating_point<T>::valu
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<is_complex<T>::value>> {
     static constexpr auto name = _<std::is_same<typename T::value_type, float>::value
-                                   || std::is_same<typename T::value_type, double>::value>(
+                                   || std::is_same<typename T::value_type, const float>::value
+                                   || std::is_same<typename T::value_type, double>::value
+                                   || std::is_same<typename T::value_type, const double>::value>(
         _("numpy.complex") + _<sizeof(typename T::value_type)*16>(), _("numpy.longcomplex")
     );
 };

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1031,8 +1031,8 @@ template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_floating_point<T>::value>> {
     static constexpr auto name = _<std::is_same<T, float>::value
                                    || std::is_same<T, const float>::value
-                                   || std::is_same<T, const double>::value
-                                   || std::is_same<T, double>::value>(
+                                   || std::is_same<T, double>::value
+                                   || std::is_same<T, const double>::value>(
         _("numpy.float") + _<sizeof(T)*8>(), _("numpy.longdouble")
     );
 };

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -438,7 +438,9 @@ TEST_SUBMODULE(numpy_array, sm) {
            [](py::array_t<double, py::array::forcecast | py::array::f_style>) {},
            "a"_a.noconvert());
 
-    // Check that const types returns correct npy format descriptor
-    sm.def("const_double", [](py::array_t<const double>) {});
+    // Check that types returns correct npy format descriptor
+    sm.def("float", [](py::array_t<float>) {});
+    sm.def("double", [](py::array_t<double>) {});
     sm.def("const_float", [](py::array_t<const float>) {});
+    sm.def("const_double", [](py::array_t<const double>) {});
 }

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -439,8 +439,8 @@ TEST_SUBMODULE(numpy_array, sm) {
            "a"_a.noconvert());
 
     // Check that types returns correct npy format descriptor
-    sm.def("float", [](py::array_t<float>) {});
-    sm.def("double", [](py::array_t<double>) {});
-    sm.def("const_float", [](py::array_t<const float>) {});
-    sm.def("const_double", [](py::array_t<const double>) {});
+    sm.def("test_fmt_desc_float", [](py::array_t<float>) {});
+    sm.def("test_fmt_desc_double", [](py::array_t<double>) {});
+    sm.def("test_fmt_desc_const_float", [](py::array_t<const float>) {});
+    sm.def("test_fmt_desc_const_double", [](py::array_t<const double>) {});
 }

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -437,4 +437,8 @@ TEST_SUBMODULE(numpy_array, sm) {
     sm.def("accept_double_f_style_forcecast_noconvert",
            [](py::array_t<double, py::array::forcecast | py::array::f_style>) {},
            "a"_a.noconvert());
+
+    // Check that const types returns correct npy format descriptor
+    sm.def("const_double", [](py::array_t<const double>) {});
+    sm.def("const_float", [](py::array_t<const float>) {});
 }

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -482,7 +482,9 @@ def test_index_using_ellipsis():
     assert a.shape == (6,)
 
 
-def test_format_descriptors_for_const_types():
+def test_format_descriptors_for_floating_point_types():
+    assert m.float.__doc__ == "float(arg0: numpy.ndarray[numpy.float32]) -> None\n"
+    assert m.double.__doc__ == "double(arg0: numpy.ndarray[numpy.float64]) -> None\n"
     assert (
         m.const_float.__doc__
         == "const_float(arg0: numpy.ndarray[numpy.float32]) -> None\n"

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -482,23 +482,17 @@ def test_index_using_ellipsis():
     assert a.shape == (6,)
 
 
-def test_format_descriptors_for_floating_point_types():
-    assert (
-        m.test_fmt_desc_float.__doc__
-        == "test_fmt_desc_float(arg0: numpy.ndarray[numpy.float32]) -> None\n"
-    )
-    assert (
-        m.test_fmt_desc_double.__doc__
-        == "test_fmt_desc_double(arg0: numpy.ndarray[numpy.float64]) -> None\n"
-    )
-    assert (
-        m.test_fmt_desc_const_float.__doc__
-        == "test_fmt_desc_const_float(arg0: numpy.ndarray[numpy.float32]) -> None\n"
-    )
-    assert (
-        m.test_fmt_desc_const_double.__doc__
-        == "test_fmt_desc_const_double(arg0: numpy.ndarray[numpy.float64]) -> None\n"
-    )
+@pytest.mark.parametrize(
+    "test_func",
+    [
+        m.test_fmt_desc_float,
+        m.test_fmt_desc_double,
+        m.test_fmt_desc_const_float,
+        m.test_fmt_desc_const_double,
+    ],
+)
+def test_format_descriptors_for_floating_point_types(test_func):
+    assert "numpy.ndarray[numpy.float" in test_func.__doc__
 
 
 @pytest.mark.parametrize("forcecast", [False, True])

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -483,15 +483,21 @@ def test_index_using_ellipsis():
 
 
 def test_format_descriptors_for_floating_point_types():
-    assert m.float.__doc__ == "float(arg0: numpy.ndarray[numpy.float32]) -> None\n"
-    assert m.double.__doc__ == "double(arg0: numpy.ndarray[numpy.float64]) -> None\n"
     assert (
-        m.const_float.__doc__
-        == "const_float(arg0: numpy.ndarray[numpy.float32]) -> None\n"
+        m.test_fmt_desc_float.__doc__
+        == "test_fmt_desc_float(arg0: numpy.ndarray[numpy.float32]) -> None\n"
     )
     assert (
-        m.const_double.__doc__
-        == "const_double(arg0: numpy.ndarray[numpy.float64]) -> None\n"
+        m.test_fmt_desc_double.__doc__
+        == "test_fmt_desc_double(arg0: numpy.ndarray[numpy.float64]) -> None\n"
+    )
+    assert (
+        m.test_fmt_desc_const_float.__doc__
+        == "test_fmt_desc_const_float(arg0: numpy.ndarray[numpy.float32]) -> None\n"
+    )
+    assert (
+        m.test_fmt_desc_const_double.__doc__
+        == "test_fmt_desc_const_double(arg0: numpy.ndarray[numpy.float64]) -> None\n"
     )
 
 

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -481,9 +481,17 @@ def test_index_using_ellipsis():
     a = m.index_using_ellipsis(np.zeros((5, 6, 7)))
     assert a.shape == (6,)
 
+
 def test_format_descriptors_for_const_types():
-    assert(m.const_float.__doc__ == "const_float(arg0: numpy.ndarray[numpy.float32]) -> None\n")
-    assert(m.const_double.__doc__ == "const_double(arg0: numpy.ndarray[numpy.float64]) -> None\n")
+    assert (
+        m.const_float.__doc__
+        == "const_float(arg0: numpy.ndarray[numpy.float32]) -> None\n"
+    )
+    assert (
+        m.const_double.__doc__
+        == "const_double(arg0: numpy.ndarray[numpy.float64]) -> None\n"
+    )
+
 
 @pytest.mark.parametrize("forcecast", [False, True])
 @pytest.mark.parametrize("contiguity", [None, "C", "F"])

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -481,6 +481,9 @@ def test_index_using_ellipsis():
     a = m.index_using_ellipsis(np.zeros((5, 6, 7)))
     assert a.shape == (6,)
 
+def test_format_descriptors_for_const_types():
+    assert(m.const_double.__doc__ == "const_double(arg0: numpy.ndarray[numpy.longdouble]) -> None\n")
+    assert(m.const_float.__doc__ == "const_float(arg0: numpy.ndarray[numpy.longdouble]) -> None\n")
 
 @pytest.mark.parametrize("forcecast", [False, True])
 @pytest.mark.parametrize("contiguity", [None, "C", "F"])

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -482,8 +482,8 @@ def test_index_using_ellipsis():
     assert a.shape == (6,)
 
 def test_format_descriptors_for_const_types():
-    assert(m.const_double.__doc__ == "const_double(arg0: numpy.ndarray[numpy.longdouble]) -> None\n")
-    assert(m.const_float.__doc__ == "const_float(arg0: numpy.ndarray[numpy.longdouble]) -> None\n")
+    assert(m.const_float.__doc__ == "const_float(arg0: numpy.ndarray[numpy.float32]) -> None\n")
+    assert(m.const_double.__doc__ == "const_double(arg0: numpy.ndarray[numpy.float64]) -> None\n")
 
 @pytest.mark.parametrize("forcecast", [False, True])
 @pytest.mark.parametrize("contiguity", [None, "C", "F"])

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -31,7 +31,7 @@ std::ostream& operator<<(std::ostream& os, const SimpleStruct& v) {
 
 struct SimpleStructReordered {
     bool bool_;
-    const float float_;
+    float float_;
     uint32_t uint_;
     long double ldbl_;
 };

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -31,7 +31,7 @@ std::ostream& operator<<(std::ostream& os, const SimpleStruct& v) {
 
 struct SimpleStructReordered {
     bool bool_;
-    float float_;
+    const float float_;
     uint32_t uint_;
     long double ldbl_;
 };


### PR DESCRIPTION
## Description

When using const T in pyarray auto-generated documentation shows long double type.

## Suggested changelog entry:

Fix auto-generated documentation string when using const T in pyarray_t.