### PR TITLE
Adjusting valgrind suppression for pypocketfft.

### DIFF
--- a/tests/valgrind-numpy-scipy.supp
+++ b/tests/valgrind-numpy-scipy.supp
@@ -111,7 +111,7 @@
    fun:_Znwm
    fun:PyInit_pypocketfft
    fun:_PyImport_LoadDynamicModuleWithSpec
-   fun:_imp_create_dynamic_impl.constprop.*
+   fun:_imp_create_dynamic_impl*
    fun:_imp_create_dynamic
    fun:cfunction_vectorcall_FASTCALL
    fun:PyVectorcall_Call


### PR DESCRIPTION
To resolve systematic failures that started to appear on 2020-05-27.