### PR TITLE
Working around Centos 8 failure.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,13 +583,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Add Python 3 (Centos 7)
-      if: matrix.centos == 7
+    - name: Add Python 3
       run: yum update -y && yum install -y python3-devel gcc-c++ make git
-
-    - name: Add Python 3 (Centos 8)
-      if: matrix.centos == 8
-      run: yum update -y && yum install -y python3-devel make git
 
     - name: Update pip
       run: python3 -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -603,13 +603,13 @@ jobs:
         -DCMAKE_CXX_STANDARD=11
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
+    # Using Debug to avoid segfault that appeared around 2021-06-04,
+    # apparently when the gcc version changed from 8.3 to 8.4.
     - name: Configure 8
       if: matrix.centos == 8
       shell: bash
       run: >
         cmake -S . -B build
-        # Using Debug to avoid segfault that appeared around 2021-06-04,
-        # apparently when the gcc version changed from 8.3 to 8.4.
         -DCMAKE_BUILD_TYPE=Debug
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,8 +583,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Add Python 3
+    - name: Add Python 3 (Centos 7)
+      if: matrix.centos == 7
       run: yum update -y && yum install -y python3-devel gcc-c++ make git
+
+    - name: Add Python 3 (Centos 8)
+      if: matrix.centos == 8
+      run: yum update -y && yum install -y python3-devel make git
 
     - name: Update pip
       run: python3 -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,10 +592,25 @@ jobs:
     - name: Install dependencies
       run: python3 -m pip install cmake -r tests/requirements.txt --prefer-binary
 
-    - name: Configure
+    - name: Configure 7
+      if: matrix.centos == 7
       shell: bash
       run: >
         cmake -S . -B build
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DDOWNLOAD_EIGEN=ON
+        -DCMAKE_CXX_STANDARD=11
+        -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
+
+    - name: Configure 8
+      if: matrix.centos == 8
+      shell: bash
+      run: >
+        cmake -S . -B build
+        # Using Debug to avoid segfault that appeared around 2021-06-04,
+        # apparently when the gcc version changed from 8.3 to 8.4.
+        -DCMAKE_BUILD_TYPE=Debug
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,25 +592,21 @@ jobs:
     - name: Install dependencies
       run: python3 -m pip install cmake -r tests/requirements.txt --prefer-binary
 
-    - name: Configure 7
+    - name: VAR_BUILD_TYPE 7
       if: matrix.centos == 7
-      shell: bash
-      run: >
-        cmake -S . -B build
-        -DPYBIND11_WERROR=ON
-        -DDOWNLOAD_CATCH=ON
-        -DDOWNLOAD_EIGEN=ON
-        -DCMAKE_CXX_STANDARD=11
-        -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
+      run: echo Release > VAR_BUILD_TYPE
 
     # Using Debug to avoid segfault that appeared around 2021-06-04,
     # apparently when the gcc version changed from 8.3 to 8.4.
-    - name: Configure 8
+    - name: VAR_BUILD_TYPE 8
       if: matrix.centos == 8
+      run: echo Debug > VAR_BUILD_TYPE
+
+    - name: Configure
       shell: bash
       run: >
         cmake -S . -B build
-        -DCMAKE_BUILD_TYPE=Debug
+        -DCMAKE_BUILD_TYPE=$(cat VAR_BUILD_TYPE)
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON


### PR DESCRIPTION
Using `-DCMAKE_BUILD_TYPE=Debug` for Centos 8 as a work around for the failure below.

The failure was first observed around 2020-06-04, when the gcc version changed from 8.3 to 8.4:

```
2359.txt: gcc-c++                  x86_64  8.3.1-5.1.el8                          appstream   12 M
2360.txt: gcc-c++                  x86_64  8.4.1-1.el8                            appstream   12 M
```

```
# cmake --build build --target pytest
Consolidate compiler generated dependencies of target cross_module_gil_utils
[  4%] Built target cross_module_gil_utils
Consolidate compiler generated dependencies of target pybind11_cross_module_tests
[  9%] Built target pybind11_cross_module_tests
Consolidate compiler generated dependencies of target pybind11_tests
[100%] Built target pybind11_tests
gmake[3]: *** [tests/CMakeFiles/pytest.dir/build.make:72: tests/CMakeFiles/pytest] Segmentation fault (core dumped)
gmake[2]: *** [CMakeFiles/Makefile2:249: tests/CMakeFiles/pytest.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:256: tests/CMakeFiles/pytest.dir/rule] Error 2
gmake: *** [Makefile:183: pytest] Error 2
```

For future reference, to reproduce the crash in a docker container (thanks @henryiii):
```
docker run --rm --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -it centos:8 /bin/bash
yum update -y && yum install -y python3-devel gcc-c++ gdb make git && python3 -m pip install --upgrade pip && git clone https://github.com/pybind/pybind11.git && cd pybind11 && python3 -m pip install cmake -r tests/requirements.txt --prefer-binary && cmake -S . -B build -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -DDOWNLOAD_EIGEN=ON -DCMAKE_CXX_STANDARD=11 -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") && cmake --build build -j 16
cd build/tests
python3 -c "import pybind11_tests" # Crashes
```