### PR TITLE
Docs: Update py::kwargs example in function.rst to pass by reference

### DIFF
--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -254,7 +254,7 @@ For instance, the following statement iterates over a Python ``dict``:
 
 .. code-block:: cpp
 
-    void print_dict(py::dict dict) {
+    void print_dict(const py::dict& dict) {
         /* Easily interact with Python types */
         for (auto item : dict)
             std::cout << "key=" << std::string(py::str(item.first)) << ", "
@@ -292,7 +292,7 @@ Such functions can also be created using pybind11:
 
 .. code-block:: cpp
 
-   void generic(py::args args, py::kwargs kwargs) {
+   void generic(py::args args, const py::kwargs& kwargs) {
        /// .. do something with args
        if (kwargs)
            /// .. do something with kwargs


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
A very common clang-tidy performance issue I have noticed is that py::dict is not trivially copyable, but I can't think of any case where where you want to actually create a shallow copy of the dict intentionally. Furthermore, not creating a shallow-copy of the dict would better match pythonic syntax in the C++ side. As such, I propose editing the documentation to have this be the default practice. There are probably a lot more areas where this could be improved, but here are the two most common pieces of code I see being copy and pasted around.

As an aside, I'd recommend enabling the clang-tidy performance checks at some point to catch these issues in the tests and other places. Not that they are performance sensitive per say, but that they should show best coding practices.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Improved documentation for best practices regarding ``py::dict`` and ``py::kwargs``
```

<!-- If the upgrade guide needs updating, note that here too -->
