### PR TITLE
Avoid string copy if possible when passing a Python object to std::ostream

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -377,7 +377,11 @@ struct type_caster<std::variant<Ts...>> : variant_caster<std::variant<Ts...>> { 
 PYBIND11_NAMESPACE_END(detail)
 
 inline std::ostream &operator<<(std::ostream &os, const handle &obj) {
+#ifdef PYBIND11_HAS_STRING_VIEW
+    os << str(obj).cast<std::string_view>();
+#else
     os << (std::string) str(obj);
+#endif
     return os;
 }
 


### PR DESCRIPTION
## Description

Changes `operator<<(std::ostream &, const handle &)` to delegate to `operator<<(std::ostream &, std::string_view)` if possible. If I understand the type caster for `string_view` correctly, I think this avoids an unnecessary copy.

The `PYBIND11_HAS_STRING_VIEW` macro is defined in `cast.h`, which is indirectly included by `stl.h`. If that's likely to change in future, it might be desirable to move the macro to `internals.h` or something.

## Suggested changelog entry:

```rst
Use ``std::string_view`` if available to avoid a copy when passing an object to a ``std::ostream``.
```