### PR TITLE
setup_helpers: try import multiprocessing.synchronize too

### DIFF
--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -410,7 +410,9 @@ class ParallelCompile(object):
                     compiler._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
 
             try:
-                import multiprocessing
+                # Importing .synchronize checks for platforms that have some multiprocessing
+                # capabilities but lack semaphores, such as AWS Lambda and Android Termux.
+                import multiprocessing.synchronize
                 from multiprocessing.pool import ThreadPool
             except ImportError:
                 threads = 1


### PR DESCRIPTION
## Description

Some "exotic" platforms like AWS Lambda and Android Termux can fork processes but cannot create semaphores due to not have /dev/shm or something of that nature. On these platforms the current setup_helpers test will pass, but parallel compilation will fail. This simple change makes the test more comprehensive.

## Suggested changelog entry:

```rst
In setup_helpers.py, test for platforms that have some multiprocessing features but lack semaphores, which ParallelCompile requires.
```


