### PR TITLE
Docs: Fix typos

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -390,7 +390,7 @@ operation on the C++ side:
    py::array b = a[py::make_tuple(0, py::ellipsis(), 0)];
 
 .. versionchanged:: 2.6
-   ``py::ellipsis()`` is now also avaliable in Python 2.
+   ``py::ellipsis()`` is now also available in Python 2.
 
 Memory view
 ===========

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -149,7 +149,7 @@ Your ``pyproject.toml`` file will likely look something like this:
     and ``pyproject.toml`` are not even contained in the wheel, so this high
     Pip requirement is only for source builds, and will not affect users of
     your binary wheels. If you are building SDists and wheels, then
-    `pypa-build`_ is the recommended offical tool.
+    `pypa-build`_ is the recommended official tool.
 
 .. _PEP 517: https://www.python.org/dev/peps/pep-0517/
 .. _cibuildwheel: https://cibuildwheel.readthedocs.io
@@ -411,7 +411,7 @@ existing targets instead:
 
 .. code-block:: cmake
 
-    cmake_minumum_required(VERSION 3.15...3.19)
+    cmake_minimum_required(VERSION 3.15...3.19)
     project(example LANGUAGES CXX)
 
     find_package(Python COMPONENTS Interpreter Development REQUIRED)
@@ -516,7 +516,7 @@ Instead of setting properties, you can set ``CMAKE_*`` variables to initialize t
     compiler flags are provided to ensure high quality code generation. In
     contrast to the ``pybind11_add_module()`` command, the CMake interface
     provides a *composable* set of targets to ensure that you retain flexibility.
-    It can be expecially important to provide or set these properties; the
+    It can be especially important to provide or set these properties; the
     :ref:`FAQ <faq:symhidden>` contains an explanation on why these are needed.
 
 .. versionadded:: 2.6


### PR DESCRIPTION
## Description
* Fix various typos in the documentation

## Suggested changelog entry:
* Fix typos in the docs