### PR TITLE
Removing `std::get_deleter` `const_cast`.

### DIFF
--- a/include/pybind11/detail/smart_holder_poc.h
+++ b/include/pybind11/detail/smart_holder_poc.h
@@ -195,8 +195,7 @@ struct smart_holder {
     }
 
     void reset_vptr_deleter_armed_flag(bool armed_flag) {
-        // The const_cast is only for certain compilers (Ubuntu 20 GCC 6.3.0 being one).
-        auto vptr_del_ptr = const_cast<guarded_delete *>(std::get_deleter<guarded_delete>(vptr));
+        auto vptr_del_ptr = std::get_deleter<guarded_delete>(vptr);
         if (vptr_del_ptr == nullptr) {
             throw std::runtime_error(
                 "smart_holder::reset_vptr_deleter_armed_flag() called in an invalid context.");


### PR DESCRIPTION
Follow-on to PR #3041.

It was a small surprise that retesting here showed that the `const_cast` is not needed. Evidently I got confused by a CI failure (under PR #3023, which was and is still a work in progress) for some intermediate state in the development that lead to PR #3041. Details omitted: I don't think it's worth anyone's time.