### PR TITLE
fix(clang-tidy): Apply performance fixes from clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,4 +10,8 @@ modernize-use-auto,
 modernize-use-emplace,
 '
 
+CheckOptions:
+- key:             performance-unnecessary-value-param.AllowedTypes
+  value:           'exception_ptr$;'
+
 HeaderFilterRegex: 'pybind11/.*h'

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -91,11 +91,9 @@ struct buffer_info {
     buffer_info(const buffer_info &) = delete;
     buffer_info& operator=(const buffer_info &) = delete;
 
-    buffer_info(buffer_info &&other) {
-        (*this) = std::move(other);
-    }
+    buffer_info(buffer_info &&other) noexcept { (*this) = std::move(other); }
 
-    buffer_info& operator=(buffer_info &&rhs) {
+    buffer_info &operator=(buffer_info &&rhs) noexcept {
         ptr = rhs.ptr;
         itemsize = rhs.itemsize;
         size = rhs.size;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1064,7 +1064,9 @@ struct kw_only {};
 struct pos_only {};
 
 template <typename T>
-arg_v arg::operator=(T &&value) const { return {std::move(*this), std::forward<T>(value)}; }
+arg_v arg::operator=(T &&value) const {
+    return {*this, std::forward<T>(value)};
+}
 
 /// Alias for backward compatibility -- to be removed in version 2.0
 template <typename /*unused*/> using arg_t = arg_v;
@@ -1286,7 +1288,7 @@ private:
                          "may be passed via py::arg() to a python function call. "
                          "(compile in debug mode for details)");
     }
-    [[noreturn]] static void nameless_argument_error(std::string type) {
+    [[noreturn]] static void nameless_argument_error(const std::string &type) {
         throw type_error("Got kwargs without a name of type '" + type + "'; only named "
                          "arguments may be passed via py::arg() to a python function call. ");
     }
@@ -1295,7 +1297,7 @@ private:
                          "(compile in debug mode for details)");
     }
 
-    [[noreturn]] static void multiple_values_error(std::string name) {
+    [[noreturn]] static void multiple_values_error(const std::string &name) {
         throw type_error("Got multiple values for keyword argument '" + name + "'");
     }
 
@@ -1304,7 +1306,8 @@ private:
                          "(compile in debug mode for details)");
     }
 
-    [[noreturn]] static void argument_cast_error(std::string name, std::string type) {
+    [[noreturn]] static void argument_cast_error(const std::string &name,
+                                                 const std::string &type) {
         throw cast_error("Unable to convert call argument '" + name
                          + "' of type '" + type + "' to Python object");
     }

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -77,8 +77,8 @@ object eval(const char (&s)[N], object global = globals(), object local = object
     return eval<mode>(expr, global, local);
 }
 
-inline void exec(str expr, object global = globals(), object local = object()) {
-    eval<eval_statements>(std::move(expr), std::move(global), std::move(local));
+inline void exec(const str &expr, object global = globals(), object local = object()) {
+    eval<eval_statements>(expr, std::move(global), std::move(local));
 }
 
 template <size_t N>

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "pybind11.h"
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
@@ -43,7 +45,7 @@ enum eval_mode {
 };
 
 template <eval_mode mode = eval_expr>
-object eval(str expr, object global = globals(), object local = object()) {
+object eval(const str &expr, object global = globals(), object local = object()) {
     if (!local)
         local = global;
 
@@ -76,7 +78,7 @@ object eval(const char (&s)[N], object global = globals(), object local = object
 }
 
 inline void exec(str expr, object global = globals(), object local = object()) {
-    eval<eval_statements>(expr, global, local);
+    eval<eval_statements>(std::move(expr), std::move(global), std::move(local));
 }
 
 template <size_t N>

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -166,9 +166,9 @@ protected:
     detail::pythonbuf buffer;
 
 public:
-    scoped_ostream_redirect(std::ostream &costream = std::cout,
-                            object pyostream       = module_::import("sys").attr("stdout"))
-        : costream(costream), buffer(std::move(pyostream)) {
+    scoped_ostream_redirect(std::ostream &costream  = std::cout,
+                            const object &pyostream = module_::import("sys").attr("stdout"))
+        : costream(costream), buffer(pyostream) {
         old = costream.rdbuf(&buffer);
     }
 

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -196,9 +196,9 @@ public:
 \endrst */
 class scoped_estream_redirect : public scoped_ostream_redirect {
 public:
-    scoped_estream_redirect(std::ostream &costream = std::cerr,
-                            object pyostream       = module_::import("sys").attr("stderr"))
-        : scoped_ostream_redirect(costream, std::move(pyostream)) {}
+    scoped_estream_redirect(std::ostream &costream  = std::cerr,
+                            const object &pyostream = module_::import("sys").attr("stderr"))
+        : scoped_ostream_redirect(costream, pyostream) {}
 };
 
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -164,7 +164,7 @@ struct npy_api {
             NPY_ULONG_, NPY_ULONGLONG_, NPY_UINT_),
     };
 
-    using PyArray_Dims = struct {
+    struct PyArray_Dims {
         Py_intptr_t *ptr;
         int len;
     };

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -164,10 +164,10 @@ struct npy_api {
             NPY_ULONG_, NPY_ULONGLONG_, NPY_UINT_),
     };
 
-    typedef struct {
+    using PyArray_Dims = struct {
         Py_intptr_t *ptr;
         int len;
-    } PyArray_Dims;
+    };
 
     static npy_api& get() {
         static npy_api api = lookup();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1412,15 +1412,15 @@ public:
 
     template <typename D, typename... Extra>
     class_ &def_readwrite_static(const char *name, D *pm, const Extra& ...extra) {
-        cpp_function fget([pm](object) -> const D &{ return *pm; }, scope(*this)),
-                     fset([pm](object, const D &value) { *pm = value; }, scope(*this));
+        cpp_function fget([pm](const object &) -> const D & { return *pm; }, scope(*this)),
+            fset([pm](const object &, const D &value) { *pm = value; }, scope(*this));
         def_property_static(name, fget, fset, return_value_policy::reference, extra...);
         return *this;
     }
 
     template <typename D, typename... Extra>
     class_ &def_readonly_static(const char *name, const D *pm, const Extra& ...extra) {
-        cpp_function fget([pm](object) -> const D &{ return *pm; }, scope(*this));
+        cpp_function fget([pm](const object &) -> const D & { return *pm; }, scope(*this));
         def_property_readonly_static(name, fget, return_value_policy::reference, extra...);
         return *this;
     }
@@ -2054,7 +2054,7 @@ exception<CppException> &register_exception(handle scope,
 }
 
 PYBIND11_NAMESPACE_BEGIN(detail)
-PYBIND11_NOINLINE inline void print(tuple args, dict kwargs) {
+PYBIND11_NOINLINE inline void print(const tuple &args, const dict &kwargs) {
     auto strings = tuple(args.size());
     for (size_t i = 0; i < args.size(); ++i) {
         strings[i] = str(args[i]);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1671,30 +1671,36 @@ struct enum_base {
             }, name("__members__")), none(), none(), ""
         );
 
-        #define PYBIND11_ENUM_OP_STRICT(op, expr, strict_behavior)                     \
-            m_base.attr(op) = cpp_function(                                            \
-                [](object a, object b) {                                               \
-                    if (!type::handle_of(a).is(type::handle_of(b)))                    \
-                        strict_behavior;                                               \
-                    return expr;                                                       \
-                },                                                                     \
-                name(op), is_method(m_base), arg("other"))
+#define PYBIND11_ENUM_OP_STRICT(op, expr, strict_behavior)                                        \
+    m_base.attr(op) = cpp_function(                                                               \
+        [](const object &a, const object &b) {                                                    \
+            if (!type::handle_of(a).is(type::handle_of(b)))                                       \
+                strict_behavior;                                                                  \
+            return expr;                                                                          \
+        },                                                                                        \
+        name(op),                                                                                 \
+        is_method(m_base),                                                                        \
+        arg("other"))
 
-        #define PYBIND11_ENUM_OP_CONV(op, expr)                                        \
-            m_base.attr(op) = cpp_function(                                            \
-                [](object a_, object b_) {                                             \
-                    int_ a(a_), b(b_);                                                 \
-                    return expr;                                                       \
-                },                                                                     \
-                name(op), is_method(m_base), arg("other"))
+#define PYBIND11_ENUM_OP_CONV(op, expr)                                                           \
+    m_base.attr(op) = cpp_function(                                                               \
+        [](const object &a_, const object &b_) {                                                  \
+            int_ a(a_), b(b_);                                                                    \
+            return expr;                                                                          \
+        },                                                                                        \
+        name(op),                                                                                 \
+        is_method(m_base),                                                                        \
+        arg("other"))
 
-        #define PYBIND11_ENUM_OP_CONV_LHS(op, expr)                                    \
-            m_base.attr(op) = cpp_function(                                            \
-                [](object a_, object b) {                                              \
-                    int_ a(a_);                                                        \
-                    return expr;                                                       \
-                },                                                                     \
-                name(op), is_method(m_base), arg("other"))
+#define PYBIND11_ENUM_OP_CONV_LHS(op, expr)                                                       \
+    m_base.attr(op) = cpp_function(                                                               \
+        [](const object &a_, const object &b) {                                                   \
+            int_ a(a_);                                                                           \
+            return expr;                                                                          \
+        },                                                                                        \
+        name(op),                                                                                 \
+        is_method(m_base),                                                                        \
+        arg("other"))
 
         if (is_convertible) {
             PYBIND11_ENUM_OP_CONV_LHS("__eq__", !b.is_none() &&  a.equal(b));

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -503,7 +503,7 @@ class accessor : public object_api<accessor<Policy>> {
 public:
     accessor(handle obj, key_type key) : obj(obj), key(std::move(key)) { }
     accessor(const accessor &) = default;
-    accessor(accessor &&) = default;
+    accessor(accessor &&) noexcept = default;
 
     // accessor overload required to override default assignment operator (templates are not allowed
     // to replace default compiler-generated assignments).
@@ -1508,7 +1508,7 @@ public:
         detail::any_container<ssize_t> shape,
         detail::any_container<ssize_t> strides) {
         return memoryview::from_buffer(
-            const_cast<void*>(ptr), itemsize, format, shape, strides, true);
+            const_cast<void *>(ptr), itemsize, format, std::move(shape), std::move(strides), true);
     }
 
     template<typename T>

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -159,10 +159,13 @@ template <typename Type, typename Value> struct list_caster {
     }
 
 private:
-    template <typename T = Type,
-              enable_if_t<std::is_same<decltype(std::declval<T>().reserve(0)), void>::value, int> = 0>
-    void reserve_maybe(sequence s, Type *) { value.reserve(s.size()); }
-    void reserve_maybe(sequence, void *) { }
+    template <
+        typename T                                                                          = Type,
+        enable_if_t<std::is_same<decltype(std::declval<T>().reserve(0)), void>::value, int> = 0>
+    void reserve_maybe(const sequence &s, Type *) {
+        value.reserve(s.size());
+    }
+    void reserve_maybe(const sequence &, void *) {}
 
 public:
     template <typename T>


### PR DESCRIPTION
## Description
* Spoke with @rwgk about applying performance fixes from clang-tidy which he was supportive of. While there are some blockers preventing this from being enabled automatically, (mainly the lack of a hierarchical config to prevent the test files from being edited), I went ahead and applied various fixes from the performance checks. I also formatted all diffs with clang-format-diff.py .
* Most of changes can be summarized as (unnecessary std::move)
* Copies that should be std::move instead
* Copying in values that should be const references.
* Forgetting to add noexcept to move constructors.
* Let me know if any of the changes should be spun off or such because they are ABI breaking or can be applied immediately. 
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:
```rst
* Various performance micro-optimizations applied to the codebase using clang-tidy.
```

<!-- If the upgrade guide needs updating, note that here too -->
