### PR TITLE
ci: patch for CentOS 8 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,6 +592,7 @@ jobs:
     - name: Install dependencies
       run: python3 -m pip install cmake -r tests/requirements.txt --prefer-binary
 
+    # Added Debug build type due to unexplained segfault after CentOS8 updated to GCC 8.4
     - name: Configure
       shell: bash
       run: >
@@ -600,6 +601,7 @@ jobs:
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
         -DCMAKE_CXX_STANDARD=11
+        -DCMAKE_BUILD_TYPE=Debug
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build


### PR DESCRIPTION
## Description

CentOS 8 is broken, this temporarily fixes it.

```console
$ docker run --rm --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -it centos:8 /bin/bash
# yum update -y && yum install -y python3-devel gcc-c++ gdb make git && python3 -m pip install --upgrade pip && git clone https://github.com/pybind/pybind11.git && cd pybind11 && python3 -m pip install cmake -r tests/requirements.txt --prefer-binary && cmake -S . -B build -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -DDOWNLOAD_EIGEN=ON -DCMAKE_CXX_STANDARD=11 -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") && cmake --build build -j 16
# cd build/tests
# python3 -c "import pybind11_tests" # Crashes
```
