### PR TITLE
Fixing clang-tidy error (related to PR #3049).

### DIFF
--- a/tests/test_class_sh_unique_ptr_member.cpp
+++ b/tests/test_class_sh_unique_ptr_member.cpp
@@ -13,7 +13,6 @@ public:
 
     int get_int() const { return 213; }
 
-private:
     pointee(const pointee &) = delete;
     pointee(pointee &&)      = delete;
     pointee &operator=(const pointee &) = delete;


### PR DESCRIPTION
Example:
```
test_class_sh_unique_ptr_member.cpp:17:5: error: deleted member function should be public [modernize-use-equals-delete,-warnings-as-errors]
    pointee(const pointee &) = delete;
    ^
```
