### PR TITLE
[smart_holder] clang-tidy fixes (related to recent clang-tidy changes on master).

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -44,4 +44,4 @@ jobs:
         -DCMAKE_CXX_STANDARD=17
 
     - name: Build
-      run: cmake --build build -j 2
+      run: cmake --build build -j 2 -- --keep-going

--- a/include/pybind11/detail/smart_holder_poc.h
+++ b/include/pybind11/detail/smart_holder_poc.h
@@ -259,7 +259,7 @@ struct smart_holder {
     void release_disowned() { vptr.reset(); }
 
     // SMART_HOLDER_WIP: review this function.
-    void ensure_can_release_ownership(const char *context = "ensure_can_release_ownership") {
+    void ensure_can_release_ownership(const char *context = "ensure_can_release_ownership") const {
         ensure_is_not_disowned(context);
         ensure_vptr_is_using_builtin_delete(context);
         ensure_use_count_1(context);

--- a/include/pybind11/detail/smart_holder_poc.h
+++ b/include/pybind11/detail/smart_holder_poc.h
@@ -122,7 +122,7 @@ struct smart_holder {
           vptr_is_external_shared_ptr{false}, is_populated{false}, is_disowned{false},
           pointee_depends_on_holder_owner{false} {}
 
-    bool has_pointee() const { return vptr.get() != nullptr; }
+    bool has_pointee() const { return vptr != nullptr; }
 
     template <typename T>
     static void ensure_pointee_is_destructible(const char *context) {
@@ -180,7 +180,7 @@ struct smart_holder {
     }
 
     void ensure_use_count_1(const char *context) const {
-        if (vptr.get() == nullptr) {
+        if (vptr == nullptr) {
             throw std::invalid_argument(std::string("Cannot disown nullptr (") + context + ").");
         }
         // In multithreaded environments accessing use_count can lead to
@@ -194,7 +194,7 @@ struct smart_holder {
         }
     }
 
-    void reset_vptr_deleter_armed_flag(bool armed_flag) {
+    void reset_vptr_deleter_armed_flag(bool armed_flag) const {
         auto vptr_del_ptr = std::get_deleter<guarded_delete>(vptr);
         if (vptr_del_ptr == nullptr) {
             throw std::runtime_error(

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -25,7 +25,7 @@ struct uconsumer { // unique_ptr consumer
     void pass_rref(std::unique_ptr<atyp> &&obj) { held = std::move(obj); }
     std::unique_ptr<atyp> rtrn_valu() { return std::move(held); }
     std::unique_ptr<atyp> &rtrn_lref() { return held; }
-    const std::unique_ptr<atyp> &rtrn_cref() { return held; }
+    const std::unique_ptr<atyp> &rtrn_cref() const { return held; }
 };
 
 // clang-format off

--- a/tests/test_class_sh_disowning_mi.cpp
+++ b/tests/test_class_sh_disowning_mi.cpp
@@ -32,13 +32,13 @@ void disown_b(std::unique_ptr<B>) {}
 // test_multiple_inheritance_python
 struct Base1 {
     Base1(int i) : i(i) {}
-    int foo() { return i; }
+    int foo() const { return i; }
     int i;
 };
 
 struct Base2 {
     Base2(int j) : j(j) {}
-    int bar() { return j; }
+    int bar() const { return j; }
     int j;
 };
 

--- a/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.cpp
+++ b/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.cpp
@@ -29,7 +29,7 @@ struct PySpBase : SpBase {
 };
 
 struct SpBaseTester {
-    std::shared_ptr<SpBase> get_object() { return m_obj; }
+    std::shared_ptr<SpBase> get_object() const { return m_obj; }
     void set_object(std::shared_ptr<SpBase> obj) { m_obj = obj; }
     bool is_base_used() { return m_obj->is_base_used(); }
     bool has_instance() { return (bool)m_obj; }


### PR DESCRIPTION
Also adding `--keep-going` to `cmake` `build` command, to get all clang-tidy errors at once.