### PR TITLE
Updating and slightly enhancing instructions for running clang-tidy.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -209,9 +209,9 @@ so you can use git to monitor the changes.
 
 ```bash
 docker run --rm -v $PWD:/mounted_pybind11 -it silkeh/clang:12
-apt-get update --yes && apt-get install --yes python3-dev python3-pytest
-cmake -S /mounted_pybind11/ -B build -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-fix"
-cmake --build build -- --keep-going -j 2
+apt-get update && apt-get install -y python3-dev python3-pytest
+cmake -S /mounted_pybind11/ -B build -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-fix" -DDOWNLOAD_EIGEN=ON -DDOWNLOAD_CATCH=ON -DCMAKE_CXX_STANDARD=17
+cmake --build build -j 2 -- --keep-going
 ```
 
 ### Include what you use

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -203,14 +203,15 @@ of the pybind11 repo.
 [`clang-tidy`][clang-tidy] performs deeper static code analyses and is
 more complex to run, compared to `clang-format`, but support for `clang-tidy`
 is built into the pybind11 CMake configuration. To run `clang-tidy`, the
-following recipe should work. Files will be modified in place, so you can
-use git to monitor the changes.
+following recipe should work. Run the `docker` command from the top-level
+directory inside your pybind11 git clone. Files will be modified in place,
+so you can use git to monitor the changes.
 
 ```bash
-docker run --rm -v $PWD:/pybind11 -it silkeh/clang:10
-apt-get update && apt-get install python3-dev python3-pytest
-cmake -S pybind11/ -B build -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-fix"
-cmake --build build
+docker run --rm -v $PWD:/mounted_pybind11 -it silkeh/clang:12
+apt-get update --yes && apt-get install --yes python3-dev python3-pytest
+cmake -S /mounted_pybind11/ -B build -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-fix"
+cmake --build build -- --keep-going -j 2
 ```
 
 ### Include what you use

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,6 +25,8 @@ jobs:
         extra_args: --hook-stage manual --all-files
 
   clang-tidy:
+    # When making changes here, please also review the "Clang-Tidy" section
+    # in .github/CONTRIBUTING.md and update as needed.
     name: Clang-Tidy
     runs-on: ubuntu-latest
     container: silkeh/clang:12


### PR DESCRIPTION
Follow-on to PR #3051 which updated the docker container version in .github/workflows/format.yml but not in the docs.

Minor clarification from where to run the docker command (for docker muggles like myself).

Adding `--yes` for convenience and `--keep-going` for engineering productivity.

Tested interactively.