### PR TITLE
CONTRIBUTING: Ensure `pip` gets upgraded; install `wheel`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,6 +59,7 @@ system with CMake 3.14+:
 ```bash
 python3 -m venv venv
 source venv/bin/activate
+pip install -U pip wheel
 pip install -r tests/requirements.txt
 cmake -S . -B build -DDOWNLOAD_CATCH=ON -DDOWNLOAD_EIGEN=ON
 cmake --build build -j4
@@ -233,7 +234,8 @@ recent CMake and Python 3):
 
 ```bash
 python3 -m venv venv
-. venv/bin/activate
+source venv/bin/activate
+pip install -U pip wheel
 pip install pytest
 cmake -S . -B build-intel -DCMAKE_CXX_COMPILER=$(which icpc) -DDOWNLOAD_CATCH=ON -DDOWNLOAD_EIGEN=ON -DPYBIND11_WERROR=ON
 ```


### PR DESCRIPTION
Homogenize how to activate venv (use `source` instead of `.`)

## Description

While briefly investigating a possible new issue (https://github.com/pybind/pybind11/pull/2972#discussion_r658848867), was doing my local build env. Re-read `CONTRIBUTING`, and noted the followigng:
- When following current version (484b0f043), noted that nominal pip version `pip-9.0.1`, as installed by Ubuntu 18.04's `python3-venv` package, was emitting warnings like `Cache entry deserialization failed, entry ignored` (due to version mismatch).
- I know in other workflows, it can be useful to have `wheel`.
- Ideally, we should choose one way to activate.

This addresess those points.

## Suggested changelog entry:

N/A