### PR TITLE
Changing .clang-format `AlignConsecutiveAssignments` to `false` and applying to smart_holder code.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,6 @@
 # clang-format --style=llvm --dump-config
 BasedOnStyle: LLVM
 AccessModifierOffset: -4
-AlignConsecutiveAssignments: true
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
@@ -15,7 +14,6 @@ IndentPPDirectives: AfterHash
 IndentWidth: 4
 Language: Cpp
 SpaceAfterCStyleCast: true
-# SpaceInEmptyBlock: true # too new
 Standard: Cpp11
 TabWidth: 4
 ...


### PR DESCRIPTION
Applying new .clang-format config merged with PR #3067.

**All changes are automatic (clang-format). NO manual changes.**
