### PR TITLE
Removing `AlignConsecutiveAssignments: true`.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,6 @@
 # clang-format --style=llvm --dump-config
 BasedOnStyle: LLVM
 AccessModifierOffset: -4
-AlignConsecutiveAssignments: true
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
@@ -15,7 +14,6 @@ IndentPPDirectives: AfterHash
 IndentWidth: 4
 Language: Cpp
 SpaceAfterCStyleCast: true
-# SpaceInEmptyBlock: true # too new
 Standard: Cpp11
 TabWidth: 4
 ...


### PR DESCRIPTION
Based on discussion in 2021-06-29 meeting between @EricCousineau-TRI, @henryiii, @rwgk, @Skylion007.

Proposed by rwgk, based on experience clang-formatting the smart_holder code:

* Removal of `AlignConsecutiveAssignments`.

Motivation: Avoid `git diff` whitespace clutter. See example below.

This also brings us closer to the pure LLVM style.

While we're at it: also cleaning out a commented-out override. (If we really want it in the future it's easy enough to add back. In the meantime the config file is cleaner.)

Note: rwgk will reformat the smart_holder code after this PR is merged. Currently the master branch is not directly affected, although this PR is meant to be a preparation for globally clang-formatting all pybind11 code (after the next release).

See also: https://github.com/pybind/pybind11/wiki/Roadmap

```diff
$ git diff
diff --git a/dummy.cpp b/dummy.cpp
index fd7d1ad8..279eb5ea 100644
--- a/dummy.cpp
+++ b/dummy.cpp
@@ -1,5 +1,6 @@
-int value1 = 1;
-int value2 = 2;
-int value3 = 3;
-int value4 = 4;
-int value5 = 5;
+int value1        = 1;
+int value2        = 2;
+int value3        = 3;
+int value4        = 4;
+int value5        = 5;
+int value_special = 99;
```
