### PR TITLE
Fix various typos 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,7 @@ jobs:
       run:  yum -y install https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc-20-9-20.9-1.x86_64.rpm https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc-2020-20.9-1.x86_64.rpm
 
     # On CentOS 7, we have to filter a few tests (compiler internal error)
-    # and allow deeper templete recursion (not needed on CentOS 8 with a newer
+    # and allow deeper template recursion (not needed on CentOS 8 with a newer
     # standard library). On some systems, you many need further workarounds:
     # https://github.com/pybind/pybind11/pull/2475
     - name: Configure

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -504,7 +504,7 @@ v2.4.0 (Sep 19, 2019)
   `#1888 <https://github.com/pybind/pybind11/pull/1888>`_.
 
 * ``py::details::overload_cast_impl`` is available in C++11 mode, can be used
-  like ``overload_cast`` with an additional set of parantheses.
+  like ``overload_cast`` with an additional set of parentheses.
   `#1581 <https://github.com/pybind/pybind11/pull/1581>`_.
 
 * Fixed ``get_include()`` on Conda.

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -93,7 +93,7 @@ to a memory dependent number.
 If you are developing rapidly and have a lot of C++ files, you may want to
 avoid rebuilding files that have not changed. For simple cases were you are
 using ``pip install -e .`` and do not have local headers, you can skip the
-rebuild if a object file is newer than it's source (headers are not checked!)
+rebuild if an object file is newer than its source (headers are not checked!)
 with the following:
 
 .. code-block:: python

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -180,7 +180,7 @@ How can I create smaller binaries?
 
 To do its job, pybind11 extensively relies on a programming technique known as
 *template metaprogramming*, which is a way of performing computation at compile
-time using type information. Template metaprogamming usually instantiates code
+time using type information. Template metaprogramming usually instantiates code
 involving significant numbers of deeply nested types that are either completely
 removed or reduced to just a few instructions during the compiler's optimization
 phase. However, due to the nested nature of these types, the resulting symbol

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -281,7 +281,7 @@ Within pybind11's CMake build system, ``pybind11_add_module`` has always been
 setting the ``-fvisibility=hidden`` flag in release mode. From now on, it's
 being applied unconditionally, even in debug mode and it can no longer be opted
 out of with the ``NO_EXTRAS`` option. The ``pybind11::module`` target now also
-adds this flag to it's interface. The ``pybind11::embed`` target is unchanged.
+adds this flag to its interface. The ``pybind11::embed`` target is unchanged.
 
 The most significant change here is for the ``pybind11::module`` target. If you
 were previously relying on default visibility, i.e. if your Python module was

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -329,7 +329,7 @@ inline bool deregister_instance(instance *self, void *valptr, const type_info *t
 inline PyObject *make_new_instance(PyTypeObject *type) {
 #if defined(PYPY_VERSION)
     // PyPy gets tp_basicsize wrong (issue 2482) under multiple inheritance when the first inherited
-    // object is a a plain Python type (i.e. not derived from an extension type).  Fix it.
+    // object is a plain Python type (i.e. not derived from an extension type).  Fix it.
     ssize_t instance_size = static_cast<ssize_t>(sizeof(instance));
     if (type->tp_basicsize < instance_size) {
         type->tp_basicsize = instance_size;

--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -85,7 +85,7 @@ class Pybind11Extension(_Extension):
     * ``stdlib=libc++`` on macOS
     * ``visibility=hidden`` and ``-g0`` on Unix
 
-    Finally, you can set ``cxx_std`` via constructor or afterwords to enable
+    Finally, you can set ``cxx_std`` via constructor or afterwards to enable
     flags for C++ std, and a few extra helper flags related to the C++ standard
     level. It is _highly_ recommended you either set this, or use the provided
     ``build_ext``, which will search for the highest supported extension for

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -521,7 +521,7 @@ def test_void_caster_2():
 
 def test_const_ref_caster():
     """Verifies that const-ref is propagated through type_caster cast_op.
-    The returned ConstRefCasted type is a mimimal type that is constructed to
+    The returned ConstRefCasted type is a minimal type that is constructed to
     reference the casting mode used.
     """
     x = False

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -65,7 +65,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     #endif
     m.def("arg_refcount_h", [](py::handle h) { GC_IF_NEEDED; return h.ref_count(); });
     m.def("arg_refcount_h", [](py::handle h, py::handle, py::handle) { GC_IF_NEEDED; return h.ref_count(); });
-    // TODO replace the following nolints as appropiate
+    // TODO replace the following nolints as appropriate
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m.def("arg_refcount_o", [](py::object o) { GC_IF_NEEDED; return o.ref_count(); });
     m.def("args_refcount", [](py::args a) {

--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -39,7 +39,7 @@ TEST_SUBMODULE(numpy_vectorize, m) {
 
     // test_type_selection
     // NumPy function which only accepts specific data types
-    // Alot of these no lints could be replaced with const refs, and probably should at some point.
+    // A lot of these no lints could be replaced with const refs, and probably should at some point.
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m.def("selective_func", [](py::array_t<int, py::array::c_style>) { return "Int branch taken."; });
     // NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/tests/valgrind-numpy-scipy.supp
+++ b/tests/valgrind-numpy-scipy.supp
@@ -2,7 +2,7 @@
 #
 # On updating a dependency, to get a list of "default" leaks in e.g. NumPy, run
 # `PYTHONMALLOC=malloc valgrind --leak-check=full --show-leak-kinds=definite,indirect python3.9-dbg -c "import numpy"`
-# To use theses suppression files, add e.g. `--suppressions=valgrind-numpy-scipy.supp`
+# To use these suppression files, add e.g. `--suppressions=valgrind-numpy-scipy.supp`
 
 {
    Leaks when importing NumPy


### PR DESCRIPTION
Found via `codespell -q 3 -L nd,ot,thist`