### PR TITLE
Adding codespell to .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,6 +81,17 @@ repos:
     stages: [manual]
     additional_dependencies: [cmake, ninja]
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.1.0
+  hooks:
+  - id: codespell
+    name: codespell
+    description: Checks for common misspellings in text files.
+    entry: codespell
+    language: python
+    types: [text]
+    args: ["-q", "3", "--skip", "*.supp", "-L", "nd,ot,thist,readded"]
+
 # The original pybind11 checks for a few C++ style items
 - repo: local
   hooks:


### PR DESCRIPTION
## Description
Follow-on to PR #3075.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Checks for common misspellings were added to the pre-commit hooks.
```