### PR TITLE
Splitting out pybind11/stl/filesystem.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,8 @@ set(PYBIND11_HEADERS
     include/pybind11/pybind11.h
     include/pybind11/pytypes.h
     include/pybind11/stl.h
-    include/pybind11/stl_bind.h)
+    include/pybind11/stl_bind.h
+    include/pybind11/stl/filesystem.h)
 
 # Compare with grep and warn if mismatched
 if(PYBIND11_MASTER_PROJECT AND NOT CMAKE_VERSION VERSION_LESS 3.12)

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -41,21 +41,11 @@
 #    include <variant>
 #    define PYBIND11_HAS_VARIANT 1
 #  endif
-// std::filesystem::path
-#  if defined(PYBIND11_CPP17) && __has_include(<filesystem>) && \
-      PY_VERSION_HEX >= 0x03060000
-#    include <filesystem>
-#    define PYBIND11_HAS_FILESYSTEM 1
-#  endif
 #elif defined(_MSC_VER) && defined(PYBIND11_CPP17)
 #  include <optional>
 #  include <variant>
 #  define PYBIND11_HAS_OPTIONAL 1
 #  define PYBIND11_HAS_VARIANT 1
-#  if PY_VERSION_HEX >= 0x03060000
-#    include <filesystem>
-#    define PYBIND11_HAS_FILESYSTEM 1
-#  endif
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
@@ -385,77 +375,6 @@ struct variant_caster<V<Ts...>> {
 #if defined(PYBIND11_HAS_VARIANT)
 template <typename... Ts>
 struct type_caster<std::variant<Ts...>> : variant_caster<std::variant<Ts...>> { };
-#endif
-
-#if defined(PYBIND11_HAS_FILESYSTEM)
-template<typename T> struct path_caster {
-
-private:
-    static PyObject* unicode_from_fs_native(const std::string& w) {
-#if !defined(PYPY_VERSION)
-        return PyUnicode_DecodeFSDefaultAndSize(w.c_str(), ssize_t(w.size()));
-#else
-        // PyPy mistakenly declares the first parameter as non-const.
-        return PyUnicode_DecodeFSDefaultAndSize(
-            const_cast<char*>(w.c_str()), ssize_t(w.size()));
-#endif
-    }
-
-    static PyObject* unicode_from_fs_native(const std::wstring& w) {
-        return PyUnicode_FromWideChar(w.c_str(), ssize_t(w.size()));
-    }
-
-public:
-    static handle cast(const T& path, return_value_policy, handle) {
-        if (auto py_str = unicode_from_fs_native(path.native())) {
-            return module::import("pathlib").attr("Path")(reinterpret_steal<object>(py_str))
-                   .release();
-        }
-        return nullptr;
-    }
-
-    bool load(handle handle, bool) {
-        // PyUnicode_FSConverter and PyUnicode_FSDecoder normally take care of
-        // calling PyOS_FSPath themselves, but that's broken on PyPy (PyPy
-        // issue #3168) so we do it ourselves instead.
-        PyObject* buf = PyOS_FSPath(handle.ptr());
-        if (!buf) {
-            PyErr_Clear();
-            return false;
-        }
-        PyObject* native = nullptr;
-        if constexpr (std::is_same_v<typename T::value_type, char>) {
-            if (PyUnicode_FSConverter(buf, &native)) {
-                if (auto c_str = PyBytes_AsString(native)) {
-                    // AsString returns a pointer to the internal buffer, which
-                    // must not be free'd.
-                    value = c_str;
-                }
-            }
-        } else if constexpr (std::is_same_v<typename T::value_type, wchar_t>) {
-            if (PyUnicode_FSDecoder(buf, &native)) {
-                if (auto c_str = PyUnicode_AsWideCharString(native, nullptr)) {
-                    // AsWideCharString returns a new string that must be free'd.
-                    value = c_str;  // Copies the string.
-                    PyMem_Free(c_str);
-                }
-            }
-        }
-        Py_XDECREF(native);
-        Py_DECREF(buf);
-        if (PyErr_Occurred()) {
-            PyErr_Clear();
-            return false;
-        } else {
-            return true;
-        }
-    }
-
-    PYBIND11_TYPE_CASTER(T, _("os.PathLike"));
-};
-
-template<> struct type_caster<std::filesystem::path>
-    : public path_caster<std::filesystem::path> {};
 #endif
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -1,0 +1,92 @@
+// Copyright (c) 2021 The Pybind Development Team.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "../detail/common.h"
+
+#ifdef __has_include
+#  if defined(PYBIND11_CPP17) && __has_include(<filesystem>) && \
+      PY_VERSION_HEX >= 0x03060000
+#    include <filesystem>
+#    define PYBIND11_HAS_FILESYSTEM 1
+#  endif
+#endif
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+#if defined(PYBIND11_HAS_FILESYSTEM)
+template<typename T> struct path_caster {
+
+private:
+    static PyObject* unicode_from_fs_native(const std::string& w) {
+#if !defined(PYPY_VERSION)
+        return PyUnicode_DecodeFSDefaultAndSize(w.c_str(), ssize_t(w.size()));
+#else
+        // PyPy mistakenly declares the first parameter as non-const.
+        return PyUnicode_DecodeFSDefaultAndSize(
+            const_cast<char*>(w.c_str()), ssize_t(w.size()));
+#endif
+    }
+
+    static PyObject* unicode_from_fs_native(const std::wstring& w) {
+        return PyUnicode_FromWideChar(w.c_str(), ssize_t(w.size()));
+    }
+
+public:
+    static handle cast(const T& path, return_value_policy, handle) {
+        if (auto py_str = unicode_from_fs_native(path.native())) {
+            return module::import("pathlib").attr("Path")(reinterpret_steal<object>(py_str))
+                   .release();
+        }
+        return nullptr;
+    }
+
+    bool load(handle handle, bool) {
+        // PyUnicode_FSConverter and PyUnicode_FSDecoder normally take care of
+        // calling PyOS_FSPath themselves, but that's broken on PyPy (PyPy
+        // issue #3168) so we do it ourselves instead.
+        PyObject* buf = PyOS_FSPath(handle.ptr());
+        if (!buf) {
+            PyErr_Clear();
+            return false;
+        }
+        PyObject* native = nullptr;
+        if constexpr (std::is_same_v<typename T::value_type, char>) {
+            if (PyUnicode_FSConverter(buf, &native)) {
+                if (auto c_str = PyBytes_AsString(native)) {
+                    // AsString returns a pointer to the internal buffer, which
+                    // must not be free'd.
+                    value = c_str;
+                }
+            }
+        } else if constexpr (std::is_same_v<typename T::value_type, wchar_t>) {
+            if (PyUnicode_FSDecoder(buf, &native)) {
+                if (auto c_str = PyUnicode_AsWideCharString(native, nullptr)) {
+                    // AsWideCharString returns a new string that must be free'd.
+                    value = c_str;  // Copies the string.
+                    PyMem_Free(c_str);
+                }
+            }
+        }
+        Py_XDECREF(native);
+        Py_DECREF(buf);
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    PYBIND11_TYPE_CASTER(T, _("os.PathLike"));
+};
+
+template<> struct type_caster<std::filesystem::path>
+    : public path_caster<std::filesystem::path> {};
+#endif // PYBIND11_HAS_FILESYSTEM
+
+PYBIND11_NAMESPACE_END(detail)
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -4,7 +4,14 @@
 
 #pragma once
 
+#include "../cast.h"
+#include "../pybind11.h"
+#include "../pytypes.h"
+
 #include "../detail/common.h"
+#include "../detail/descr.h"
+
+#include <string>
 
 #ifdef __has_include
 #  if defined(PYBIND11_CPP17) && __has_include(<filesystem>) && \
@@ -38,7 +45,7 @@ private:
 public:
     static handle cast(const T& path, return_value_policy, handle) {
         if (auto py_str = unicode_from_fs_native(path.native())) {
-            return module::import("pathlib").attr("Path")(reinterpret_steal<object>(py_str))
+            return module_::import("pathlib").attr("Path")(reinterpret_steal<object>(py_str))
                    .release();
         }
         return nullptr;

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -88,9 +88,8 @@ public:
         if (PyErr_Occurred()) {
             PyErr_Clear();
             return false;
-        } else {
-            return true;
         }
+        return true;
     }
 
     PYBIND11_TYPE_CASTER(T, _("os.PathLike"));

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -21,6 +21,11 @@
 #  endif
 #endif
 
+#if !defined(PYBIND11_HAS_FILESYSTEM) && !defined(PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL)
+#    error                                                                                        \
+        "#include <filesystem> is not available. (Use -DPYBIND11_HAS_FILESYSTEM_IS_OPTIONAL to ignore.)"
+#endif
+
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -34,6 +34,7 @@ main_headers = {
     "include/pybind11/pytypes.h",
     "include/pybind11/stl.h",
     "include/pybind11/stl_bind.h",
+    "include/pybind11/stl/filesystem.h",
 }
 
 detail_headers = {

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -34,7 +34,6 @@ main_headers = {
     "include/pybind11/pytypes.h",
     "include/pybind11/stl.h",
     "include/pybind11/stl_bind.h",
-    "include/pybind11/stl/filesystem.h",
 }
 
 detail_headers = {
@@ -45,6 +44,10 @@ detail_headers = {
     "include/pybind11/detail/internals.h",
     "include/pybind11/detail/type_caster_base.h",
     "include/pybind11/detail/typeid.h",
+}
+
+stl_headers = {
+    "include/pybind11/stl/filesystem.h",
 }
 
 cmake_files = {
@@ -68,7 +71,7 @@ py_files = {
     "setup_helpers.pyi",
 }
 
-headers = main_headers | detail_headers
+headers = main_headers | detail_headers | stl_headers
 src_files = headers | cmake_files
 all_files = src_files | py_files
 
@@ -78,6 +81,7 @@ sdist_files = {
     "pybind11/include",
     "pybind11/include/pybind11",
     "pybind11/include/pybind11/detail",
+    "pybind11/include/pybind11/stl",
     "pybind11/share",
     "pybind11/share/cmake",
     "pybind11/share/cmake/pybind11",

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -10,6 +10,10 @@
 #include "pybind11_tests.h"
 #include "constructor_stats.h"
 #include <pybind11/stl.h>
+
+#ifndef PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL
+#define PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL
+#endif
 #include <pybind11/stl/filesystem.h>
 
 #include <vector>

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -10,6 +10,7 @@
 #include "pybind11_tests.h"
 #include "constructor_stats.h"
 #include <pybind11/stl.h>
+#include <pybind11/stl/filesystem.h>
 
 #include <vector>
 #include <string>

--- a/tools/setup_global.py.in
+++ b/tools/setup_global.py.in
@@ -33,8 +33,9 @@ class InstallHeadersNested(install_headers):
 
 main_headers = glob.glob("pybind11/include/pybind11/*.h")
 detail_headers = glob.glob("pybind11/include/pybind11/detail/*.h")
+stl_headers = glob.glob("pybind11/include/pybind11/stl/*.h")
 cmake_files = glob.glob("pybind11/share/cmake/pybind11/*.cmake")
-headers = main_headers + detail_headers
+headers = main_headers + detail_headers + stl_headers
 
 cmdclass = {"install_headers": InstallHeadersNested}
 $extra_cmd
@@ -58,6 +59,7 @@ setup(
         (base + "share/cmake/pybind11", cmake_files),
         (base + "include/pybind11", main_headers),
         (base + "include/pybind11/detail", detail_headers),
+        (base + "include/pybind11/stl", stl_headers),
     ],
     cmdclass=cmdclass,
 )

--- a/tools/setup_main.py.in
+++ b/tools/setup_main.py.in
@@ -16,12 +16,14 @@ setup(
         "pybind11",
         "pybind11.include.pybind11",
         "pybind11.include.pybind11.detail",
+        "pybind11.include.pybind11.stl",
         "pybind11.share.cmake.pybind11",
     ],
     package_data={
         "pybind11": ["py.typed", "*.pyi"],
         "pybind11.include.pybind11": ["*.h"],
         "pybind11.include.pybind11.detail": ["*.h"],
+        "pybind11.include.pybind11.stl": ["*.h"],
         "pybind11.share.cmake.pybind11": ["*.cmake"],
     },
     extras_require={


### PR DESCRIPTION
Unfortunately PR #2730 forces users of pybind11/stl.h to link against `-lstdc++fs` (or similar, depending on the platform) even if they don't actually use the new type caster. This issue is resolved here by moving the new type caster to pybind11/stl/filesystem.h. The `std::filessytem`-related link options will be needed only if the new header is included.

Further refinements of the cmake files (see PR comments) is beyond the scope of this PR and left for follow-on PRs.

Example breakage due to PR #2730: https://github.com/deepmind/open_spiel/runs/2999582108

This PR is mostly following the suggestion here: https://github.com/pybind/pybind11/pull/2730#issuecomment-750507575

Except using pybind11/stl/filesystem.h instead of pybind11/stlfs.h, as decided via chat.

stl.h restored to the exact state before merging PR #2730 via:
```
git checkout 733f8de24feed964f96b639a0a44247f46bed868 stl.h
```

NOTE: I will edit the #2730 change log entry after this PR is merged.