### PR TITLE
Global clang-format: pure LLVM

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,17 +3,9 @@
 # clang-format --style=llvm --dump-config
 BasedOnStyle: LLVM
 AccessModifierOffset: -4
-AlwaysBreakTemplateDeclarations: Yes
-BinPackArguments: false
-BinPackParameters: false
-BreakBeforeBinaryOperators: All
-BreakConstructorInitializers: BeforeColon
 ColumnLimit: 99
-IndentCaseLabels: true
-IndentPPDirectives: AfterHash
 IndentWidth: 4
 Language: Cpp
-SpaceAfterCStyleCast: true
 Standard: Cpp11
 TabWidth: 4
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,19 @@ repos:
 
 - repo: local
   hooks:
+  - id: docker-clang-format
+    name: Docker Clang Format
+    language: docker_image
+    types:
+    - c++
+    entry: silkeh/clang:12
+    args:
+    - clang-format
+    - -style=file
+    - -i
+
+- repo: local
+  hooks:
   - id: check-style
     name: Classic check-style
     language: system

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -18,44 +18,60 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 /// @{
 
 /// Annotation for methods
-struct is_method { handle class_; is_method(const handle &c) : class_(c) { } };
+struct is_method {
+    handle class_;
+    is_method(const handle &c) : class_(c) {}
+};
 
 /// Annotation for operators
-struct is_operator { };
+struct is_operator {};
 
 /// Annotation for classes that cannot be subclassed
-struct is_final { };
+struct is_final {};
 
 /// Annotation for parent scope
-struct scope { handle value; scope(const handle &s) : value(s) { } };
+struct scope {
+    handle value;
+    scope(const handle &s) : value(s) {}
+};
 
 /// Annotation for documentation
-struct doc { const char *value; doc(const char *value) : value(value) { } };
+struct doc {
+    const char *value;
+    doc(const char *value) : value(value) {}
+};
 
 /// Annotation for function names
-struct name { const char *value; name(const char *value) : value(value) { } };
+struct name {
+    const char *value;
+    name(const char *value) : value(value) {}
+};
 
 /// Annotation indicating that a function is an overload associated with a given "sibling"
-struct sibling { handle value; sibling(const handle &value) : value(value.ptr()) { } };
+struct sibling {
+    handle value;
+    sibling(const handle &value) : value(value.ptr()) {}
+};
 
 /// Annotation indicating that a class derives from another given type
 template <typename T> struct base {
 
-    PYBIND11_DEPRECATED("base<T>() was deprecated in favor of specifying 'T' as a template argument to class_")
-    base() { } // NOLINT(modernize-use-equals-default): breaks MSVC 2015 when adding an attribute
+    PYBIND11_DEPRECATED(
+        "base<T>() was deprecated in favor of specifying 'T' as a template argument to class_")
+    base() {} // NOLINT(modernize-use-equals-default): breaks MSVC 2015 when adding an attribute
 };
 
 /// Keep patient alive while nurse lives
-template <size_t Nurse, size_t Patient> struct keep_alive { };
+template <size_t Nurse, size_t Patient> struct keep_alive {};
 
 /// Annotation indicating that a class is involved in a multiple inheritance relationship
-struct multiple_inheritance { };
+struct multiple_inheritance {};
 
 /// Annotation which enables dynamic attributes, i.e. adds `__dict__` to a class
-struct dynamic_attr { };
+struct dynamic_attr {};
 
 /// Annotation which enables the buffer protocol for a type
-struct buffer_protocol { };
+struct buffer_protocol {};
 
 /// Annotation which requests that a special metaclass is created for a type
 struct metaclass {
@@ -66,17 +82,20 @@ struct metaclass {
     metaclass() {}
 
     /// Override pybind11's default metaclass
-    explicit metaclass(handle value) : value(value) { }
+    explicit metaclass(handle value) : value(value) {}
 };
 
 /// Annotation that marks a class as local to the module:
-struct module_local { const bool value; constexpr module_local(bool v = true) : value(v) { } };
+struct module_local {
+    const bool value;
+    constexpr module_local(bool v = true) : value(v) {}
+};
 
 /// Annotation to mark enums as an arithmetic type
-struct arithmetic { };
+struct arithmetic {};
 
 /// Mark a function for addition at the beginning of the existing overload chain instead of the end
-struct prepend { };
+struct prepend {};
 
 // clang-format off
 /** \rst
@@ -102,16 +121,14 @@ template <typename... Ts> struct call_guard;
 
 template <> struct call_guard<> { using type = detail::void_type; };
 
-template <typename T>
-struct call_guard<T> {
+template <typename T> struct call_guard<T> {
     static_assert(std::is_default_constructible<T>::value,
                   "The guard type must be default constructible");
 
     using type = T;
 };
 
-template <typename T, typename... Ts>
-struct call_guard<T, Ts...> {
+template <typename T, typename... Ts> struct call_guard<T, Ts...> {
     struct type {
         T guard{}; // Compose multiple guard types with left-to-right default-constructor order
         typename call_guard<Ts...>::type next{};
@@ -137,15 +154,16 @@ struct argument_record {
     bool none : 1;     ///< True if None is allowed when loading
 
     argument_record(const char *name, const char *descr, handle value, bool convert, bool none)
-        : name(name), descr(descr), value(value), convert(convert), none(none) { }
+        : name(name), descr(descr), value(value), convert(convert), none(none) {}
 };
 
-/// Internal data structure which holds metadata about a bound function (signature, overloads, etc.)
+/// Internal data structure which holds metadata about a bound function (signature, overloads,
+/// etc.)
 struct function_record {
     function_record()
         : is_constructor(false), is_new_style_constructor(false), is_stateless(false),
-          is_operator(false), is_method(false), has_args(false),
-          has_kwargs(false), has_kw_only_args(false), prepend(false) { }
+          is_operator(false), is_method(false), has_args(false), has_kwargs(false),
+          has_kw_only_args(false), prepend(false) {}
 
     /// Function name
     char *name = nullptr; /* why no C++ strings? They generate heavier code.. */
@@ -160,13 +178,13 @@ struct function_record {
     std::vector<argument_record> args;
 
     /// Pointer to lambda function which converts arguments and performs the actual call
-    handle (*impl) (function_call &) = nullptr;
+    handle (*impl)(function_call &) = nullptr;
 
     /// Storage for the wrapped function pointer and captured data, if any
-    void *data[3] = { };
+    void *data[3] = {};
 
     /// Pointer to custom destructor for 'data' (if needed)
-    void (*free_data) (function_record *ptr) = nullptr;
+    void (*free_data)(function_record *ptr) = nullptr;
 
     /// Return value policy associated with this function
     return_value_policy policy = return_value_policy::automatic;
@@ -224,7 +242,7 @@ struct function_record {
 struct type_record {
     PYBIND11_NOINLINE type_record()
         : multiple_inheritance(false), dynamic_attr(false), buffer_protocol(false),
-          default_holder(true), module_local(false), is_final(false) { }
+          default_holder(true), module_local(false), is_final(false) {}
 
     /// Handle to the parent scope
     handle scope;
@@ -293,12 +311,12 @@ struct type_record {
             std::string tname(base.name());
             detail::clean_type_id(tname);
             pybind11_fail("generic_type: type \"" + std::string(name) + "\" " +
-                    (default_holder ? "does not have" : "has") +
-                    " a non-default holder type while its base \"" + tname + "\" " +
-                    (base_info->default_holder ? "does not" : "does"));
+                          (default_holder ? "does not have" : "has") +
+                          " a non-default holder type while its base \"" + tname + "\" " +
+                          (base_info->default_holder ? "does not" : "does"));
         }
 
-        bases.append((PyObject *) base_info->type);
+        bases.append((PyObject *)base_info->type);
 
         if (base_info->type->tp_dictoffset != 0)
             dynamic_attr = true;
@@ -308,14 +326,13 @@ struct type_record {
     }
 };
 
-inline function_call::function_call(const function_record &f, handle p) :
-        func(f), parent(p) {
+inline function_call::function_call(const function_record &f, handle p) : func(f), parent(p) {
     args.reserve(f.nargs);
     args_convert.reserve(f.nargs);
 }
 
 /// Tag for a new-style `__init__` defined in `detail/init.h`
-struct is_new_style_constructor { };
+struct is_new_style_constructor {};
 
 /**
  * Partial template specializations to process custom attributes provided to
@@ -327,10 +344,10 @@ template <typename T, typename SFINAE = void> struct process_attribute;
 
 template <typename T> struct process_attribute_default {
     /// Default implementation: do nothing
-    static void init(const T &, function_record *) { }
-    static void init(const T &, type_record *) { }
-    static void precall(function_call &) { }
-    static void postcall(function_call &, handle) { }
+    static void init(const T &, function_record *) {}
+    static void init(const T &, type_record *) {}
+    static void precall(function_call &) {}
+    static void postcall(function_call &, handle) {}
 };
 
 /// Process an attribute specifying the function's name
@@ -348,21 +365,26 @@ template <> struct process_attribute<const char *> : process_attribute_default<c
     static void init(const char *d, function_record *r) { r->doc = const_cast<char *>(d); }
     static void init(const char *d, type_record *r) { r->doc = const_cast<char *>(d); }
 };
-template <> struct process_attribute<char *> : process_attribute<const char *> { };
+template <> struct process_attribute<char *> : process_attribute<const char *> {};
 
 /// Process an attribute indicating the function's return value policy
-template <> struct process_attribute<return_value_policy> : process_attribute_default<return_value_policy> {
+template <>
+struct process_attribute<return_value_policy> : process_attribute_default<return_value_policy> {
     static void init(const return_value_policy &p, function_record *r) { r->policy = p; }
 };
 
-/// Process an attribute which indicates that this is an overloaded function associated with a given sibling
+/// Process an attribute which indicates that this is an overloaded function associated with a
+/// given sibling
 template <> struct process_attribute<sibling> : process_attribute_default<sibling> {
     static void init(const sibling &s, function_record *r) { r->sibling = s.value; }
 };
 
 /// Process an attribute which indicates that this function is a method
 template <> struct process_attribute<is_method> : process_attribute_default<is_method> {
-    static void init(const is_method &s, function_record *r) { r->is_method = true; r->scope = s.class_; }
+    static void init(const is_method &s, function_record *r) {
+        r->is_method = true;
+        r->scope = s.class_;
+    }
 };
 
 /// Process an attribute which indicates the parent scope of a method
@@ -375,8 +397,12 @@ template <> struct process_attribute<is_operator> : process_attribute_default<is
     static void init(const is_operator &, function_record *r) { r->is_operator = true; }
 };
 
-template <> struct process_attribute<is_new_style_constructor> : process_attribute_default<is_new_style_constructor> {
-    static void init(const is_new_style_constructor &, function_record *r) { r->is_new_style_constructor = true; }
+template <>
+struct process_attribute<is_new_style_constructor>
+    : process_attribute_default<is_new_style_constructor> {
+    static void init(const is_new_style_constructor &, function_record *r) {
+        r->is_new_style_constructor = true;
+    }
 };
 
 inline void process_kw_only_arg(const arg &a, function_record *r) {
@@ -389,10 +415,12 @@ inline void process_kw_only_arg(const arg &a, function_record *r) {
 template <> struct process_attribute<arg> : process_attribute_default<arg> {
     static void init(const arg &a, function_record *r) {
         if (r->is_method && r->args.empty())
-            r->args.emplace_back("self", nullptr, handle(), true /*convert*/, false /*none not allowed*/);
+            r->args.emplace_back("self", nullptr, handle(), true /*convert*/,
+                                 false /*none not allowed*/);
         r->args.emplace_back(a.name, nullptr, handle(), !a.flag_noconvert, a.flag_none);
 
-        if (r->has_kw_only_args) process_kw_only_arg(a, r);
+        if (r->has_kw_only_args)
+            process_kw_only_arg(a, r);
     }
 };
 
@@ -400,23 +428,26 @@ template <> struct process_attribute<arg> : process_attribute_default<arg> {
 template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
     static void init(const arg_v &a, function_record *r) {
         if (r->is_method && r->args.empty())
-            r->args.emplace_back("self", nullptr /*descr*/, handle() /*parent*/, true /*convert*/, false /*none not allowed*/);
+            r->args.emplace_back("self", nullptr /*descr*/, handle() /*parent*/, true /*convert*/,
+                                 false /*none not allowed*/);
 
         if (!a.value) {
 #if !defined(NDEBUG)
             std::string descr("'");
-            if (a.name) descr += std::string(a.name) + ": ";
+            if (a.name)
+                descr += std::string(a.name) + ": ";
             descr += a.type + "'";
             if (r->is_method) {
                 if (r->name)
-                    descr += " in method '" + (std::string) str(r->scope) + "." + (std::string) r->name + "'";
+                    descr += " in method '" + (std::string)str(r->scope) + "." +
+                             (std::string)r->name + "'";
                 else
-                    descr += " in method of '" + (std::string) str(r->scope) + "'";
+                    descr += " in method of '" + (std::string)str(r->scope) + "'";
             } else if (r->name) {
-                descr += " in function '" + (std::string) r->name + "'";
+                descr += " in function '" + (std::string)r->name + "'";
             }
-            pybind11_fail("arg(): could not convert default argument "
-                          + descr + " into a Python object (type not registered yet?)");
+            pybind11_fail("arg(): could not convert default argument " + descr +
+                          " into a Python object (type not registered yet?)");
 #else
             pybind11_fail("arg(): could not convert default argument "
                           "into a Python object (type not registered yet?). "
@@ -425,15 +456,14 @@ template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
         }
         r->args.emplace_back(a.name, a.descr, a.value.inc_ref(), !a.flag_noconvert, a.flag_none);
 
-        if (r->has_kw_only_args) process_kw_only_arg(a, r);
+        if (r->has_kw_only_args)
+            process_kw_only_arg(a, r);
     }
 };
 
 /// Process a keyword-only-arguments-follow pseudo argument
 template <> struct process_attribute<kw_only> : process_attribute_default<kw_only> {
-    static void init(const kw_only &, function_record *r) {
-        r->has_kw_only_args = true;
-    }
+    static void init(const kw_only &, function_record *r) { r->has_kw_only_args = true; }
 };
 
 /// Process a positional-only-argument maker
@@ -443,31 +473,32 @@ template <> struct process_attribute<pos_only> : process_attribute_default<pos_o
     }
 };
 
-/// Process a parent class attribute.  Single inheritance only (class_ itself already guarantees that)
+/// Process a parent class attribute.  Single inheritance only (class_ itself already guarantees
+/// that)
 template <typename T>
-struct process_attribute<T, enable_if_t<is_pyobject<T>::value>> : process_attribute_default<handle> {
+struct process_attribute<T, enable_if_t<is_pyobject<T>::value>>
+    : process_attribute_default<handle> {
     static void init(const handle &h, type_record *r) { r->bases.append(h); }
 };
 
 /// Process a parent class attribute (deprecated, does not support multiple inheritance)
-template <typename T>
-struct process_attribute<base<T>> : process_attribute_default<base<T>> {
+template <typename T> struct process_attribute<base<T>> : process_attribute_default<base<T>> {
     static void init(const base<T> &, type_record *r) { r->add_base(typeid(T), nullptr); }
 };
 
 /// Process a multiple inheritance attribute
 template <>
 struct process_attribute<multiple_inheritance> : process_attribute_default<multiple_inheritance> {
-    static void init(const multiple_inheritance &, type_record *r) { r->multiple_inheritance = true; }
+    static void init(const multiple_inheritance &, type_record *r) {
+        r->multiple_inheritance = true;
+    }
 };
 
-template <>
-struct process_attribute<dynamic_attr> : process_attribute_default<dynamic_attr> {
+template <> struct process_attribute<dynamic_attr> : process_attribute_default<dynamic_attr> {
     static void init(const dynamic_attr &, type_record *r) { r->dynamic_attr = true; }
 };
 
-template <>
-struct process_attribute<is_final> : process_attribute_default<is_final> {
+template <> struct process_attribute<is_final> : process_attribute_default<is_final> {
     static void init(const is_final &, type_record *r) { r->is_final = true; }
 };
 
@@ -476,76 +507,80 @@ struct process_attribute<buffer_protocol> : process_attribute_default<buffer_pro
     static void init(const buffer_protocol &, type_record *r) { r->buffer_protocol = true; }
 };
 
-template <>
-struct process_attribute<metaclass> : process_attribute_default<metaclass> {
+template <> struct process_attribute<metaclass> : process_attribute_default<metaclass> {
     static void init(const metaclass &m, type_record *r) { r->metaclass = m.value; }
 };
 
-template <>
-struct process_attribute<module_local> : process_attribute_default<module_local> {
+template <> struct process_attribute<module_local> : process_attribute_default<module_local> {
     static void init(const module_local &l, type_record *r) { r->module_local = l.value; }
 };
 
 /// Process a 'prepend' attribute, putting this at the beginning of the overload chain
-template <>
-struct process_attribute<prepend> : process_attribute_default<prepend> {
+template <> struct process_attribute<prepend> : process_attribute_default<prepend> {
     static void init(const prepend &, function_record *r) { r->prepend = true; }
 };
 
 /// Process an 'arithmetic' attribute for enums (does nothing here)
-template <>
-struct process_attribute<arithmetic> : process_attribute_default<arithmetic> {};
+template <> struct process_attribute<arithmetic> : process_attribute_default<arithmetic> {};
 
 template <typename... Ts>
-struct process_attribute<call_guard<Ts...>> : process_attribute_default<call_guard<Ts...>> { };
+struct process_attribute<call_guard<Ts...>> : process_attribute_default<call_guard<Ts...>> {};
 
 /**
  * Process a keep_alive call policy -- invokes keep_alive_impl during the
  * pre-call handler if both Nurse, Patient != 0 and use the post-call handler
  * otherwise
  */
-template <size_t Nurse, size_t Patient> struct process_attribute<keep_alive<Nurse, Patient>> : public process_attribute_default<keep_alive<Nurse, Patient>> {
+template <size_t Nurse, size_t Patient>
+struct process_attribute<keep_alive<Nurse, Patient>>
+    : public process_attribute_default<keep_alive<Nurse, Patient>> {
     template <size_t N = Nurse, size_t P = Patient, enable_if_t<N != 0 && P != 0, int> = 0>
-    static void precall(function_call &call) { keep_alive_impl(Nurse, Patient, call, handle()); }
+    static void precall(function_call &call) {
+        keep_alive_impl(Nurse, Patient, call, handle());
+    }
     template <size_t N = Nurse, size_t P = Patient, enable_if_t<N != 0 && P != 0, int> = 0>
-    static void postcall(function_call &, handle) { }
+    static void postcall(function_call &, handle) {}
     template <size_t N = Nurse, size_t P = Patient, enable_if_t<N == 0 || P == 0, int> = 0>
-    static void precall(function_call &) { }
+    static void precall(function_call &) {}
     template <size_t N = Nurse, size_t P = Patient, enable_if_t<N == 0 || P == 0, int> = 0>
-    static void postcall(function_call &call, handle ret) { keep_alive_impl(Nurse, Patient, call, ret); }
+    static void postcall(function_call &call, handle ret) {
+        keep_alive_impl(Nurse, Patient, call, ret);
+    }
 };
 
 /// Recursively iterate over variadic template arguments
 template <typename... Args> struct process_attributes {
-    static void init(const Args&... args, function_record *r) {
-        int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0) ... };
+    static void init(const Args &...args, function_record *r) {
+        int unused[] = {0,
+                        (process_attribute<typename std::decay<Args>::type>::init(args, r), 0)...};
         ignore_unused(unused);
     }
-    static void init(const Args&... args, type_record *r) {
-        int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0) ... };
+    static void init(const Args &...args, type_record *r) {
+        int unused[] = {0,
+                        (process_attribute<typename std::decay<Args>::type>::init(args, r), 0)...};
         ignore_unused(unused);
     }
     static void precall(function_call &call) {
-        int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::precall(call), 0) ... };
+        int unused[] = {0,
+                        (process_attribute<typename std::decay<Args>::type>::precall(call), 0)...};
         ignore_unused(unused);
     }
     static void postcall(function_call &call, handle fn_ret) {
-        int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::postcall(call, fn_ret), 0) ... };
+        int unused[] = {
+            0, (process_attribute<typename std::decay<Args>::type>::postcall(call, fn_ret), 0)...};
         ignore_unused(unused);
     }
 };
 
-template <typename T>
-using is_call_guard = is_instantiation<call_guard, T>;
+template <typename T> using is_call_guard = is_instantiation<call_guard, T>;
 
 /// Extract the ``type`` from the first `call_guard` in `Extras...` (or `void_type` if none found)
 template <typename... Extra>
 using extract_guard_t = typename exactly_one_t<is_call_guard, call_guard<>, Extra...>::type;
 
 /// Check the number of named arguments at compile time
-template <typename... Extra,
-          size_t named = constexpr_sum(std::is_base_of<arg, Extra>::value...),
-          size_t self  = constexpr_sum(std::is_same<is_method, Extra>::value...)>
+template <typename... Extra, size_t named = constexpr_sum(std::is_base_of<arg, Extra>::value...),
+          size_t self = constexpr_sum(std::is_same<is_method, Extra>::value...)>
 constexpr bool expected_num_args(size_t nargs, bool has_args, bool has_kwargs) {
     return named == 0 || (self + named + size_t(has_args) + size_t(has_kwargs)) == nargs;
 }

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -78,6 +78,7 @@ struct arithmetic { };
 /// Mark a function for addition at the beginning of the existing overload chain instead of the end
 struct prepend { };
 
+// clang-format off
 /** \rst
     A call policy which places one or more guard variables (``Ts...``) around the function call.
 
@@ -95,7 +96,8 @@ struct prepend { };
             T scope_guard;
             return foo(args...); // forwarded arguments
         });
- \endrst */
+\endrst */
+// clang-format on
 template <typename... Ts> struct call_guard;
 
 template <> struct call_guard<> { using type = detail::void_type; };

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -62,7 +62,8 @@ struct metaclass {
     handle value;
 
     PYBIND11_DEPRECATED("py::metaclass() is no longer required. It's turned on by default now.")
-    metaclass() { } // NOLINT(modernize-use-equals-default): breaks MSVC 2015 when adding an attribute
+    // NOLINTNEXTLINE(modernize-use-equals-default): breaks MSVC 2015 when adding an attribute
+    metaclass() {}
 
     /// Override pybind11's default metaclass
     explicit metaclass(handle value) : value(value) { }

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -38,58 +38,67 @@ PYBIND11_NAMESPACE_END(detail)
 
 /// Information record describing a Python buffer object
 struct buffer_info {
-    void *ptr = nullptr;          // Pointer to the underlying storage
-    ssize_t itemsize = 0;         // Size of individual items in bytes
-    ssize_t size = 0;             // Total number of entries
-    std::string format;           // For homogeneous buffers, this should be set to format_descriptor<T>::format()
-    ssize_t ndim = 0;             // Number of dimensions
-    std::vector<ssize_t> shape;   // Shape of the tensor (1 entry per dimension)
-    std::vector<ssize_t> strides; // Number of bytes between adjacent entries (for each per dimension)
-    bool readonly = false;        // flag to indicate if the underlying storage may be written to
+    void *ptr = nullptr;  // Pointer to the underlying storage
+    ssize_t itemsize = 0; // Size of individual items in bytes
+    ssize_t size = 0;     // Total number of entries
+    std::string
+        format; // For homogeneous buffers, this should be set to format_descriptor<T>::format()
+    ssize_t ndim = 0;           // Number of dimensions
+    std::vector<ssize_t> shape; // Shape of the tensor (1 entry per dimension)
+    std::vector<ssize_t>
+        strides;           // Number of bytes between adjacent entries (for each per dimension)
+    bool readonly = false; // flag to indicate if the underlying storage may be written to
 
     buffer_info() = default;
 
     buffer_info(void *ptr, ssize_t itemsize, const std::string &format, ssize_t ndim,
-                detail::any_container<ssize_t> shape_in, detail::any_container<ssize_t> strides_in, bool readonly=false)
-    : ptr(ptr), itemsize(itemsize), size(1), format(format), ndim(ndim),
-      shape(std::move(shape_in)), strides(std::move(strides_in)), readonly(readonly) {
-        if (ndim != (ssize_t) shape.size() || ndim != (ssize_t) strides.size())
+                detail::any_container<ssize_t> shape_in, detail::any_container<ssize_t> strides_in,
+                bool readonly = false)
+        : ptr(ptr), itemsize(itemsize), size(1), format(format), ndim(ndim),
+          shape(std::move(shape_in)), strides(std::move(strides_in)), readonly(readonly) {
+        if (ndim != (ssize_t)shape.size() || ndim != (ssize_t)strides.size())
             pybind11_fail("buffer_info: ndim doesn't match shape and/or strides length");
-        for (size_t i = 0; i < (size_t) ndim; ++i)
+        for (size_t i = 0; i < (size_t)ndim; ++i)
             size *= shape[i];
     }
 
     template <typename T>
-    buffer_info(T *ptr, detail::any_container<ssize_t> shape_in, detail::any_container<ssize_t> strides_in, bool readonly=false)
-    : buffer_info(private_ctr_tag(), ptr, sizeof(T), format_descriptor<T>::format(), static_cast<ssize_t>(shape_in->size()), std::move(shape_in), std::move(strides_in), readonly) { }
+    buffer_info(T *ptr, detail::any_container<ssize_t> shape_in,
+                detail::any_container<ssize_t> strides_in, bool readonly = false)
+        : buffer_info(private_ctr_tag(), ptr, sizeof(T), format_descriptor<T>::format(),
+                      static_cast<ssize_t>(shape_in->size()), std::move(shape_in),
+                      std::move(strides_in), readonly) {}
 
-    buffer_info(void *ptr, ssize_t itemsize, const std::string &format, ssize_t size, bool readonly=false)
-    : buffer_info(ptr, itemsize, format, 1, {size}, {itemsize}, readonly) { }
+    buffer_info(void *ptr, ssize_t itemsize, const std::string &format, ssize_t size,
+                bool readonly = false)
+        : buffer_info(ptr, itemsize, format, 1, {size}, {itemsize}, readonly) {}
 
     template <typename T>
-    buffer_info(T *ptr, ssize_t size, bool readonly=false)
-    : buffer_info(ptr, sizeof(T), format_descriptor<T>::format(), size, readonly) { }
+    buffer_info(T *ptr, ssize_t size, bool readonly = false)
+        : buffer_info(ptr, sizeof(T), format_descriptor<T>::format(), size, readonly) {}
 
     template <typename T>
-    buffer_info(const T *ptr, ssize_t size, bool readonly=true)
-    : buffer_info(const_cast<T*>(ptr), sizeof(T), format_descriptor<T>::format(), size, readonly) { }
+    buffer_info(const T *ptr, ssize_t size, bool readonly = true)
+        : buffer_info(const_cast<T *>(ptr), sizeof(T), format_descriptor<T>::format(), size,
+                      readonly) {}
 
     explicit buffer_info(Py_buffer *view, bool ownview = true)
-    : buffer_info(view->buf, view->itemsize, view->format, view->ndim,
-            {view->shape, view->shape + view->ndim},
-            /* Though buffer::request() requests PyBUF_STRIDES, ctypes objects
-             * ignore this flag and return a view with NULL strides.
-             * When strides are NULL, build them manually.  */
-            view->strides
-            ? std::vector<ssize_t>(view->strides, view->strides + view->ndim)
-            : detail::c_strides({view->shape, view->shape + view->ndim}, view->itemsize),
-            view->readonly) {
+        : buffer_info(
+              view->buf, view->itemsize, view->format, view->ndim,
+              {view->shape, view->shape + view->ndim},
+              /* Though buffer::request() requests PyBUF_STRIDES, ctypes objects
+               * ignore this flag and return a view with NULL strides.
+               * When strides are NULL, build them manually.  */
+              view->strides
+                  ? std::vector<ssize_t>(view->strides, view->strides + view->ndim)
+                  : detail::c_strides({view->shape, view->shape + view->ndim}, view->itemsize),
+              view->readonly) {
         this->m_view = view;
         this->ownview = ownview;
     }
 
     buffer_info(const buffer_info &) = delete;
-    buffer_info& operator=(const buffer_info &) = delete;
+    buffer_info &operator=(const buffer_info &) = delete;
 
     buffer_info(buffer_info &&other) noexcept { (*this) = std::move(other); }
 
@@ -108,17 +117,23 @@ struct buffer_info {
     }
 
     ~buffer_info() {
-        if (m_view && ownview) { PyBuffer_Release(m_view); delete m_view; }
+        if (m_view && ownview) {
+            PyBuffer_Release(m_view);
+            delete m_view;
+        }
     }
 
     Py_buffer *view() const { return m_view; }
     Py_buffer *&view() { return m_view; }
-private:
-    struct private_ctr_tag { };
 
-    buffer_info(private_ctr_tag, void *ptr, ssize_t itemsize, const std::string &format, ssize_t ndim,
-                detail::any_container<ssize_t> &&shape_in, detail::any_container<ssize_t> &&strides_in, bool readonly)
-    : buffer_info(ptr, itemsize, format, ndim, std::move(shape_in), std::move(strides_in), readonly) { }
+private:
+    struct private_ctr_tag {};
+
+    buffer_info(private_ctr_tag, void *ptr, ssize_t itemsize, const std::string &format,
+                ssize_t ndim, detail::any_container<ssize_t> &&shape_in,
+                detail::any_container<ssize_t> &&strides_in, bool readonly)
+        : buffer_info(ptr, itemsize, format, ndim, std::move(shape_in), std::move(strides_in),
+                      readonly) {}
 
     Py_buffer *m_view = nullptr;
     bool ownview = false;
@@ -127,16 +142,20 @@ private:
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 template <typename T, typename SFINAE = void> struct compare_buffer_info {
-    static bool compare(const buffer_info& b) {
-        return b.format == format_descriptor<T>::format() && b.itemsize == (ssize_t) sizeof(T);
+    static bool compare(const buffer_info &b) {
+        return b.format == format_descriptor<T>::format() && b.itemsize == (ssize_t)sizeof(T);
     }
 };
 
-template <typename T> struct compare_buffer_info<T, detail::enable_if_t<std::is_integral<T>::value>> {
-    static bool compare(const buffer_info& b) {
-        return (size_t) b.itemsize == sizeof(T) && (b.format == format_descriptor<T>::value ||
-            ((sizeof(T) == sizeof(long)) && b.format == (std::is_unsigned<T>::value ? "L" : "l")) ||
-            ((sizeof(T) == sizeof(size_t)) && b.format == (std::is_unsigned<T>::value ? "N" : "n")));
+template <typename T>
+struct compare_buffer_info<T, detail::enable_if_t<std::is_integral<T>::value>> {
+    static bool compare(const buffer_info &b) {
+        return (size_t)b.itemsize == sizeof(T) &&
+               (b.format == format_descriptor<T>::value ||
+                ((sizeof(T) == sizeof(long)) &&
+                 b.format == (std::is_unsigned<T>::value ? "L" : "l")) ||
+                ((sizeof(T) == sizeof(size_t)) &&
+                 b.format == (std::is_unsigned<T>::value ? "N" : "n")));
     }
 };
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1095,9 +1095,11 @@ arg_v arg::operator=(T &&value) const {
 template <typename /*unused*/> using arg_t = arg_v;
 
 inline namespace literals {
+// clang-format off
 /** \rst
     String literal version of `arg`
- \endrst */
+\endrst */
+// clang-format on
 constexpr arg operator"" _a(const char *name, size_t) { return arg(name); }
 } // namespace literals
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -10,11 +10,11 @@
 
 #pragma once
 
-#include "pytypes.h"
 #include "detail/common.h"
 #include "detail/descr.h"
 #include "detail/type_caster_base.h"
 #include "detail/typeid.h"
+#include "pytypes.h"
 #include <array>
 #include <cstring>
 #include <functional>
@@ -28,56 +28,62 @@
 #include <vector>
 
 #if defined(PYBIND11_CPP17)
-#  if defined(__has_include)
-#    if __has_include(<string_view>)
-#      define PYBIND11_HAS_STRING_VIEW
-#    endif
-#  elif defined(_MSC_VER)
-#    define PYBIND11_HAS_STRING_VIEW
-#  endif
+#if defined(__has_include)
+#if __has_include(<string_view>)
+#define PYBIND11_HAS_STRING_VIEW
+#endif
+#elif defined(_MSC_VER)
+#define PYBIND11_HAS_STRING_VIEW
+#endif
 #endif
 #ifdef PYBIND11_HAS_STRING_VIEW
 #include <string_view>
 #endif
 
 #if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
-#  define PYBIND11_HAS_U8STRING
+#define PYBIND11_HAS_U8STRING
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-template <typename type, typename SFINAE = void> class type_caster : public type_caster_base<type> { };
+template <typename type, typename SFINAE = void>
+class type_caster : public type_caster_base<type> {};
 template <typename type> using make_caster = type_caster<intrinsic_t<type>>;
 
 // Shortcut for calling a caster's `cast_op_type` cast operator for casting a type_caster to a T
-template <typename T> typename make_caster<T>::template cast_op_type<T> cast_op(make_caster<T> &caster) {
+template <typename T>
+typename make_caster<T>::template cast_op_type<T> cast_op(make_caster<T> &caster) {
     return caster.operator typename make_caster<T>::template cast_op_type<T>();
 }
-template <typename T> typename make_caster<T>::template cast_op_type<typename std::add_rvalue_reference<T>::type>
+template <typename T>
+typename make_caster<T>::template cast_op_type<typename std::add_rvalue_reference<T>::type>
 cast_op(make_caster<T> &&caster) {
-    return std::move(caster).operator
-        typename make_caster<T>::template cast_op_type<typename std::add_rvalue_reference<T>::type>();
+    return std::move(caster).operator typename make_caster<T>::
+        template cast_op_type<typename std::add_rvalue_reference<T>::type>();
 }
 
 template <typename type> class type_caster<std::reference_wrapper<type>> {
 private:
     using caster_t = make_caster<type>;
     caster_t subcaster;
-    using reference_t = type&;
-    using subcaster_cast_op_type =
-        typename caster_t::template cast_op_type<reference_t>;
+    using reference_t = type &;
+    using subcaster_cast_op_type = typename caster_t::template cast_op_type<reference_t>;
 
-    static_assert(std::is_same<typename std::remove_const<type>::type &, subcaster_cast_op_type>::value ||
-                  std::is_same<reference_t, subcaster_cast_op_type>::value,
-                  "std::reference_wrapper<T> caster requires T to have a caster with an "
-                  "`operator T &()` or `operator const T &()`");
+    static_assert(
+        std::is_same<typename std::remove_const<type>::type &, subcaster_cast_op_type>::value ||
+            std::is_same<reference_t, subcaster_cast_op_type>::value,
+        "std::reference_wrapper<T> caster requires T to have a caster with an "
+        "`operator T &()` or `operator const T &()`");
+
 public:
     bool load(handle src, bool convert) { return subcaster.load(src, convert); }
     static constexpr auto name = caster_t::name;
-    static handle cast(const std::reference_wrapper<type> &src, return_value_policy policy, handle parent) {
+    static handle cast(const std::reference_wrapper<type> &src, return_value_policy policy,
+                       handle parent) {
         // It is definitely wrong to take ownership of this pointer, so mask that rvp
-        if (policy == return_value_policy::take_ownership || policy == return_value_policy::automatic)
+        if (policy == return_value_policy::take_ownership ||
+            policy == return_value_policy::automatic)
             policy = return_value_policy::automatic_reference;
         return caster_t::cast(&src.get(), policy, parent);
     }
@@ -105,27 +111,26 @@ public:                                                                         
     operator type *() { return &value; }                                                          \
     operator type &() { return value; }                                                           \
     operator type &&() && { return std::move(value); }                                            \
-    template <typename T_>                                                                        \
-    using cast_op_type = pybind11::detail::movable_cast_op_type<T_>
+    template <typename T_> using cast_op_type = pybind11::detail::movable_cast_op_type<T_>
 
-template <typename CharT> using is_std_char_type = any_of<
-    std::is_same<CharT, char>, /* std::string */
+template <typename CharT>
+using is_std_char_type = any_of<std::is_same<CharT, char>, /* std::string */
 #if defined(PYBIND11_HAS_U8STRING)
-    std::is_same<CharT, char8_t>, /* std::u8string */
+                                std::is_same<CharT, char8_t>, /* std::u8string */
 #endif
-    std::is_same<CharT, char16_t>, /* std::u16string */
-    std::is_same<CharT, char32_t>, /* std::u32string */
-    std::is_same<CharT, wchar_t> /* std::wstring */
->;
-
+                                std::is_same<CharT, char16_t>, /* std::u16string */
+                                std::is_same<CharT, char32_t>, /* std::u32string */
+                                std::is_same<CharT, wchar_t>   /* std::wstring */
+                                >;
 
 template <typename T>
 struct type_caster<T, enable_if_t<std::is_arithmetic<T>::value && !is_std_char_type<T>::value>> {
     using _py_type_0 = conditional_t<sizeof(T) <= sizeof(long), long, long long>;
-    using _py_type_1 = conditional_t<std::is_signed<T>::value, _py_type_0, typename std::make_unsigned<_py_type_0>::type>;
+    using _py_type_1 = conditional_t<std::is_signed<T>::value, _py_type_0,
+                                     typename std::make_unsigned<_py_type_0>::type>;
     using py_type = conditional_t<std::is_floating_point<T>::value, double, _py_type_1>;
-public:
 
+public:
     bool load(handle src, bool convert) {
         py_type py_value;
 
@@ -142,7 +147,7 @@ public:
 
         if (std::is_floating_point<T>::value) {
             if (convert || PyFloat_Check(src.ptr()))
-                py_value = (py_type) PyFloat_AsDouble(src.ptr());
+                py_value = (py_type)PyFloat_AsDouble(src.ptr());
             else
                 return false;
         } else if (PyFloat_Check(src.ptr())) {
@@ -153,14 +158,13 @@ public:
             handle src_or_index = src;
 #if PY_VERSION_HEX < 0x03080000
             object index;
-            if (!PYBIND11_LONG_CHECK(src.ptr())) {  // So: index_check(src.ptr())
+            if (!PYBIND11_LONG_CHECK(src.ptr())) { // So: index_check(src.ptr())
                 index = reinterpret_steal<object>(PyNumber_Index(src.ptr()));
                 if (!index) {
                     PyErr_Clear();
                     if (!convert)
                         return false;
-                }
-                else {
+                } else {
                     src_or_index = index;
                 }
             }
@@ -169,66 +173,77 @@ public:
                 py_value = as_unsigned<py_type>(src_or_index.ptr());
             } else { // signed integer:
                 py_value = sizeof(T) <= sizeof(long)
-                    ? (py_type) PyLong_AsLong(src_or_index.ptr())
-                    : (py_type) PYBIND11_LONG_AS_LONGLONG(src_or_index.ptr());
+                               ? (py_type)PyLong_AsLong(src_or_index.ptr())
+                               : (py_type)PYBIND11_LONG_AS_LONGLONG(src_or_index.ptr());
             }
         }
 
         // Python API reported an error
-        bool py_err = py_value == (py_type) -1 && PyErr_Occurred();
+        bool py_err = py_value == (py_type)-1 && PyErr_Occurred();
 
         // Check to see if the conversion is valid (integers should match exactly)
         // Signed/unsigned checks happen elsewhere
-        if (py_err || (std::is_integral<T>::value && sizeof(py_type) != sizeof(T) && py_value != (py_type) (T) py_value)) {
+        if (py_err || (std::is_integral<T>::value && sizeof(py_type) != sizeof(T) &&
+                       py_value != (py_type)(T)py_value)) {
             PyErr_Clear();
             if (py_err && convert && PyNumber_Check(src.ptr())) {
                 auto tmp = reinterpret_steal<object>(std::is_floating_point<T>::value
-                                                     ? PyNumber_Float(src.ptr())
-                                                     : PyNumber_Long(src.ptr()));
+                                                         ? PyNumber_Float(src.ptr())
+                                                         : PyNumber_Long(src.ptr()));
                 PyErr_Clear();
                 return load(tmp, false);
             }
             return false;
         }
 
-        value = (T) py_value;
+        value = (T)py_value;
         return true;
     }
 
-    template<typename U = T>
+    template <typename U = T>
     static typename std::enable_if<std::is_floating_point<U>::value, handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyFloat_FromDouble((double) src);
+        return PyFloat_FromDouble((double)src);
     }
 
-    template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && std::is_signed<U>::value && (sizeof(U) <= sizeof(long)), handle>::type
+    template <typename U = T>
+    static typename std::enable_if<!std::is_floating_point<U>::value && std::is_signed<U>::value &&
+                                       (sizeof(U) <= sizeof(long)),
+                                   handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PYBIND11_LONG_FROM_SIGNED((long) src);
+        return PYBIND11_LONG_FROM_SIGNED((long)src);
     }
 
-    template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && std::is_unsigned<U>::value && (sizeof(U) <= sizeof(unsigned long)), handle>::type
-    cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PYBIND11_LONG_FROM_UNSIGNED((unsigned long) src);
+    template <typename U = T>
+    static
+        typename std::enable_if<!std::is_floating_point<U>::value && std::is_unsigned<U>::value &&
+                                    (sizeof(U) <= sizeof(unsigned long)),
+                                handle>::type
+        cast(U src, return_value_policy /* policy */, handle /* parent */) {
+        return PYBIND11_LONG_FROM_UNSIGNED((unsigned long)src);
     }
 
-    template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && std::is_signed<U>::value && (sizeof(U) > sizeof(long)), handle>::type
+    template <typename U = T>
+    static typename std::enable_if<!std::is_floating_point<U>::value && std::is_signed<U>::value &&
+                                       (sizeof(U) > sizeof(long)),
+                                   handle>::type
     cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromLongLong((long long) src);
+        return PyLong_FromLongLong((long long)src);
     }
 
-    template<typename U = T>
-    static typename std::enable_if<!std::is_floating_point<U>::value && std::is_unsigned<U>::value && (sizeof(U) > sizeof(unsigned long)), handle>::type
-    cast(U src, return_value_policy /* policy */, handle /* parent */) {
-        return PyLong_FromUnsignedLongLong((unsigned long long) src);
+    template <typename U = T>
+    static
+        typename std::enable_if<!std::is_floating_point<U>::value && std::is_unsigned<U>::value &&
+                                    (sizeof(U) > sizeof(unsigned long)),
+                                handle>::type
+        cast(U src, return_value_policy /* policy */, handle /* parent */) {
+        return PyLong_FromUnsignedLongLong((unsigned long long)src);
     }
 
     PYBIND11_TYPE_CASTER(T, _<std::is_integral<T>::value>("int", "float"));
 };
 
-template<typename T> struct void_caster {
+template <typename T> struct void_caster {
 public:
     bool load(handle src, bool) {
         if (src && src.is_none())
@@ -263,7 +278,7 @@ public:
         }
 
         /* Check if this is a C++ type */
-        auto &bases = all_type_info((PyTypeObject *) type::handle_of(h).ptr());
+        auto &bases = all_type_info((PyTypeObject *)type::handle_of(h).ptr());
         if (bases.size() == 1) { // Only allowing loading from a single-value type
             value = values_and_holders(reinterpret_cast<instance *>(h.ptr())).begin()->value_ptr();
             return true;
@@ -279,19 +294,21 @@ public:
         return none().inc_ref();
     }
 
-    template <typename T> using cast_op_type = void*&;
+    template <typename T> using cast_op_type = void *&;
     operator void *&() { return value; }
     static constexpr auto name = _("capsule");
+
 private:
     void *value = nullptr;
 };
 
-template <> class type_caster<std::nullptr_t> : public void_caster<std::nullptr_t> { };
+template <> class type_caster<std::nullptr_t> : public void_caster<std::nullptr_t> {};
 
 template <> class type_caster<bool> {
 public:
     bool load(handle src, bool convert) {
-        if (!src) return false;
+        if (!src)
+            return false;
         if (src.ptr() == Py_True) {
             value = true;
             return true;
@@ -305,14 +322,14 @@ public:
 
             Py_ssize_t res = -1;
             if (src.is_none()) {
-                res = 0;  // None is implicitly converted to False
+                res = 0; // None is implicitly converted to False
             }
-            #if defined(PYPY_VERSION)
+#if defined(PYPY_VERSION)
             // On PyPy, check that "__bool__" (or "__nonzero__" on Python 2.7) attr exists
             else if (hasattr(src, PYBIND11_BOOL_ATTR)) {
                 res = PyObject_IsTrue(src.ptr());
             }
-            #else
+#else
             // Alternate approach for CPython: this does the same as the above, but optimized
             // using the CPython API so as to avoid an unneeded attribute lookup.
             else if (auto tp_as_number = src.ptr()->ob_type->tp_as_number) {
@@ -320,9 +337,9 @@ public:
                     res = (*PYBIND11_NB_BOOL(tp_as_number))(src.ptr());
                 }
             }
-            #endif
+#endif
             if (res == 0 || res == 1) {
-                value = (bool) res;
+                value = (bool)res;
                 return true;
             }
             PyErr_Clear();
@@ -341,15 +358,19 @@ template <typename StringType, bool IsView = false> struct string_caster {
 
     // Simplify life by being able to assume standard char sizes (the standard only guarantees
     // minimums, but Python requires exact sizes)
-    static_assert(!std::is_same<CharT, char>::value || sizeof(CharT) == 1, "Unsupported char size != 1");
+    static_assert(!std::is_same<CharT, char>::value || sizeof(CharT) == 1,
+                  "Unsupported char size != 1");
 #if defined(PYBIND11_HAS_U8STRING)
-    static_assert(!std::is_same<CharT, char8_t>::value || sizeof(CharT) == 1, "Unsupported char8_t size != 1");
+    static_assert(!std::is_same<CharT, char8_t>::value || sizeof(CharT) == 1,
+                  "Unsupported char8_t size != 1");
 #endif
-    static_assert(!std::is_same<CharT, char16_t>::value || sizeof(CharT) == 2, "Unsupported char16_t size != 2");
-    static_assert(!std::is_same<CharT, char32_t>::value || sizeof(CharT) == 4, "Unsupported char32_t size != 4");
+    static_assert(!std::is_same<CharT, char16_t>::value || sizeof(CharT) == 2,
+                  "Unsupported char16_t size != 2");
+    static_assert(!std::is_same<CharT, char32_t>::value || sizeof(CharT) == 4,
+                  "Unsupported char32_t size != 4");
     // wchar_t can be either 16 bits (Windows) or 32 (everywhere else)
     static_assert(!std::is_same<CharT, wchar_t>::value || sizeof(CharT) == 2 || sizeof(CharT) == 4,
-            "Unsupported wchar_t size != 2/4");
+                  "Unsupported wchar_t size != 2/4");
     static constexpr size_t UTF_N = 8 * sizeof(CharT);
 
     bool load(handle src, bool) {
@@ -373,18 +394,32 @@ template <typename StringType, bool IsView = false> struct string_caster {
                 return false;
 
             temp = reinterpret_steal<object>(PyUnicode_FromObject(load_src.ptr()));
-            if (!temp) { PyErr_Clear(); return false; }
+            if (!temp) {
+                PyErr_Clear();
+                return false;
+            }
             load_src = temp;
 #endif
         }
 
-        auto utfNbytes = reinterpret_steal<object>(PyUnicode_AsEncodedString(
-            load_src.ptr(), UTF_N == 8 ? "utf-8" : UTF_N == 16 ? "utf-16" : "utf-32", nullptr));
-        if (!utfNbytes) { PyErr_Clear(); return false; }
+        auto utfNbytes =
+            reinterpret_steal<object>(PyUnicode_AsEncodedString(load_src.ptr(),
+                                                                UTF_N == 8    ? "utf-8"
+                                                                : UTF_N == 16 ? "utf-16"
+                                                                              : "utf-32",
+                                                                nullptr));
+        if (!utfNbytes) {
+            PyErr_Clear();
+            return false;
+        }
 
-        const auto *buffer = reinterpret_cast<const CharT *>(PYBIND11_BYTES_AS_STRING(utfNbytes.ptr()));
-        size_t length = (size_t) PYBIND11_BYTES_SIZE(utfNbytes.ptr()) / sizeof(CharT);
-        if (UTF_N > 8) { buffer++; length--; } // Skip BOM for UTF-16/32
+        const auto *buffer =
+            reinterpret_cast<const CharT *>(PYBIND11_BYTES_AS_STRING(utfNbytes.ptr()));
+        size_t length = (size_t)PYBIND11_BYTES_SIZE(utfNbytes.ptr()) / sizeof(CharT);
+        if (UTF_N > 8) {
+            buffer++;
+            length--;
+        } // Skip BOM for UTF-16/32
         value = StringType(buffer, length);
 
         // If we're loading a string_view we need to keep the encoded Python object alive:
@@ -394,11 +429,13 @@ template <typename StringType, bool IsView = false> struct string_caster {
         return true;
     }
 
-    static handle cast(const StringType &src, return_value_policy /* policy */, handle /* parent */) {
+    static handle cast(const StringType &src, return_value_policy /* policy */,
+                       handle /* parent */) {
         const char *buffer = reinterpret_cast<const char *>(src.data());
         auto nbytes = ssize_t(src.size() * sizeof(CharT));
         handle s = decode_utfN(buffer, nbytes);
-        if (!s) throw error_already_set();
+        if (!s)
+            throw error_already_set();
         return s;
     }
 
@@ -407,14 +444,18 @@ template <typename StringType, bool IsView = false> struct string_caster {
 private:
     static handle decode_utfN(const char *buffer, ssize_t nbytes) {
 #if !defined(PYPY_VERSION)
-        return
-            UTF_N == 8  ? PyUnicode_DecodeUTF8(buffer, nbytes, nullptr) :
-            UTF_N == 16 ? PyUnicode_DecodeUTF16(buffer, nbytes, nullptr, nullptr) :
-                          PyUnicode_DecodeUTF32(buffer, nbytes, nullptr, nullptr);
+        return UTF_N == 8    ? PyUnicode_DecodeUTF8(buffer, nbytes, nullptr)
+               : UTF_N == 16 ? PyUnicode_DecodeUTF16(buffer, nbytes, nullptr, nullptr)
+                             : PyUnicode_DecodeUTF32(buffer, nbytes, nullptr, nullptr);
 #else
-        // PyPy segfaults when on PyUnicode_DecodeUTF16 (and possibly on PyUnicode_DecodeUTF32 as well),
-        // so bypass the whole thing by just passing the encoding as a string value, which works properly:
-        return PyUnicode_Decode(buffer, nbytes, UTF_N == 8 ? "utf-8" : UTF_N == 16 ? "utf-16" : "utf-32", nullptr);
+        // PyPy segfaults when on PyUnicode_DecodeUTF16 (and possibly on PyUnicode_DecodeUTF32 as
+        // well), so bypass the whole thing by just passing the encoding as a string value, which
+        // works properly:
+        return PyUnicode_Decode(buffer, nbytes,
+                                UTF_N == 8    ? "utf-8"
+                                : UTF_N == 16 ? "utf-16"
+                                              : "utf-32",
+                                nullptr);
 #endif
     }
 
@@ -428,7 +469,7 @@ private:
             // without any encoding attempt.
             const char *bytes = PYBIND11_BYTES_AS_STRING(src.ptr());
             if (bytes) {
-                value = StringType(bytes, (size_t) PYBIND11_BYTES_SIZE(src.ptr()));
+                value = StringType(bytes, (size_t)PYBIND11_BYTES_SIZE(src.ptr()));
                 return true;
             }
         }
@@ -437,16 +478,20 @@ private:
     }
 
     template <typename C = CharT>
-    bool load_bytes(enable_if_t<!std::is_same<C, char>::value, handle>) { return false; }
+    bool load_bytes(enable_if_t<!std::is_same<C, char>::value, handle>) {
+        return false;
+    }
 };
 
 template <typename CharT, class Traits, class Allocator>
-struct type_caster<std::basic_string<CharT, Traits, Allocator>, enable_if_t<is_std_char_type<CharT>::value>>
+struct type_caster<std::basic_string<CharT, Traits, Allocator>,
+                   enable_if_t<is_std_char_type<CharT>::value>>
     : string_caster<std::basic_string<CharT, Traits, Allocator>> {};
 
 #ifdef PYBIND11_HAS_STRING_VIEW
 template <typename CharT, class Traits>
-struct type_caster<std::basic_string_view<CharT, Traits>, enable_if_t<is_std_char_type<CharT>::value>>
+struct type_caster<std::basic_string_view<CharT, Traits>,
+                   enable_if_t<is_std_char_type<CharT>::value>>
     : string_caster<std::basic_string_view<CharT, Traits>, true> {};
 #endif
 
@@ -458,12 +503,15 @@ template <typename CharT> struct type_caster<CharT, enable_if_t<is_std_char_type
     StringCaster str_caster;
     bool none = false;
     CharT one_char = 0;
+
 public:
     bool load(handle src, bool convert) {
-        if (!src) return false;
+        if (!src)
+            return false;
         if (src.is_none()) {
             // Defer accepting None to other overloads (if we aren't in convert mode):
-            if (!convert) return false;
+            if (!convert)
+                return false;
             none = true;
             return true;
         }
@@ -471,21 +519,25 @@ public:
     }
 
     static handle cast(const CharT *src, return_value_policy policy, handle parent) {
-        if (src == nullptr) return pybind11::none().inc_ref();
+        if (src == nullptr)
+            return pybind11::none().inc_ref();
         return StringCaster::cast(StringType(src), policy, parent);
     }
 
     static handle cast(CharT src, return_value_policy policy, handle parent) {
         if (std::is_same<char, CharT>::value) {
-            handle s = PyUnicode_DecodeLatin1((const char *) &src, 1, nullptr);
-            if (!s) throw error_already_set();
+            handle s = PyUnicode_DecodeLatin1((const char *)&src, 1, nullptr);
+            if (!s)
+                throw error_already_set();
             return s;
         }
         return StringCaster::cast(StringType(1, src), policy, parent);
     }
 
-    operator CharT*() { return none ? nullptr : const_cast<CharT *>(static_cast<StringType &>(str_caster).c_str()); }
-    operator CharT&() {
+    operator CharT *() {
+        return none ? nullptr : const_cast<CharT *>(static_cast<StringType &>(str_caster).c_str());
+    }
+    operator CharT &() {
         if (none)
             throw value_error("Cannot convert None to a character");
 
@@ -495,21 +547,24 @@ public:
             throw value_error("Cannot convert empty string to a character");
 
         // If we're in UTF-8 mode, we have two possible failures: one for a unicode character that
-        // is too high, and one for multiple unicode characters (caught later), so we need to figure
-        // out how long the first encoded character is in bytes to distinguish between these two
-        // errors.  We also allow want to allow unicode characters U+0080 through U+00FF, as those
-        // can fit into a single char value.
+        // is too high, and one for multiple unicode characters (caught later), so we need to
+        // figure out how long the first encoded character is in bytes to distinguish between these
+        // two errors.  We also allow want to allow unicode characters U+0080 through U+00FF, as
+        // those can fit into a single char value.
         if (StringCaster::UTF_N == 8 && str_len > 1 && str_len <= 4) {
             auto v0 = static_cast<unsigned char>(value[0]);
             size_t char0_bytes = !(v0 & 0x80) ? 1 : // low bits only: 0-127
-                (v0 & 0xE0) == 0xC0 ? 2 : // 0b110xxxxx - start of 2-byte sequence
-                (v0 & 0xF0) == 0xE0 ? 3 : // 0b1110xxxx - start of 3-byte sequence
-                4; // 0b11110xxx - start of 4-byte sequence
+                                     (v0 & 0xE0) == 0xC0 ? 2
+                                                         : // 0b110xxxxx - start of 2-byte sequence
+                                     (v0 & 0xF0) == 0xE0 ? 3
+                                                         : // 0b1110xxxx - start of 3-byte sequence
+                                     4;                    // 0b11110xxx - start of 4-byte sequence
 
             if (char0_bytes == str_len) {
                 // If we have a 128-255 value, we can decode it into a single char:
                 if (char0_bytes == 2 && (v0 & 0xFC) == 0xC0) { // 0x110000xx 0x10xxxxxx
-                    one_char = static_cast<CharT>(((v0 & 3) << 6) + (static_cast<unsigned char>(value[1]) & 0x3F));
+                    one_char = static_cast<CharT>(((v0 & 3) << 6) +
+                                                  (static_cast<unsigned char>(value[1]) & 0x3F));
                     return one_char;
                 }
                 // Otherwise we have a single character, but it's > U+00FF
@@ -538,12 +593,12 @@ public:
 };
 
 // Base implementation for std::tuple and std::pair
-template <template<typename...> class Tuple, typename... Ts> class tuple_caster {
+template <template <typename...> class Tuple, typename... Ts> class tuple_caster {
     using type = Tuple<Ts...>;
     static constexpr auto size = sizeof...(Ts);
     using indices = make_index_sequence<size>;
-public:
 
+public:
     bool load(handle src, bool convert) {
         if (!isinstance<sequence>(src))
             return false;
@@ -553,15 +608,14 @@ public:
         return load_impl(seq, convert, indices{});
     }
 
-    template <typename T>
-    static handle cast(T &&src, return_value_policy policy, handle parent) {
+    template <typename T> static handle cast(T &&src, return_value_policy policy, handle parent) {
         return cast_impl(std::forward<T>(src), policy, parent, indices{});
     }
 
     // copied from the PYBIND11_TYPE_CASTER macro
-    template <typename T>
-    static handle cast(T *src, return_value_policy policy, handle parent) {
-        if (!src) return none().release();
+    template <typename T> static handle cast(T *src, return_value_policy policy, handle parent) {
+        if (!src)
+            return none().release();
         if (policy == return_value_policy::take_ownership) {
             auto h = cast(std::move(*src), policy, parent);
             delete src;
@@ -578,10 +632,12 @@ public:
     operator type() && { return std::move(*this).implicit_cast(indices{}); }
 
 protected:
-    template <size_t... Is>
-    type implicit_cast(index_sequence<Is...>) & { return type(cast_op<Ts>(std::get<Is>(subcasters))...); }
-    template <size_t... Is>
-    type implicit_cast(index_sequence<Is...>) && { return type(cast_op<Ts>(std::move(std::get<Is>(subcasters)))...); }
+    template <size_t... Is> type implicit_cast(index_sequence<Is...>) & {
+        return type(cast_op<Ts>(std::get<Is>(subcasters))...);
+    }
+    template <size_t... Is> type implicit_cast(index_sequence<Is...>) && {
+        return type(cast_op<Ts>(std::move(std::get<Is>(subcasters)))...);
+    }
 
     static constexpr bool load_impl(const sequence &, bool, index_sequence<>) { return true; }
 
@@ -600,16 +656,16 @@ protected:
 
     /* Implementation: Convert a C++ tuple into a Python tuple */
     template <typename T, size_t... Is>
-    static handle cast_impl(T &&src, return_value_policy policy, handle parent, index_sequence<Is...>) {
-        std::array<object, size> entries{{
-            reinterpret_steal<object>(make_caster<Ts>::cast(std::get<Is>(std::forward<T>(src)), policy, parent))...
-        }};
-        for (const auto &entry: entries)
+    static handle cast_impl(T &&src, return_value_policy policy, handle parent,
+                            index_sequence<Is...>) {
+        std::array<object, size> entries{{reinterpret_steal<object>(
+            make_caster<Ts>::cast(std::get<Is>(std::forward<T>(src)), policy, parent))...}};
+        for (const auto &entry : entries)
             if (!entry)
                 return handle();
         tuple result(size);
         int counter = 0;
-        for (auto & entry: entries)
+        for (auto &entry : entries)
             PyTuple_SET_ITEM(result.ptr(), counter++, entry.release().ptr());
         return result.release();
     }
@@ -617,16 +673,15 @@ protected:
     Tuple<make_caster<Ts>...> subcasters;
 };
 
-template <typename T1, typename T2> class type_caster<std::pair<T1, T2>>
-    : public tuple_caster<std::pair, T1, T2> {};
+template <typename T1, typename T2>
+class type_caster<std::pair<T1, T2>> : public tuple_caster<std::pair, T1, T2> {};
 
-template <typename... Ts> class type_caster<std::tuple<Ts...>>
-    : public tuple_caster<std::tuple, Ts...> {};
+template <typename... Ts>
+class type_caster<std::tuple<Ts...>> : public tuple_caster<std::tuple, Ts...> {};
 
 /// Helper class which abstracts away certain actions. Users can provide specializations for
 /// custom holders, but it's only necessary if the type has a non-standard interface.
-template <typename T>
-struct holder_helper {
+template <typename T> struct holder_helper {
     static auto get(const T &p) -> decltype(p.get()) { return p.get(); }
 };
 
@@ -640,7 +695,7 @@ struct copyable_holder_caster : public type_caster_base<type> {
 public:
     using base = type_caster_base<type>;
     static_assert(std::is_base_of<base, type_caster<type>>::value,
-            "Holder classes are only supported for custom types");
+                  "Holder classes are only supported for custom types");
     using base::base;
     using base::cast;
     using base::typeinfo;
@@ -650,12 +705,12 @@ public:
         return base::template load_impl<copyable_holder_caster<type, holder_type>>(src, convert);
     }
 
-    explicit operator type*() { return this->value; }
+    explicit operator type *() { return this->value; }
     // static_cast works around compiler error with MSVC 17 and CUDA 10.2
     // see issue #2180
-    explicit operator type&() { return *(static_cast<type *>(this->value)); }
-    explicit operator holder_type*() { return std::addressof(holder); }
-    explicit operator holder_type&() { return holder; }
+    explicit operator type &() { return *(static_cast<type *>(this->value)); }
+    explicit operator holder_type *() { return std::addressof(holder); }
+    explicit operator holder_type &() { return holder; }
 
     static handle cast(const holder_type &src, return_value_policy, handle) {
         const auto *ptr = holder_helper<holder_type>::get(src);
@@ -679,21 +734,25 @@ protected:
 #if defined(NDEBUG)
                          "(compile in debug mode for type information)");
 #else
-                         "of type '"
-                         + type_id<holder_type>() + "''");
+                         "of type '" +
+                         type_id<holder_type>() + "''");
 #endif
     }
 
-    template <typename T = holder_type, detail::enable_if_t<!std::is_constructible<T, const T &, type*>::value, int> = 0>
-    bool try_implicit_casts(handle, bool) { return false; }
+    template <typename T = holder_type,
+              detail::enable_if_t<!std::is_constructible<T, const T &, type *>::value, int> = 0>
+    bool try_implicit_casts(handle, bool) {
+        return false;
+    }
 
-    template <typename T = holder_type, detail::enable_if_t<std::is_constructible<T, const T &, type*>::value, int> = 0>
+    template <typename T = holder_type,
+              detail::enable_if_t<std::is_constructible<T, const T &, type *>::value, int> = 0>
     bool try_implicit_casts(handle src, bool convert) {
         for (auto &cast : typeinfo->implicit_casts) {
             copyable_holder_caster sub_caster(*cast.first);
             if (sub_caster.load(src, convert)) {
                 value = cast.second(sub_caster.value);
-                holder = holder_type(sub_caster.holder, (type *) value);
+                holder = holder_type(sub_caster.holder, (type *)value);
                 return true;
             }
         }
@@ -702,13 +761,12 @@ protected:
 
     static bool try_direct_conversions(handle) { return false; }
 
-
     holder_type holder;
 };
 
 /// Specialize for the common std::shared_ptr, so users don't need to
 template <typename T>
-class type_caster<std::shared_ptr<T>> : public copyable_holder_caster<T, std::shared_ptr<T>> { };
+class type_caster<std::shared_ptr<T>> : public copyable_holder_caster<T, std::shared_ptr<T>> {};
 
 /// Type caster for holder types like std::unique_ptr.
 /// Please consider the SFINAE hook an implementation detail, as explained
@@ -716,7 +774,7 @@ class type_caster<std::shared_ptr<T>> : public copyable_holder_caster<T, std::sh
 template <typename type, typename holder_type, typename SFINAE = void>
 struct move_only_holder_caster {
     static_assert(std::is_base_of<type_caster_base<type>, type_caster<type>>::value,
-            "Holder classes are only supported for custom types");
+                  "Holder classes are only supported for custom types");
 
     static handle cast(holder_type &&src, return_value_policy, handle) {
         auto *ptr = holder_helper<holder_type>::get(src);
@@ -727,34 +785,42 @@ struct move_only_holder_caster {
 
 template <typename type, typename deleter>
 class type_caster<std::unique_ptr<type, deleter>>
-    : public move_only_holder_caster<type, std::unique_ptr<type, deleter>> { };
+    : public move_only_holder_caster<type, std::unique_ptr<type, deleter>> {};
 
 template <typename type, typename holder_type>
 using type_caster_holder = conditional_t<is_copy_constructible<holder_type>::value,
                                          copyable_holder_caster<type, holder_type>,
                                          move_only_holder_caster<type, holder_type>>;
 
-template <typename T, bool Value = false> struct always_construct_holder { static constexpr bool value = Value; };
+template <typename T, bool Value = false> struct always_construct_holder {
+    static constexpr bool value = Value;
+};
 
 /// Create a specialization for custom holder types (silently ignores std::shared_ptr)
-#define PYBIND11_DECLARE_HOLDER_TYPE(type, holder_type, ...) \
-    namespace pybind11 { namespace detail { \
-    template <typename type> \
-    struct always_construct_holder<holder_type> : always_construct_holder<void, ##__VA_ARGS__>  { }; \
-    template <typename type> \
-    class type_caster<holder_type, enable_if_t<!is_shared_ptr<holder_type>::value>> \
-        : public type_caster_holder<type, holder_type> { }; \
-    }}
+#define PYBIND11_DECLARE_HOLDER_TYPE(type, holder_type, ...)                                      \
+    namespace pybind11 {                                                                          \
+    namespace detail {                                                                            \
+    template <typename type>                                                                      \
+    struct always_construct_holder<holder_type> : always_construct_holder<void, ##__VA_ARGS__> {  \
+    };                                                                                            \
+    template <typename type>                                                                      \
+    class type_caster<holder_type, enable_if_t<!is_shared_ptr<holder_type>::value>>               \
+        : public type_caster_holder<type, holder_type> {};                                        \
+    }                                                                                             \
+    }
 
 // PYBIND11_DECLARE_HOLDER_TYPE holder types:
-template <typename base, typename holder> struct is_holder_type :
-    std::is_base_of<detail::type_caster_holder<base, holder>, detail::type_caster<holder>> {};
+template <typename base, typename holder>
+struct is_holder_type
+    : std::is_base_of<detail::type_caster_holder<base, holder>, detail::type_caster<holder>> {};
 // Specialization for always-supported unique_ptr holders:
-template <typename base, typename deleter> struct is_holder_type<base, std::unique_ptr<base, deleter>> :
-    std::true_type {};
+template <typename base, typename deleter>
+struct is_holder_type<base, std::unique_ptr<base, deleter>> : std::true_type {};
 
 template <typename T> struct handle_type_name { static constexpr auto name = _<T>(); };
-template <> struct handle_type_name<bytes> { static constexpr auto name = _(PYBIND11_BYTES_NAME); };
+template <> struct handle_type_name<bytes> {
+    static constexpr auto name = _(PYBIND11_BYTES_NAME);
+};
 template <> struct handle_type_name<int_> { static constexpr auto name = _("int"); };
 template <> struct handle_type_name<iterable> { static constexpr auto name = _("Iterable"); };
 template <> struct handle_type_name<iterator> { static constexpr auto name = _("Iterator"); };
@@ -762,10 +828,12 @@ template <> struct handle_type_name<none> { static constexpr auto name = _("None
 template <> struct handle_type_name<args> { static constexpr auto name = _("*args"); };
 template <> struct handle_type_name<kwargs> { static constexpr auto name = _("**kwargs"); };
 
-template <typename type>
-struct pyobject_caster {
+template <typename type> struct pyobject_caster {
     template <typename T = type, enable_if_t<std::is_same<T, handle>::value, int> = 0>
-    bool load(handle src, bool /* convert */) { value = src; return static_cast<bool>(value); }
+    bool load(handle src, bool /* convert */) {
+        value = src;
+        return static_cast<bool>(value);
+    }
 
     template <typename T = type, enable_if_t<std::is_base_of<object, T>::value, int> = 0>
     bool load(handle src, bool /* convert */) {
@@ -775,7 +843,8 @@ struct pyobject_caster {
         // un-cluttered later after Python 2 support is dropped.
         if (std::is_same<T, str>::value && isinstance<bytes>(src)) {
             PyObject *str_from_bytes = PyUnicode_FromEncodedObject(src.ptr(), "utf-8", nullptr);
-            if (!str_from_bytes) throw error_already_set();
+            if (!str_from_bytes)
+                throw error_already_set();
             value = reinterpret_steal<type>(str_from_bytes);
             return true;
         }
@@ -793,7 +862,7 @@ struct pyobject_caster {
 };
 
 template <typename T>
-class type_caster<T, enable_if_t<is_pyobject<T>::value>> : public pyobject_caster<T> { };
+class type_caster<T, enable_if_t<is_pyobject<T>::value>> : public pyobject_caster<T> {};
 
 // Our conditions for enabling moving are quite restrictive:
 // At compile time:
@@ -804,34 +873,35 @@ class type_caster<T, enable_if_t<is_pyobject<T>::value>> : public pyobject_caste
 // - if the type is non-copy-constructible, the object must be the sole owner of the type (i.e. it
 //   must have ref_count() == 1)h
 // If any of the above are not satisfied, we fall back to copying.
-template <typename T> using move_is_plain_type = satisfies_none_of<T,
-    std::is_void, std::is_pointer, std::is_reference, std::is_const
->;
+template <typename T>
+using move_is_plain_type =
+    satisfies_none_of<T, std::is_void, std::is_pointer, std::is_reference, std::is_const>;
 template <typename T, typename SFINAE = void> struct move_always : std::false_type {};
-template <typename T> struct move_always<T, enable_if_t<all_of<
-    move_is_plain_type<T>,
-    negation<is_copy_constructible<T>>,
-    std::is_move_constructible<T>,
-    std::is_same<decltype(std::declval<make_caster<T>>().operator T&()), T&>
->::value>> : std::true_type {};
+template <typename T>
+struct move_always<
+    T,
+    enable_if_t<all_of<
+        move_is_plain_type<T>, negation<is_copy_constructible<T>>, std::is_move_constructible<T>,
+        std::is_same<decltype(std::declval<make_caster<T>>().operator T &()), T &>>::value>>
+    : std::true_type {};
 template <typename T, typename SFINAE = void> struct move_if_unreferenced : std::false_type {};
-template <typename T> struct move_if_unreferenced<T, enable_if_t<all_of<
-    move_is_plain_type<T>,
-    negation<move_always<T>>,
-    std::is_move_constructible<T>,
-    std::is_same<decltype(std::declval<make_caster<T>>().operator T&()), T&>
->::value>> : std::true_type {};
+template <typename T>
+struct move_if_unreferenced<
+    T, enable_if_t<all_of<
+           move_is_plain_type<T>, negation<move_always<T>>, std::is_move_constructible<T>,
+           std::is_same<decltype(std::declval<make_caster<T>>().operator T &()), T &>>::value>>
+    : std::true_type {};
 template <typename T> using move_never = none_of<move_always<T>, move_if_unreferenced<T>>;
 
 // Detect whether returning a `type` from a cast on type's type_caster is going to result in a
 // reference or pointer to a local variable of the type_caster.  Basically, only
 // non-reference/pointer `type`s and reference/pointers from a type_caster_generic are safe;
 // everything else returns a reference/pointer to a local variable.
-template <typename type> using cast_is_temporary_value_reference = bool_constant<
-    (std::is_reference<type>::value || std::is_pointer<type>::value) &&
-    !std::is_base_of<type_caster_generic, make_caster<type>>::value &&
-    !std::is_same<intrinsic_t<type>, void>::value
->;
+template <typename type>
+using cast_is_temporary_value_reference =
+    bool_constant<(std::is_reference<type>::value || std::is_pointer<type>::value) &&
+                  !std::is_base_of<type_caster_generic, make_caster<type>>::value &&
+                  !std::is_same<intrinsic_t<type>, void>::value>;
 
 // When a value returned from a C++ function is being cast back to Python, we almost always want to
 // force `policy = move`, regardless of the return value policy the function/method was declared
@@ -840,23 +910,28 @@ template <typename Return, typename SFINAE = void> struct return_value_policy_ov
     static return_value_policy policy(return_value_policy p) { return p; }
 };
 
-template <typename Return> struct return_value_policy_override<Return,
-        detail::enable_if_t<std::is_base_of<type_caster_generic, make_caster<Return>>::value, void>> {
+template <typename Return>
+struct return_value_policy_override<
+    Return,
+    detail::enable_if_t<std::is_base_of<type_caster_generic, make_caster<Return>>::value, void>> {
     static return_value_policy policy(return_value_policy p) {
-        return !std::is_lvalue_reference<Return>::value &&
-               !std::is_pointer<Return>::value
-                   ? return_value_policy::move : p;
+        return !std::is_lvalue_reference<Return>::value && !std::is_pointer<Return>::value
+                   ? return_value_policy::move
+                   : p;
     }
 };
 
 // Basic python -> C++ casting; throws if casting fails
-template <typename T, typename SFINAE> type_caster<T, SFINAE> &load_type(type_caster<T, SFINAE> &conv, const handle &handle) {
+template <typename T, typename SFINAE>
+type_caster<T, SFINAE> &load_type(type_caster<T, SFINAE> &conv, const handle &handle) {
     if (!conv.load(handle, true)) {
 #if defined(NDEBUG)
-        throw cast_error("Unable to cast Python instance to C++ type (compile in debug mode for details)");
+        throw cast_error(
+            "Unable to cast Python instance to C++ type (compile in debug mode for details)");
 #else
         throw cast_error("Unable to cast Python instance of type " +
-            (std::string) str(type::handle_of(handle)) + " to C++ type '" + type_id<T>() + "'");
+                         (std::string)str(type::handle_of(handle)) + " to C++ type '" +
+                         type_id<T>() + "'");
 #endif
     }
     return conv;
@@ -875,13 +950,15 @@ template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> =
 T cast(const handle &handle) {
     using namespace detail;
     static_assert(!cast_is_temporary_value_reference<T>::value,
-            "Unable to cast type to reference: value is local to type caster");
+                  "Unable to cast type to reference: value is local to type caster");
     return cast_op<T>(load_type<T>(handle));
 }
 
 // pytype -> pytype (calls converting constructor)
 template <typename T, detail::enable_if_t<detail::is_pyobject<T>::value, int> = 0>
-T cast(const handle &handle) { return T(reinterpret_borrow<object>(handle)); }
+T cast(const handle &handle) {
+    return T(reinterpret_borrow<object>(handle));
+}
 
 // C++ type -> py::object
 template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
@@ -889,30 +966,34 @@ object cast(T &&value, return_value_policy policy = return_value_policy::automat
             handle parent = handle()) {
     using no_ref_T = typename std::remove_reference<T>::type;
     if (policy == return_value_policy::automatic)
-        policy = std::is_pointer<no_ref_T>::value ? return_value_policy::take_ownership :
-                 std::is_lvalue_reference<T>::value ? return_value_policy::copy : return_value_policy::move;
+        policy = std::is_pointer<no_ref_T>::value     ? return_value_policy::take_ownership
+                 : std::is_lvalue_reference<T>::value ? return_value_policy::copy
+                                                      : return_value_policy::move;
     else if (policy == return_value_policy::automatic_reference)
-        policy = std::is_pointer<no_ref_T>::value ? return_value_policy::reference :
-                 std::is_lvalue_reference<T>::value ? return_value_policy::copy : return_value_policy::move;
-    return reinterpret_steal<object>(detail::make_caster<T>::cast(std::forward<T>(value), policy, parent));
+        policy = std::is_pointer<no_ref_T>::value     ? return_value_policy::reference
+                 : std::is_lvalue_reference<T>::value ? return_value_policy::copy
+                                                      : return_value_policy::move;
+    return reinterpret_steal<object>(
+        detail::make_caster<T>::cast(std::forward<T>(value), policy, parent));
 }
 
 template <typename T> T handle::cast() const { return pybind11::cast<T>(*this); }
 template <> inline void handle::cast() const { return; }
 
-template <typename T>
-detail::enable_if_t<!detail::move_never<T>::value, T> move(object &&obj) {
+template <typename T> detail::enable_if_t<!detail::move_never<T>::value, T> move(object &&obj) {
     if (obj.ref_count() > 1)
 #if defined(NDEBUG)
-        throw cast_error("Unable to cast Python instance to C++ rvalue: instance has multiple references"
+        throw cast_error(
+            "Unable to cast Python instance to C++ rvalue: instance has multiple references"
             " (compile in debug mode for details)");
 #else
-        throw cast_error("Unable to move from Python " + (std::string) str(type::handle_of(obj)) +
-                " instance to C++ " + type_id<T>() + " instance: instance has multiple references");
+        throw cast_error("Unable to move from Python " + (std::string)str(type::handle_of(obj)) +
+                         " instance to C++ " + type_id<T>() +
+                         " instance: instance has multiple references");
 #endif
 
     // Move into a temporary and return that, because the reference may be a local value of `conv`
-    T ret = std::move(detail::load_type<T>(obj).operator T&());
+    T ret = std::move(detail::load_type<T>(obj).operator T &());
     return ret;
 }
 
@@ -924,7 +1005,8 @@ detail::enable_if_t<!detail::move_never<T>::value, T> move(object &&obj) {
 template <typename T> detail::enable_if_t<detail::move_always<T>::value, T> cast(object &&object) {
     return move<T>(std::move(object));
 }
-template <typename T> detail::enable_if_t<detail::move_if_unreferenced<T>::value, T> cast(object &&object) {
+template <typename T>
+detail::enable_if_t<detail::move_if_unreferenced<T>::value, T> cast(object &&object) {
     if (object.ref_count() > 1)
         return cast<T>(object);
     return move<T>(std::move(object));
@@ -941,28 +1023,40 @@ template <> inline void object::cast() && { return; }
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 // Declared in pytypes.h:
-template <typename T, enable_if_t<!is_pyobject<T>::value, int>>
-object object_or_cast(T &&o) { return pybind11::cast(std::forward<T>(o)); }
+template <typename T, enable_if_t<!is_pyobject<T>::value, int>> object object_or_cast(T &&o) {
+    return pybind11::cast(std::forward<T>(o));
+}
 
-struct override_unused {}; // Placeholder type for the unneeded (and dead code) static variable in the PYBIND11_OVERRIDE_OVERRIDE macro
-template <typename ret_type> using override_caster_t = conditional_t<
-    cast_is_temporary_value_reference<ret_type>::value, make_caster<ret_type>, override_unused>;
+struct override_unused {}; // Placeholder type for the unneeded (and dead code) static variable in
+                           // the PYBIND11_OVERRIDE_OVERRIDE macro
+template <typename ret_type>
+using override_caster_t = conditional_t<cast_is_temporary_value_reference<ret_type>::value,
+                                        make_caster<ret_type>, override_unused>;
 
 // Trampoline use: for reference/pointer types to value-converted values, we do a value cast, then
 // store the result in the given variable.  For other types, this is a no-op.
-template <typename T> enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_ref(object &&o, make_caster<T> &caster) {
+template <typename T>
+enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_ref(object &&o,
+                                                                     make_caster<T> &caster) {
     return cast_op<T>(load_type(caster, o));
 }
-template <typename T> enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_ref(object &&, override_unused &) {
-    pybind11_fail("Internal error: cast_ref fallback invoked"); }
+template <typename T>
+enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_ref(object &&,
+                                                                      override_unused &) {
+    pybind11_fail("Internal error: cast_ref fallback invoked");
+}
 
-// Trampoline use: Having a pybind11::cast with an invalid reference type is going to static_assert, even
-// though if it's in dead code, so we provide a "trampoline" to pybind11::cast that only does anything in
-// cases where pybind11::cast is valid.
-template <typename T> enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&o) {
-    return pybind11::cast<T>(std::move(o)); }
-template <typename T> enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&) {
-    pybind11_fail("Internal error: cast_safe fallback invoked"); }
+// Trampoline use: Having a pybind11::cast with an invalid reference type is going to
+// static_assert, even though if it's in dead code, so we provide a "trampoline" to pybind11::cast
+// that only does anything in cases where pybind11::cast is valid.
+template <typename T>
+enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&o) {
+    return pybind11::cast<T>(std::move(o));
+}
+template <typename T>
+enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&) {
+    pybind11_fail("Internal error: cast_safe fallback invoked");
+}
 template <> inline void cast_safe<void>(object &&) {}
 
 PYBIND11_NAMESPACE_END(detail)
@@ -977,27 +1071,27 @@ inline cast_error cast_error_unable_to_convert_call_arg() {
 #else
 inline cast_error cast_error_unable_to_convert_call_arg(const std::string &name,
                                                         const std::string &type) {
-    return cast_error("Unable to convert call argument '" + name + "' of type '" + type
-                      + "' to Python object");
+    return cast_error("Unable to convert call argument '" + name + "' of type '" + type +
+                      "' to Python object");
 }
 #endif
 
 template <return_value_policy policy = return_value_policy::automatic_reference>
-tuple make_tuple() { return tuple(0); }
+tuple make_tuple() {
+    return tuple(0);
+}
 
-template <return_value_policy policy = return_value_policy::automatic_reference,
-          typename... Args> tuple make_tuple(Args&&... args_) {
+template <return_value_policy policy = return_value_policy::automatic_reference, typename... Args>
+tuple make_tuple(Args &&...args_) {
     constexpr size_t size = sizeof...(Args);
-    std::array<object, size> args {
-        { reinterpret_steal<object>(detail::make_caster<Args>::cast(
-            std::forward<Args>(args_), policy, nullptr))... }
-    };
+    std::array<object, size> args{{reinterpret_steal<object>(
+        detail::make_caster<Args>::cast(std::forward<Args>(args_), policy, nullptr))...}};
     for (size_t i = 0; i < args.size(); i++) {
         if (!args[i]) {
 #if defined(NDEBUG)
             throw cast_error_unable_to_convert_call_arg();
 #else
-            std::array<std::string, size> argtypes { {type_id<Args>()...} };
+            std::array<std::string, size> argtypes{{type_id<Args>()...}};
             throw cast_error_unable_to_convert_call_arg(std::to_string(i), argtypes[i]);
 #endif
         }
@@ -1012,18 +1106,27 @@ template <return_value_policy policy = return_value_policy::automatic_reference,
 /// \ingroup annotations
 /// Annotation for arguments
 struct arg {
-    /// Constructs an argument with the name of the argument; if null or omitted, this is a positional argument.
-    constexpr explicit arg(const char *name = nullptr) : name(name), flag_noconvert(false), flag_none(true) { }
+    /// Constructs an argument with the name of the argument; if null or omitted, this is a
+    /// positional argument.
+    constexpr explicit arg(const char *name = nullptr)
+        : name(name), flag_noconvert(false), flag_none(true) {}
     /// Assign a value to this argument
     template <typename T> arg_v operator=(T &&value) const;
     /// Indicate that the type should not be converted in the type caster
-    arg &noconvert(bool flag = true) { flag_noconvert = flag; return *this; }
+    arg &noconvert(bool flag = true) {
+        flag_noconvert = flag;
+        return *this;
+    }
     /// Indicates that the argument should/shouldn't allow None (e.g. for nullable pointer args)
-    arg &none(bool flag = true) { flag_none = flag; return *this; }
+    arg &none(bool flag = true) {
+        flag_none = flag;
+        return *this;
+    }
 
-    const char *name; ///< If non-null, this is a named kwargs argument
-    bool flag_noconvert : 1; ///< If set, do not allow conversion (requires a supporting type caster!)
-    bool flag_none : 1; ///< If set (the default), allow None to be passed to this argument
+    const char *name;        ///< If non-null, this is a named kwargs argument
+    bool flag_noconvert : 1; ///< If set, do not allow conversion (requires a supporting type
+                             ///< caster!)
+    bool flag_none : 1;      ///< If set (the default), allow None to be passed to this argument
 };
 
 /// \ingroup annotations
@@ -1032,13 +1135,12 @@ struct arg_v : arg {
 private:
     template <typename T>
     arg_v(arg &&base, T &&x, const char *descr = nullptr)
-        : arg(base),
-          value(reinterpret_steal<object>(
-              detail::make_caster<T>::cast(x, return_value_policy::automatic, {})
-          )),
+        : arg(base), value(reinterpret_steal<object>(
+                         detail::make_caster<T>::cast(x, return_value_policy::automatic, {}))),
           descr(descr)
 #if !defined(NDEBUG)
-        , type(type_id<T>())
+          ,
+          type(type_id<T>())
 #endif
     {
         // Workaround! See:
@@ -1053,18 +1155,24 @@ public:
     /// Direct construction with name, default, and description
     template <typename T>
     arg_v(const char *name, T &&x, const char *descr = nullptr)
-        : arg_v(arg(name), std::forward<T>(x), descr) { }
+        : arg_v(arg(name), std::forward<T>(x), descr) {}
 
     /// Called internally when invoking `py::arg("a") = value`
     template <typename T>
     arg_v(const arg &base, T &&x, const char *descr = nullptr)
-        : arg_v(arg(base), std::forward<T>(x), descr) { }
+        : arg_v(arg(base), std::forward<T>(x), descr) {}
 
     /// Same as `arg::noconvert()`, but returns *this as arg_v&, not arg&
-    arg_v &noconvert(bool flag = true) { arg::noconvert(flag); return *this; }
+    arg_v &noconvert(bool flag = true) {
+        arg::noconvert(flag);
+        return *this;
+    }
 
     /// Same as `arg::nonone()`, but returns *this as arg_v&, not arg&
-    arg_v &none(bool flag = true) { arg::none(flag); return *this; }
+    arg_v &none(bool flag = true) {
+        arg::none(flag);
+        return *this;
+    }
 
     /// The default value
     object value;
@@ -1077,17 +1185,16 @@ public:
 };
 
 /// \ingroup annotations
-/// Annotation indicating that all following arguments are keyword-only; the is the equivalent of an
-/// unnamed '*' argument (in Python 3)
+/// Annotation indicating that all following arguments are keyword-only; the is the equivalent of
+/// an unnamed '*' argument (in Python 3)
 struct kw_only {};
 
 /// \ingroup annotations
-/// Annotation indicating that all previous arguments are positional-only; the is the equivalent of an
-/// unnamed '/' argument (in Python 3.8)
+/// Annotation indicating that all previous arguments are positional-only; the is the equivalent of
+/// an unnamed '/' argument (in Python 3.8)
 struct pos_only {};
 
-template <typename T>
-arg_v arg::operator=(T &&value) const {
+template <typename T> arg_v arg::operator=(T &&value) const {
     return {*this, std::forward<T>(value)};
 }
 
@@ -1132,21 +1239,22 @@ struct function_call {
     handle init_self;
 };
 
-
 /// Helper class which loads arguments for C++ functions called from Python
-template <typename... Args>
-class argument_loader {
+template <typename... Args> class argument_loader {
     using indices = make_index_sequence<sizeof...(Args)>;
 
-    template <typename Arg> using argument_is_args   = std::is_same<intrinsic_t<Arg>, args>;
+    template <typename Arg> using argument_is_args = std::is_same<intrinsic_t<Arg>, args>;
     template <typename Arg> using argument_is_kwargs = std::is_same<intrinsic_t<Arg>, kwargs>;
     // Get args/kwargs argument positions relative to the end of the argument list:
-    static constexpr auto args_pos = constexpr_first<argument_is_args, Args...>() - (int) sizeof...(Args),
-                        kwargs_pos = constexpr_first<argument_is_kwargs, Args...>() - (int) sizeof...(Args);
+    static constexpr auto args_pos =
+                              constexpr_first<argument_is_args, Args...>() - (int)sizeof...(Args),
+                          kwargs_pos = constexpr_first<argument_is_kwargs, Args...>() -
+                                       (int)sizeof...(Args);
 
-    static constexpr bool args_kwargs_are_last = kwargs_pos >= - 1 && args_pos >= kwargs_pos - 1;
+    static constexpr bool args_kwargs_are_last = kwargs_pos >= -1 && args_pos >= kwargs_pos - 1;
 
-    static_assert(args_kwargs_are_last, "py::args/py::kwargs are only permitted as the last argument(s) of a function");
+    static_assert(args_kwargs_are_last,
+                  "py::args/py::kwargs are only permitted as the last argument(s) of a function");
 
 public:
     static constexpr bool has_kwargs = kwargs_pos < 0;
@@ -1154,13 +1262,12 @@ public:
 
     static constexpr auto arg_names = concat(type_descr(make_caster<Args>::name)...);
 
-    bool load_args(function_call &call) {
-        return load_impl_sequence(call, indices{});
-    }
+    bool load_args(function_call &call) { return load_impl_sequence(call, indices{}); }
 
     template <typename Return, typename Guard, typename Func>
     enable_if_t<!std::is_void<Return>::value, Return> call(Func &&f) && {
-        return std::move(*this).template call_impl<Return>(std::forward<Func>(f), indices{}, Guard{});
+        return std::move(*this).template call_impl<Return>(std::forward<Func>(f), indices{},
+                                                           Guard{});
     }
 
     template <typename Return, typename Guard, typename Func>
@@ -1170,11 +1277,9 @@ public:
     }
 
 private:
-
     static bool load_impl_sequence(function_call &, index_sequence<>) { return true; }
 
-    template <size_t... Is>
-    bool load_impl_sequence(function_call &call, index_sequence<Is...>) {
+    template <size_t... Is> bool load_impl_sequence(function_call &call, index_sequence<Is...>) {
 #ifdef __cpp_fold_expressions
         if ((... || !std::get<Is>(argcasters).load(call.args[Is], call.args_convert[Is])))
             return false;
@@ -1196,12 +1301,11 @@ private:
 
 /// Helper class which collects only positional arguments for a Python function call.
 /// A fancier version below can collect any argument, but this one is optimal for simple calls.
-template <return_value_policy policy>
-class simple_collector {
+template <return_value_policy policy> class simple_collector {
 public:
     template <typename... Ts>
     explicit simple_collector(Ts &&...values)
-        : m_args(pybind11::make_tuple<policy>(std::forward<Ts>(values)...)) { }
+        : m_args(pybind11::make_tuple<policy>(std::forward<Ts>(values)...)) {}
 
     const tuple &args() const & { return m_args; }
     dict kwargs() const { return {}; }
@@ -1221,15 +1325,13 @@ private:
 };
 
 /// Helper class which collects positional, keyword, * and ** arguments for a Python function call
-template <return_value_policy policy>
-class unpacking_collector {
+template <return_value_policy policy> class unpacking_collector {
 public:
-    template <typename... Ts>
-    explicit unpacking_collector(Ts &&...values) {
+    template <typename... Ts> explicit unpacking_collector(Ts &&...values) {
         // Tuples aren't (easily) resizable so a list is needed for collection,
         // but the actual function call strictly requires a tuple.
         auto args_list = list();
-        int _[] = { 0, (process(args_list, std::forward<Ts>(values)), 0)... };
+        int _[] = {0, (process(args_list, std::forward<Ts>(values)), 0)...};
         ignore_unused(_);
 
         m_args = std::move(args_list);
@@ -1250,15 +1352,15 @@ public:
     }
 
 private:
-    template <typename T>
-    void process(list &args_list, T &&x) {
-        auto o = reinterpret_steal<object>(detail::make_caster<T>::cast(std::forward<T>(x), policy, {}));
+    template <typename T> void process(list &args_list, T &&x) {
+        auto o = reinterpret_steal<object>(
+            detail::make_caster<T>::cast(std::forward<T>(x), policy, {}));
         if (!o) {
 #if defined(NDEBUG)
             throw cast_error_unable_to_convert_call_arg();
 #else
-            throw cast_error_unable_to_convert_call_arg(
-                std::to_string(args_list.size()), type_id<T>());
+            throw cast_error_unable_to_convert_call_arg(std::to_string(args_list.size()),
+                                                        type_id<T>());
 #endif
         }
         args_list.append(o);
@@ -1269,7 +1371,7 @@ private:
             args_list.append(a);
     }
 
-    void process(list &/*args_list*/, arg_v a) {
+    void process(list & /*args_list*/, arg_v a) {
         if (!a.name)
 #if defined(NDEBUG)
             nameless_argument_error();
@@ -1294,7 +1396,7 @@ private:
         m_kwargs[a.name] = a.value;
     }
 
-    void process(list &/*args_list*/, detail::kwargs_proxy kp) {
+    void process(list & /*args_list*/, detail::kwargs_proxy kp) {
         if (!kp)
             return;
         for (auto k : reinterpret_borrow<dict>(kp)) {
@@ -1315,7 +1417,8 @@ private:
                          "(compile in debug mode for details)");
     }
     [[noreturn]] static void nameless_argument_error(const std::string &type) {
-        throw type_error("Got kwargs without a name of type '" + type + "'; only named "
+        throw type_error("Got kwargs without a name of type '" + type +
+                         "'; only named "
                          "arguments may be passed via py::arg() to a python function call. ");
     }
     [[noreturn]] static void multiple_values_error() {
@@ -1336,10 +1439,8 @@ private:
 // We need to put this into a separate function because the Intel compiler
 // fails to compile enable_if_t<!all_of<is_positional<Args>...>::value>
 // (tested with ICC 2021.1 Beta 20200827).
-template <typename... Args>
-constexpr bool args_are_all_positional()
-{
-  return all_of<is_positional<Args>...>::value;
+template <typename... Args> constexpr bool args_are_all_positional() {
+    return all_of<is_positional<Args>...>::value;
 }
 
 /// Collect only positional arguments for a Python function call
@@ -1354,12 +1455,12 @@ template <return_value_policy policy, typename... Args,
           typename = enable_if_t<!args_are_all_positional<Args...>()>>
 unpacking_collector<policy> collect_arguments(Args &&...args) {
     // Following argument order rules for generalized unpacking according to PEP 448
-    static_assert(
-        constexpr_last<is_positional, Args...>() < constexpr_first<is_keyword_or_ds, Args...>()
-        && constexpr_last<is_s_unpacking, Args...>() < constexpr_first<is_ds_unpacking, Args...>(),
-        "Invalid function call: positional args must precede keywords and ** unpacking; "
-        "* unpacking must precede ** unpacking"
-    );
+    static_assert(constexpr_last<is_positional, Args...>() <
+                          constexpr_first<is_keyword_or_ds, Args...>() &&
+                      constexpr_last<is_s_unpacking, Args...>() <
+                          constexpr_first<is_ds_unpacking, Args...>(),
+                  "Invalid function call: positional args must precede keywords and ** unpacking; "
+                  "* unpacking must precede ** unpacking");
     return unpacking_collector<policy>(std::forward<Args>(args)...);
 }
 
@@ -1382,25 +1483,23 @@ object object_api<Derived>::call(Args &&...args) const {
 
 PYBIND11_NAMESPACE_END(detail)
 
-
-template<typename T>
-handle type::handle_of() {
-   static_assert(
-      std::is_base_of<detail::type_caster_generic, detail::make_caster<T>>::value,
-      "py::type::of<T> only supports the case where T is a registered C++ types."
-    );
+template <typename T> handle type::handle_of() {
+    static_assert(std::is_base_of<detail::type_caster_generic, detail::make_caster<T>>::value,
+                  "py::type::of<T> only supports the case where T is a registered C++ types.");
 
     return detail::get_type_handle(typeid(T), true);
 }
 
-
-#define PYBIND11_MAKE_OPAQUE(...) \
-    namespace pybind11 { namespace detail { \
-        template<> class type_caster<__VA_ARGS__> : public type_caster_base<__VA_ARGS__> { }; \
-    }}
+#define PYBIND11_MAKE_OPAQUE(...)                                                                 \
+    namespace pybind11 {                                                                          \
+    namespace detail {                                                                            \
+    template <> class type_caster<__VA_ARGS__> : public type_caster_base<__VA_ARGS__> {};         \
+    }                                                                                             \
+    }
 
 /// Lets you pass a type containing a `,` through a macro parameter without needing a separate
-/// typedef, e.g.: `PYBIND11_OVERRIDE(PYBIND11_TYPE(ReturnType<A, B>), PYBIND11_TYPE(Parent<C, D>), f, arg)`
+/// typedef, e.g.: `PYBIND11_OVERRIDE(PYBIND11_TYPE(ReturnType<A, B>), PYBIND11_TYPE(Parent<C, D>),
+/// f, arg)`
 #define PYBIND11_TYPE(...) __VA_ARGS__
 
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -11,20 +11,20 @@
 #pragma once
 
 #include "pybind11.h"
+#include <chrono>
 #include <cmath>
 #include <ctime>
-#include <chrono>
 #include <datetime.h>
 
 // Backport the PyDateTime_DELTA functions from Python3.3 if required
 #ifndef PyDateTime_DELTA_GET_DAYS
-#define PyDateTime_DELTA_GET_DAYS(o)         (((PyDateTime_Delta*)o)->days)
+#define PyDateTime_DELTA_GET_DAYS(o) (((PyDateTime_Delta *)o)->days)
 #endif
 #ifndef PyDateTime_DELTA_GET_SECONDS
-#define PyDateTime_DELTA_GET_SECONDS(o)      (((PyDateTime_Delta*)o)->seconds)
+#define PyDateTime_DELTA_GET_SECONDS(o) (((PyDateTime_Delta *)o)->seconds)
 #endif
 #ifndef PyDateTime_DELTA_GET_MICROSECONDS
-#define PyDateTime_DELTA_GET_MICROSECONDS(o) (((PyDateTime_Delta*)o)->microseconds)
+#define PyDateTime_DELTA_GET_MICROSECONDS(o) (((PyDateTime_Delta *)o)->microseconds)
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
@@ -35,38 +35,47 @@ public:
     using rep = typename type::rep;
     using period = typename type::period;
 
-    using days = std::chrono::duration<int_least32_t, std::ratio<86400>>; // signed 25 bits required by the standard.
+    using days =
+        std::chrono::duration<int_least32_t,
+                              std::ratio<86400>>; // signed 25 bits required by the standard.
 
     bool load(handle src, bool) {
         using namespace std::chrono;
 
         // Lazy initialise the PyDateTime import
-        if (!PyDateTimeAPI) { PyDateTime_IMPORT; }
+        if (!PyDateTimeAPI) {
+            PyDateTime_IMPORT;
+        }
 
-        if (!src) return false;
+        if (!src)
+            return false;
         // If invoked with datetime.delta object
         if (PyDelta_Check(src.ptr())) {
             value = type(duration_cast<duration<rep, period>>(
-                  days(PyDateTime_DELTA_GET_DAYS(src.ptr()))
-                + seconds(PyDateTime_DELTA_GET_SECONDS(src.ptr()))
-                + microseconds(PyDateTime_DELTA_GET_MICROSECONDS(src.ptr()))));
+                days(PyDateTime_DELTA_GET_DAYS(src.ptr())) +
+                seconds(PyDateTime_DELTA_GET_SECONDS(src.ptr())) +
+                microseconds(PyDateTime_DELTA_GET_MICROSECONDS(src.ptr()))));
             return true;
         }
         // If invoked with a float we assume it is seconds and convert
         if (PyFloat_Check(src.ptr())) {
-            value = type(duration_cast<duration<rep, period>>(duration<double>(PyFloat_AsDouble(src.ptr()))));
+            value = type(duration_cast<duration<rep, period>>(
+                duration<double>(PyFloat_AsDouble(src.ptr()))));
             return true;
         }
         return false;
     }
 
     // If this is a duration just return it back
-    static const std::chrono::duration<rep, period>& get_duration(const std::chrono::duration<rep, period> &src) {
+    static const std::chrono::duration<rep, period> &
+    get_duration(const std::chrono::duration<rep, period> &src) {
         return src;
     }
 
     // If this is a time_point get the time_since_epoch
-    template <typename Clock> static std::chrono::duration<rep, period> get_duration(const std::chrono::time_point<Clock, std::chrono::duration<rep, period>> &src) {
+    template <typename Clock>
+    static std::chrono::duration<rep, period>
+    get_duration(const std::chrono::time_point<Clock, std::chrono::duration<rep, period>> &src) {
         return src.time_since_epoch();
     }
 
@@ -78,9 +87,12 @@ public:
         auto d = get_duration(src);
 
         // Lazy initialise the PyDateTime import
-        if (!PyDateTimeAPI) { PyDateTime_IMPORT; }
+        if (!PyDateTimeAPI) {
+            PyDateTime_IMPORT;
+        }
 
-        // Declare these special duration types so the conversions happen with the correct primitive types (int)
+        // Declare these special duration types so the conversions happen with the correct
+        // primitive types (int)
         using dd_t = duration<int, std::ratio<86400>>;
         using ss_t = duration<int, std::ratio<1>>;
         using us_t = duration<int, std::micro>;
@@ -96,71 +108,79 @@ public:
 };
 
 // This is for casting times on the system clock into datetime.datetime instances
-template <typename Duration> class type_caster<std::chrono::time_point<std::chrono::system_clock, Duration>> {
+template <typename Duration>
+class type_caster<std::chrono::time_point<std::chrono::system_clock, Duration>> {
 public:
     using type = std::chrono::time_point<std::chrono::system_clock, Duration>;
     bool load(handle src, bool) {
         using namespace std::chrono;
 
         // Lazy initialise the PyDateTime import
-        if (!PyDateTimeAPI) { PyDateTime_IMPORT; }
+        if (!PyDateTimeAPI) {
+            PyDateTime_IMPORT;
+        }
 
-        if (!src) return false;
+        if (!src)
+            return false;
 
         std::tm cal;
         microseconds msecs;
 
         if (PyDateTime_Check(src.ptr())) {
-            cal.tm_sec   = PyDateTime_DATE_GET_SECOND(src.ptr());
-            cal.tm_min   = PyDateTime_DATE_GET_MINUTE(src.ptr());
-            cal.tm_hour  = PyDateTime_DATE_GET_HOUR(src.ptr());
-            cal.tm_mday  = PyDateTime_GET_DAY(src.ptr());
-            cal.tm_mon   = PyDateTime_GET_MONTH(src.ptr()) - 1;
-            cal.tm_year  = PyDateTime_GET_YEAR(src.ptr()) - 1900;
+            cal.tm_sec = PyDateTime_DATE_GET_SECOND(src.ptr());
+            cal.tm_min = PyDateTime_DATE_GET_MINUTE(src.ptr());
+            cal.tm_hour = PyDateTime_DATE_GET_HOUR(src.ptr());
+            cal.tm_mday = PyDateTime_GET_DAY(src.ptr());
+            cal.tm_mon = PyDateTime_GET_MONTH(src.ptr()) - 1;
+            cal.tm_year = PyDateTime_GET_YEAR(src.ptr()) - 1900;
             cal.tm_isdst = -1;
-            msecs        = microseconds(PyDateTime_DATE_GET_MICROSECOND(src.ptr()));
+            msecs = microseconds(PyDateTime_DATE_GET_MICROSECOND(src.ptr()));
         } else if (PyDate_Check(src.ptr())) {
-            cal.tm_sec   = 0;
-            cal.tm_min   = 0;
-            cal.tm_hour  = 0;
-            cal.tm_mday  = PyDateTime_GET_DAY(src.ptr());
-            cal.tm_mon   = PyDateTime_GET_MONTH(src.ptr()) - 1;
-            cal.tm_year  = PyDateTime_GET_YEAR(src.ptr()) - 1900;
+            cal.tm_sec = 0;
+            cal.tm_min = 0;
+            cal.tm_hour = 0;
+            cal.tm_mday = PyDateTime_GET_DAY(src.ptr());
+            cal.tm_mon = PyDateTime_GET_MONTH(src.ptr()) - 1;
+            cal.tm_year = PyDateTime_GET_YEAR(src.ptr()) - 1900;
             cal.tm_isdst = -1;
-            msecs        = microseconds(0);
+            msecs = microseconds(0);
         } else if (PyTime_Check(src.ptr())) {
-            cal.tm_sec   = PyDateTime_TIME_GET_SECOND(src.ptr());
-            cal.tm_min   = PyDateTime_TIME_GET_MINUTE(src.ptr());
-            cal.tm_hour  = PyDateTime_TIME_GET_HOUR(src.ptr());
-            cal.tm_mday  = 1;   // This date (day, month, year) = (1, 0, 70)
-            cal.tm_mon   = 0;   // represents 1-Jan-1970, which is the first
-            cal.tm_year  = 70;  // earliest available date for Python's datetime
+            cal.tm_sec = PyDateTime_TIME_GET_SECOND(src.ptr());
+            cal.tm_min = PyDateTime_TIME_GET_MINUTE(src.ptr());
+            cal.tm_hour = PyDateTime_TIME_GET_HOUR(src.ptr());
+            cal.tm_mday = 1;  // This date (day, month, year) = (1, 0, 70)
+            cal.tm_mon = 0;   // represents 1-Jan-1970, which is the first
+            cal.tm_year = 70; // earliest available date for Python's datetime
             cal.tm_isdst = -1;
-            msecs        = microseconds(PyDateTime_TIME_GET_MICROSECOND(src.ptr()));
-        }
-        else return false;
+            msecs = microseconds(PyDateTime_TIME_GET_MICROSECOND(src.ptr()));
+        } else
+            return false;
 
         value = time_point_cast<Duration>(system_clock::from_time_t(std::mktime(&cal)) + msecs);
         return true;
     }
 
-    static handle cast(const std::chrono::time_point<std::chrono::system_clock, Duration> &src, return_value_policy /* policy */, handle /* parent */) {
+    static handle cast(const std::chrono::time_point<std::chrono::system_clock, Duration> &src,
+                       return_value_policy /* policy */, handle /* parent */) {
         using namespace std::chrono;
 
         // Lazy initialise the PyDateTime import
-        if (!PyDateTimeAPI) { PyDateTime_IMPORT; }
+        if (!PyDateTimeAPI) {
+            PyDateTime_IMPORT;
+        }
 
-        // Get out microseconds, and make sure they are positive, to avoid bug in eastern hemisphere time zones
-        // (cfr. https://github.com/pybind/pybind11/issues/2417)
+        // Get out microseconds, and make sure they are positive, to avoid bug in eastern
+        // hemisphere time zones (cfr. https://github.com/pybind/pybind11/issues/2417)
         using us_t = duration<int, std::micro>;
         auto us = duration_cast<us_t>(src.time_since_epoch() % seconds(1));
         if (us.count() < 0)
             us += seconds(1);
 
         // Subtract microseconds BEFORE `system_clock::to_time_t`, because:
-        // > If std::time_t has lower precision, it is implementation-defined whether the value is rounded or truncated.
-        // (https://en.cppreference.com/w/cpp/chrono/system_clock/to_time_t)
-        std::time_t tt = system_clock::to_time_t(time_point_cast<system_clock::duration>(src - us));
+        // > If std::time_t has lower precision, it is implementation-defined whether the value is
+        // rounded or truncated. (https://en.cppreference.com/w/cpp/chrono/system_clock/to_time_t)
+        std::time_t tt =
+            system_clock::to_time_t(time_point_cast<system_clock::duration>(src - us));
 
         // std::localtime returns a pointer to a static internal std::tm object on success,
         // or null pointer otherwise
@@ -172,13 +192,9 @@ public:
         // otherwise other code that is using localtime may break this (not just python code)
         std::tm localtime = *localtime_ptr;
 
-        return PyDateTime_FromDateAndTime(localtime.tm_year + 1900,
-                                          localtime.tm_mon + 1,
-                                          localtime.tm_mday,
-                                          localtime.tm_hour,
-                                          localtime.tm_min,
-                                          localtime.tm_sec,
-                                          us.count());
+        return PyDateTime_FromDateAndTime(localtime.tm_year + 1900, localtime.tm_mon + 1,
+                                          localtime.tm_mday, localtime.tm_hour, localtime.tm_min,
+                                          localtime.tm_sec, us.count());
     }
     PYBIND11_TYPE_CASTER(type, _("datetime.datetime"));
 };
@@ -186,13 +202,13 @@ public:
 // Other clocks that are not the system clock are not measured as datetime.datetime objects
 // since they are not measured on calendar time. So instead we just make them timedeltas
 // Or if they have passed us a time as a float we convert that
-template <typename Clock, typename Duration> class type_caster<std::chrono::time_point<Clock, Duration>>
-: public duration_caster<std::chrono::time_point<Clock, Duration>> {
-};
+template <typename Clock, typename Duration>
+class type_caster<std::chrono::time_point<Clock, Duration>>
+    : public duration_caster<std::chrono::time_point<Clock, Duration>> {};
 
-template <typename Rep, typename Period> class type_caster<std::chrono::duration<Rep, Period>>
-: public duration_caster<std::chrono::duration<Rep, Period>> {
-};
+template <typename Rep, typename Period>
+class type_caster<std::chrono::duration<Rep, Period>>
+    : public duration_caster<std::chrono::duration<Rep, Period>> {};
 
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -14,27 +14,30 @@
 
 /// glibc defines I as a macro which breaks things, e.g., boost template names
 #ifdef I
-#  undef I
+#undef I
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
-template <typename T> struct format_descriptor<std::complex<T>, detail::enable_if_t<std::is_floating_point<T>::value>> {
+template <typename T>
+struct format_descriptor<std::complex<T>, detail::enable_if_t<std::is_floating_point<T>::value>> {
     static constexpr const char c = format_descriptor<T>::c;
-    static constexpr const char value[3] = { 'Z', c, '\0' };
+    static constexpr const char value[3] = {'Z', c, '\0'};
     static std::string format() { return std::string(value); }
 };
 
 #ifndef PYBIND11_CPP17
 
-template <typename T> constexpr const char format_descriptor<
+template <typename T>
+constexpr const char format_descriptor<
     std::complex<T>, detail::enable_if_t<std::is_floating_point<T>::value>>::value[3];
 
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-template <typename T> struct is_fmt_numeric<std::complex<T>, detail::enable_if_t<std::is_floating_point<T>::value>> {
+template <typename T>
+struct is_fmt_numeric<std::complex<T>, detail::enable_if_t<std::is_floating_point<T>::value>> {
     static constexpr bool value = true;
     static constexpr int index = is_fmt_numeric<T>::index + 3;
 };
@@ -51,12 +54,13 @@ public:
             PyErr_Clear();
             return false;
         }
-        value = std::complex<T>((T) result.real, (T) result.imag);
+        value = std::complex<T>((T)result.real, (T)result.imag);
         return true;
     }
 
-    static handle cast(const std::complex<T> &src, return_value_policy /* policy */, handle /* parent */) {
-        return PyComplex_FromDoubles((double) src.real(), (double) src.imag());
+    static handle cast(const std::complex<T> &src, return_value_policy /* policy */,
+                       handle /* parent */) {
+        return PyComplex_FromDoubles((double)src.real(), (double)src.imag());
     }
 
     PYBIND11_TYPE_CASTER(std::complex<T>, _("complex"));

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -801,7 +801,7 @@ struct nodelete { template <typename T> void operator()(T*) { } };
 PYBIND11_NAMESPACE_BEGIN(detail)
 template <typename... Args>
 struct overload_cast_impl {
-    constexpr overload_cast_impl() {}; // NOLINT(modernize-use-equals-default):  MSVC 2015 needs this
+    constexpr overload_cast_impl() {} // NOLINT(modernize-use-equals-default): MSVC 2015 needs this
 
     template <typename Return>
     constexpr auto operator()(Return (*pf)(Args...)) const noexcept

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -17,108 +17,109 @@
 #define PYBIND11_NAMESPACE_END(name) }
 
 // Robust support for some features and loading modules compiled against different pybind versions
-// requires forcing hidden visibility on pybind code, so we enforce this by setting the attribute on
-// the main `pybind11` namespace.
+// requires forcing hidden visibility on pybind code, so we enforce this by setting the attribute
+// on the main `pybind11` namespace.
 #if !defined(PYBIND11_NAMESPACE)
-#  ifdef __GNUG__
-#    define PYBIND11_NAMESPACE pybind11 __attribute__((visibility("hidden")))
-#  else
-#    define PYBIND11_NAMESPACE pybind11
-#  endif
+#ifdef __GNUG__
+#define PYBIND11_NAMESPACE pybind11 __attribute__((visibility("hidden")))
+#else
+#define PYBIND11_NAMESPACE pybind11
+#endif
 #endif
 
 #if !(defined(_MSC_VER) && __cplusplus == 199711L)
-#  if __cplusplus >= 201402L
-#    define PYBIND11_CPP14
-#    if __cplusplus >= 201703L
-#      define PYBIND11_CPP17
-#    endif
-#  endif
+#if __cplusplus >= 201402L
+#define PYBIND11_CPP14
+#if __cplusplus >= 201703L
+#define PYBIND11_CPP17
+#endif
+#endif
 #elif defined(_MSC_VER) && __cplusplus == 199711L
-// MSVC sets _MSVC_LANG rather than __cplusplus (supposedly until the standard is fully implemented)
-// Unless you use the /Zc:__cplusplus flag on Visual Studio 2017 15.7 Preview 3 or newer
-#  if _MSVC_LANG >= 201402L
-#    define PYBIND11_CPP14
-#    if _MSVC_LANG > 201402L && _MSC_VER >= 1910
-#      define PYBIND11_CPP17
-#    endif
-#  endif
+// MSVC sets _MSVC_LANG rather than __cplusplus (supposedly until the standard is fully
+// implemented) Unless you use the /Zc:__cplusplus flag on Visual Studio 2017 15.7 Preview 3 or
+// newer
+#if _MSVC_LANG >= 201402L
+#define PYBIND11_CPP14
+#if _MSVC_LANG > 201402L && _MSC_VER >= 1910
+#define PYBIND11_CPP17
+#endif
+#endif
 #endif
 
 // Compiler version assertions
 #if defined(__INTEL_COMPILER)
-#  if __INTEL_COMPILER < 1800
-#    error pybind11 requires Intel C++ compiler v18 or newer
-#  elif __INTEL_COMPILER < 1900 && defined(PYBIND11_CPP14)
-#    error pybind11 supports only C++11 with Intel C++ compiler v18. Use v19 or newer for C++14.
-#  endif
+#if __INTEL_COMPILER < 1800
+#error pybind11 requires Intel C++ compiler v18 or newer
+#elif __INTEL_COMPILER < 1900 && defined(PYBIND11_CPP14)
+#error pybind11 supports only C++11 with Intel C++ compiler v18. Use v19 or newer for C++14.
+#endif
 #elif defined(__clang__) && !defined(__apple_build_version__)
-#  if __clang_major__ < 3 || (__clang_major__ == 3 && __clang_minor__ < 3)
-#    error pybind11 requires clang 3.3 or newer
-#  endif
+#if __clang_major__ < 3 || (__clang_major__ == 3 && __clang_minor__ < 3)
+#error pybind11 requires clang 3.3 or newer
+#endif
 #elif defined(__clang__)
 // Apple changes clang version macros to its Xcode version; the first Xcode release based on
 // (upstream) clang 3.3 was Xcode 5:
-#  if __clang_major__ < 5
-#    error pybind11 requires Xcode/clang 5.0 or newer
-#  endif
+#if __clang_major__ < 5
+#error pybind11 requires Xcode/clang 5.0 or newer
+#endif
 #elif defined(__GNUG__)
-#  if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
-#    error pybind11 requires gcc 4.8 or newer
-#  endif
+#if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
+#error pybind11 requires gcc 4.8 or newer
+#endif
 #elif defined(_MSC_VER)
 // Pybind hits various compiler bugs in 2015u2 and earlier, and also makes use of some stl features
 // (e.g. std::negation) added in 2015u3:
-#  if _MSC_FULL_VER < 190024210
-#    error pybind11 requires MSVC 2015 update 3 or newer
-#  endif
+#if _MSC_FULL_VER < 190024210
+#error pybind11 requires MSVC 2015 update 3 or newer
+#endif
 #endif
 
 #if !defined(PYBIND11_EXPORT)
-#  if defined(WIN32) || defined(_WIN32)
-#    define PYBIND11_EXPORT __declspec(dllexport)
-#  else
-#    define PYBIND11_EXPORT __attribute__ ((visibility("default")))
-#  endif
+#if defined(WIN32) || defined(_WIN32)
+#define PYBIND11_EXPORT __declspec(dllexport)
+#else
+#define PYBIND11_EXPORT __attribute__((visibility("default")))
+#endif
 #endif
 
 #if defined(_MSC_VER)
-#  define PYBIND11_NOINLINE __declspec(noinline)
+#define PYBIND11_NOINLINE __declspec(noinline)
 #else
-#  define PYBIND11_NOINLINE __attribute__ ((noinline))
+#define PYBIND11_NOINLINE __attribute__((noinline))
 #endif
 
 #if defined(PYBIND11_CPP14)
-#  define PYBIND11_DEPRECATED(reason) [[deprecated(reason)]]
+#define PYBIND11_DEPRECATED(reason) [[deprecated(reason)]]
 #else
-#  define PYBIND11_DEPRECATED(reason) __attribute__((deprecated(reason)))
+#define PYBIND11_DEPRECATED(reason) __attribute__((deprecated(reason)))
 #endif
 
 #if defined(PYBIND11_CPP17)
-#  define PYBIND11_MAYBE_UNUSED [[maybe_unused]]
+#define PYBIND11_MAYBE_UNUSED [[maybe_unused]]
 #elif defined(_MSC_VER) && !defined(__clang__)
-#  define PYBIND11_MAYBE_UNUSED
+#define PYBIND11_MAYBE_UNUSED
 #else
-#  define PYBIND11_MAYBE_UNUSED __attribute__ ((__unused__))
+#define PYBIND11_MAYBE_UNUSED __attribute__((__unused__))
 #endif
 
 /* Don't let Python.h #define (v)snprintf as macro because they are implemented
    properly in Visual Studio since 2015. */
 #if defined(_MSC_VER) && _MSC_VER >= 1900
-#  define HAVE_SNPRINTF 1
+#define HAVE_SNPRINTF 1
 #endif
 
 /// Include Python header, disable linking to pythonX_d.lib on Windows in debug mode
 #if defined(_MSC_VER)
-#  if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4)
-#    define HAVE_ROUND 1
-#  endif
-#  pragma warning(push)
-#  pragma warning(disable: 4510 4610 4512 4005)
-#  if defined(_DEBUG) && !defined(Py_DEBUG)
-#    define PYBIND11_DEBUG_MARKER
-#    undef _DEBUG
-#  endif
+#if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4)
+#define HAVE_ROUND 1
+#endif
+#pragma warning(push)
+#pragma warning(disable : 4510 4610 4512 4005)
+#if defined(_DEBUG) && !defined(Py_DEBUG)
+#define PYBIND11_DEBUG_MARKER
+#undef _DEBUG
+#endif
 #endif
 
 #include <Python.h>
@@ -129,43 +130,43 @@
    tends to weak havok in C++ codebases that expect these to work
    like regular functions (potentially with several overloads) */
 #if defined(isalnum)
-#  undef isalnum
-#  undef isalpha
-#  undef islower
-#  undef isspace
-#  undef isupper
-#  undef tolower
-#  undef toupper
+#undef isalnum
+#undef isalpha
+#undef islower
+#undef isspace
+#undef isupper
+#undef tolower
+#undef toupper
 #endif
 
 #if defined(copysign)
-#  undef copysign
+#undef copysign
 #endif
 
 #if defined(_MSC_VER)
-#  if defined(PYBIND11_DEBUG_MARKER)
-#    define _DEBUG
-#    undef PYBIND11_DEBUG_MARKER
-#  endif
-#  pragma warning(pop)
+#if defined(PYBIND11_DEBUG_MARKER)
+#define _DEBUG
+#undef PYBIND11_DEBUG_MARKER
+#endif
+#pragma warning(pop)
 #endif
 
 #include <cstddef>
 #include <cstring>
-#include <forward_list>
-#include <vector>
-#include <string>
-#include <stdexcept>
 #include <exception>
-#include <unordered_set>
-#include <unordered_map>
+#include <forward_list>
 #include <memory>
-#include <typeindex>
+#include <stdexcept>
+#include <string>
 #include <type_traits>
+#include <typeindex>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 #if defined(__has_include)
-#  if __has_include(<version>)
-#    include <version>
-#  endif
+#if __has_include(<version>)
+#include <version>
+#endif
 #endif
 
 // #define PYBIND11_STR_LEGACY_PERMISSIVE
@@ -193,8 +194,8 @@
 #define PYBIND11_BYTES_SIZE PyBytes_Size
 #define PYBIND11_LONG_CHECK(o) PyLong_Check(o)
 #define PYBIND11_LONG_AS_LONGLONG(o) PyLong_AsLongLong(o)
-#define PYBIND11_LONG_FROM_SIGNED(o) PyLong_FromSsize_t((ssize_t) o)
-#define PYBIND11_LONG_FROM_UNSIGNED(o) PyLong_FromSize_t((size_t) o)
+#define PYBIND11_LONG_FROM_SIGNED(o) PyLong_FromSsize_t((ssize_t)o)
+#define PYBIND11_LONG_FROM_UNSIGNED(o) PyLong_FromSize_t((size_t)o)
 #define PYBIND11_BYTES_NAME "bytes"
 #define PYBIND11_STRING_NAME "str"
 #define PYBIND11_SLICE_OBJECT PyObject
@@ -205,8 +206,8 @@
 #define PYBIND11_BUILTINS_MODULE "builtins"
 // Providing a separate declaration to make Clang's -Wmissing-prototypes happy.
 // See comment for PYBIND11_MODULE below for why this is marked "maybe unused".
-#define PYBIND11_PLUGIN_IMPL(name) \
-    extern "C" PYBIND11_MAYBE_UNUSED PYBIND11_EXPORT PyObject *PyInit_##name(); \
+#define PYBIND11_PLUGIN_IMPL(name)                                                                \
+    extern "C" PYBIND11_MAYBE_UNUSED PYBIND11_EXPORT PyObject *PyInit_##name();                   \
     extern "C" PYBIND11_EXPORT PyObject *PyInit_##name()
 
 #else
@@ -220,9 +221,10 @@
 #define PYBIND11_BYTES_AS_STRING PyString_AsString
 #define PYBIND11_BYTES_SIZE PyString_Size
 #define PYBIND11_LONG_CHECK(o) (PyInt_Check(o) || PyLong_Check(o))
-#define PYBIND11_LONG_AS_LONGLONG(o) (PyInt_Check(o) ? (long long) PyLong_AsLong(o) : PyLong_AsLongLong(o))
-#define PYBIND11_LONG_FROM_SIGNED(o) PyInt_FromSsize_t((ssize_t) o) // Returns long if needed.
-#define PYBIND11_LONG_FROM_UNSIGNED(o) PyInt_FromSize_t((size_t) o) // Returns long if needed.
+#define PYBIND11_LONG_AS_LONGLONG(o)                                                              \
+    (PyInt_Check(o) ? (long long)PyLong_AsLong(o) : PyLong_AsLongLong(o))
+#define PYBIND11_LONG_FROM_SIGNED(o) PyInt_FromSsize_t((ssize_t)o) // Returns long if needed.
+#define PYBIND11_LONG_FROM_UNSIGNED(o) PyInt_FromSize_t((size_t)o) // Returns long if needed.
 #define PYBIND11_BYTES_NAME "str"
 #define PYBIND11_STRING_NAME "unicode"
 #define PYBIND11_SLICE_OBJECT PySliceObject
@@ -233,43 +235,42 @@
 #define PYBIND11_BUILTINS_MODULE "__builtin__"
 // Providing a separate PyInit decl to make Clang's -Wmissing-prototypes happy.
 // See comment for PYBIND11_MODULE below for why this is marked "maybe unused".
-#define PYBIND11_PLUGIN_IMPL(name) \
-    static PyObject *pybind11_init_wrapper();                           \
-    extern "C" PYBIND11_MAYBE_UNUSED PYBIND11_EXPORT void init##name(); \
-    extern "C" PYBIND11_EXPORT void init##name() {                      \
-        (void)pybind11_init_wrapper();                                  \
-    }                                                                   \
+#define PYBIND11_PLUGIN_IMPL(name)                                                                \
+    static PyObject *pybind11_init_wrapper();                                                     \
+    extern "C" PYBIND11_MAYBE_UNUSED PYBIND11_EXPORT void init##name();                           \
+    extern "C" PYBIND11_EXPORT void init##name() { (void)pybind11_init_wrapper(); }               \
     PyObject *pybind11_init_wrapper()
 #endif
 
 #if PY_VERSION_HEX >= 0x03050000 && PY_VERSION_HEX < 0x03050200
 extern "C" {
-    struct _Py_atomic_address { void *value; };
-    PyAPI_DATA(_Py_atomic_address) _PyThreadState_Current;
+struct _Py_atomic_address {
+    void *value;
+};
+PyAPI_DATA(_Py_atomic_address) _PyThreadState_Current;
 }
 #endif
 
-#define PYBIND11_TRY_NEXT_OVERLOAD ((PyObject *) 1) // special failure return code
+#define PYBIND11_TRY_NEXT_OVERLOAD ((PyObject *)1) // special failure return code
 #define PYBIND11_STRINGIFY(x) #x
 #define PYBIND11_TOSTRING(x) PYBIND11_STRINGIFY(x)
 #define PYBIND11_CONCAT(first, second) first##second
-#define PYBIND11_ENSURE_INTERNALS_READY \
-    pybind11::detail::get_internals();
+#define PYBIND11_ENSURE_INTERNALS_READY pybind11::detail::get_internals();
 
-#define PYBIND11_CHECK_PYTHON_VERSION \
-    {                                                                          \
-        const char *compiled_ver = PYBIND11_TOSTRING(PY_MAJOR_VERSION)         \
-            "." PYBIND11_TOSTRING(PY_MINOR_VERSION);                           \
-        const char *runtime_ver = Py_GetVersion();                             \
-        size_t len = std::strlen(compiled_ver);                                \
-        if (std::strncmp(runtime_ver, compiled_ver, len) != 0                  \
-                || (runtime_ver[len] >= '0' && runtime_ver[len] <= '9')) {     \
-            PyErr_Format(PyExc_ImportError,                                    \
-                "Python version mismatch: module was compiled for Python %s, " \
-                "but the interpreter version is incompatible: %s.",            \
-                compiled_ver, runtime_ver);                                    \
-            return nullptr;                                                    \
-        }                                                                      \
+#define PYBIND11_CHECK_PYTHON_VERSION                                                             \
+    {                                                                                             \
+        const char *compiled_ver =                                                                \
+            PYBIND11_TOSTRING(PY_MAJOR_VERSION) "." PYBIND11_TOSTRING(PY_MINOR_VERSION);          \
+        const char *runtime_ver = Py_GetVersion();                                                \
+        size_t len = std::strlen(compiled_ver);                                                   \
+        if (std::strncmp(runtime_ver, compiled_ver, len) != 0 ||                                  \
+            (runtime_ver[len] >= '0' && runtime_ver[len] <= '9')) {                               \
+            PyErr_Format(PyExc_ImportError,                                                       \
+                         "Python version mismatch: module was compiled for Python %s, "           \
+                         "but the interpreter version is incompatible: %s.",                      \
+                         compiled_ver, runtime_ver);                                              \
+            return nullptr;                                                                       \
+        }                                                                                         \
     }
 
 #define PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
@@ -299,16 +300,17 @@ extern "C" {
         }
 \endrst */
 // clang-format on
-#define PYBIND11_PLUGIN(name)                                                  \
-    PYBIND11_DEPRECATED("PYBIND11_PLUGIN is deprecated, use PYBIND11_MODULE")  \
-    static PyObject *pybind11_init();                                          \
-    PYBIND11_PLUGIN_IMPL(name) {                                               \
-        PYBIND11_CHECK_PYTHON_VERSION                                          \
-        PYBIND11_ENSURE_INTERNALS_READY                                        \
-        try {                                                                  \
-            return pybind11_init();                                            \
-        } PYBIND11_CATCH_INIT_EXCEPTIONS                                       \
-    }                                                                          \
+#define PYBIND11_PLUGIN(name)                                                                     \
+    PYBIND11_DEPRECATED("PYBIND11_PLUGIN is deprecated, use PYBIND11_MODULE")                     \
+    static PyObject *pybind11_init();                                                             \
+    PYBIND11_PLUGIN_IMPL(name) {                                                                  \
+        PYBIND11_CHECK_PYTHON_VERSION                                                             \
+        PYBIND11_ENSURE_INTERNALS_READY                                                           \
+        try {                                                                                     \
+            return pybind11_init();                                                               \
+        }                                                                                         \
+        PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
+    }                                                                                             \
     PyObject *pybind11_init()
 
 // clang-format off
@@ -334,29 +336,28 @@ extern "C" {
         }
 \endrst */
 // clang-format on
-#define PYBIND11_MODULE(name, variable)                                        \
-    static ::pybind11::module_::module_def                                     \
-        PYBIND11_CONCAT(pybind11_module_def_, name) PYBIND11_MAYBE_UNUSED;     \
-    PYBIND11_MAYBE_UNUSED                                                      \
-    static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);  \
-    PYBIND11_PLUGIN_IMPL(name) {                                               \
-        PYBIND11_CHECK_PYTHON_VERSION                                          \
-        PYBIND11_ENSURE_INTERNALS_READY                                        \
-        auto m = ::pybind11::module_::create_extension_module(                 \
-            PYBIND11_TOSTRING(name), nullptr,                                  \
-            &PYBIND11_CONCAT(pybind11_module_def_, name));                     \
-        try {                                                                  \
-            PYBIND11_CONCAT(pybind11_init_, name)(m);                          \
-            return m.ptr();                                                    \
-        } PYBIND11_CATCH_INIT_EXCEPTIONS                                       \
-    }                                                                          \
-    void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &variable)
-
+#define PYBIND11_MODULE(name, variable)                                                           \
+    static ::pybind11::module_::module_def PYBIND11_CONCAT(pybind11_module_def_, name)            \
+        PYBIND11_MAYBE_UNUSED;                                                                    \
+    PYBIND11_MAYBE_UNUSED                                                                         \
+    static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);                     \
+    PYBIND11_PLUGIN_IMPL(name) {                                                                  \
+        PYBIND11_CHECK_PYTHON_VERSION                                                             \
+        PYBIND11_ENSURE_INTERNALS_READY                                                           \
+        auto m = ::pybind11::module_::create_extension_module(                                    \
+            PYBIND11_TOSTRING(name), nullptr, &PYBIND11_CONCAT(pybind11_module_def_, name));      \
+        try {                                                                                     \
+            PYBIND11_CONCAT(pybind11_init_, name)(m);                                             \
+            return m.ptr();                                                                       \
+        }                                                                                         \
+        PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
+    }                                                                                             \
+    void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ & variable)
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 using ssize_t = Py_ssize_t;
-using size_t  = std::size_t;
+using size_t = std::size_t;
 
 /// Approach used to cast a previously unknown C++ instance into a Python object
 enum class return_value_policy : uint8_t {
@@ -412,10 +413,14 @@ enum class return_value_policy : uint8_t {
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-inline static constexpr int log2(size_t n, int k = 0) { return (n <= 1) ? k : log2(n >> 1, k + 1); }
+inline static constexpr int log2(size_t n, int k = 0) {
+    return (n <= 1) ? k : log2(n >> 1, k + 1);
+}
 
 // Returns the size as a multiple of sizeof(void *), rounded up.
-inline static constexpr size_t size_in_ptrs(size_t s) { return 1 + ((s - 1) >> log2(sizeof(void *))); }
+inline static constexpr size_t size_in_ptrs(size_t s) {
+    return 1 + ((s - 1) >> log2(sizeof(void *)));
+}
 
 /**
  * The space to allocate for simple layout instance holders (see below) in multiple of the size of
@@ -425,7 +430,7 @@ inline static constexpr size_t size_in_ptrs(size_t s) { return 1 + ((s - 1) >> l
  */
 constexpr size_t instance_simple_holder_in_ptrs() {
     static_assert(sizeof(std::shared_ptr<int>) >= sizeof(std::unique_ptr<int>),
-            "pybind assumes std::shared_ptrs are at least as big as std::unique_ptrs");
+                  "pybind assumes std::shared_ptrs are at least as big as std::unique_ptrs");
     return size_in_ptrs(sizeof(std::shared_ptr<int>));
 }
 
@@ -441,8 +446,8 @@ struct nonsimple_values_and_holders {
 /// The 'instance' type which needs to be standard layout (need to be able to use 'offsetof')
 struct instance {
     PyObject_HEAD
-    /// Storage for pointers and holder; see simple_layout, below, for a description
-    union {
+        /// Storage for pointers and holder; see simple_layout, below, for a description
+        union {
         void *simple_value_holder[1 + instance_simple_holder_in_ptrs()];
         nonsimple_values_and_holders nonsimple;
     };
@@ -453,21 +458,21 @@ struct instance {
     /**
      * An instance has two possible value/holder layouts.
      *
-     * Simple layout (when this flag is true), means the `simple_value_holder` is set with a pointer
-     * and the holder object governing that pointer, i.e. [val1*][holder].  This layout is applied
-     * whenever there is no python-side multiple inheritance of bound C++ types *and* the type's
-     * holder will fit in the default space (which is large enough to hold either a std::unique_ptr
-     * or std::shared_ptr).
+     * Simple layout (when this flag is true), means the `simple_value_holder` is set with a
+     * pointer and the holder object governing that pointer, i.e. [val1*][holder].  This layout is
+     * applied whenever there is no python-side multiple inheritance of bound C++ types *and* the
+     * type's holder will fit in the default space (which is large enough to hold either a
+     * std::unique_ptr or std::shared_ptr).
      *
-     * Non-simple layout applies when using custom holders that require more space than `shared_ptr`
-     * (which is typically the size of two pointers), or when multiple inheritance is used on the
-     * python side.  Non-simple layout allocates the required amount of memory to have multiple
-     * bound C++ classes as parents.  Under this layout, `nonsimple.values_and_holders` is set to a
-     * pointer to allocated space of the required space to hold a sequence of value pointers and
-     * holders followed `status`, a set of bit flags (1 byte each), i.e.
-     * [val1*][holder1][val2*][holder2]...[bb...]  where each [block] is rounded up to a multiple of
-     * `sizeof(void *)`.  `nonsimple.status` is, for convenience, a pointer to the
-     * beginning of the [bb...] block (but not independently allocated).
+     * Non-simple layout applies when using custom holders that require more space than
+     * `shared_ptr` (which is typically the size of two pointers), or when multiple inheritance is
+     * used on the python side.  Non-simple layout allocates the required amount of memory to have
+     * multiple bound C++ classes as parents.  Under this layout, `nonsimple.values_and_holders` is
+     * set to a pointer to allocated space of the required space to hold a sequence of value
+     * pointers and holders followed `status`, a set of bit flags (1 byte each), i.e.
+     * [val1*][holder1][val2*][holder2]...[bb...]  where each [block] is rounded up to a multiple
+     * of `sizeof(void *)`.  `nonsimple.status` is, for convenience, a pointer to the beginning of
+     * the [bb...] block (but not independently allocated).
      *
      * Status bits indicate whether the associated holder is constructed (&
      * status_holder_constructed) and whether the value pointer is registered (&
@@ -481,7 +486,8 @@ struct instance {
     /// If true, get_internals().patients has an entry for this object
     bool has_patients : 1;
 
-    /// Initializes all of the above type/values/holders data (but not the instance values themselves)
+    /// Initializes all of the above type/values/holders data (but not the instance values
+    /// themselves)
     void allocate_layout();
 
     /// Destroys/deallocates all of the above
@@ -490,24 +496,27 @@ struct instance {
     /// Returns the value_and_holder wrapper for the given type (or the first, if `find_type`
     /// omitted).  Returns a default-constructed (with `.inst = nullptr`) object on failure if
     /// `throw_if_missing` is false.
-    value_and_holder get_value_and_holder(const type_info *find_type = nullptr, bool throw_if_missing = true);
+    value_and_holder get_value_and_holder(const type_info *find_type = nullptr,
+                                          bool throw_if_missing = true);
 
     /// Bit values for the non-simple status flags
-    static constexpr uint8_t status_holder_constructed  = 1;
+    static constexpr uint8_t status_holder_constructed = 1;
     static constexpr uint8_t status_instance_registered = 2;
 };
 
-static_assert(std::is_standard_layout<instance>::value, "Internal error: `pybind11::detail::instance` is not standard layout!");
+static_assert(std::is_standard_layout<instance>::value,
+              "Internal error: `pybind11::detail::instance` is not standard layout!");
 
 /// from __cpp_future__ import (convenient aliases from C++14/17)
 #if defined(PYBIND11_CPP14) && (!defined(_MSC_VER) || _MSC_VER >= 1910)
-using std::enable_if_t;
 using std::conditional_t;
+using std::enable_if_t;
 using std::remove_cv_t;
 using std::remove_reference_t;
 #else
 template <bool B, typename T = void> using enable_if_t = typename std::enable_if<B, T>::type;
-template <bool B, typename T, typename F> using conditional_t = typename std::conditional<B, T, F>::type;
+template <bool B, typename T, typename F>
+using conditional_t = typename std::conditional<B, T, F>::type;
 template <typename T> using remove_cv_t = typename std::remove_cv<T>::type;
 template <typename T> using remove_reference_t = typename std::remove_reference<T>::type;
 #endif
@@ -517,32 +526,37 @@ template <typename T> using remove_reference_t = typename std::remove_reference<
 using std::index_sequence;
 using std::make_index_sequence;
 #else
-template<size_t ...> struct index_sequence  { };
-template<size_t N, size_t ...S> struct make_index_sequence_impl : make_index_sequence_impl <N - 1, N - 1, S...> { };
-template<size_t ...S> struct make_index_sequence_impl <0, S...> { using type = index_sequence<S...>; };
-template<size_t N> using make_index_sequence = typename make_index_sequence_impl<N>::type;
+template <size_t...> struct index_sequence {};
+template <size_t N, size_t... S>
+struct make_index_sequence_impl : make_index_sequence_impl<N - 1, N - 1, S...> {};
+template <size_t... S> struct make_index_sequence_impl<0, S...> {
+    using type = index_sequence<S...>;
+};
+template <size_t N> using make_index_sequence = typename make_index_sequence_impl<N>::type;
 #endif
 
 /// Make an index sequence of the indices of true arguments
 template <typename ISeq, size_t, bool...> struct select_indices_impl { using type = ISeq; };
-template <size_t... IPrev, size_t I, bool B, bool... Bs> struct select_indices_impl<index_sequence<IPrev...>, I, B, Bs...>
-    : select_indices_impl<conditional_t<B, index_sequence<IPrev..., I>, index_sequence<IPrev...>>, I + 1, Bs...> {};
-template <bool... Bs> using select_indices = typename select_indices_impl<index_sequence<>, 0, Bs...>::type;
+template <size_t... IPrev, size_t I, bool B, bool... Bs>
+struct select_indices_impl<index_sequence<IPrev...>, I, B, Bs...>
+    : select_indices_impl<conditional_t<B, index_sequence<IPrev..., I>, index_sequence<IPrev...>>,
+                          I + 1, Bs...> {};
+template <bool... Bs>
+using select_indices = typename select_indices_impl<index_sequence<>, 0, Bs...>::type;
 
 /// Backports of std::bool_constant and std::negation to accommodate older compilers
 template <bool B> using bool_constant = std::integral_constant<bool, B>;
-template <typename T> struct negation : bool_constant<!T::value> { };
+template <typename T> struct negation : bool_constant<!T::value> {};
 
 // PGI/Intel cannot detect operator delete with the "compatible" void_t impl, so
 // using the new one (C++14 defect, so generally works on newer compilers, even
 // if not in C++17 mode)
 #if defined(__PGIC__) || defined(__INTEL_COMPILER)
-template<typename... > using void_t = void;
+template <typename...> using void_t = void;
 #else
 template <typename...> struct void_t_impl { using type = void; };
 template <typename... Ts> using void_t = typename void_t_impl<Ts...>::type;
 #endif
-
 
 /// Compile-time all/any/none of that check the boolean value of all template types
 #if defined(__cpp_fold_expressions) && !(defined(_MSC_VER) && (_MSC_VER < 1916))
@@ -550,9 +564,8 @@ template <class... Ts> using all_of = bool_constant<(Ts::value && ...)>;
 template <class... Ts> using any_of = bool_constant<(Ts::value || ...)>;
 #elif !defined(_MSC_VER)
 template <bool...> struct bools {};
-template <class... Ts> using all_of = std::is_same<
-    bools<Ts::value..., true>,
-    bools<true, Ts::value...>>;
+template <class... Ts>
+using all_of = std::is_same<bools<Ts::value..., true>, bools<true, Ts::value...>>;
 template <class... Ts> using any_of = negation<all_of<negation<Ts>...>>;
 #else
 // MSVC has trouble with the above, but supports std::conjunction, which we can use instead (albeit
@@ -562,69 +575,95 @@ template <class... Ts> using any_of = std::disjunction<Ts...>;
 #endif
 template <class... Ts> using none_of = negation<any_of<Ts...>>;
 
-template <class T, template<class> class... Predicates> using satisfies_all_of = all_of<Predicates<T>...>;
-template <class T, template<class> class... Predicates> using satisfies_any_of = any_of<Predicates<T>...>;
-template <class T, template<class> class... Predicates> using satisfies_none_of = none_of<Predicates<T>...>;
+template <class T, template <class> class... Predicates>
+using satisfies_all_of = all_of<Predicates<T>...>;
+template <class T, template <class> class... Predicates>
+using satisfies_any_of = any_of<Predicates<T>...>;
+template <class T, template <class> class... Predicates>
+using satisfies_none_of = none_of<Predicates<T>...>;
 
 /// Strip the class from a method type
-template <typename T> struct remove_class { };
-template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...)> { using type = R (A...); };
-template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...) const> { using type = R (A...); };
+template <typename T> struct remove_class {};
+template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...)> {
+    using type = R(A...);
+};
+template <typename C, typename R, typename... A> struct remove_class<R (C::*)(A...) const> {
+    using type = R(A...);
+};
 
 /// Helper template to strip away type modifiers
-template <typename T> struct intrinsic_type                       { using type = T; };
-template <typename T> struct intrinsic_type<const T>              { using type = typename intrinsic_type<T>::type; };
-template <typename T> struct intrinsic_type<T*>                   { using type = typename intrinsic_type<T>::type; };
-template <typename T> struct intrinsic_type<T&>                   { using type = typename intrinsic_type<T>::type; };
-template <typename T> struct intrinsic_type<T&&>                  { using type = typename intrinsic_type<T>::type; };
-template <typename T, size_t N> struct intrinsic_type<const T[N]> { using type = typename intrinsic_type<T>::type; };
-template <typename T, size_t N> struct intrinsic_type<T[N]>       { using type = typename intrinsic_type<T>::type; };
+template <typename T> struct intrinsic_type { using type = T; };
+template <typename T> struct intrinsic_type<const T> {
+    using type = typename intrinsic_type<T>::type;
+};
+template <typename T> struct intrinsic_type<T *> {
+    using type = typename intrinsic_type<T>::type;
+};
+template <typename T> struct intrinsic_type<T &> {
+    using type = typename intrinsic_type<T>::type;
+};
+template <typename T> struct intrinsic_type<T &&> {
+    using type = typename intrinsic_type<T>::type;
+};
+template <typename T, size_t N> struct intrinsic_type<const T[N]> {
+    using type = typename intrinsic_type<T>::type;
+};
+template <typename T, size_t N> struct intrinsic_type<T[N]> {
+    using type = typename intrinsic_type<T>::type;
+};
 template <typename T> using intrinsic_t = typename intrinsic_type<T>::type;
 
 /// Helper type to replace 'void' in some expressions
-struct void_type { };
+struct void_type {};
 
 /// Helper template which holds a list of types
-template <typename...> struct type_list { };
+template <typename...> struct type_list {};
 
 /// Compile-time integer sum
 #ifdef __cpp_fold_expressions
-template <typename... Ts> constexpr size_t constexpr_sum(Ts... ns) { return (0 + ... + size_t{ns}); }
+template <typename... Ts> constexpr size_t constexpr_sum(Ts... ns) {
+    return (0 + ... + size_t{ns});
+}
 #else
 constexpr size_t constexpr_sum() { return 0; }
-template <typename T, typename... Ts>
-constexpr size_t constexpr_sum(T n, Ts... ns) { return size_t{n} + constexpr_sum(ns...); }
+template <typename T, typename... Ts> constexpr size_t constexpr_sum(T n, Ts... ns) {
+    return size_t{n} + constexpr_sum(ns...);
+}
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(constexpr_impl)
 /// Implementation details for constexpr functions
 constexpr int first(int i) { return i; }
-template <typename T, typename... Ts>
-constexpr int first(int i, T v, Ts... vs) { return v ? i : first(i + 1, vs...); }
+template <typename T, typename... Ts> constexpr int first(int i, T v, Ts... vs) {
+    return v ? i : first(i + 1, vs...);
+}
 
 constexpr int last(int /*i*/, int result) { return result; }
-template <typename T, typename... Ts>
-constexpr int last(int i, int result, T v, Ts... vs) { return last(i + 1, v ? i : result, vs...); }
+template <typename T, typename... Ts> constexpr int last(int i, int result, T v, Ts... vs) {
+    return last(i + 1, v ? i : result, vs...);
+}
 PYBIND11_NAMESPACE_END(constexpr_impl)
 
-/// Return the index of the first type in Ts which satisfies Predicate<T>.  Returns sizeof...(Ts) if
-/// none match.
-template <template<typename> class Predicate, typename... Ts>
-constexpr int constexpr_first() { return constexpr_impl::first(0, Predicate<Ts>::value...); }
+/// Return the index of the first type in Ts which satisfies Predicate<T>.  Returns sizeof...(Ts)
+/// if none match.
+template <template <typename> class Predicate, typename... Ts> constexpr int constexpr_first() {
+    return constexpr_impl::first(0, Predicate<Ts>::value...);
+}
 
 /// Return the index of the last type in Ts which satisfies Predicate<T>, or -1 if none match.
-template <template<typename> class Predicate, typename... Ts>
-constexpr int constexpr_last() { return constexpr_impl::last(0, -1, Predicate<Ts>::value...); }
+template <template <typename> class Predicate, typename... Ts> constexpr int constexpr_last() {
+    return constexpr_impl::last(0, -1, Predicate<Ts>::value...);
+}
 
 /// Return the Nth element from the parameter pack
-template <size_t N, typename T, typename... Ts>
-struct pack_element { using type = typename pack_element<N - 1, Ts...>::type; };
-template <typename T, typename... Ts>
-struct pack_element<0, T, Ts...> { using type = T; };
+template <size_t N, typename T, typename... Ts> struct pack_element {
+    using type = typename pack_element<N - 1, Ts...>::type;
+};
+template <typename T, typename... Ts> struct pack_element<0, T, Ts...> { using type = T; };
 
 /// Return the one and only type which matches the predicate, or Default if none match.
 /// If more than one type matches the predicate, fail at compile-time.
-template <template<typename> class Predicate, typename Default, typename... Ts>
+template <template <typename> class Predicate, typename Default, typename... Ts>
 struct exactly_one {
     static constexpr auto found = constexpr_sum(Predicate<Ts>::value...);
     static_assert(found <= 1, "Found more than one type matching the predicate");
@@ -632,10 +671,11 @@ struct exactly_one {
     static constexpr auto index = found ? constexpr_first<Predicate, Ts...>() : 0;
     using type = conditional_t<found, typename pack_element<index, Ts...>::type, Default>;
 };
-template <template<typename> class P, typename Default>
-struct exactly_one<P, Default> { using type = Default; };
+template <template <typename> class P, typename Default> struct exactly_one<P, Default> {
+    using type = Default;
+};
 
-template <template<typename> class Predicate, typename Default, typename... Ts>
+template <template <typename> class Predicate, typename Default, typename... Ts>
 using exactly_one_t = typename exactly_one<Predicate, Default, Ts...>::type;
 
 /// Defer the evaluation of type T until types Us are instantiated
@@ -644,36 +684,41 @@ template <typename T, typename... Us> using deferred_t = typename deferred_type<
 
 /// Like is_base_of, but requires a strict base (i.e. `is_strict_base_of<T, T>::value == false`,
 /// unlike `std::is_base_of`)
-template <typename Base, typename Derived> using is_strict_base_of = bool_constant<
-    std::is_base_of<Base, Derived>::value && !std::is_same<Base, Derived>::value>;
+template <typename Base, typename Derived>
+using is_strict_base_of =
+    bool_constant<std::is_base_of<Base, Derived>::value && !std::is_same<Base, Derived>::value>;
 
-/// Like is_base_of, but also requires that the base type is accessible (i.e. that a Derived pointer
-/// can be converted to a Base pointer)
-/// For unions, `is_base_of<T, T>::value` is False, so we need to check `is_same` as well.
-template <typename Base, typename Derived> using is_accessible_base_of = bool_constant<
-    (std::is_same<Base, Derived>::value || std::is_base_of<Base, Derived>::value) && std::is_convertible<Derived *, Base *>::value>;
+/// Like is_base_of, but also requires that the base type is accessible (i.e. that a Derived
+/// pointer can be converted to a Base pointer) For unions, `is_base_of<T, T>::value` is False, so
+/// we need to check `is_same` as well.
+template <typename Base, typename Derived>
+using is_accessible_base_of =
+    bool_constant<(std::is_same<Base, Derived>::value || std::is_base_of<Base, Derived>::value) &&
+                  std::is_convertible<Derived *, Base *>::value>;
 
-template <template<typename...> class Base>
-struct is_template_base_of_impl {
+template <template <typename...> class Base> struct is_template_base_of_impl {
     template <typename... Us> static std::true_type check(Base<Us...> *);
     static std::false_type check(...);
 };
 
 /// Check if a template is the base of a type. For example:
 /// `is_template_base_of<Base, T>` is true if `struct T : Base<U> {}` where U can be anything
-template <template<typename...> class Base, typename T>
+template <template <typename...> class Base, typename T>
 #if !defined(_MSC_VER)
-using is_template_base_of = decltype(is_template_base_of_impl<Base>::check((intrinsic_t<T>*)nullptr));
+using is_template_base_of =
+    decltype(is_template_base_of_impl<Base>::check((intrinsic_t<T> *)nullptr));
 #else // MSVC2015 has trouble with decltype in template aliases
-struct is_template_base_of : decltype(is_template_base_of_impl<Base>::check((intrinsic_t<T>*)nullptr)) { };
+struct is_template_base_of
+    : decltype(is_template_base_of_impl<Base>::check((intrinsic_t<T> *)nullptr)) {
+};
 #endif
 
 /// Check if T is an instantiation of the template `Class`. For example:
 /// `is_instantiation<shared_ptr, T>` is true if `T == shared_ptr<U>` where U can be anything.
-template <template<typename...> class Class, typename T>
-struct is_instantiation : std::false_type { };
-template <template<typename...> class Class, typename... Us>
-struct is_instantiation<Class, Class<Us...>> : std::true_type { };
+template <template <typename...> class Class, typename T>
+struct is_instantiation : std::false_type {};
+template <template <typename...> class Class, typename... Us>
+struct is_instantiation<Class, Class<Us...>> : std::true_type {};
 
 /// Check if T is std::shared_ptr<U> where U can be anything
 template <typename T> using is_shared_ptr = is_instantiation<std::shared_ptr, T>;
@@ -681,11 +726,14 @@ template <typename T> using is_shared_ptr = is_instantiation<std::shared_ptr, T>
 /// Check if T looks like an input iterator
 template <typename T, typename = void> struct is_input_iterator : std::false_type {};
 template <typename T>
-struct is_input_iterator<T, void_t<decltype(*std::declval<T &>()), decltype(++std::declval<T &>())>>
+struct is_input_iterator<T,
+                         void_t<decltype(*std::declval<T &>()), decltype(++std::declval<T &>())>>
     : std::true_type {};
 
-template <typename T> using is_function_pointer = bool_constant<
-    std::is_pointer<T>::value && std::is_function<typename std::remove_pointer<T>::type>::value>;
+template <typename T>
+using is_function_pointer =
+    bool_constant<std::is_pointer<T>::value &&
+                  std::is_function<typename std::remove_pointer<T>::type>::value>;
 
 template <typename F> struct strip_function_object {
     // If you are encountering an
@@ -698,23 +746,19 @@ template <typename F> struct strip_function_object {
 // Extracts the function signature from a function, function pointer or lambda.
 template <typename Function, typename F = remove_reference_t<Function>>
 using function_signature_t = conditional_t<
-    std::is_function<F>::value,
-    F,
-    typename conditional_t<
-        std::is_pointer<F>::value || std::is_member_pointer<F>::value,
-        std::remove_pointer<F>,
-        strip_function_object<F>
-    >::type
->;
+    std::is_function<F>::value, F,
+    typename conditional_t<std::is_pointer<F>::value || std::is_member_pointer<F>::value,
+                           std::remove_pointer<F>, strip_function_object<F>>::type>;
 
 /// Returns true if the type looks like a lambda: that is, isn't a function, pointer or member
 /// pointer.  Note that this can catch all sorts of other things, too; this is intended to be used
 /// in a place where passing a lambda makes sense.
-template <typename T> using is_lambda = satisfies_none_of<remove_reference_t<T>,
-        std::is_function, std::is_pointer, std::is_member_pointer>;
+template <typename T>
+using is_lambda = satisfies_none_of<remove_reference_t<T>, std::is_function, std::is_pointer,
+                                    std::is_member_pointer>;
 
 /// Ignore that a variable is unused in compiler warnings
-inline void ignore_unused(const int *) { }
+inline void ignore_unused(const int *) {}
 
 // [workaround(intel)] Internal error on fold expression
 /// Apply a function over each element of a parameter pack
@@ -723,14 +767,16 @@ inline void ignore_unused(const int *) { }
 #define PYBIND11_EXPAND_SIDE_EFFECTS(PATTERN) (((PATTERN), void()), ...)
 #else
 using expand_side_effects = bool[];
-#define PYBIND11_EXPAND_SIDE_EFFECTS(PATTERN) (void)pybind11::detail::expand_side_effects{ ((PATTERN), void(), false)..., false }
+#define PYBIND11_EXPAND_SIDE_EFFECTS(PATTERN)                                                     \
+    (void)pybind11::detail::expand_side_effects { ((PATTERN), void(), false)..., false }
 #endif
 
 PYBIND11_NAMESPACE_END(detail)
 
 #if defined(_MSC_VER)
-#  pragma warning(push)
-#  pragma warning(disable: 4275) // warning C4275: An exported class was derived from a class that wasn't exported. Can be ignored when derived from a STL class.
+#pragma warning(push)
+#pragma warning(disable : 4275) // warning C4275: An exported class was derived from a class that
+                                // wasn't exported. Can be ignored when derived from a STL class.
 #endif
 /// C++ bindings of builtin Python exceptions
 class PYBIND11_EXPORT builtin_exception : public std::runtime_error {
@@ -740,14 +786,15 @@ public:
     virtual void set_error() const = 0;
 };
 #if defined(_MSC_VER)
-#  pragma warning(pop)
+#pragma warning(pop)
 #endif
 
-#define PYBIND11_RUNTIME_EXCEPTION(name, type) \
-    class PYBIND11_EXPORT name : public builtin_exception { public: \
-        using builtin_exception::builtin_exception; \
-        name() : name("") { } \
-        void set_error() const override { PyErr_SetString(type, what()); } \
+#define PYBIND11_RUNTIME_EXCEPTION(name, type)                                                    \
+    class PYBIND11_EXPORT name : public builtin_exception {                                       \
+    public:                                                                                       \
+        using builtin_exception::builtin_exception;                                               \
+        name() : name("") {}                                                                      \
+        void set_error() const override { PyErr_SetString(type, what()); }                        \
     };
 
 PYBIND11_RUNTIME_EXCEPTION(stop_iteration, PyExc_StopIteration)
@@ -757,13 +804,19 @@ PYBIND11_RUNTIME_EXCEPTION(value_error, PyExc_ValueError)
 PYBIND11_RUNTIME_EXCEPTION(type_error, PyExc_TypeError)
 PYBIND11_RUNTIME_EXCEPTION(buffer_error, PyExc_BufferError)
 PYBIND11_RUNTIME_EXCEPTION(import_error, PyExc_ImportError)
-PYBIND11_RUNTIME_EXCEPTION(cast_error, PyExc_RuntimeError) /// Thrown when pybind11::cast or handle::call fail due to a type casting error
+PYBIND11_RUNTIME_EXCEPTION(cast_error,
+                           PyExc_RuntimeError) /// Thrown when pybind11::cast or handle::call fail
+                                               /// due to a type casting error
 PYBIND11_RUNTIME_EXCEPTION(reference_cast_error, PyExc_RuntimeError) /// Used internally
 
-[[noreturn]] PYBIND11_NOINLINE inline void pybind11_fail(const char *reason) { throw std::runtime_error(reason); }
-[[noreturn]] PYBIND11_NOINLINE inline void pybind11_fail(const std::string &reason) { throw std::runtime_error(reason); }
+[[noreturn]] PYBIND11_NOINLINE inline void pybind11_fail(const char *reason) {
+    throw std::runtime_error(reason);
+}
+[[noreturn]] PYBIND11_NOINLINE inline void pybind11_fail(const std::string &reason) {
+    throw std::runtime_error(reason);
+}
 
-template <typename T, typename SFINAE = void> struct format_descriptor { };
+template <typename T, typename SFINAE = void> struct format_descriptor {};
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 // Returns the index of the given type in the type char array below, and in the list in numpy.h
@@ -771,25 +824,34 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 // complex float,double,long double.  Note that the long double types only participate when long
 // double is actually longer than double (it isn't under MSVC).
 // NB: not only the string below but also complex.h and numpy.h rely on this order.
-template <typename T, typename SFINAE = void> struct is_fmt_numeric { static constexpr bool value = false; };
+template <typename T, typename SFINAE = void> struct is_fmt_numeric {
+    static constexpr bool value = false;
+};
 template <typename T> struct is_fmt_numeric<T, enable_if_t<std::is_arithmetic<T>::value>> {
     static constexpr bool value = true;
-    static constexpr int index = std::is_same<T, bool>::value ? 0 : 1 + (
-        std::is_integral<T>::value ? detail::log2(sizeof(T))*2 + std::is_unsigned<T>::value : 8 + (
-        std::is_same<T, double>::value ? 1 : std::is_same<T, long double>::value ? 2 : 0));
+    static constexpr int index =
+        std::is_same<T, bool>::value
+            ? 0
+            : 1 + (std::is_integral<T>::value
+                       ? detail::log2(sizeof(T)) * 2 + std::is_unsigned<T>::value
+                       : 8 + (std::is_same<T, double>::value        ? 1
+                              : std::is_same<T, long double>::value ? 2
+                                                                    : 0));
 };
 PYBIND11_NAMESPACE_END(detail)
 
-template <typename T> struct format_descriptor<T, detail::enable_if_t<std::is_arithmetic<T>::value>> {
+template <typename T>
+struct format_descriptor<T, detail::enable_if_t<std::is_arithmetic<T>::value>> {
     static constexpr const char c = "?bBhHiIqQfdg"[detail::is_fmt_numeric<T>::index];
-    static constexpr const char value[2] = { c, '\0' };
+    static constexpr const char value[2] = {c, '\0'};
     static std::string format() { return std::string(1, c); }
 };
 
 #if !defined(PYBIND11_CPP17)
 
-template <typename T> constexpr const char format_descriptor<
-    T, detail::enable_if_t<std::is_arithmetic<T>::value>>::value[2];
+template <typename T>
+constexpr const char
+    format_descriptor<T, detail::enable_if_t<std::is_arithmetic<T>::value>>::value[2];
 
 #endif
 
@@ -801,24 +863,30 @@ struct error_scope {
 };
 
 /// Dummy destructor wrapper that can be used to expose classes with a private destructor
-struct nodelete { template <typename T> void operator()(T*) { } };
+struct nodelete {
+    template <typename T> void operator()(T *) {}
+};
 
 PYBIND11_NAMESPACE_BEGIN(detail)
-template <typename... Args>
-struct overload_cast_impl {
+template <typename... Args> struct overload_cast_impl {
     constexpr overload_cast_impl() {} // NOLINT(modernize-use-equals-default): MSVC 2015 needs this
 
     template <typename Return>
-    constexpr auto operator()(Return (*pf)(Args...)) const noexcept
-                              -> decltype(pf) { return pf; }
+    constexpr auto operator()(Return (*pf)(Args...)) const noexcept -> decltype(pf) {
+        return pf;
+    }
 
     template <typename Return, typename Class>
     constexpr auto operator()(Return (Class::*pmf)(Args...), std::false_type = {}) const noexcept
-                              -> decltype(pmf) { return pmf; }
+        -> decltype(pmf) {
+        return pmf;
+    }
 
     template <typename Return, typename Class>
     constexpr auto operator()(Return (Class::*pmf)(Args...) const, std::true_type) const noexcept
-                              -> decltype(pmf) { return pmf; }
+        -> decltype(pmf) {
+        return pmf;
+    }
 };
 PYBIND11_NAMESPACE_END(detail)
 
@@ -850,27 +918,30 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 // Adaptor for converting arbitrary container arguments into a vector; implicitly convertible from
 // any standard container (or C-style array) supporting std::begin/std::end, any singleton
 // arithmetic type (if T is arithmetic), or explicitly constructible from an iterator pair.
-template <typename T>
-class any_container {
+template <typename T> class any_container {
     std::vector<T> v;
+
 public:
     any_container() = default;
 
     // Can construct from a pair of iterators
     template <typename It, typename = enable_if_t<is_input_iterator<It>::value>>
-    any_container(It first, It last) : v(first, last) { }
+    any_container(It first, It last) : v(first, last) {}
 
-    // Implicit conversion constructor from any arbitrary container type with values convertible to T
-    template <typename Container, typename = enable_if_t<std::is_convertible<decltype(*std::begin(std::declval<const Container &>())), T>::value>>
-    any_container(const Container &c) : any_container(std::begin(c), std::end(c)) { }
+    // Implicit conversion constructor from any arbitrary container type with values convertible to
+    // T
+    template <typename Container,
+              typename = enable_if_t<std::is_convertible<
+                  decltype(*std::begin(std::declval<const Container &>())), T>::value>>
+    any_container(const Container &c) : any_container(std::begin(c), std::end(c)) {}
 
-    // initializer_list's aren't deducible, so don't get matched by the above template; we need this
-    // to explicitly allow implicit conversion from one:
+    // initializer_list's aren't deducible, so don't get matched by the above template; we need
+    // this to explicitly allow implicit conversion from one:
     template <typename TIn, typename = enable_if_t<std::is_convertible<TIn, T>::value>>
-    any_container(const std::initializer_list<TIn> &c) : any_container(c.begin(), c.end()) { }
+    any_container(const std::initializer_list<TIn> &c) : any_container(c.begin(), c.end()) {}
 
     // Avoid copying if given an rvalue vector of the correct type.
-    any_container(std::vector<T> &&v) : v(std::move(v)) { }
+    any_container(std::vector<T> &&v) : v(std::move(v)) {}
 
     // Moves the vector out of an rvalue any_container
     operator std::vector<T> &&() && { return std::move(v); }
@@ -885,10 +956,11 @@ public:
 };
 
 // Forward-declaration; see detail/class.h
-std::string get_fully_qualified_tp_name(PyTypeObject*);
+std::string get_fully_qualified_tp_name(PyTypeObject *);
 
 template <typename T>
-inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_from_this<T> *holder_value_ptr) {
+inline static std::shared_ptr<T>
+try_get_shared_from_this(std::enable_shared_from_this<T> *holder_value_ptr) {
 // Pre C++17, this code path exploits undefined behavior, but is known to work on many platforms.
 // Use at your own risk!
 // See also https://en.cppreference.com/w/cpp/memory/enable_shared_from_this, and in particular
@@ -898,8 +970,7 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 #else
     try {
         return holder_value_ptr->shared_from_this();
-    }
-    catch (const std::bad_weak_ptr &) {
+    } catch (const std::bad_weak_ptr &) {
         return nullptr;
     }
 #endif

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -281,6 +281,7 @@ extern "C" {
             return nullptr;                                                    \
         }                                                                      \
 
+// clang-format off
 /** \rst
     ***Deprecated in favor of PYBIND11_MODULE***
 
@@ -296,6 +297,7 @@ extern "C" {
             return m.ptr();
         }
 \endrst */
+// clang-format on
 #define PYBIND11_PLUGIN(name)                                                  \
     PYBIND11_DEPRECATED("PYBIND11_PLUGIN is deprecated, use PYBIND11_MODULE")  \
     static PyObject *pybind11_init();                                          \
@@ -308,6 +310,7 @@ extern "C" {
     }                                                                          \
     PyObject *pybind11_init()
 
+// clang-format off
 /** \rst
     This macro creates the entry point that will be invoked when the Python interpreter
     imports an extension module. The module name is given as the fist argument and it
@@ -329,6 +332,7 @@ extern "C" {
             });
         }
 \endrst */
+// clang-format on
 #define PYBIND11_MODULE(name, variable)                                        \
     static ::pybind11::module_::module_def                                     \
         PYBIND11_CONCAT(pybind11_module_def_, name) PYBIND11_MAYBE_UNUSED;     \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -272,14 +272,15 @@ extern "C" {
         }                                                                      \
     }
 
-#define PYBIND11_CATCH_INIT_EXCEPTIONS \
-        catch (pybind11::error_already_set &e) {                               \
-            PyErr_SetString(PyExc_ImportError, e.what());                      \
-            return nullptr;                                                    \
-        } catch (const std::exception &e) {                                    \
-            PyErr_SetString(PyExc_ImportError, e.what());                      \
-            return nullptr;                                                    \
-        }                                                                      \
+#define PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
+    catch (pybind11::error_already_set & e) {                                                     \
+        PyErr_SetString(PyExc_ImportError, e.what());                                             \
+        return nullptr;                                                                           \
+    }                                                                                             \
+    catch (const std::exception &e) {                                                             \
+        PyErr_SetString(PyExc_ImportError, e.what());                                             \
+        return nullptr;                                                                           \
+    }
 
 // clang-format off
 /** \rst

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -15,24 +15,23 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 #if !defined(_MSC_VER)
-#  define PYBIND11_DESCR_CONSTEXPR static constexpr
+#define PYBIND11_DESCR_CONSTEXPR static constexpr
 #else
-#  define PYBIND11_DESCR_CONSTEXPR const
+#define PYBIND11_DESCR_CONSTEXPR const
 #endif
 
 /* Concatenate type signatures at compile time */
-template <size_t N, typename... Ts>
-struct descr {
+template <size_t N, typename... Ts> struct descr {
     char text[N + 1]{'\0'};
 
     constexpr descr() = default;
-    constexpr descr(char const (&s)[N+1]) : descr(s, make_index_sequence<N>()) { }
+    constexpr descr(char const (&s)[N + 1]) : descr(s, make_index_sequence<N>()) {}
 
     template <size_t... Is>
-    constexpr descr(char const (&s)[N+1], index_sequence<Is...>) : text{s[Is]..., '\0'} { }
+    constexpr descr(char const (&s)[N + 1], index_sequence<Is...>) : text{s[Is]..., '\0'} {}
 
     template <typename... Chars>
-    constexpr descr(char c, Chars... cs) : text{c, static_cast<char>(cs)..., '\0'} { }
+    constexpr descr(char c, Chars... cs) : text{c, static_cast<char>(cs)..., '\0'} {}
 
     static constexpr std::array<const std::type_info *, sizeof...(Ts) + 1> types() {
         return {{&typeid(Ts)..., nullptr}};
@@ -40,39 +39,45 @@ struct descr {
 };
 
 template <size_t N1, size_t N2, typename... Ts1, typename... Ts2, size_t... Is1, size_t... Is2>
-constexpr descr<N1 + N2, Ts1..., Ts2...> plus_impl(const descr<N1, Ts1...> &a, const descr<N2, Ts2...> &b,
-                                                   index_sequence<Is1...>, index_sequence<Is2...>) {
+constexpr descr<N1 + N2, Ts1..., Ts2...>
+plus_impl(const descr<N1, Ts1...> &a, const descr<N2, Ts2...> &b, index_sequence<Is1...>,
+          index_sequence<Is2...>) {
     return {a.text[Is1]..., b.text[Is2]...};
 }
 
 template <size_t N1, size_t N2, typename... Ts1, typename... Ts2>
-constexpr descr<N1 + N2, Ts1..., Ts2...> operator+(const descr<N1, Ts1...> &a, const descr<N2, Ts2...> &b) {
+constexpr descr<N1 + N2, Ts1..., Ts2...> operator+(const descr<N1, Ts1...> &a,
+                                                   const descr<N2, Ts2...> &b) {
     return plus_impl(a, b, make_index_sequence<N1>(), make_index_sequence<N2>());
 }
 
-template <size_t N>
-constexpr descr<N - 1> _(char const(&text)[N]) { return descr<N - 1>(text); }
-constexpr descr<0> _(char const(&)[1]) { return {}; }
+template <size_t N> constexpr descr<N - 1> _(char const (&text)[N]) { return descr<N - 1>(text); }
+constexpr descr<0> _(char const (&)[1]) { return {}; }
 
-template <size_t Rem, size_t... Digits> struct int_to_str : int_to_str<Rem/10, Rem%10, Digits...> { };
-template <size_t...Digits> struct int_to_str<0, Digits...> {
+template <size_t Rem, size_t... Digits>
+struct int_to_str : int_to_str<Rem / 10, Rem % 10, Digits...> {};
+template <size_t... Digits> struct int_to_str<0, Digits...> {
     static constexpr auto digits = descr<sizeof...(Digits)>(('0' + Digits)...);
 };
 
 // Ternary description (like std::conditional)
 template <bool B, size_t N1, size_t N2>
-constexpr enable_if_t<B, descr<N1 - 1>> _(char const(&text1)[N1], char const(&)[N2]) {
+constexpr enable_if_t<B, descr<N1 - 1>> _(char const (&text1)[N1], char const (&)[N2]) {
     return _(text1);
 }
 template <bool B, size_t N1, size_t N2>
-constexpr enable_if_t<!B, descr<N2 - 1>> _(char const(&)[N1], char const(&text2)[N2]) {
+constexpr enable_if_t<!B, descr<N2 - 1>> _(char const (&)[N1], char const (&text2)[N2]) {
     return _(text2);
 }
 
 template <bool B, typename T1, typename T2>
-constexpr enable_if_t<B, T1> _(const T1 &d, const T2 &) { return d; }
+constexpr enable_if_t<B, T1> _(const T1 &d, const T2 &) {
+    return d;
+}
 template <bool B, typename T1, typename T2>
-constexpr enable_if_t<!B, T2> _(const T1 &, const T2 &d) { return d; }
+constexpr enable_if_t<!B, T2> _(const T1 &, const T2 &d) {
+    return d;
+}
 
 template <size_t Size> auto constexpr _() -> decltype(int_to_str<Size / 10, Size % 10>::digits) {
     return int_to_str<Size / 10, Size % 10>::digits;
@@ -83,7 +88,9 @@ template <typename Type> constexpr descr<1, Type> _() { return {'%'}; }
 constexpr descr<0> concat() { return {}; }
 
 template <size_t N, typename... Ts>
-constexpr descr<N, Ts...> concat(const descr<N, Ts...> &descr) { return descr; }
+constexpr descr<N, Ts...> concat(const descr<N, Ts...> &descr) {
+    return descr;
+}
 
 template <size_t N, typename... Ts, typename... Args>
 constexpr auto concat(const descr<N, Ts...> &d, const Args &...args)

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -14,8 +14,7 @@
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-template <>
-class type_caster<value_and_holder> {
+template <> class type_caster<value_and_holder> {
 public:
     bool load(handle h, bool) {
         value = reinterpret_cast<value_and_holder *>(h.ptr());
@@ -33,7 +32,8 @@ private:
 PYBIND11_NAMESPACE_BEGIN(initimpl)
 
 inline void no_nullptr(void *ptr) {
-    if (!ptr) throw type_error("pybind11::init(): factory function returned nullptr");
+    if (!ptr)
+        throw type_error("pybind11::init(): factory function returned nullptr");
 }
 
 // Implementing functions for all forms of py::init<...> and py::init(...)
@@ -41,26 +41,31 @@ template <typename Class> using Cpp = typename Class::type;
 template <typename Class> using Alias = typename Class::type_alias;
 template <typename Class> using Holder = typename Class::holder_type;
 
-template <typename Class> using is_alias_constructible = std::is_constructible<Alias<Class>, Cpp<Class> &&>;
+template <typename Class>
+using is_alias_constructible = std::is_constructible<Alias<Class>, Cpp<Class> &&>;
 
 // Takes a Cpp pointer and returns true if it actually is a polymorphic Alias instance.
-template <typename Class, enable_if_t<Class::has_alias, int> = 0>
-bool is_alias(Cpp<Class> *ptr) {
+template <typename Class, enable_if_t<Class::has_alias, int> = 0> bool is_alias(Cpp<Class> *ptr) {
     return dynamic_cast<Alias<Class> *>(ptr) != nullptr;
 }
 // Failing fallback version of the above for a no-alias class (always returns false)
-template <typename /*Class*/>
-constexpr bool is_alias(void *) { return false; }
+template <typename /*Class*/> constexpr bool is_alias(void *) { return false; }
 
 // Constructs and returns a new object; if the given arguments don't map to a constructor, we fall
 // back to brace aggregate initiailization so that for aggregate initialization can be used with
 // py::init, e.g.  `py::init<int, int>` to initialize a `struct T { int a; int b; }`.  For
 // non-aggregate types, we need to use an ordinary T(...) constructor (invoking as `T{...}` usually
 // works, but will not do the expected thing when `T` has an `initializer_list<T>` constructor).
-template <typename Class, typename... Args, detail::enable_if_t<std::is_constructible<Class, Args...>::value, int> = 0>
-inline Class *construct_or_initialize(Args &&...args) { return new Class(std::forward<Args>(args)...); }
-template <typename Class, typename... Args, detail::enable_if_t<!std::is_constructible<Class, Args...>::value, int> = 0>
-inline Class *construct_or_initialize(Args &&...args) { return new Class{std::forward<Args>(args)...}; }
+template <typename Class, typename... Args,
+          detail::enable_if_t<std::is_constructible<Class, Args...>::value, int> = 0>
+inline Class *construct_or_initialize(Args &&...args) {
+    return new Class(std::forward<Args>(args)...);
+}
+template <typename Class, typename... Args,
+          detail::enable_if_t<!std::is_constructible<Class, Args...>::value, int> = 0>
+inline Class *construct_or_initialize(Args &&...args) {
+    return new Class{std::forward<Args>(args)...};
+}
 
 // Attempts to constructs an alias using a `Alias(Cpp &&)` constructor.  This allows types with
 // an alias to provide only a single Cpp factory function as long as the Alias can be
@@ -68,8 +73,8 @@ inline Class *construct_or_initialize(Args &&...args) { return new Class{std::fo
 // can, when appropriate, simply define a `Alias(Cpp &&)` constructor rather than needing to
 // inherit all the base class constructors.
 template <typename Class>
-void construct_alias_from_cpp(std::true_type /*is_alias_constructible*/,
-                              value_and_holder &v_h, Cpp<Class> &&base) {
+void construct_alias_from_cpp(std::true_type /*is_alias_constructible*/, value_and_holder &v_h,
+                              Cpp<Class> &&base) {
     v_h.value_ptr() = new Alias<Class>(std::move(base));
 }
 template <typename Class>
@@ -81,19 +86,17 @@ template <typename Class>
 
 // Error-generating fallback for factories that don't match one of the below construction
 // mechanisms.
-template <typename Class>
-void construct(...) {
+template <typename Class> void construct(...) {
     static_assert(!std::is_same<Class, Class>::value /* always false */,
-            "pybind11::init(): init function must return a compatible pointer, "
-            "holder, or value");
+                  "pybind11::init(): init function must return a compatible pointer, "
+                  "holder, or value");
 }
 
 // Pointer return v1: the factory function returns a class pointer for a registered class.
 // If we don't need an alias (because this class doesn't have one, or because the final type is
 // inherited on the Python side) we can simply take over ownership.  Otherwise we need to try to
 // construct an Alias from the returned base instance.
-template <typename Class>
-void construct(value_and_holder &v_h, Cpp<Class> *ptr, bool need_alias) {
+template <typename Class> void construct(value_and_holder &v_h, Cpp<Class> *ptr, bool need_alias) {
     no_nullptr(ptr);
     if (Class::has_alias && need_alias && !is_alias<Class>(ptr)) {
         // We're going to try to construct an alias by moving the cpp type.  Whether or not
@@ -105,7 +108,7 @@ void construct(value_and_holder &v_h, Cpp<Class> *ptr, bool need_alias) {
         // the holder and destruction happens when we leave the C++ scope, and the holder
         // class gets to handle the destruction however it likes.
         v_h.value_ptr() = ptr;
-        v_h.set_instance_registered(true); // To prevent init_instance from registering it
+        v_h.set_instance_registered(true);          // To prevent init_instance from registering it
         v_h.type->init_instance(v_h.inst, nullptr); // Set up the holder
         Holder<Class> temp_holder(std::move(v_h.holder<Holder<Class>>())); // Steal the holder
         v_h.type->dealloc(v_h); // Destroys the moved-out holder remains, resets value ptr to null
@@ -128,7 +131,8 @@ void construct(value_and_holder &v_h, Alias<Class> *alias_ptr, bool) {
 
 // Holder return: copy its pointer, and move or copy the returned holder into the new instance's
 // holder.  This also handles types like std::shared_ptr<T> and std::unique_ptr<T> where T is a
-// derived type (through those holder's implicit conversion from derived class holder constructors).
+// derived type (through those holder's implicit conversion from derived class holder
+// constructors).
 template <typename Class>
 void construct(value_and_holder &v_h, Holder<Class> holder, bool need_alias) {
     auto *ptr = holder_helper<Holder<Class>>::get(holder);
@@ -149,7 +153,7 @@ void construct(value_and_holder &v_h, Holder<Class> holder, bool need_alias) {
 template <typename Class>
 void construct(value_and_holder &v_h, Cpp<Class> &&result, bool need_alias) {
     static_assert(std::is_move_constructible<Cpp<Class>>::value,
-        "pybind11::init() return-by-value factory function requires a movable class");
+                  "pybind11::init() return-by-value factory function requires a movable class");
     if (Class::has_alias && need_alias)
         construct_alias_from_cpp<Class>(is_alias_constructible<Class>{}, v_h, std::move(result));
     else
@@ -159,59 +163,75 @@ void construct(value_and_holder &v_h, Cpp<Class> &&result, bool need_alias) {
 // return-by-value version 2: returning a value of the alias type itself.  We move-construct an
 // Alias instance (even if no the python-side inheritance is involved).  The is intended for
 // cases where Alias initialization is always desired.
-template <typename Class>
-void construct(value_and_holder &v_h, Alias<Class> &&result, bool) {
-    static_assert(std::is_move_constructible<Alias<Class>>::value,
+template <typename Class> void construct(value_and_holder &v_h, Alias<Class> &&result, bool) {
+    static_assert(
+        std::is_move_constructible<Alias<Class>>::value,
         "pybind11::init() return-by-alias-value factory function requires a movable alias class");
     v_h.value_ptr() = new Alias<Class>(std::move(result));
 }
 
 // Implementing class for py::init<...>()
-template <typename... Args>
-struct constructor {
+template <typename... Args> struct constructor {
     template <typename Class, typename... Extra, enable_if_t<!Class::has_alias, int> = 0>
-    static void execute(Class &cl, const Extra&... extra) {
-        cl.def("__init__", [](value_and_holder &v_h, Args... args) {
-            v_h.value_ptr() = construct_or_initialize<Cpp<Class>>(std::forward<Args>(args)...);
-        }, is_new_style_constructor(), extra...);
-    }
-
-    template <typename Class, typename... Extra,
-              enable_if_t<Class::has_alias &&
-                          std::is_constructible<Cpp<Class>, Args...>::value, int> = 0>
-    static void execute(Class &cl, const Extra&... extra) {
-        cl.def("__init__", [](value_and_holder &v_h, Args... args) {
-            if (Py_TYPE(v_h.inst) == v_h.type->type)
+    static void execute(Class &cl, const Extra &...extra) {
+        cl.def(
+            "__init__",
+            [](value_and_holder &v_h, Args... args) {
                 v_h.value_ptr() = construct_or_initialize<Cpp<Class>>(std::forward<Args>(args)...);
-            else
-                v_h.value_ptr() = construct_or_initialize<Alias<Class>>(std::forward<Args>(args)...);
-        }, is_new_style_constructor(), extra...);
+            },
+            is_new_style_constructor(), extra...);
     }
 
     template <typename Class, typename... Extra,
-              enable_if_t<Class::has_alias &&
-                          !std::is_constructible<Cpp<Class>, Args...>::value, int> = 0>
-    static void execute(Class &cl, const Extra&... extra) {
-        cl.def("__init__", [](value_and_holder &v_h, Args... args) {
-            v_h.value_ptr() = construct_or_initialize<Alias<Class>>(std::forward<Args>(args)...);
-        }, is_new_style_constructor(), extra...);
+              enable_if_t<Class::has_alias && std::is_constructible<Cpp<Class>, Args...>::value,
+                          int> = 0>
+    static void execute(Class &cl, const Extra &...extra) {
+        cl.def(
+            "__init__",
+            [](value_and_holder &v_h, Args... args) {
+                if (Py_TYPE(v_h.inst) == v_h.type->type)
+                    v_h.value_ptr() =
+                        construct_or_initialize<Cpp<Class>>(std::forward<Args>(args)...);
+                else
+                    v_h.value_ptr() =
+                        construct_or_initialize<Alias<Class>>(std::forward<Args>(args)...);
+            },
+            is_new_style_constructor(), extra...);
+    }
+
+    template <typename Class, typename... Extra,
+              enable_if_t<Class::has_alias && !std::is_constructible<Cpp<Class>, Args...>::value,
+                          int> = 0>
+    static void execute(Class &cl, const Extra &...extra) {
+        cl.def(
+            "__init__",
+            [](value_and_holder &v_h, Args... args) {
+                v_h.value_ptr() =
+                    construct_or_initialize<Alias<Class>>(std::forward<Args>(args)...);
+            },
+            is_new_style_constructor(), extra...);
     }
 };
 
 // Implementing class for py::init_alias<...>()
 template <typename... Args> struct alias_constructor {
     template <typename Class, typename... Extra,
-              enable_if_t<Class::has_alias && std::is_constructible<Alias<Class>, Args...>::value, int> = 0>
-    static void execute(Class &cl, const Extra&... extra) {
-        cl.def("__init__", [](value_and_holder &v_h, Args... args) {
-            v_h.value_ptr() = construct_or_initialize<Alias<Class>>(std::forward<Args>(args)...);
-        }, is_new_style_constructor(), extra...);
+              enable_if_t<Class::has_alias && std::is_constructible<Alias<Class>, Args...>::value,
+                          int> = 0>
+    static void execute(Class &cl, const Extra &...extra) {
+        cl.def(
+            "__init__",
+            [](value_and_holder &v_h, Args... args) {
+                v_h.value_ptr() =
+                    construct_or_initialize<Alias<Class>>(std::forward<Args>(args)...);
+            },
+            is_new_style_constructor(), extra...);
     }
 };
 
 // Implementation class for py::init(Func) and py::init(Func, AliasFunc)
-template <typename CFunc, typename AFunc = void_type (*)(),
-          typename = function_signature_t<CFunc>, typename = function_signature_t<AFunc>>
+template <typename CFunc, typename AFunc = void_type (*)(), typename = function_signature_t<CFunc>,
+          typename = function_signature_t<AFunc>>
 struct factory;
 
 // Specialization for py::init(Func)
@@ -219,7 +239,7 @@ template <typename Func, typename Return, typename... Args>
 struct factory<Func, void_type (*)(), Return(Args...)> {
     remove_reference_t<Func> class_factory;
 
-    factory(Func &&f) : class_factory(std::forward<Func>(f)) { }
+    factory(Func &&f) : class_factory(std::forward<Func>(f)) {}
 
     // The given class either has no alias or has no separate alias factory;
     // this always constructs the class itself.  If the class is registered with an alias
@@ -228,22 +248,27 @@ struct factory<Func, void_type (*)(), Return(Args...)> {
     // instance, or the alias needs to be constructible from a `Class &&` argument.
     template <typename Class, typename... Extra>
     void execute(Class &cl, const Extra &...extra) && {
-        #if defined(PYBIND11_CPP14)
-        cl.def("__init__", [func = std::move(class_factory)]
-        #else
+#if defined(PYBIND11_CPP14)
+        cl.def(
+            "__init__",
+            [func = std::move(class_factory)]
+#else
         auto &func = class_factory;
-        cl.def("__init__", [func]
-        #endif
-        (value_and_holder &v_h, Args... args) {
-            construct<Class>(v_h, func(std::forward<Args>(args)...),
-                             Py_TYPE(v_h.inst) != v_h.type->type);
-        }, is_new_style_constructor(), extra...);
+        cl.def(
+            "__init__",
+            [func]
+#endif
+            (value_and_holder &v_h, Args... args) {
+                construct<Class>(v_h, func(std::forward<Args>(args)...),
+                                 Py_TYPE(v_h.inst) != v_h.type->type);
+            },
+            is_new_style_constructor(), extra...);
     }
 };
 
 // Specialization for py::init(Func, AliasFunc)
-template <typename CFunc, typename AFunc,
-          typename CReturn, typename... CArgs, typename AReturn, typename... AArgs>
+template <typename CFunc, typename AFunc, typename CReturn, typename... CArgs, typename AReturn,
+          typename... AArgs>
 struct factory<CFunc, AFunc, CReturn(CArgs...), AReturn(AArgs...)> {
     static_assert(sizeof...(CArgs) == sizeof...(AArgs),
                   "pybind11::init(class_factory, alias_factory): class and alias factories "
@@ -256,29 +281,34 @@ struct factory<CFunc, AFunc, CReturn(CArgs...), AReturn(AArgs...)> {
     remove_reference_t<AFunc> alias_factory;
 
     factory(CFunc &&c, AFunc &&a)
-        : class_factory(std::forward<CFunc>(c)), alias_factory(std::forward<AFunc>(a)) { }
+        : class_factory(std::forward<CFunc>(c)), alias_factory(std::forward<AFunc>(a)) {}
 
     // The class factory is called when the `self` type passed to `__init__` is the direct
     // class (i.e. not inherited), the alias factory when `self` is a Python-side subtype.
     template <typename Class, typename... Extra>
-    void execute(Class &cl, const Extra&... extra) && {
+    void execute(Class &cl, const Extra &...extra) && {
         static_assert(Class::has_alias, "The two-argument version of `py::init()` can "
                                         "only be used if the class has an alias");
-        #if defined(PYBIND11_CPP14)
-        cl.def("__init__", [class_func = std::move(class_factory), alias_func = std::move(alias_factory)]
-        #else
+#if defined(PYBIND11_CPP14)
+        cl.def(
+            "__init__",
+            [class_func = std::move(class_factory), alias_func = std::move(alias_factory)]
+#else
         auto &class_func = class_factory;
         auto &alias_func = alias_factory;
-        cl.def("__init__", [class_func, alias_func]
-        #endif
-        (value_and_holder &v_h, CArgs... args) {
-            if (Py_TYPE(v_h.inst) == v_h.type->type)
-                // If the instance type equals the registered type we don't have inheritance, so
-                // don't need the alias and can construct using the class function:
-                construct<Class>(v_h, class_func(std::forward<CArgs>(args)...), false);
-            else
-                construct<Class>(v_h, alias_func(std::forward<CArgs>(args)...), true);
-        }, is_new_style_constructor(), extra...);
+        cl.def(
+            "__init__",
+            [class_func, alias_func]
+#endif
+            (value_and_holder &v_h, CArgs... args) {
+                if (Py_TYPE(v_h.inst) == v_h.type->type)
+                    // If the instance type equals the registered type we don't have inheritance,
+                    // so don't need the alias and can construct using the class function:
+                    construct<Class>(v_h, class_func(std::forward<CArgs>(args)...), false);
+                else
+                    construct<Class>(v_h, alias_func(std::forward<CArgs>(args)...), true);
+            },
+            is_new_style_constructor(), extra...);
     }
 };
 
@@ -299,16 +329,16 @@ void setstate(value_and_holder &v_h, std::pair<T, O> &&result, bool need_alias) 
         // See PR #2972 for details.
         return;
     }
-    setattr((PyObject *) v_h.inst, "__dict__", d);
+    setattr((PyObject *)v_h.inst, "__dict__", d);
 }
 
 /// Implementation for py::pickle(GetState, SetState)
-template <typename Get, typename Set,
-          typename = function_signature_t<Get>, typename = function_signature_t<Set>>
+template <typename Get, typename Set, typename = function_signature_t<Get>,
+          typename = function_signature_t<Set>>
 struct pickle_factory;
 
-template <typename Get, typename Set,
-          typename RetState, typename Self, typename NewInstance, typename ArgState>
+template <typename Get, typename Set, typename RetState, typename Self, typename NewInstance,
+          typename ArgState>
 struct pickle_factory<Get, Set, RetState(Self), NewInstance(ArgState)> {
     static_assert(std::is_same<intrinsic_t<RetState>, intrinsic_t<ArgState>>::value,
                   "The type returned by `__getstate__` must be the same "
@@ -317,23 +347,27 @@ struct pickle_factory<Get, Set, RetState(Self), NewInstance(ArgState)> {
     remove_reference_t<Get> get;
     remove_reference_t<Set> set;
 
-    pickle_factory(Get get, Set set)
-        : get(std::forward<Get>(get)), set(std::forward<Set>(set)) { }
+    pickle_factory(Get get, Set set) : get(std::forward<Get>(get)), set(std::forward<Set>(set)) {}
 
     template <typename Class, typename... Extra>
     void execute(Class &cl, const Extra &...extra) && {
         cl.def("__getstate__", std::move(get));
 
 #if defined(PYBIND11_CPP14)
-        cl.def("__setstate__", [func = std::move(set)]
+        cl.def(
+            "__setstate__",
+            [func = std::move(set)]
 #else
         auto &func = set;
-        cl.def("__setstate__", [func]
+        cl.def(
+            "__setstate__",
+            [func]
 #endif
-        (value_and_holder &v_h, ArgState state) {
-            setstate<Class>(v_h, func(std::forward<ArgState>(state)),
-                            Py_TYPE(v_h.inst) != v_h.type->type);
-        }, is_new_style_constructor(), extra...);
+            (value_and_holder &v_h, ArgState state) {
+                setstate<Class>(v_h, func(std::forward<ArgState>(state)),
+                                Py_TYPE(v_h.inst) != v_h.type->type);
+            },
+            is_new_style_constructor(), extra...);
     }
 };
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -21,30 +21,27 @@ inline PyObject *make_object_base_type(PyTypeObject *metaclass);
 // The old Python Thread Local Storage (TLS) API is deprecated in Python 3.7 in favor of the new
 // Thread Specific Storage (TSS) API.
 #if PY_VERSION_HEX >= 0x03070000
-#    define PYBIND11_TLS_KEY_INIT(var) Py_tss_t *var = nullptr
-#    define PYBIND11_TLS_GET_VALUE(key) PyThread_tss_get((key))
-#    define PYBIND11_TLS_REPLACE_VALUE(key, value) PyThread_tss_set((key), (value))
-#    define PYBIND11_TLS_DELETE_VALUE(key) PyThread_tss_set((key), nullptr)
-#    define PYBIND11_TLS_FREE(key) PyThread_tss_free(key)
+#define PYBIND11_TLS_KEY_INIT(var) Py_tss_t *var = nullptr
+#define PYBIND11_TLS_GET_VALUE(key) PyThread_tss_get((key))
+#define PYBIND11_TLS_REPLACE_VALUE(key, value) PyThread_tss_set((key), (value))
+#define PYBIND11_TLS_DELETE_VALUE(key) PyThread_tss_set((key), nullptr)
+#define PYBIND11_TLS_FREE(key) PyThread_tss_free(key)
 #else
-    // Usually an int but a long on Cygwin64 with Python 3.x
-#    define PYBIND11_TLS_KEY_INIT(var) decltype(PyThread_create_key()) var = 0
-#    define PYBIND11_TLS_GET_VALUE(key) PyThread_get_key_value((key))
-#    if PY_MAJOR_VERSION < 3
-#        define PYBIND11_TLS_DELETE_VALUE(key)                               \
-             PyThread_delete_key_value(key)
-#        define PYBIND11_TLS_REPLACE_VALUE(key, value)                       \
-             do {                                                            \
-                 PyThread_delete_key_value((key));                           \
-                 PyThread_set_key_value((key), (value));                     \
-             } while (false)
-#    else
-#        define PYBIND11_TLS_DELETE_VALUE(key)                               \
-             PyThread_set_key_value((key), nullptr)
-#        define PYBIND11_TLS_REPLACE_VALUE(key, value)                       \
-             PyThread_set_key_value((key), (value))
-#    endif
-#    define PYBIND11_TLS_FREE(key) (void)key
+// Usually an int but a long on Cygwin64 with Python 3.x
+#define PYBIND11_TLS_KEY_INIT(var) decltype(PyThread_create_key()) var = 0
+#define PYBIND11_TLS_GET_VALUE(key) PyThread_get_key_value((key))
+#if PY_MAJOR_VERSION < 3
+#define PYBIND11_TLS_DELETE_VALUE(key) PyThread_delete_key_value(key)
+#define PYBIND11_TLS_REPLACE_VALUE(key, value)                                                    \
+    do {                                                                                          \
+        PyThread_delete_key_value((key));                                                         \
+        PyThread_set_key_value((key), (value));                                                   \
+    } while (false)
+#else
+#define PYBIND11_TLS_DELETE_VALUE(key) PyThread_set_key_value((key), nullptr)
+#define PYBIND11_TLS_REPLACE_VALUE(key, value) PyThread_set_key_value((key), (value))
+#endif
+#define PYBIND11_TLS_FREE(key) (void)key
 #endif
 
 // Python loads modules by default with dlopen with the RTLD_LOCAL flag; under libc++ and possibly
@@ -83,9 +80,9 @@ template <typename value_type>
 using type_map = std::unordered_map<std::type_index, value_type, type_hash, type_equal_to>;
 
 struct override_hash {
-    inline size_t operator()(const std::pair<const PyObject *, const char *>& v) const {
+    inline size_t operator()(const std::pair<const PyObject *, const char *> &v) const {
         size_t value = std::hash<const void *>()(v.first);
-        value ^= std::hash<const void *>()(v.second) + 0x9e3779b9 + (value<<6) + (value>>2);
+        value ^= std::hash<const void *>()(v.second) + 0x9e3779b9 + (value << 6) + (value >> 2);
         return value;
     }
 };
@@ -95,15 +92,19 @@ struct override_hash {
 /// `PYBIND11_INTERNALS_VERSION` must be incremented.
 struct internals {
     type_map<type_info *> registered_types_cpp; // std::type_index -> pybind11's type information
-    std::unordered_map<PyTypeObject *, std::vector<type_info *>> registered_types_py; // PyTypeObject* -> base type_info(s)
-    std::unordered_multimap<const void *, instance*> registered_instances; // void * -> instance*
-    std::unordered_set<std::pair<const PyObject *, const char *>, override_hash> inactive_override_cache;
+    std::unordered_map<PyTypeObject *, std::vector<type_info *>>
+        registered_types_py; // PyTypeObject* -> base type_info(s)
+    std::unordered_multimap<const void *, instance *> registered_instances; // void * -> instance*
+    std::unordered_set<std::pair<const PyObject *, const char *>, override_hash>
+        inactive_override_cache;
     type_map<std::vector<bool (*)(PyObject *, void *&)>> direct_conversions;
     std::unordered_map<const PyObject *, std::vector<PyObject *>> patients;
-    std::forward_list<void (*) (std::exception_ptr)> registered_exception_translators;
-    std::unordered_map<std::string, void *> shared_data; // Custom data to be shared across extensions
+    std::forward_list<void (*)(std::exception_ptr)> registered_exception_translators;
+    std::unordered_map<std::string, void *>
+        shared_data;                              // Custom data to be shared across extensions
     std::vector<PyObject *> loader_patient_stack; // Used by `loader_life_support`
-    std::forward_list<std::string> static_strings; // Stores the std::strings backing detail::c_str()
+    std::forward_list<std::string>
+        static_strings; // Stores the std::strings backing detail::c_str()
     PyTypeObject *static_property_type;
     PyTypeObject *default_metaclass;
     PyObject *instance_base;
@@ -112,12 +113,12 @@ struct internals {
     PyInterpreterState *istate = nullptr;
     ~internals() {
         // This destructor is called *after* Py_Finalize() in finalize_interpreter().
-        // That *SHOULD BE* fine. The following details what happens when PyThread_tss_free is called.
-        // PYBIND11_TLS_FREE is PyThread_tss_free on python 3.7+. On older python, it does nothing.
-        // PyThread_tss_free calls PyThread_tss_delete and PyMem_RawFree.
-        // PyThread_tss_delete just calls TlsFree (on Windows) or pthread_key_delete (on *NIX). Neither
-        // of those have anything to do with CPython internals.
-        // PyMem_RawFree *requires* that the `tstate` be allocated with the CPython allocator.
+        // That *SHOULD BE* fine. The following details what happens when PyThread_tss_free is
+        // called. PYBIND11_TLS_FREE is PyThread_tss_free on python 3.7+. On older python, it does
+        // nothing. PyThread_tss_free calls PyThread_tss_delete and PyMem_RawFree.
+        // PyThread_tss_delete just calls TlsFree (on Windows) or pthread_key_delete (on *NIX).
+        // Neither of those have anything to do with CPython internals. PyMem_RawFree *requires*
+        // that the `tstate` be allocated with the CPython allocator.
         PYBIND11_TLS_FREE(tstate);
     }
 #endif
@@ -154,67 +155,71 @@ struct type_info {
 
 /// On MSVC, debug and release builds are not ABI-compatible!
 #if defined(_MSC_VER) && defined(_DEBUG)
-#  define PYBIND11_BUILD_TYPE "_debug"
+#define PYBIND11_BUILD_TYPE "_debug"
 #else
-#  define PYBIND11_BUILD_TYPE ""
+#define PYBIND11_BUILD_TYPE ""
 #endif
 
 /// Let's assume that different compilers are ABI-incompatible.
 /// A user can manually set this string if they know their
 /// compiler is compatible.
 #ifndef PYBIND11_COMPILER_TYPE
-#  if defined(_MSC_VER)
-#    define PYBIND11_COMPILER_TYPE "_msvc"
-#  elif defined(__INTEL_COMPILER)
-#    define PYBIND11_COMPILER_TYPE "_icc"
-#  elif defined(__clang__)
-#    define PYBIND11_COMPILER_TYPE "_clang"
-#  elif defined(__PGI)
-#    define PYBIND11_COMPILER_TYPE "_pgi"
-#  elif defined(__MINGW32__)
-#    define PYBIND11_COMPILER_TYPE "_mingw"
-#  elif defined(__CYGWIN__)
-#    define PYBIND11_COMPILER_TYPE "_gcc_cygwin"
-#  elif defined(__GNUC__)
-#    define PYBIND11_COMPILER_TYPE "_gcc"
-#  else
-#    define PYBIND11_COMPILER_TYPE "_unknown"
-#  endif
+#if defined(_MSC_VER)
+#define PYBIND11_COMPILER_TYPE "_msvc"
+#elif defined(__INTEL_COMPILER)
+#define PYBIND11_COMPILER_TYPE "_icc"
+#elif defined(__clang__)
+#define PYBIND11_COMPILER_TYPE "_clang"
+#elif defined(__PGI)
+#define PYBIND11_COMPILER_TYPE "_pgi"
+#elif defined(__MINGW32__)
+#define PYBIND11_COMPILER_TYPE "_mingw"
+#elif defined(__CYGWIN__)
+#define PYBIND11_COMPILER_TYPE "_gcc_cygwin"
+#elif defined(__GNUC__)
+#define PYBIND11_COMPILER_TYPE "_gcc"
+#else
+#define PYBIND11_COMPILER_TYPE "_unknown"
+#endif
 #endif
 
 /// Also standard libs
 #ifndef PYBIND11_STDLIB
-#  if defined(_LIBCPP_VERSION)
-#    define PYBIND11_STDLIB "_libcpp"
-#  elif defined(__GLIBCXX__) || defined(__GLIBCPP__)
-#    define PYBIND11_STDLIB "_libstdcpp"
-#  else
-#    define PYBIND11_STDLIB ""
-#  endif
+#if defined(_LIBCPP_VERSION)
+#define PYBIND11_STDLIB "_libcpp"
+#elif defined(__GLIBCXX__) || defined(__GLIBCPP__)
+#define PYBIND11_STDLIB "_libstdcpp"
+#else
+#define PYBIND11_STDLIB ""
+#endif
 #endif
 
 /// On Linux/OSX, changes in __GXX_ABI_VERSION__ indicate ABI incompatibility.
 #ifndef PYBIND11_BUILD_ABI
-#  if defined(__GXX_ABI_VERSION)
-#    define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
-#  else
-#    define PYBIND11_BUILD_ABI ""
-#  endif
+#if defined(__GXX_ABI_VERSION)
+#define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
+#else
+#define PYBIND11_BUILD_ABI ""
+#endif
 #endif
 
 #ifndef PYBIND11_INTERNALS_KIND
-#  if defined(WITH_THREAD)
-#    define PYBIND11_INTERNALS_KIND ""
-#  else
-#    define PYBIND11_INTERNALS_KIND "_without_thread"
-#  endif
+#if defined(WITH_THREAD)
+#define PYBIND11_INTERNALS_KIND ""
+#else
+#define PYBIND11_INTERNALS_KIND "_without_thread"
+#endif
 #endif
 
-#define PYBIND11_INTERNALS_ID "__pybind11_internals_v" \
-    PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION) PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI PYBIND11_BUILD_TYPE "__"
+#define PYBIND11_INTERNALS_ID                                                                     \
+    "__pybind11_internals_v" PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION)                        \
+        PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI         \
+            PYBIND11_BUILD_TYPE "__"
 
-#define PYBIND11_MODULE_LOCAL_ID "__pybind11_module_local_v" \
-    PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION) PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI PYBIND11_BUILD_TYPE "__"
+#define PYBIND11_MODULE_LOCAL_ID                                                                  \
+    "__pybind11_module_local_v" PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION)                     \
+        PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI         \
+            PYBIND11_BUILD_TYPE "__"
 
 /// Each module locally stores a pointer to the `internals` data. The data
 /// itself is shared among modules with the same `PYBIND11_INTERNALS_ID`.
@@ -225,17 +230,38 @@ inline internals **&get_internals_pp() {
 
 inline void translate_exception(std::exception_ptr p) {
     try {
-        if (p) std::rethrow_exception(p);
-    } catch (error_already_set &e)           { e.restore();                                    return;
-    } catch (const builtin_exception &e)     { e.set_error();                                  return;
-    } catch (const std::bad_alloc &e)        { PyErr_SetString(PyExc_MemoryError,   e.what()); return;
-    } catch (const std::domain_error &e)     { PyErr_SetString(PyExc_ValueError,    e.what()); return;
-    } catch (const std::invalid_argument &e) { PyErr_SetString(PyExc_ValueError,    e.what()); return;
-    } catch (const std::length_error &e)     { PyErr_SetString(PyExc_ValueError,    e.what()); return;
-    } catch (const std::out_of_range &e)     { PyErr_SetString(PyExc_IndexError,    e.what()); return;
-    } catch (const std::range_error &e)      { PyErr_SetString(PyExc_ValueError,    e.what()); return;
-    } catch (const std::overflow_error &e)   { PyErr_SetString(PyExc_OverflowError, e.what()); return;
-    } catch (const std::exception &e)        { PyErr_SetString(PyExc_RuntimeError,  e.what()); return;
+        if (p)
+            std::rethrow_exception(p);
+    } catch (error_already_set &e) {
+        e.restore();
+        return;
+    } catch (const builtin_exception &e) {
+        e.set_error();
+        return;
+    } catch (const std::bad_alloc &e) {
+        PyErr_SetString(PyExc_MemoryError, e.what());
+        return;
+    } catch (const std::domain_error &e) {
+        PyErr_SetString(PyExc_ValueError, e.what());
+        return;
+    } catch (const std::invalid_argument &e) {
+        PyErr_SetString(PyExc_ValueError, e.what());
+        return;
+    } catch (const std::length_error &e) {
+        PyErr_SetString(PyExc_ValueError, e.what());
+        return;
+    } catch (const std::out_of_range &e) {
+        PyErr_SetString(PyExc_IndexError, e.what());
+        return;
+    } catch (const std::range_error &e) {
+        PyErr_SetString(PyExc_ValueError, e.what());
+        return;
+    } catch (const std::overflow_error &e) {
+        PyErr_SetString(PyExc_OverflowError, e.what());
+        return;
+    } catch (const std::exception &e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+        return;
     } catch (...) {
         PyErr_SetString(PyExc_RuntimeError, "Caught an unknown exception!");
         return;
@@ -245,9 +271,14 @@ inline void translate_exception(std::exception_ptr p) {
 #if !defined(__GLIBCXX__)
 inline void translate_local_exception(std::exception_ptr p) {
     try {
-        if (p) std::rethrow_exception(p);
-    } catch (error_already_set &e)       { e.restore();   return;
-    } catch (const builtin_exception &e) { e.set_error(); return;
+        if (p)
+            std::rethrow_exception(p);
+    } catch (error_already_set &e) {
+        e.restore();
+        return;
+    } catch (const builtin_exception &e) {
+        e.set_error();
+        return;
     }
 }
 #endif
@@ -261,7 +292,7 @@ PYBIND11_NOINLINE inline internals &get_internals() {
     // Ensure that the GIL is held since we will need to make Python calls.
     // Cannot use py::gil_scoped_acquire here since that constructor calls get_internals.
     struct gil_scoped_acquire_local {
-        gil_scoped_acquire_local() : state (PyGILState_Ensure()) {}
+        gil_scoped_acquire_local() : state(PyGILState_Ensure()) {}
         ~gil_scoped_acquire_local() { PyGILState_Release(state); }
         const PyGILState_STATE state;
     } gil;
@@ -282,26 +313,27 @@ PYBIND11_NOINLINE inline internals &get_internals() {
         (*internals_pp)->registered_exception_translators.push_front(&translate_local_exception);
 #endif
     } else {
-        if (!internals_pp) internals_pp = new internals*();
+        if (!internals_pp)
+            internals_pp = new internals *();
         auto *&internals_ptr = *internals_pp;
         internals_ptr = new internals();
 #if defined(WITH_THREAD)
 
-        #if PY_VERSION_HEX < 0x03090000
-                PyEval_InitThreads();
-        #endif
+#if PY_VERSION_HEX < 0x03090000
+        PyEval_InitThreads();
+#endif
         PyThreadState *tstate = PyThreadState_Get();
-        #if PY_VERSION_HEX >= 0x03070000
-            internals_ptr->tstate = PyThread_tss_alloc();
-            if (!internals_ptr->tstate || PyThread_tss_create(internals_ptr->tstate))
-                pybind11_fail("get_internals: could not successfully initialize the TSS key!");
-            PyThread_tss_set(internals_ptr->tstate, tstate);
-        #else
-            internals_ptr->tstate = PyThread_create_key();
-            if (internals_ptr->tstate == -1)
-                pybind11_fail("get_internals: could not successfully initialize the TLS key!");
-            PyThread_set_key_value(internals_ptr->tstate, tstate);
-        #endif
+#if PY_VERSION_HEX >= 0x03070000
+        internals_ptr->tstate = PyThread_tss_alloc();
+        if (!internals_ptr->tstate || PyThread_tss_create(internals_ptr->tstate))
+            pybind11_fail("get_internals: could not successfully initialize the TSS key!");
+        PyThread_tss_set(internals_ptr->tstate, tstate);
+#else
+        internals_ptr->tstate = PyThread_create_key();
+        if (internals_ptr->tstate == -1)
+            pybind11_fail("get_internals: could not successfully initialize the TLS key!");
+        PyThread_set_key_value(internals_ptr->tstate, tstate);
+#endif
         internals_ptr->istate = tstate->interp;
 #endif
         builtins[id] = capsule(internals_pp);
@@ -323,8 +355,7 @@ inline type_map<type_info *> &registered_local_types_cpp() {
 /// `c_str()`.  Such strings objects have a long storage duration -- the internal strings are only
 /// cleared when the program exits or after interpreter shutdown (when embedding), and so are
 /// suitable for c-style strings needed by Python internals (such as PyTypeObject's tp_name).
-template <typename... Args>
-const char *c_str(Args &&...args) {
+template <typename... Args> const char *c_str(Args &&...args) {
     auto &strings = get_internals().static_strings;
     strings.emplace_front(std::forward<Args>(args)...);
     return strings.front().c_str();
@@ -350,11 +381,10 @@ inline PYBIND11_NOINLINE void *set_shared_data(const std::string &name, void *da
 /// Returns a typed reference to a shared data entry (by using `get_shared_data()`) if
 /// such entry exists. Otherwise, a new object of default-constructible type `T` is
 /// added to the shared data under the given name and a reference to it is returned.
-template<typename T>
-T &get_or_create_shared_data(const std::string &name) {
+template <typename T> T &get_or_create_shared_data(const std::string &name) {
     auto &internals = detail::get_internals();
     auto it = internals.shared_data.find(name);
-    T *ptr = (T *) (it != internals.shared_data.end() ? it->second : nullptr);
+    T *ptr = (T *)(it != internals.shared_data.end() ? it->second : nullptr);
     if (!ptr) {
         ptr = new T();
         internals.shared_data[name] = ptr;

--- a/include/pybind11/detail/typeid.h
+++ b/include/pybind11/detail/typeid.h
@@ -24,7 +24,8 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 inline void erase_all(std::string &string, const std::string &search) {
     for (size_t pos = 0;;) {
         pos = string.find(search, pos);
-        if (pos == std::string::npos) break;
+        if (pos == std::string::npos)
+            break;
         string.erase(pos, search.length());
     }
 }
@@ -32,8 +33,8 @@ inline void erase_all(std::string &string, const std::string &search) {
 PYBIND11_NOINLINE inline void clean_type_id(std::string &name) {
 #if defined(__GNUG__)
     int status = 0;
-    std::unique_ptr<char, void (*)(void *)> res {
-        abi::__cxa_demangle(name.c_str(), nullptr, nullptr, &status), std::free };
+    std::unique_ptr<char, void (*)(void *)> res{
+        abi::__cxa_demangle(name.c_str(), nullptr, nullptr, &status), std::free};
     if (status == 0)
         name = res.get();
 #else

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -12,25 +12,26 @@
 #include "numpy.h"
 
 #if defined(__INTEL_COMPILER)
-#  pragma warning(disable: 1682) // implicit conversion of a 64-bit integral type to a smaller integral type (potential portability problem)
+#pragma warning(disable : 1682) // implicit conversion of a 64-bit integral type to a smaller
+                                // integral type (potential portability problem)
 #elif defined(__GNUG__) || defined(__clang__)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#  ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#ifdef __clang__
 //   Eigen generates a bunch of implicit-copy-constructor-is-deprecated warnings with -Wdeprecated
 //   under Clang, so disable that warning here:
-#    pragma GCC diagnostic ignored "-Wdeprecated"
-#  endif
-#  if __GNUC__ >= 7
-#    pragma GCC diagnostic ignored "-Wint-in-bool-context"
-#  endif
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
+#if __GNUC__ >= 7
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#endif
 #endif
 
 #if defined(_MSC_VER)
-#  pragma warning(push)
-#  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
-#  pragma warning(disable: 4996) // warning C4996: std::unary_negate is deprecated in C++17
+#pragma warning(push)
+#pragma warning(disable : 4127) // warning C4127: Conditional expression is constant
+#pragma warning(disable : 4996) // warning C4996: std::unary_negate is deprecated in C++17
 #endif
 
 #include <Eigen/Core>
@@ -39,7 +40,8 @@
 // Eigen prior to 3.2.7 doesn't have proper move constructors--but worse, some classes get implicit
 // move constructors that break things.  We could detect this an explicitly copy, but an extra copy
 // of matrices seems highly undesirable.
-static_assert(EIGEN_VERSION_AT_LEAST(3,2,7), "Eigen support in pybind11 requires Eigen >= 3.2.7");
+static_assert(EIGEN_VERSION_AT_LEAST(3, 2, 7),
+              "Eigen support in pybind11 requires Eigen >= 3.2.7");
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
@@ -50,58 +52,63 @@ template <typename MatrixType> using EigenDMap = Eigen::Map<MatrixType, 0, Eigen
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-#if EIGEN_VERSION_AT_LEAST(3,3,0)
+#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
 using EigenIndex = Eigen::Index;
 #else
 using EigenIndex = EIGEN_DEFAULT_DENSE_INDEX_TYPE;
 #endif
 
 // Matches Eigen::Map, Eigen::Ref, blocks, etc:
-template <typename T> using is_eigen_dense_map = all_of<is_template_base_of<Eigen::DenseBase, T>, std::is_base_of<Eigen::MapBase<T, Eigen::ReadOnlyAccessors>, T>>;
-template <typename T> using is_eigen_mutable_map = std::is_base_of<Eigen::MapBase<T, Eigen::WriteAccessors>, T>;
-template <typename T> using is_eigen_dense_plain = all_of<negation<is_eigen_dense_map<T>>, is_template_base_of<Eigen::PlainObjectBase, T>>;
+template <typename T>
+using is_eigen_dense_map = all_of<is_template_base_of<Eigen::DenseBase, T>,
+                                  std::is_base_of<Eigen::MapBase<T, Eigen::ReadOnlyAccessors>, T>>;
+template <typename T>
+using is_eigen_mutable_map = std::is_base_of<Eigen::MapBase<T, Eigen::WriteAccessors>, T>;
+template <typename T>
+using is_eigen_dense_plain =
+    all_of<negation<is_eigen_dense_map<T>>, is_template_base_of<Eigen::PlainObjectBase, T>>;
 template <typename T> using is_eigen_sparse = is_template_base_of<Eigen::SparseMatrixBase, T>;
 // Test for objects inheriting from EigenBase<Derived> that aren't captured by the above.  This
 // basically covers anything that can be assigned to a dense matrix but that don't have a typical
 // matrix data layout that can be copied from their .data().  For example, DiagonalMatrix and
 // SelfAdjointView fall into this category.
-template <typename T> using is_eigen_other = all_of<
-    is_template_base_of<Eigen::EigenBase, T>,
-    negation<any_of<is_eigen_dense_map<T>, is_eigen_dense_plain<T>, is_eigen_sparse<T>>>
->;
+template <typename T>
+using is_eigen_other =
+    all_of<is_template_base_of<Eigen::EigenBase, T>,
+           negation<any_of<is_eigen_dense_map<T>, is_eigen_dense_plain<T>, is_eigen_sparse<T>>>>;
 
 // Captures numpy/eigen conformability status (returned by EigenProps::conformable()):
 template <bool EigenRowMajor> struct EigenConformable {
     bool conformable = false;
     EigenIndex rows = 0, cols = 0;
-    EigenDStride stride{0, 0};      // Only valid if negativestrides is false!
-    bool negativestrides = false;   // If true, do not use stride!
+    EigenDStride stride{0, 0};    // Only valid if negativestrides is false!
+    bool negativestrides = false; // If true, do not use stride!
 
     EigenConformable(bool fits = false) : conformable{fits} {}
     // Matrix type:
-    EigenConformable(EigenIndex r, EigenIndex c,
-            EigenIndex rstride, EigenIndex cstride) :
-        conformable{true}, rows{r}, cols{c} {
-        // TODO: when Eigen bug #747 is fixed, remove the tests for non-negativity. http://eigen.tuxfamily.org/bz/show_bug.cgi?id=747
+    EigenConformable(EigenIndex r, EigenIndex c, EigenIndex rstride, EigenIndex cstride)
+        : conformable{true}, rows{r}, cols{c} {
+        // TODO: when Eigen bug #747 is fixed, remove the tests for non-negativity.
+        // http://eigen.tuxfamily.org/bz/show_bug.cgi?id=747
         if (rstride < 0 || cstride < 0) {
             negativestrides = true;
         } else {
             stride = {EigenRowMajor ? rstride : cstride /* outer stride */,
-                      EigenRowMajor ? cstride : rstride /* inner stride */ };
+                      EigenRowMajor ? cstride : rstride /* inner stride */};
         }
     }
     // Vector type:
     EigenConformable(EigenIndex r, EigenIndex c, EigenIndex stride)
-        : EigenConformable(r, c, r == 1 ? c*stride : stride, c == 1 ? r : r*stride) {}
+        : EigenConformable(r, c, r == 1 ? c * stride : stride, c == 1 ? r : r * stride) {}
 
     template <typename props> bool stride_compatible() const {
         // To have compatible strides, we need (on both dimensions) one of fully dynamic strides,
-        // matching strides, or a dimension size of 1 (in which case the stride value is irrelevant)
-        return
-            !negativestrides &&
-            (props::inner_stride == Eigen::Dynamic || props::inner_stride == stride.inner() ||
+        // matching strides, or a dimension size of 1 (in which case the stride value is
+        // irrelevant)
+        return !negativestrides &&
+               (props::inner_stride == Eigen::Dynamic || props::inner_stride == stride.inner() ||
                 (EigenRowMajor ? cols : rows) == 1) &&
-            (props::outer_stride == Eigen::Dynamic || props::outer_stride == stride.outer() ||
+               (props::outer_stride == Eigen::Dynamic || props::outer_stride == stride.outer() ||
                 (EigenRowMajor ? rows : cols) == 1);
     }
     operator bool() const { return conformable; }
@@ -109,34 +116,42 @@ template <bool EigenRowMajor> struct EigenConformable {
 
 template <typename Type> struct eigen_extract_stride { using type = Type; };
 template <typename PlainObjectType, int MapOptions, typename StrideType>
-struct eigen_extract_stride<Eigen::Map<PlainObjectType, MapOptions, StrideType>> { using type = StrideType; };
+struct eigen_extract_stride<Eigen::Map<PlainObjectType, MapOptions, StrideType>> {
+    using type = StrideType;
+};
 template <typename PlainObjectType, int Options, typename StrideType>
-struct eigen_extract_stride<Eigen::Ref<PlainObjectType, Options, StrideType>> { using type = StrideType; };
+struct eigen_extract_stride<Eigen::Ref<PlainObjectType, Options, StrideType>> {
+    using type = StrideType;
+};
 
 // Helper struct for extracting information from an Eigen type
 template <typename Type_> struct EigenProps {
     using Type = Type_;
     using Scalar = typename Type::Scalar;
     using StrideType = typename eigen_extract_stride<Type>::type;
-    static constexpr EigenIndex
-        rows = Type::RowsAtCompileTime,
-        cols = Type::ColsAtCompileTime,
-        size = Type::SizeAtCompileTime;
+    static constexpr EigenIndex rows = Type::RowsAtCompileTime, cols = Type::ColsAtCompileTime,
+                                size = Type::SizeAtCompileTime;
     static constexpr bool
         row_major = Type::IsRowMajor,
         vector = Type::IsVectorAtCompileTime, // At least one dimension has fixed size 1
-        fixed_rows = rows != Eigen::Dynamic,
-        fixed_cols = cols != Eigen::Dynamic,
-        fixed = size != Eigen::Dynamic, // Fully-fixed size
+        fixed_rows = rows != Eigen::Dynamic, fixed_cols = cols != Eigen::Dynamic,
+        fixed = size != Eigen::Dynamic,       // Fully-fixed size
         dynamic = !fixed_rows && !fixed_cols; // Fully-dynamic size
 
-    template <EigenIndex i, EigenIndex ifzero> using if_zero = std::integral_constant<EigenIndex, i == 0 ? ifzero : i>;
-    static constexpr EigenIndex inner_stride = if_zero<StrideType::InnerStrideAtCompileTime, 1>::value,
-                                outer_stride = if_zero<StrideType::OuterStrideAtCompileTime,
-                                                       vector ? size : row_major ? cols : rows>::value;
-    static constexpr bool dynamic_stride = inner_stride == Eigen::Dynamic && outer_stride == Eigen::Dynamic;
-    static constexpr bool requires_row_major = !dynamic_stride && !vector && (row_major ? inner_stride : outer_stride) == 1;
-    static constexpr bool requires_col_major = !dynamic_stride && !vector && (row_major ? outer_stride : inner_stride) == 1;
+    template <EigenIndex i, EigenIndex ifzero>
+    using if_zero = std::integral_constant<EigenIndex, i == 0 ? ifzero : i>;
+    static constexpr EigenIndex inner_stride =
+                                    if_zero<StrideType::InnerStrideAtCompileTime, 1>::value,
+                                outer_stride = if_zero < StrideType::OuterStrideAtCompileTime,
+                                vector      ? size
+                                : row_major ? cols
+                                            : rows > ::value;
+    static constexpr bool dynamic_stride =
+        inner_stride == Eigen::Dynamic && outer_stride == Eigen::Dynamic;
+    static constexpr bool requires_row_major =
+        !dynamic_stride && !vector && (row_major ? inner_stride : outer_stride) == 1;
+    static constexpr bool requires_col_major =
+        !dynamic_stride && !vector && (row_major ? outer_stride : inner_stride) == 1;
 
     // Takes an input array and determines whether we can make it fit into the Eigen type.  If
     // the array is a vector, we attempt to fit it into either an Eigen 1xN or Nx1 vector
@@ -148,21 +163,19 @@ template <typename Type_> struct EigenProps {
 
         if (dims == 2) { // Matrix type: require exact match (or dynamic)
 
-            EigenIndex
-                np_rows = a.shape(0),
-                np_cols = a.shape(1),
-                np_rstride = a.strides(0) / static_cast<ssize_t>(sizeof(Scalar)),
-                np_cstride = a.strides(1) / static_cast<ssize_t>(sizeof(Scalar));
+            EigenIndex np_rows = a.shape(0), np_cols = a.shape(1),
+                       np_rstride = a.strides(0) / static_cast<ssize_t>(sizeof(Scalar)),
+                       np_cstride = a.strides(1) / static_cast<ssize_t>(sizeof(Scalar));
             if ((fixed_rows && np_rows != rows) || (fixed_cols && np_cols != cols))
                 return false;
 
             return {np_rows, np_cols, np_rstride, np_cstride};
         }
 
-        // Otherwise we're storing an n-vector.  Only one of the strides will be used, but whichever
-        // is used, we want the (single) numpy stride value.
+        // Otherwise we're storing an n-vector.  Only one of the strides will be used, but
+        // whichever is used, we want the (single) numpy stride value.
         const EigenIndex n = a.shape(0),
-              stride = a.strides(0) / static_cast<ssize_t>(sizeof(Scalar));
+                         stride = a.strides(0) / static_cast<ssize_t>(sizeof(Scalar));
 
         if (vector) { // Eigen type is a compile-time vector
             if (fixed && size != n)
@@ -176,45 +189,49 @@ template <typename Type_> struct EigenProps {
         if (fixed_cols) {
             // Since this isn't a vector, cols must be != 1.  We allow this only if it exactly
             // equals the number of elements (rows is Dynamic, and so 1 row is allowed).
-            if (cols != n) return false;
+            if (cols != n)
+                return false;
             return {1, n, stride};
         } // Otherwise it's either fully dynamic, or column dynamic; both become a column vector
-            if (fixed_rows && rows != n) return false;
-            return {n, 1, stride};
+        if (fixed_rows && rows != n)
+            return false;
+        return {n, 1, stride};
     }
 
-    static constexpr bool show_writeable = is_eigen_dense_map<Type>::value && is_eigen_mutable_map<Type>::value;
+    static constexpr bool show_writeable =
+        is_eigen_dense_map<Type>::value && is_eigen_mutable_map<Type>::value;
     static constexpr bool show_order = is_eigen_dense_map<Type>::value;
     static constexpr bool show_c_contiguous = show_order && requires_row_major;
-    static constexpr bool show_f_contiguous = !show_c_contiguous && show_order && requires_col_major;
+    static constexpr bool show_f_contiguous =
+        !show_c_contiguous && show_order && requires_col_major;
 
     static constexpr auto descriptor =
-        _("numpy.ndarray[") + npy_format_descriptor<Scalar>::name +
-        _("[")  + _<fixed_rows>(_<(size_t) rows>(), _("m")) +
-        _(", ") + _<fixed_cols>(_<(size_t) cols>(), _("n")) +
-        _("]") +
-        // For a reference type (e.g. Ref<MatrixXd>) we have other constraints that might need to be
-        // satisfied: writeable=True (for a mutable reference), and, depending on the map's stride
-        // options, possibly f_contiguous or c_contiguous.  We include them in the descriptor output
-        // to provide some hint as to why a TypeError is occurring (otherwise it can be confusing to
-        // see that a function accepts a 'numpy.ndarray[float64[3,2]]' and an error message that you
-        // *gave* a numpy.ndarray of the right type and dimensions.
+        _("numpy.ndarray[") + npy_format_descriptor<Scalar>::name + _("[") +
+        _<fixed_rows>(_<(size_t)rows>(), _("m")) + _(", ") +
+        _<fixed_cols>(_<(size_t)cols>(), _("n")) + _("]") +
+        // For a reference type (e.g. Ref<MatrixXd>) we have other constraints that might need to
+        // be satisfied: writeable=True (for a mutable reference), and, depending on the map's
+        // stride options, possibly f_contiguous or c_contiguous.  We include them in the
+        // descriptor output to provide some hint as to why a TypeError is occurring (otherwise it
+        // can be confusing to see that a function accepts a 'numpy.ndarray[float64[3,2]]' and an
+        // error message that you *gave* a numpy.ndarray of the right type and dimensions.
         _<show_writeable>(", flags.writeable", "") +
         _<show_c_contiguous>(", flags.c_contiguous", "") +
-        _<show_f_contiguous>(", flags.f_contiguous", "") +
-        _("]");
+        _<show_f_contiguous>(", flags.f_contiguous", "") + _("]");
 };
 
 // Casts an Eigen type to numpy array.  If given a base, the numpy array references the src data,
 // otherwise it'll make a copy.  writeable lets you turn off the writeable flag for the array.
-template <typename props> handle eigen_array_cast(typename props::Type const &src, handle base = handle(), bool writeable = true) {
+template <typename props>
+handle eigen_array_cast(typename props::Type const &src, handle base = handle(),
+                        bool writeable = true) {
     constexpr ssize_t elem_size = sizeof(typename props::Scalar);
     array a;
     if (props::vector)
-        a = array({ src.size() }, { elem_size * src.innerStride() }, src.data(), base);
+        a = array({src.size()}, {elem_size * src.innerStride()}, src.data(), base);
     else
-        a = array({ src.rows(), src.cols() }, { elem_size * src.rowStride(), elem_size * src.colStride() },
-                  src.data(), base);
+        a = array({src.rows(), src.cols()},
+                  {elem_size * src.rowStride(), elem_size * src.colStride()}, src.data(), base);
 
     if (!writeable)
         array_proxy(a.ptr())->flags &= ~detail::npy_api::NPY_ARRAY_WRITEABLE_;
@@ -233,10 +250,10 @@ handle eigen_ref_array(Type &src, handle parent = none()) {
     return eigen_array_cast<props>(src, parent, !std::is_const<Type>::value);
 }
 
-// Takes a pointer to some dense, plain Eigen type, builds a capsule around it, then returns a numpy
-// array that references the encapsulated data with a python-side reference to the capsule to tie
-// its destruction to that of any dependent python objects.  Const-ness is determined by whether or
-// not the Type of the pointer given is const.
+// Takes a pointer to some dense, plain Eigen type, builds a capsule around it, then returns a
+// numpy array that references the encapsulated data with a python-side reference to the capsule to
+// tie its destruction to that of any dependent python objects.  Const-ness is determined by
+// whether or not the Type of the pointer given is const.
 template <typename props, typename Type, typename = enable_if_t<is_eigen_dense_plain<Type>::value>>
 handle eigen_encapsulate(Type *src) {
     capsule base(src, [](void *o) { delete static_cast<Type *>(o); });
@@ -245,8 +262,7 @@ handle eigen_encapsulate(Type *src) {
 
 // Type caster for regular, dense matrix types (e.g. MatrixXd), but not maps/refs/etc. of dense
 // types.
-template<typename Type>
-struct type_caster<Type, enable_if_t<is_eigen_dense_plain<Type>::value>> {
+template <typename Type> struct type_caster<Type, enable_if_t<is_eigen_dense_plain<Type>::value>> {
     using Scalar = typename Type::Scalar;
     using props = EigenProps<Type>;
 
@@ -272,8 +288,10 @@ struct type_caster<Type, enable_if_t<is_eigen_dense_plain<Type>::value>> {
         // Allocate the new type, then build a numpy reference into it
         value = Type(fits.rows, fits.cols);
         auto ref = reinterpret_steal<array>(eigen_ref_array<props>(value));
-        if (dims == 1) ref = ref.squeeze();
-        else if (ref.ndim() == 1) buf = buf.squeeze();
+        if (dims == 1)
+            ref = ref.squeeze();
+        else if (ref.ndim() == 1)
+            buf = buf.squeeze();
 
         int result = detail::npy_api::get().PyArray_CopyInto_(ref.ptr(), buf.ptr());
 
@@ -286,30 +304,28 @@ struct type_caster<Type, enable_if_t<is_eigen_dense_plain<Type>::value>> {
     }
 
 private:
-
     // Cast implementation
     template <typename CType>
     static handle cast_impl(CType *src, return_value_policy policy, handle parent) {
         switch (policy) {
-            case return_value_policy::take_ownership:
-            case return_value_policy::automatic:
-                return eigen_encapsulate<props>(src);
-            case return_value_policy::move:
-                return eigen_encapsulate<props>(new CType(std::move(*src)));
-            case return_value_policy::copy:
-                return eigen_array_cast<props>(*src);
-            case return_value_policy::reference:
-            case return_value_policy::automatic_reference:
-                return eigen_ref_array<props>(*src);
-            case return_value_policy::reference_internal:
-                return eigen_ref_array<props>(*src, parent);
-            default:
-                throw cast_error("unhandled return_value_policy: should not happen!");
+        case return_value_policy::take_ownership:
+        case return_value_policy::automatic:
+            return eigen_encapsulate<props>(src);
+        case return_value_policy::move:
+            return eigen_encapsulate<props>(new CType(std::move(*src)));
+        case return_value_policy::copy:
+            return eigen_array_cast<props>(*src);
+        case return_value_policy::reference:
+        case return_value_policy::automatic_reference:
+            return eigen_ref_array<props>(*src);
+        case return_value_policy::reference_internal:
+            return eigen_ref_array<props>(*src, parent);
+        default:
+            throw cast_error("unhandled return_value_policy: should not happen!");
         };
     }
 
 public:
-
     // Normal returned non-reference, non-const value:
     static handle cast(Type &&src, return_value_policy /* policy */, handle parent) {
         return cast_impl(&src, return_value_policy::move, parent);
@@ -320,13 +336,15 @@ public:
     }
     // lvalue reference return; default (automatic) becomes copy
     static handle cast(Type &src, return_value_policy policy, handle parent) {
-        if (policy == return_value_policy::automatic || policy == return_value_policy::automatic_reference)
+        if (policy == return_value_policy::automatic ||
+            policy == return_value_policy::automatic_reference)
             policy = return_value_policy::copy;
         return cast_impl(&src, policy, parent);
     }
     // const lvalue reference return; default (automatic) becomes copy
     static handle cast(const Type &src, return_value_policy policy, handle parent) {
-        if (policy == return_value_policy::automatic || policy == return_value_policy::automatic_reference)
+        if (policy == return_value_policy::automatic ||
+            policy == return_value_policy::automatic_reference)
             policy = return_value_policy::copy;
         return cast(&src, policy, parent);
     }
@@ -341,9 +359,9 @@ public:
 
     static constexpr auto name = props::descriptor;
 
-    operator Type*() { return &value; }
-    operator Type&() { return value; }
-    operator Type&&() && { return std::move(value); }
+    operator Type *() { return &value; }
+    operator Type &() { return value; }
+    operator Type &&() && { return std::move(value); }
     template <typename T> using cast_op_type = movable_cast_op_type<T>;
 
 private:
@@ -356,26 +374,25 @@ private:
     using props = EigenProps<MapType>;
 
 public:
-
     // Directly referencing a ref/map's data is a bit dangerous (whatever the map/ref points to has
-    // to stay around), but we'll allow it under the assumption that you know what you're doing (and
-    // have an appropriate keep_alive in place).  We return a numpy array pointing directly at the
-    // ref's data (The numpy array ends up read-only if the ref was to a const matrix type.) Note
-    // that this means you need to ensure you don't destroy the object in some other way (e.g. with
-    // an appropriate keep_alive, or with a reference to a statically allocated matrix).
+    // to stay around), but we'll allow it under the assumption that you know what you're doing
+    // (and have an appropriate keep_alive in place).  We return a numpy array pointing directly at
+    // the ref's data (The numpy array ends up read-only if the ref was to a const matrix type.)
+    // Note that this means you need to ensure you don't destroy the object in some other way (e.g.
+    // with an appropriate keep_alive, or with a reference to a statically allocated matrix).
     static handle cast(const MapType &src, return_value_policy policy, handle parent) {
         switch (policy) {
-            case return_value_policy::copy:
-                return eigen_array_cast<props>(src);
-            case return_value_policy::reference_internal:
-                return eigen_array_cast<props>(src, parent, is_eigen_mutable_map<MapType>::value);
-            case return_value_policy::reference:
-            case return_value_policy::automatic:
-            case return_value_policy::automatic_reference:
-                return eigen_array_cast<props>(src, none(), is_eigen_mutable_map<MapType>::value);
-            default:
-                // move, take_ownership don't make any sense for a ref/map:
-                pybind11_fail("Invalid return_value_policy for Eigen Map/Ref/Block type");
+        case return_value_policy::copy:
+            return eigen_array_cast<props>(src);
+        case return_value_policy::reference_internal:
+            return eigen_array_cast<props>(src, parent, is_eigen_mutable_map<MapType>::value);
+        case return_value_policy::reference:
+        case return_value_policy::automatic:
+        case return_value_policy::automatic_reference:
+            return eigen_array_cast<props>(src, none(), is_eigen_mutable_map<MapType>::value);
+        default:
+            // move, take_ownership don't make any sense for a ref/map:
+            pybind11_fail("Invalid return_value_policy for Eigen Map/Ref/Block type");
         }
     }
 
@@ -390,39 +407,44 @@ public:
 };
 
 // We can return any map-like object (but can only load Refs, specialized next):
-template <typename Type> struct type_caster<Type, enable_if_t<is_eigen_dense_map<Type>::value>>
-    : eigen_map_caster<Type> {};
+template <typename Type>
+struct type_caster<Type, enable_if_t<is_eigen_dense_map<Type>::value>> : eigen_map_caster<Type> {};
 
 // Loader for Ref<...> arguments.  See the documentation for info on how to make this work without
 // copying (it requires some extra effort in many cases).
 template <typename PlainObjectType, typename StrideType>
 struct type_caster<
     Eigen::Ref<PlainObjectType, 0, StrideType>,
-    enable_if_t<is_eigen_dense_map<Eigen::Ref<PlainObjectType, 0, StrideType>>::value>
-> : public eigen_map_caster<Eigen::Ref<PlainObjectType, 0, StrideType>> {
+    enable_if_t<is_eigen_dense_map<Eigen::Ref<PlainObjectType, 0, StrideType>>::value>>
+    : public eigen_map_caster<Eigen::Ref<PlainObjectType, 0, StrideType>> {
 private:
     using Type = Eigen::Ref<PlainObjectType, 0, StrideType>;
     using props = EigenProps<Type>;
     using Scalar = typename props::Scalar;
     using MapType = Eigen::Map<PlainObjectType, 0, StrideType>;
-    using Array = array_t<Scalar, array::forcecast |
-                ((props::row_major ? props::inner_stride : props::outer_stride) == 1 ? array::c_style :
-                 (props::row_major ? props::outer_stride : props::inner_stride) == 1 ? array::f_style : 0)>;
+    using Array =
+        array_t<Scalar, array::forcecast |
+                            ((props::row_major ? props::inner_stride : props::outer_stride) == 1
+                                 ? array::c_style
+                             : (props::row_major ? props::outer_stride : props::inner_stride) == 1
+                                 ? array::f_style
+                                 : 0)>;
     static constexpr bool need_writeable = is_eigen_mutable_map<Type>::value;
     // Delay construction (these have no default constructor)
     std::unique_ptr<MapType> map;
     std::unique_ptr<Type> ref;
     // Our array.  When possible, this is just a numpy array pointing to the source data, but
-    // sometimes we can't avoid copying (e.g. input is not a numpy array at all, has an incompatible
-    // layout, or is an array of a type that needs to be converted).  Using a numpy temporary
-    // (rather than an Eigen temporary) saves an extra copy when we need both type conversion and
-    // storage order conversion.  (Note that we refuse to use this temporary copy when loading an
-    // argument for a Ref<M> with M non-const, i.e. a read-write reference).
+    // sometimes we can't avoid copying (e.g. input is not a numpy array at all, has an
+    // incompatible layout, or is an array of a type that needs to be converted).  Using a numpy
+    // temporary (rather than an Eigen temporary) saves an extra copy when we need both type
+    // conversion and storage order conversion.  (Note that we refuse to use this temporary copy
+    // when loading an argument for a Ref<M> with M non-const, i.e. a read-write reference).
     Array copy_or_ref;
+
 public:
     bool load(handle src, bool convert) {
-        // First check whether what we have is already an array of the right type.  If not, we can't
-        // avoid a copy (because the copy is also going to do type conversion).
+        // First check whether what we have is already an array of the right type.  If not, we
+        // can't avoid a copy (because the copy is also going to do type conversion).
         bool need_copy = !isinstance<Array>(src);
 
         EigenConformable<props::row_major> fits;
@@ -433,13 +455,13 @@ public:
 
             if (aref && (!need_writeable || aref.writeable())) {
                 fits = props::conformable(aref);
-                if (!fits) return false; // Incompatible dimensions
+                if (!fits)
+                    return false; // Incompatible dimensions
                 if (!fits.template stride_compatible<props>())
                     need_copy = true;
                 else
                     copy_or_ref = std::move(aref);
-            }
-            else {
+            } else {
                 need_copy = true;
             }
         }
@@ -448,10 +470,12 @@ public:
             // We need to copy: If we need a mutable reference, or we're not supposed to convert
             // (either because we're in the no-convert overload pass, or because we're explicitly
             // instructed not to copy (via `py::arg().noconvert()`) we have to fail loading.
-            if (!convert || need_writeable) return false;
+            if (!convert || need_writeable)
+                return false;
 
             Array copy = Array::ensure(src);
-            if (!copy) return false;
+            if (!copy)
+                return false;
             fits = props::conformable(copy);
             if (!fits || !fits.template stride_compatible<props>())
                 return false;
@@ -460,69 +484,91 @@ public:
         }
 
         ref.reset();
-        map.reset(new MapType(data(copy_or_ref), fits.rows, fits.cols, make_stride(fits.stride.outer(), fits.stride.inner())));
+        map.reset(new MapType(data(copy_or_ref), fits.rows, fits.cols,
+                              make_stride(fits.stride.outer(), fits.stride.inner())));
         ref.reset(new Type(*map));
 
         return true;
     }
 
-    operator Type*() { return ref.get(); }
-    operator Type&() { return *ref; }
+    operator Type *() { return ref.get(); }
+    operator Type &() { return *ref; }
     template <typename _T> using cast_op_type = pybind11::detail::cast_op_type<_T>;
 
 private:
     template <typename T = Type, enable_if_t<is_eigen_mutable_map<T>::value, int> = 0>
-    Scalar *data(Array &a) { return a.mutable_data(); }
+    Scalar *data(Array &a) {
+        return a.mutable_data();
+    }
 
     template <typename T = Type, enable_if_t<!is_eigen_mutable_map<T>::value, int> = 0>
-    const Scalar *data(Array &a) { return a.data(); }
+    const Scalar *data(Array &a) {
+        return a.data();
+    }
 
     // Attempt to figure out a constructor of `Stride` that will work.
     // If both strides are fixed, use a default constructor:
-    template <typename S> using stride_ctor_default = bool_constant<
-        S::InnerStrideAtCompileTime != Eigen::Dynamic && S::OuterStrideAtCompileTime != Eigen::Dynamic &&
-        std::is_default_constructible<S>::value>;
+    template <typename S>
+    using stride_ctor_default = bool_constant<S::InnerStrideAtCompileTime != Eigen::Dynamic &&
+                                              S::OuterStrideAtCompileTime != Eigen::Dynamic &&
+                                              std::is_default_constructible<S>::value>;
     // Otherwise, if there is a two-index constructor, assume it is (outer,inner) like
     // Eigen::Stride, and use it:
-    template <typename S> using stride_ctor_dual = bool_constant<
-        !stride_ctor_default<S>::value && std::is_constructible<S, EigenIndex, EigenIndex>::value>;
+    template <typename S>
+    using stride_ctor_dual =
+        bool_constant<!stride_ctor_default<S>::value &&
+                      std::is_constructible<S, EigenIndex, EigenIndex>::value>;
     // Otherwise, if there is a one-index constructor, and just one of the strides is dynamic, use
     // it (passing whichever stride is dynamic).
-    template <typename S> using stride_ctor_outer = bool_constant<
-        !any_of<stride_ctor_default<S>, stride_ctor_dual<S>>::value &&
-        S::OuterStrideAtCompileTime == Eigen::Dynamic && S::InnerStrideAtCompileTime != Eigen::Dynamic &&
-        std::is_constructible<S, EigenIndex>::value>;
-    template <typename S> using stride_ctor_inner = bool_constant<
-        !any_of<stride_ctor_default<S>, stride_ctor_dual<S>>::value &&
-        S::InnerStrideAtCompileTime == Eigen::Dynamic && S::OuterStrideAtCompileTime != Eigen::Dynamic &&
-        std::is_constructible<S, EigenIndex>::value>;
+    template <typename S>
+    using stride_ctor_outer =
+        bool_constant<!any_of<stride_ctor_default<S>, stride_ctor_dual<S>>::value &&
+                      S::OuterStrideAtCompileTime == Eigen::Dynamic &&
+                      S::InnerStrideAtCompileTime != Eigen::Dynamic &&
+                      std::is_constructible<S, EigenIndex>::value>;
+    template <typename S>
+    using stride_ctor_inner =
+        bool_constant<!any_of<stride_ctor_default<S>, stride_ctor_dual<S>>::value &&
+                      S::InnerStrideAtCompileTime == Eigen::Dynamic &&
+                      S::OuterStrideAtCompileTime != Eigen::Dynamic &&
+                      std::is_constructible<S, EigenIndex>::value>;
 
     template <typename S = StrideType, enable_if_t<stride_ctor_default<S>::value, int> = 0>
-    static S make_stride(EigenIndex, EigenIndex) { return S(); }
+    static S make_stride(EigenIndex, EigenIndex) {
+        return S();
+    }
     template <typename S = StrideType, enable_if_t<stride_ctor_dual<S>::value, int> = 0>
-    static S make_stride(EigenIndex outer, EigenIndex inner) { return S(outer, inner); }
+    static S make_stride(EigenIndex outer, EigenIndex inner) {
+        return S(outer, inner);
+    }
     template <typename S = StrideType, enable_if_t<stride_ctor_outer<S>::value, int> = 0>
-    static S make_stride(EigenIndex outer, EigenIndex) { return S(outer); }
+    static S make_stride(EigenIndex outer, EigenIndex) {
+        return S(outer);
+    }
     template <typename S = StrideType, enable_if_t<stride_ctor_inner<S>::value, int> = 0>
-    static S make_stride(EigenIndex, EigenIndex inner) { return S(inner); }
-
+    static S make_stride(EigenIndex, EigenIndex inner) {
+        return S(inner);
+    }
 };
 
 // type_caster for special matrix types (e.g. DiagonalMatrix), which are EigenBase, but not
 // EigenDense (i.e. they don't have a data(), at least not with the usual matrix layout).
 // load() is not supported, but we can cast them into the python domain by first copying to a
 // regular Eigen::Matrix, then casting that.
-template <typename Type>
-struct type_caster<Type, enable_if_t<is_eigen_other<Type>::value>> {
+template <typename Type> struct type_caster<Type, enable_if_t<is_eigen_other<Type>::value>> {
 protected:
-    using Matrix = Eigen::Matrix<typename Type::Scalar, Type::RowsAtCompileTime, Type::ColsAtCompileTime>;
+    using Matrix =
+        Eigen::Matrix<typename Type::Scalar, Type::RowsAtCompileTime, Type::ColsAtCompileTime>;
     using props = EigenProps<Matrix>;
+
 public:
     static handle cast(const Type &src, return_value_policy /* policy */, handle /* parent */) {
         handle h = eigen_encapsulate<props>(new Matrix(src));
         return h;
     }
-    static handle cast(const Type *src, return_value_policy policy, handle parent) { return cast(*src, policy, parent); }
+    static handle cast(const Type *src, return_value_policy policy, handle parent) {
+        return cast(*src, policy, parent);
+    }
 
     static constexpr auto name = props::descriptor;
 
@@ -534,8 +580,7 @@ public:
     template <typename> using cast_op_type = Type;
 };
 
-template<typename Type>
-struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
+template <typename Type> struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
     using Scalar = typename Type::Scalar;
     using StorageIndex = remove_reference_t<decltype(*std::declval<Type>().outerIndexPtr())>;
     using Index = typename Type::Index;
@@ -547,8 +592,7 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
 
         auto obj = reinterpret_borrow<object>(src);
         object sparse_module = module_::import("scipy.sparse");
-        object matrix_type = sparse_module.attr(
-            rowMajor ? "csr_matrix" : "csc_matrix");
+        object matrix_type = sparse_module.attr(rowMajor ? "csr_matrix" : "csc_matrix");
 
         if (!type::handle_of(obj).is(matrix_type)) {
             try {
@@ -558,47 +602,47 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
             }
         }
 
-        auto values = array_t<Scalar>((object) obj.attr("data"));
-        auto innerIndices = array_t<StorageIndex>((object) obj.attr("indices"));
-        auto outerIndices = array_t<StorageIndex>((object) obj.attr("indptr"));
-        auto shape = pybind11::tuple((pybind11::object) obj.attr("shape"));
+        auto values = array_t<Scalar>((object)obj.attr("data"));
+        auto innerIndices = array_t<StorageIndex>((object)obj.attr("indices"));
+        auto outerIndices = array_t<StorageIndex>((object)obj.attr("indptr"));
+        auto shape = pybind11::tuple((pybind11::object)obj.attr("shape"));
         auto nnz = obj.attr("nnz").cast<Index>();
 
         if (!values || !innerIndices || !outerIndices)
             return false;
 
         value = Eigen::MappedSparseMatrix<Scalar, Type::Flags, StorageIndex>(
-            shape[0].cast<Index>(), shape[1].cast<Index>(), nnz,
-            outerIndices.mutable_data(), innerIndices.mutable_data(), values.mutable_data());
+            shape[0].cast<Index>(), shape[1].cast<Index>(), nnz, outerIndices.mutable_data(),
+            innerIndices.mutable_data(), values.mutable_data());
 
         return true;
     }
 
     static handle cast(const Type &src, return_value_policy /* policy */, handle /* parent */) {
-        const_cast<Type&>(src).makeCompressed();
+        const_cast<Type &>(src).makeCompressed();
 
-        object matrix_type = module_::import("scipy.sparse").attr(
-            rowMajor ? "csr_matrix" : "csc_matrix");
+        object matrix_type =
+            module_::import("scipy.sparse").attr(rowMajor ? "csr_matrix" : "csc_matrix");
 
         array data(src.nonZeros(), src.valuePtr());
         array outerIndices((rowMajor ? src.rows() : src.cols()) + 1, src.outerIndexPtr());
         array innerIndices(src.nonZeros(), src.innerIndexPtr());
 
-        return matrix_type(
-            std::make_tuple(data, innerIndices, outerIndices),
-            std::make_pair(src.rows(), src.cols())
-        ).release();
+        return matrix_type(std::make_tuple(data, innerIndices, outerIndices),
+                           std::make_pair(src.rows(), src.cols()))
+            .release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, _<(Type::IsRowMajor) != 0>("scipy.sparse.csr_matrix[", "scipy.sparse.csc_matrix[")
-            + npy_format_descriptor<Scalar>::name + _("]"));
+    PYBIND11_TYPE_CASTER(Type, _<(Type::IsRowMajor) != 0>("scipy.sparse.csr_matrix[",
+                                                          "scipy.sparse.csc_matrix[") +
+                                   npy_format_descriptor<Scalar>::name + _("]"));
 };
 
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
 
 #if defined(__GNUG__) || defined(__clang__)
-#  pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #elif defined(_MSC_VER)
-#  pragma warning(pop)
+#pragma warning(pop)
 #endif

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -9,25 +9,21 @@
 
 #pragma once
 
-#include "pybind11.h"
 #include "eval.h"
+#include "pybind11.h"
 
 #if defined(PYPY_VERSION)
-#  error Embedding the interpreter is not supported with PyPy
+#error Embedding the interpreter is not supported with PyPy
 #endif
 
 #if PY_MAJOR_VERSION >= 3
-#  define PYBIND11_EMBEDDED_MODULE_IMPL(name)            \
-      extern "C" PyObject *pybind11_init_impl_##name();  \
-      extern "C" PyObject *pybind11_init_impl_##name() { \
-          return pybind11_init_wrapper_##name();         \
-      }
+#define PYBIND11_EMBEDDED_MODULE_IMPL(name)                                                       \
+    extern "C" PyObject *pybind11_init_impl_##name();                                             \
+    extern "C" PyObject *pybind11_init_impl_##name() { return pybind11_init_wrapper_##name(); }
 #else
-#  define PYBIND11_EMBEDDED_MODULE_IMPL(name)            \
-      extern "C" void pybind11_init_impl_##name();       \
-      extern "C" void pybind11_init_impl_##name() {      \
-          pybind11_init_wrapper_##name();                \
-      }
+#define PYBIND11_EMBEDDED_MODULE_IMPL(name)                                                       \
+    extern "C" void pybind11_init_impl_##name();                                                  \
+    extern "C" void pybind11_init_impl_##name() { pybind11_init_wrapper_##name(); }
 #endif
 
 // clang-format off
@@ -47,25 +43,22 @@
         }
 \endrst */
 // clang-format on
-#define PYBIND11_EMBEDDED_MODULE(name, variable)                                \
-    static ::pybind11::module_::module_def                                      \
-        PYBIND11_CONCAT(pybind11_module_def_, name);                            \
-    static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);   \
-    static PyObject PYBIND11_CONCAT(*pybind11_init_wrapper_, name)() {          \
-        auto m = ::pybind11::module_::create_extension_module(                  \
-            PYBIND11_TOSTRING(name), nullptr,                                   \
-            &PYBIND11_CONCAT(pybind11_module_def_, name));                      \
-        try {                                                                   \
-            PYBIND11_CONCAT(pybind11_init_, name)(m);                           \
-            return m.ptr();                                                     \
-        } PYBIND11_CATCH_INIT_EXCEPTIONS                                        \
-    }                                                                           \
-    PYBIND11_EMBEDDED_MODULE_IMPL(name)                                         \
-    ::pybind11::detail::embedded_module PYBIND11_CONCAT(pybind11_module_, name) \
-                              (PYBIND11_TOSTRING(name),                         \
-                               PYBIND11_CONCAT(pybind11_init_impl_, name));     \
-    void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &variable)
-
+#define PYBIND11_EMBEDDED_MODULE(name, variable)                                                  \
+    static ::pybind11::module_::module_def PYBIND11_CONCAT(pybind11_module_def_, name);           \
+    static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);                     \
+    static PyObject PYBIND11_CONCAT(*pybind11_init_wrapper_, name)() {                            \
+        auto m = ::pybind11::module_::create_extension_module(                                    \
+            PYBIND11_TOSTRING(name), nullptr, &PYBIND11_CONCAT(pybind11_module_def_, name));      \
+        try {                                                                                     \
+            PYBIND11_CONCAT(pybind11_init_, name)(m);                                             \
+            return m.ptr();                                                                       \
+        }                                                                                         \
+        PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
+    }                                                                                             \
+    PYBIND11_EMBEDDED_MODULE_IMPL(name)                                                           \
+    ::pybind11::detail::embedded_module PYBIND11_CONCAT(pybind11_module_, name)(                  \
+        PYBIND11_TOSTRING(name), PYBIND11_CONCAT(pybind11_init_impl_, name));                     \
+    void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ & variable)
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -30,6 +30,7 @@
       }
 #endif
 
+// clang-format off
 /** \rst
     Add a new module to the table of builtins for the interpreter. Must be
     defined in global scope. The first macro parameter is the name of the
@@ -44,7 +45,8 @@
                 return "Hello, World!";
             });
         }
- \endrst */
+\endrst */
+// clang-format on
 #define PYBIND11_EMBEDDED_MODULE(name, variable)                                \
     static ::pybind11::module_::module_def                                      \
         PYBIND11_CONCAT(pybind11_module_def_, name);                            \
@@ -87,6 +89,7 @@ struct embedded_module {
 
 PYBIND11_NAMESPACE_END(detail)
 
+// clang-format off
 /** \rst
     Initialize the Python interpreter. No other pybind11 or CPython API functions can be
     called before this is done; with the exception of `PYBIND11_EMBEDDED_MODULE`. The
@@ -99,7 +102,8 @@ PYBIND11_NAMESPACE_END(detail)
     of throwing exceptions on errors.)
 
     .. _Python documentation: https://docs.python.org/3/c-api/init.html#c.Py_InitializeEx
- \endrst */
+\endrst */
+// clang-format on
 inline void initialize_interpreter(bool init_signal_handlers = true) {
     if (Py_IsInitialized())
         pybind11_fail("The interpreter is already running");
@@ -110,6 +114,7 @@ inline void initialize_interpreter(bool init_signal_handlers = true) {
     module_::import("sys").attr("path").cast<list>().append(".");
 }
 
+// clang-format off
 /** \rst
     Shut down the Python interpreter. No pybind11 or CPython API functions can be called
     after this. In addition, pybind11 objects must not outlive the interpreter:
@@ -144,7 +149,8 @@ inline void initialize_interpreter(bool init_signal_handlers = true) {
         in the CPython documentation. In short, not all interpreter memory may be
         freed, either due to reference cycles or user-created global data.
 
- \endrst */
+\endrst */
+// clang-format on
 inline void finalize_interpreter() {
     handle builtins(PyEval_GetBuiltins());
     const char *id = PYBIND11_INTERNALS_ID;
@@ -165,6 +171,7 @@ inline void finalize_interpreter() {
     }
 }
 
+// clang-format off
 /** \rst
     Scope guard version of `initialize_interpreter` and `finalize_interpreter`.
     This a move-only guard and only a single instance can exist.
@@ -177,7 +184,8 @@ inline void finalize_interpreter() {
             py::scoped_interpreter guard{};
             py::print(Hello, World!);
         } // <-- interpreter shutdown
- \endrst */
+\endrst */
+// clang-format on
 class scoped_interpreter {
 public:
     scoped_interpreter(bool init_signal_handlers = true) {

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -14,14 +14,12 @@
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
-
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 // forward declarations
 PyThreadState *get_thread_state_unchecked();
 
 PYBIND11_NAMESPACE_END(detail)
-
 
 #if defined(WITH_THREAD) && !defined(PYPY_VERSION)
 
@@ -51,7 +49,7 @@ class gil_scoped_acquire {
 public:
     PYBIND11_NOINLINE gil_scoped_acquire() {
         auto const &internals = detail::get_internals();
-        tstate = (PyThreadState *) PYBIND11_TLS_GET_VALUE(internals.tstate);
+        tstate = (PyThreadState *)PYBIND11_TLS_GET_VALUE(internals.tstate);
 
         if (!tstate) {
             /* Check if the GIL was acquired using the PyGILState_* API instead (e.g. if
@@ -64,10 +62,10 @@ public:
 
         if (!tstate) {
             tstate = PyThreadState_New(internals.istate);
-            #if !defined(NDEBUG)
-                if (!tstate)
-                    pybind11_fail("scoped_acquire: could not create thread state!");
-            #endif
+#if !defined(NDEBUG)
+            if (!tstate)
+                pybind11_fail("scoped_acquire: could not create thread state!");
+#endif
             tstate->gilstate_counter = 0;
             PYBIND11_TLS_REPLACE_VALUE(internals.tstate, tstate);
         } else {
@@ -81,23 +79,21 @@ public:
         inc_ref();
     }
 
-    void inc_ref() {
-        ++tstate->gilstate_counter;
-    }
+    void inc_ref() { ++tstate->gilstate_counter; }
 
     PYBIND11_NOINLINE void dec_ref() {
         --tstate->gilstate_counter;
-        #if !defined(NDEBUG)
-            if (detail::get_thread_state_unchecked() != tstate)
-                pybind11_fail("scoped_acquire::dec_ref(): thread state must be current!");
-            if (tstate->gilstate_counter < 0)
-                pybind11_fail("scoped_acquire::dec_ref(): reference count underflow!");
-        #endif
+#if !defined(NDEBUG)
+        if (detail::get_thread_state_unchecked() != tstate)
+            pybind11_fail("scoped_acquire::dec_ref(): thread state must be current!");
+        if (tstate->gilstate_counter < 0)
+            pybind11_fail("scoped_acquire::dec_ref(): reference count underflow!");
+#endif
         if (tstate->gilstate_counter == 0) {
-            #if !defined(NDEBUG)
-                if (!release)
-                    pybind11_fail("scoped_acquire::dec_ref(): internal error!");
-            #endif
+#if !defined(NDEBUG)
+            if (!release)
+                pybind11_fail("scoped_acquire::dec_ref(): internal error!");
+#endif
             PyThreadState_Clear(tstate);
             if (active)
                 PyThreadState_DeleteCurrent();
@@ -111,15 +107,14 @@ public:
     /// could be shutting down when this is called, as thread deletion is not
     /// allowed during shutdown. Check _Py_IsFinalizing() on Python 3.7+, and
     /// protect subsequent code.
-    PYBIND11_NOINLINE void disarm() {
-        active = false;
-    }
+    PYBIND11_NOINLINE void disarm() { active = false; }
 
     PYBIND11_NOINLINE ~gil_scoped_acquire() {
         dec_ref();
         if (release)
-           PyEval_SaveThread();
+            PyEval_SaveThread();
     }
+
 private:
     PyThreadState *tstate = nullptr;
     bool release = true;
@@ -145,9 +140,7 @@ public:
     /// could be shutting down when this is called, as thread deletion is not
     /// allowed during shutdown. Check _Py_IsFinalizing() on Python 3.7+, and
     /// protect subsequent code.
-    PYBIND11_NOINLINE void disarm() {
-        active = false;
-    }
+    PYBIND11_NOINLINE void disarm() { active = false; }
 
     ~gil_scoped_release() {
         if (!tstate)
@@ -160,6 +153,7 @@ public:
             PYBIND11_TLS_REPLACE_VALUE(key, tstate);
         }
     }
+
 private:
     PyThreadState *tstate;
     bool disassoc;
@@ -168,6 +162,7 @@ private:
 #elif defined(PYPY_VERSION)
 class gil_scoped_acquire {
     PyGILState_STATE state;
+
 public:
     gil_scoped_acquire() { state = PyGILState_Ensure(); }
     ~gil_scoped_acquire() { PyGILState_Release(state); }
@@ -176,6 +171,7 @@ public:
 
 class gil_scoped_release {
     PyThreadState *state;
+
 public:
     gil_scoped_release() { state = PyEval_SaveThread(); }
     ~gil_scoped_release() { PyEval_RestoreThread(state); }

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -135,6 +135,7 @@ public:
 PYBIND11_NAMESPACE_END(detail)
 
 
+// clang-format off
 /** \rst
     This a move-only guard that redirects output.
 
@@ -158,7 +159,8 @@ PYBIND11_NAMESPACE_END(detail)
             py::scoped_ostream_redirect output{std::cerr, py::module::import("sys").attr("stderr")};
             std::cout << "Hello, World!";
         }
- \endrst */
+\endrst */
+// clang-format on
 class scoped_ostream_redirect {
 protected:
     std::streambuf *old;
@@ -183,6 +185,7 @@ public:
 };
 
 
+// clang-format off
 /** \rst
     Like `scoped_ostream_redirect`, but redirects cerr by default. This class
     is provided primary to make ``py::call_guard`` easier to make.
@@ -194,6 +197,7 @@ public:
                           scoped_estream_redirect>());
 
 \endrst */
+// clang-format on
 class scoped_estream_redirect : public scoped_ostream_redirect {
 public:
     scoped_estream_redirect(std::ostream &costream  = std::cerr,
@@ -230,6 +234,7 @@ public:
 
 PYBIND11_NAMESPACE_END(detail)
 
+// clang-format off
 /** \rst
     This is a helper function to add a C++ redirect context manager to Python
     instead of using a C++ guard. To use it, add the following to your binding code:
@@ -256,7 +261,8 @@ PYBIND11_NAMESPACE_END(detail)
         with m.ostream_redirect(stdout=true, stderr=true):
             m.noisy_function_with_error_printing()
 
- \endrst */
+\endrst */
+// clang-format on
 inline class_<detail::OstreamRedirect>
 add_ostream_redirect(module_ m, const std::string &name = "ostream_redirect") {
     return class_<detail::OstreamRedirect>(std::move(m), name.c_str(), module_local())

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -134,7 +134,6 @@ public:
 
 PYBIND11_NAMESPACE_END(detail)
 
-
 // clang-format off
 /** \rst
     This a move-only guard that redirects output.
@@ -183,7 +182,6 @@ public:
     scoped_ostream_redirect &operator=(const scoped_ostream_redirect &) = delete;
     scoped_ostream_redirect &operator=(scoped_ostream_redirect &&) = delete;
 };
-
 
 // clang-format off
 /** \rst

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -48,29 +48,21 @@ private:
     size_t utf8_remainder() const {
         const auto rbase = std::reverse_iterator<char *>(pbase());
         const auto rpptr = std::reverse_iterator<char *>(pptr());
-        auto is_ascii = [](char c) {
-            return (static_cast<unsigned char>(c) & 0x80) == 0x00;
-        };
-        auto is_leading = [](char c) {
-            return (static_cast<unsigned char>(c) & 0xC0) == 0xC0;
-        };
-        auto is_leading_2b = [](char c) {
-            return static_cast<unsigned char>(c) <= 0xDF;
-        };
-        auto is_leading_3b = [](char c) {
-            return static_cast<unsigned char>(c) <= 0xEF;
-        };
+        auto is_ascii = [](char c) { return (static_cast<unsigned char>(c) & 0x80) == 0x00; };
+        auto is_leading = [](char c) { return (static_cast<unsigned char>(c) & 0xC0) == 0xC0; };
+        auto is_leading_2b = [](char c) { return static_cast<unsigned char>(c) <= 0xDF; };
+        auto is_leading_3b = [](char c) { return static_cast<unsigned char>(c) <= 0xEF; };
         // If the last character is ASCII, there are no incomplete code points
         if (is_ascii(*rpptr))
             return 0;
         // Otherwise, work back from the end of the buffer and find the first
         // UTF-8 leading byte
-        const auto rpend   = rbase - rpptr >= 3 ? rpptr + 3 : rbase;
+        const auto rpend = rbase - rpptr >= 3 ? rpptr + 3 : rbase;
         const auto leading = std::find_if(rpptr, rpend, is_leading);
         if (leading == rbase)
             return 0;
-        const auto dist    = static_cast<size_t>(leading - rpptr);
-        size_t remainder   = 0;
+        const auto dist = static_cast<size_t>(leading - rpptr);
+        size_t remainder = 0;
 
         if (dist == 0)
             remainder = 1; // 1-byte code point is impossible
@@ -94,7 +86,7 @@ private:
             // Placed inside gil_scoped_acquire as a mutex to avoid a race.
             if (pbase() != pptr()) { // Check again under the lock
                 // This subtraction cannot be negative, so dropping the sign.
-                auto size        = static_cast<size_t>(pptr() - pbase());
+                auto size = static_cast<size_t>(pptr() - pbase());
                 size_t remainder = utf8_remainder();
 
                 if (size > remainder) {
@@ -113,9 +105,7 @@ private:
         return 0;
     }
 
-    int sync() override {
-        return _sync();
-    }
+    int sync() override { return _sync(); }
 
 public:
     pythonbuf(const object &pyostream, size_t buffer_size = 1024)
@@ -124,12 +114,10 @@ public:
         setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
     }
 
-    pythonbuf(pythonbuf&&) = default;
+    pythonbuf(pythonbuf &&) = default;
 
     /// Sync before destroy
-    ~pythonbuf() override {
-        _sync();
-    }
+    ~pythonbuf() override { _sync(); }
 };
 
 PYBIND11_NAMESPACE_END(detail)
@@ -167,15 +155,13 @@ protected:
     detail::pythonbuf buffer;
 
 public:
-    scoped_ostream_redirect(std::ostream &costream  = std::cout,
+    scoped_ostream_redirect(std::ostream &costream = std::cout,
                             const object &pyostream = module_::import("sys").attr("stdout"))
         : costream(costream), buffer(pyostream) {
         old = costream.rdbuf(&buffer);
     }
 
-    ~scoped_ostream_redirect() {
-        costream.rdbuf(old);
-    }
+    ~scoped_ostream_redirect() { costream.rdbuf(old); }
 
     scoped_ostream_redirect(const scoped_ostream_redirect &) = delete;
     scoped_ostream_redirect(scoped_ostream_redirect &&other) = default;
@@ -198,11 +184,10 @@ public:
 // clang-format on
 class scoped_estream_redirect : public scoped_ostream_redirect {
 public:
-    scoped_estream_redirect(std::ostream &costream  = std::cerr,
+    scoped_estream_redirect(std::ostream &costream = std::cerr,
                             const object &pyostream = module_::import("sys").attr("stderr"))
         : scoped_ostream_redirect(costream, pyostream) {}
 };
-
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -9,25 +9,25 @@
 
 #pragma once
 
-#include "pybind11.h"
 #include "complex.h"
-#include <numeric>
+#include "pybind11.h"
 #include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
+#include <numeric>
 #include <sstream>
 #include <string>
-#include <functional>
 #include <type_traits>
+#include <typeindex>
 #include <utility>
 #include <vector>
-#include <typeindex>
 
 #if defined(_MSC_VER)
-#  pragma warning(push)
-#  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
+#pragma warning(push)
+#pragma warning(disable : 4127) // warning C4127: Conditional expression is constant
 #endif
 
 /* This will be true on all flat address space platforms and allows us to reduce the
@@ -49,8 +49,7 @@ template <> struct handle_type_name<array> { static constexpr auto name = _("num
 template <typename type, typename SFINAE = void> struct npy_format_descriptor;
 
 struct PyArrayDescr_Proxy {
-    PyObject_HEAD
-    PyObject *typeobj;
+    PyObject_HEAD PyObject *typeobj;
     char kind;
     char type;
     char byteorder;
@@ -64,8 +63,7 @@ struct PyArrayDescr_Proxy {
 };
 
 struct PyArray_Proxy {
-    PyObject_HEAD
-    char *data;
+    PyObject_HEAD char *data;
     int nd;
     ssize_t *dimensions;
     ssize_t *strides;
@@ -75,22 +73,21 @@ struct PyArray_Proxy {
 };
 
 struct PyVoidScalarObject_Proxy {
-    PyObject_VAR_HEAD
-    char *obval;
+    PyObject_VAR_HEAD char *obval;
     PyArrayDescr_Proxy *descr;
     int flags;
     PyObject *base;
 };
 
 struct numpy_type_info {
-    PyObject* dtype_ptr;
+    PyObject *dtype_ptr;
     std::string format_str;
 };
 
 struct numpy_internals {
     std::unordered_map<std::type_index, numpy_type_info> registered_dtypes;
 
-    numpy_type_info *get_type_info(const std::type_info& tinfo, bool throw_if_missing = true) {
+    numpy_type_info *get_type_info(const std::type_info &tinfo, bool throw_if_missing = true) {
         auto it = registered_dtypes.find(std::type_index(tinfo));
         if (it != registered_dtypes.end())
             return &(it->second);
@@ -99,17 +96,17 @@ struct numpy_internals {
         return nullptr;
     }
 
-    template<typename T> numpy_type_info *get_type_info(bool throw_if_missing = true) {
+    template <typename T> numpy_type_info *get_type_info(bool throw_if_missing = true) {
         return get_type_info(typeid(typename std::remove_cv<T>::type), throw_if_missing);
     }
 };
 
-inline PYBIND11_NOINLINE void load_numpy_internals(numpy_internals* &ptr) {
+inline PYBIND11_NOINLINE void load_numpy_internals(numpy_internals *&ptr) {
     ptr = &get_or_create_shared_data<numpy_internals>("_numpy_internals");
 }
 
-inline numpy_internals& get_numpy_internals() {
-    static numpy_internals* ptr = nullptr;
+inline numpy_internals &get_numpy_internals() {
+    static numpy_internals *ptr = nullptr;
     if (!ptr)
         load_numpy_internals(ptr);
     return *ptr;
@@ -137,15 +134,26 @@ struct npy_api {
         NPY_ARRAY_ALIGNED_ = 0x0100,
         NPY_ARRAY_WRITEABLE_ = 0x0400,
         NPY_BOOL_ = 0,
-        NPY_BYTE_, NPY_UBYTE_,
-        NPY_SHORT_, NPY_USHORT_,
-        NPY_INT_, NPY_UINT_,
-        NPY_LONG_, NPY_ULONG_,
-        NPY_LONGLONG_, NPY_ULONGLONG_,
-        NPY_FLOAT_, NPY_DOUBLE_, NPY_LONGDOUBLE_,
-        NPY_CFLOAT_, NPY_CDOUBLE_, NPY_CLONGDOUBLE_,
+        NPY_BYTE_,
+        NPY_UBYTE_,
+        NPY_SHORT_,
+        NPY_USHORT_,
+        NPY_INT_,
+        NPY_UINT_,
+        NPY_LONG_,
+        NPY_ULONG_,
+        NPY_LONGLONG_,
+        NPY_ULONGLONG_,
+        NPY_FLOAT_,
+        NPY_DOUBLE_,
+        NPY_LONGDOUBLE_,
+        NPY_CFLOAT_,
+        NPY_CDOUBLE_,
+        NPY_CLONGDOUBLE_,
         NPY_OBJECT_ = 17,
-        NPY_STRING_, NPY_UNICODE_, NPY_VOID_,
+        NPY_STRING_,
+        NPY_UNICODE_,
+        NPY_VOID_,
         // Platform-dependent normalization
         NPY_INT8_ = NPY_BYTE_,
         NPY_UINT8_ = NPY_UBYTE_,
@@ -154,14 +162,15 @@ struct npy_api {
         // `npy_common.h` defines the integer aliases. In order, it checks:
         // NPY_BITSOF_LONG, NPY_BITSOF_LONGLONG, NPY_BITSOF_INT, NPY_BITSOF_SHORT, NPY_BITSOF_CHAR
         // and assigns the alias to the first matching size, so we should check in this order.
-        NPY_INT32_ = platform_lookup<std::int32_t, long, int, short>(
-            NPY_LONG_, NPY_INT_, NPY_SHORT_),
+        NPY_INT32_ =
+            platform_lookup<std::int32_t, long, int, short>(NPY_LONG_, NPY_INT_, NPY_SHORT_),
         NPY_UINT32_ = platform_lookup<std::uint32_t, unsigned long, unsigned int, unsigned short>(
             NPY_ULONG_, NPY_UINT_, NPY_USHORT_),
-        NPY_INT64_ = platform_lookup<std::int64_t, long, long long, int>(
-            NPY_LONG_, NPY_LONGLONG_, NPY_INT_),
-        NPY_UINT64_ = platform_lookup<std::uint64_t, unsigned long, unsigned long long, unsigned int>(
-            NPY_ULONG_, NPY_ULONGLONG_, NPY_UINT_),
+        NPY_INT64_ = platform_lookup<std::int64_t, long, long long, int>(NPY_LONG_, NPY_LONGLONG_,
+                                                                         NPY_INT_),
+        NPY_UINT64_ =
+            platform_lookup<std::uint64_t, unsigned long, unsigned long long, unsigned int>(
+                NPY_ULONG_, NPY_ULONGLONG_, NPY_UINT_),
     };
 
     struct PyArray_Dims {
@@ -169,23 +178,22 @@ struct npy_api {
         int len;
     };
 
-    static npy_api& get() {
+    static npy_api &get() {
         static npy_api api = lookup();
         return api;
     }
 
     bool PyArray_Check_(PyObject *obj) const {
-        return (bool) PyObject_TypeCheck(obj, PyArray_Type_);
+        return (bool)PyObject_TypeCheck(obj, PyArray_Type_);
     }
     bool PyArrayDescr_Check_(PyObject *obj) const {
-        return (bool) PyObject_TypeCheck(obj, PyArrayDescr_Type_);
+        return (bool)PyObject_TypeCheck(obj, PyArrayDescr_Type_);
     }
 
     unsigned int (*PyArray_GetNDArrayCFeatureVersion_)();
     PyObject *(*PyArray_DescrFromType_)(int);
-    PyObject *(*PyArray_NewFromDescr_)
-        (PyTypeObject *, PyObject *, int, Py_intptr_t const *,
-         Py_intptr_t const *, void *, int, PyObject *);
+    PyObject *(*PyArray_NewFromDescr_)(PyTypeObject *, PyObject *, int, Py_intptr_t const *,
+                                       Py_intptr_t const *, void *, int, PyObject *);
     // Unused. Not removed because that affects ABI of the class.
     PyObject *(*PyArray_DescrNewFromType_)(int);
     int (*PyArray_CopyInto_)(PyObject *, PyObject *);
@@ -194,15 +202,16 @@ struct npy_api {
     PyTypeObject *PyVoidArrType_Type_;
     PyTypeObject *PyArrayDescr_Type_;
     PyObject *(*PyArray_DescrFromScalar_)(PyObject *);
-    PyObject *(*PyArray_FromAny_) (PyObject *, PyObject *, int, int, int, PyObject *);
-    int (*PyArray_DescrConverter_) (PyObject *, PyObject **);
-    bool (*PyArray_EquivTypes_) (PyObject *, PyObject *);
-    int (*PyArray_GetArrayParamsFromObject_)(PyObject *, PyObject *, unsigned char, PyObject **, int *,
-                                             Py_intptr_t *, PyObject **, PyObject *);
+    PyObject *(*PyArray_FromAny_)(PyObject *, PyObject *, int, int, int, PyObject *);
+    int (*PyArray_DescrConverter_)(PyObject *, PyObject **);
+    bool (*PyArray_EquivTypes_)(PyObject *, PyObject *);
+    int (*PyArray_GetArrayParamsFromObject_)(PyObject *, PyObject *, unsigned char, PyObject **,
+                                             int *, Py_intptr_t *, PyObject **, PyObject *);
     PyObject *(*PyArray_Squeeze_)(PyObject *);
     // Unused. Not removed because that affects ABI of the class.
     int (*PyArray_SetBaseObject_)(PyObject *, PyObject *);
-    PyObject* (*PyArray_Resize_)(PyObject*, PyArray_Dims*, int, int);
+    PyObject *(*PyArray_Resize_)(PyObject *, PyArray_Dims *, int, int);
+
 private:
     enum functions {
         API_PyArray_GetNDArrayCFeatureVersion = 211,
@@ -228,12 +237,12 @@ private:
         module_ m = module_::import("numpy.core.multiarray");
         auto c = m.attr("_ARRAY_API");
 #if PY_MAJOR_VERSION >= 3
-        void **api_ptr = (void **) PyCapsule_GetPointer(c.ptr(), NULL);
+        void **api_ptr = (void **)PyCapsule_GetPointer(c.ptr(), NULL);
 #else
-        void **api_ptr = (void **) PyCObject_AsVoidPtr(c.ptr());
+        void **api_ptr = (void **)PyCObject_AsVoidPtr(c.ptr());
 #endif
         npy_api api;
-#define DECL_NPY_API(Func) api.Func##_ = (decltype(api.Func##_)) api_ptr[API_##Func];
+#define DECL_NPY_API(Func) api.Func##_ = (decltype(api.Func##_))api_ptr[API_##Func];
         DECL_NPY_API(PyArray_GetNDArrayCFeatureVersion);
         if (api.PyArray_GetNDArrayCFeatureVersion_() < 0x7)
             pybind11_fail("pybind11 numpy support requires numpy >= 1.7.0");
@@ -258,42 +267,40 @@ private:
     }
 };
 
-inline PyArray_Proxy* array_proxy(void* ptr) {
-    return reinterpret_cast<PyArray_Proxy*>(ptr);
+inline PyArray_Proxy *array_proxy(void *ptr) { return reinterpret_cast<PyArray_Proxy *>(ptr); }
+
+inline const PyArray_Proxy *array_proxy(const void *ptr) {
+    return reinterpret_cast<const PyArray_Proxy *>(ptr);
 }
 
-inline const PyArray_Proxy* array_proxy(const void* ptr) {
-    return reinterpret_cast<const PyArray_Proxy*>(ptr);
+inline PyArrayDescr_Proxy *array_descriptor_proxy(PyObject *ptr) {
+    return reinterpret_cast<PyArrayDescr_Proxy *>(ptr);
 }
 
-inline PyArrayDescr_Proxy* array_descriptor_proxy(PyObject* ptr) {
-   return reinterpret_cast<PyArrayDescr_Proxy*>(ptr);
+inline const PyArrayDescr_Proxy *array_descriptor_proxy(const PyObject *ptr) {
+    return reinterpret_cast<const PyArrayDescr_Proxy *>(ptr);
 }
 
-inline const PyArrayDescr_Proxy* array_descriptor_proxy(const PyObject* ptr) {
-   return reinterpret_cast<const PyArrayDescr_Proxy*>(ptr);
-}
-
-inline bool check_flags(const void* ptr, int flag) {
+inline bool check_flags(const void *ptr, int flag) {
     return (flag == (array_proxy(ptr)->flags & flag));
 }
 
-template <typename T> struct is_std_array : std::false_type { };
-template <typename T, size_t N> struct is_std_array<std::array<T, N>> : std::true_type { };
-template <typename T> struct is_complex : std::false_type { };
-template <typename T> struct is_complex<std::complex<T>> : std::true_type { };
+template <typename T> struct is_std_array : std::false_type {};
+template <typename T, size_t N> struct is_std_array<std::array<T, N>> : std::true_type {};
+template <typename T> struct is_complex : std::false_type {};
+template <typename T> struct is_complex<std::complex<T>> : std::true_type {};
 
 template <typename T> struct array_info_scalar {
     using type = T;
     static constexpr bool is_array = false;
     static constexpr bool is_empty = false;
     static constexpr auto extents = _("");
-    static void append_extents(list& /* shape */) { }
+    static void append_extents(list & /* shape */) {}
 };
 // Computes underlying type and a comma-separated list of extents for array
 // types (any mix of std::array and built-in arrays). An array of char is
 // treated as scalar because it gets special handling.
-template <typename T> struct array_info : array_info_scalar<T> { };
+template <typename T> struct array_info : array_info_scalar<T> {};
 template <typename T, size_t N> struct array_info<std::array<T, N>> {
     using type = typename array_info<T>::type;
     static constexpr bool is_array = true;
@@ -301,42 +308,44 @@ template <typename T, size_t N> struct array_info<std::array<T, N>> {
     static constexpr size_t extent = N;
 
     // appends the extents to shape
-    static void append_extents(list& shape) {
+    static void append_extents(list &shape) {
         shape.append(N);
         array_info<T>::append_extents(shape);
     }
 
-    static constexpr auto extents = _<array_info<T>::is_array>(
-        concat(_<N>(), array_info<T>::extents), _<N>()
-    );
+    static constexpr auto extents =
+        _<array_info<T>::is_array>(concat(_<N>(), array_info<T>::extents), _<N>());
 };
 // For numpy we have special handling for arrays of characters, so we don't include
 // the size in the array extents.
-template <size_t N> struct array_info<char[N]> : array_info_scalar<char[N]> { };
-template <size_t N> struct array_info<std::array<char, N>> : array_info_scalar<std::array<char, N>> { };
-template <typename T, size_t N> struct array_info<T[N]> : array_info<std::array<T, N>> { };
+template <size_t N> struct array_info<char[N]> : array_info_scalar<char[N]> {};
+template <size_t N>
+struct array_info<std::array<char, N>> : array_info_scalar<std::array<char, N>> {};
+template <typename T, size_t N> struct array_info<T[N]> : array_info<std::array<T, N>> {};
 template <typename T> using remove_all_extents_t = typename array_info<T>::type;
 
-template <typename T> using is_pod_struct = all_of<
-    std::is_standard_layout<T>,     // since we're accessing directly in memory we need a standard layout type
-#if defined(__GLIBCXX__) && (__GLIBCXX__ < 20150422 || __GLIBCXX__ == 20150623 || __GLIBCXX__ == 20150626 || __GLIBCXX__ == 20160803)
-    // libstdc++ < 5 (including versions 4.8.5, 4.9.3 and 4.9.4 which were released after 5)
-    // don't implement is_trivially_copyable, so approximate it
-    std::is_trivially_destructible<T>,
-    satisfies_any_of<T, std::has_trivial_copy_constructor, std::has_trivial_copy_assign>,
+template <typename T>
+using is_pod_struct =
+    all_of<std::is_standard_layout<T>, // since we're accessing directly in memory we need a
+                                       // standard layout type
+#if defined(__GLIBCXX__) && (__GLIBCXX__ < 20150422 || __GLIBCXX__ == 20150623 ||                 \
+                             __GLIBCXX__ == 20150626 || __GLIBCXX__ == 20160803)
+           // libstdc++ < 5 (including versions 4.8.5, 4.9.3 and 4.9.4 which were released after 5)
+           // don't implement is_trivially_copyable, so approximate it
+           std::is_trivially_destructible<T>,
+           satisfies_any_of<T, std::has_trivial_copy_constructor, std::has_trivial_copy_assign>,
 #else
-    std::is_trivially_copyable<T>,
+           std::is_trivially_copyable<T>,
 #endif
-    satisfies_none_of<T, std::is_reference, std::is_array, is_std_array, std::is_arithmetic, is_complex, std::is_enum>
->;
+           satisfies_none_of<T, std::is_reference, std::is_array, is_std_array, std::is_arithmetic,
+                             is_complex, std::is_enum>>;
 
 // Replacement for std::is_pod (deprecated in C++20)
-template <typename T> using is_pod = all_of<
-    std::is_standard_layout<T>,
-    std::is_trivial<T>
->;
+template <typename T> using is_pod = all_of<std::is_standard_layout<T>, std::is_trivial<T>>;
 
-template <ssize_t Dim = 0, typename Strides> ssize_t byte_offset_unsafe(const Strides &) { return 0; }
+template <ssize_t Dim = 0, typename Strides> ssize_t byte_offset_unsafe(const Strides &) {
+    return 0;
+}
 template <ssize_t Dim = 0, typename Strides, typename... Ix>
 ssize_t byte_offset_unsafe(const Strides &strides, ssize_t i, Ix... index) {
     return i * strides[Dim] + byte_offset_unsafe<Dim + 1>(strides, index...);
@@ -344,34 +353,35 @@ ssize_t byte_offset_unsafe(const Strides &strides, ssize_t i, Ix... index) {
 
 /**
  * Proxy class providing unsafe, unchecked const access to array data.  This is constructed through
- * the `unchecked<T, N>()` method of `array` or the `unchecked<N>()` method of `array_t<T>`.  `Dims`
+ * the `unchecked<T, N>()` method of `array` or the `unchecked<N>()` method of `array_t<T>`. `Dims`
  * will be -1 for dimensions determined at runtime.
  */
-template <typename T, ssize_t Dims>
-class unchecked_reference {
+template <typename T, ssize_t Dims> class unchecked_reference {
 protected:
     static constexpr bool Dynamic = Dims < 0;
     const unsigned char *data_;
     // Storing the shape & strides in local variables (i.e. these arrays) allows the compiler to
     // make large performance gains on big, nested loops, but requires compile-time dimensions
-    conditional_t<Dynamic, const ssize_t *, std::array<ssize_t, (size_t) Dims>>
-            shape_, strides_;
+    conditional_t<Dynamic, const ssize_t *, std::array<ssize_t, (size_t)Dims>> shape_, strides_;
     const ssize_t dims_;
 
     friend class pybind11::array;
     // Constructor for compile-time dimensions:
     template <bool Dyn = Dynamic>
-    unchecked_reference(const void *data, const ssize_t *shape, const ssize_t *strides, enable_if_t<!Dyn, ssize_t>)
-    : data_{reinterpret_cast<const unsigned char *>(data)}, dims_{Dims} {
-        for (size_t i = 0; i < (size_t) dims_; i++) {
+    unchecked_reference(const void *data, const ssize_t *shape, const ssize_t *strides,
+                        enable_if_t<!Dyn, ssize_t>)
+        : data_{reinterpret_cast<const unsigned char *>(data)}, dims_{Dims} {
+        for (size_t i = 0; i < (size_t)dims_; i++) {
             shape_[i] = shape[i];
             strides_[i] = strides[i];
         }
     }
     // Constructor for runtime dimensions:
     template <bool Dyn = Dynamic>
-    unchecked_reference(const void *data, const ssize_t *shape, const ssize_t *strides, enable_if_t<Dyn, ssize_t> dims)
-    : data_{reinterpret_cast<const unsigned char *>(data)}, shape_{shape}, strides_{strides}, dims_{dims} {}
+    unchecked_reference(const void *data, const ssize_t *shape, const ssize_t *strides,
+                        enable_if_t<Dyn, ssize_t> dims)
+        : data_{reinterpret_cast<const unsigned char *>(data)}, shape_{shape}, strides_{strides},
+          dims_{dims} {}
 
 public:
     /**
@@ -381,15 +391,18 @@ public:
      */
     template <typename... Ix> const T &operator()(Ix... index) const {
         static_assert(ssize_t{sizeof...(Ix)} == Dims || Dynamic,
-                "Invalid number of indices for unchecked array reference");
-        return *reinterpret_cast<const T *>(data_ + byte_offset_unsafe(strides_, ssize_t(index)...));
+                      "Invalid number of indices for unchecked array reference");
+        return *reinterpret_cast<const T *>(data_ +
+                                            byte_offset_unsafe(strides_, ssize_t(index)...));
     }
     /**
      * Unchecked const reference access to data; this operator only participates if the reference
      * is to a 1-dimensional array.  When present, this is exactly equivalent to `obj(index)`.
      */
     template <ssize_t D = Dims, typename = enable_if_t<D == 1 || Dynamic>>
-    const T &operator[](ssize_t index) const { return operator()(index); }
+    const T &operator[](ssize_t index) const {
+        return operator()(index);
+    }
 
     /// Pointer access to the data at the given indices.
     template <typename... Ix> const T *data(Ix... ix) const { return &operator()(ssize_t(ix)...); }
@@ -398,26 +411,25 @@ public:
     constexpr static ssize_t itemsize() { return sizeof(T); }
 
     /// Returns the shape (i.e. size) of dimension `dim`
-    ssize_t shape(ssize_t dim) const { return shape_[(size_t) dim]; }
+    ssize_t shape(ssize_t dim) const { return shape_[(size_t)dim]; }
 
     /// Returns the number of dimensions of the array
     ssize_t ndim() const { return dims_; }
 
-    /// Returns the total number of elements in the referenced array, i.e. the product of the shapes
-    template <bool Dyn = Dynamic>
-    enable_if_t<!Dyn, ssize_t> size() const {
-        return std::accumulate(shape_.begin(), shape_.end(), (ssize_t) 1, std::multiplies<ssize_t>());
+    /// Returns the total number of elements in the referenced array, i.e. the product of the
+    /// shapes
+    template <bool Dyn = Dynamic> enable_if_t<!Dyn, ssize_t> size() const {
+        return std::accumulate(shape_.begin(), shape_.end(), (ssize_t)1,
+                               std::multiplies<ssize_t>());
     }
-    template <bool Dyn = Dynamic>
-    enable_if_t<Dyn, ssize_t> size() const {
-        return std::accumulate(shape_, shape_ + ndim(), (ssize_t) 1, std::multiplies<ssize_t>());
+    template <bool Dyn = Dynamic> enable_if_t<Dyn, ssize_t> size() const {
+        return std::accumulate(shape_, shape_ + ndim(), (ssize_t)1, std::multiplies<ssize_t>());
     }
 
-    /// Returns the total number of bytes used by the referenced data.  Note that the actual span in
-    /// memory may be larger if the referenced array has non-contiguous strides (e.g. for a slice).
-    ssize_t nbytes() const {
-        return size() * itemsize();
-    }
+    /// Returns the total number of bytes used by the referenced data.  Note that the actual span
+    /// in memory may be larger if the referenced array has non-contiguous strides (e.g. for a
+    /// slice).
+    ssize_t nbytes() const { return size() * itemsize(); }
 };
 
 template <typename T, ssize_t Dims>
@@ -426,15 +438,16 @@ class unchecked_mutable_reference : public unchecked_reference<T, Dims> {
     using ConstBase = unchecked_reference<T, Dims>;
     using ConstBase::ConstBase;
     using ConstBase::Dynamic;
+
 public:
     // Bring in const-qualified versions from base class
     using ConstBase::operator();
     using ConstBase::operator[];
 
     /// Mutable, unchecked access to data at the given indices.
-    template <typename... Ix> T& operator()(Ix... index) {
+    template <typename... Ix> T &operator()(Ix... index) {
         static_assert(ssize_t{sizeof...(Ix)} == Dims || Dynamic,
-                "Invalid number of indices for unchecked array reference");
+                      "Invalid number of indices for unchecked array reference");
         return const_cast<T &>(ConstBase::operator()(index...));
     }
     /**
@@ -443,18 +456,21 @@ public:
      * exactly equivalent to `obj(index)`.
      */
     template <ssize_t D = Dims, typename = enable_if_t<D == 1 || Dynamic>>
-    T &operator[](ssize_t index) { return operator()(index); }
+    T &operator[](ssize_t index) {
+        return operator()(index);
+    }
 
     /// Mutable pointer access to the data at the given indices.
     template <typename... Ix> T *mutable_data(Ix... ix) { return &operator()(ssize_t(ix)...); }
 };
 
-template <typename T, ssize_t Dim>
-struct type_caster<unchecked_reference<T, Dim>> {
-    static_assert(Dim == 0 && Dim > 0 /* always fail */, "unchecked array proxy object is not castable");
+template <typename T, ssize_t Dim> struct type_caster<unchecked_reference<T, Dim>> {
+    static_assert(Dim == 0 && Dim > 0 /* always fail */,
+                  "unchecked array proxy object is not castable");
 };
 template <typename T, ssize_t Dim>
-struct type_caster<unchecked_mutable_reference<T, Dim>> : type_caster<unchecked_reference<T, Dim>> {};
+struct type_caster<unchecked_mutable_reference<T, Dim>>
+    : type_caster<unchecked_reference<T, Dim>> {};
 
 PYBIND11_NAMESPACE_END(detail)
 
@@ -465,14 +481,15 @@ public:
     explicit dtype(const buffer_info &info) {
         dtype descr(_dtype_from_pep3118()(PYBIND11_STR_TYPE(info.format)));
         // If info.itemsize == 0, use the value calculated from the format string
-        m_ptr = descr.strip_padding(info.itemsize ? info.itemsize : descr.itemsize()).release().ptr();
+        m_ptr =
+            descr.strip_padding(info.itemsize ? info.itemsize : descr.itemsize()).release().ptr();
     }
 
     explicit dtype(const std::string &format) {
         m_ptr = from_args(pybind11::str(format)).release().ptr();
     }
 
-    dtype(const char *format) : dtype(std::string(format)) { }
+    dtype(const char *format) : dtype(std::string(format)) {}
 
     dtype(list names, list formats, list offsets, ssize_t itemsize) {
         dict args;
@@ -497,20 +514,14 @@ public:
     }
 
     /// Size of the data type in bytes.
-    ssize_t itemsize() const {
-        return detail::array_descriptor_proxy(m_ptr)->elsize;
-    }
+    ssize_t itemsize() const { return detail::array_descriptor_proxy(m_ptr)->elsize; }
 
     /// Returns true for structured data types.
-    bool has_fields() const {
-        return detail::array_descriptor_proxy(m_ptr)->names != nullptr;
-    }
+    bool has_fields() const { return detail::array_descriptor_proxy(m_ptr)->names != nullptr; }
 
     /// Single-character code for dtype's kind.
     /// For example, floating point types are 'f' and integral types are 'i'.
-    char kind() const {
-        return detail::array_descriptor_proxy(m_ptr)->kind;
-    }
+    char kind() const { return detail::array_descriptor_proxy(m_ptr)->kind; }
 
     /// Single-character for dtype's type.
     /// For example, ``float`` is 'f', ``double`` 'd', ``int`` 'i', and ``long`` 'd'.
@@ -524,7 +535,10 @@ public:
 private:
     static object _dtype_from_pep3118() {
         static PyObject *obj = module_::import("numpy.core._internal")
-            .attr("_dtype_from_pep3118").cast<object>().release().ptr();
+                                   .attr("_dtype_from_pep3118")
+                                   .cast<object>()
+                                   .release()
+                                   .ptr();
         return reinterpret_borrow<object>(obj);
     }
 
@@ -534,7 +548,11 @@ private:
         if (!has_fields())
             return *this;
 
-        struct field_descr { PYBIND11_STR_TYPE name; object format; pybind11::int_ offset; };
+        struct field_descr {
+            PYBIND11_STR_TYPE name;
+            object format;
+            pybind11::int_ offset;
+        };
         std::vector<field_descr> field_descriptors;
 
         for (auto field : attr("fields").attr("items")()) {
@@ -544,16 +562,17 @@ private:
             auto offset = spec[1].cast<tuple>()[1].cast<pybind11::int_>();
             if (!len(name) && format.kind() == 'V')
                 continue;
-            field_descriptors.push_back({(PYBIND11_STR_TYPE) name, format.strip_padding(format.itemsize()), offset});
+            field_descriptors.push_back(
+                {(PYBIND11_STR_TYPE)name, format.strip_padding(format.itemsize()), offset});
         }
 
         std::sort(field_descriptors.begin(), field_descriptors.end(),
-                  [](const field_descr& a, const field_descr& b) {
+                  [](const field_descr &a, const field_descr &b) {
                       return a.offset.cast<int>() < b.offset.cast<int>();
                   });
 
         list names, formats, offsets;
-        for (auto& descr : field_descriptors) {
+        for (auto &descr : field_descriptors) {
             names.append(descr.name);
             formats.append(descr.format);
             offsets.append(descr.offset);
@@ -593,7 +612,8 @@ public:
         if (base && ptr) {
             if (isinstance<array>(base))
                 /* Copy flags from base (except ownership bit) */
-                flags = reinterpret_borrow<array>(base).flags() & ~detail::npy_api::NPY_ARRAY_OWNDATA_;
+                flags =
+                    reinterpret_borrow<array>(base).flags() & ~detail::npy_api::NPY_ARRAY_OWNDATA_;
             else
                 /* Writable by default, easy to downgrade later on if needed */
                 flags = detail::npy_api::NPY_ARRAY_WRITEABLE_;
@@ -601,43 +621,47 @@ public:
 
         auto &api = detail::npy_api::get();
         auto tmp = reinterpret_steal<object>(api.PyArray_NewFromDescr_(
-            api.PyArray_Type_, descr.release().ptr(), (int) ndim,
+            api.PyArray_Type_, descr.release().ptr(), (int)ndim,
             // Use reinterpret_cast for PyPy on Windows (remove if fixed, checked on 7.3.1)
-            reinterpret_cast<Py_intptr_t*>(shape->data()),
-            reinterpret_cast<Py_intptr_t*>(strides->data()),
-            const_cast<void *>(ptr), flags, nullptr));
+            reinterpret_cast<Py_intptr_t *>(shape->data()),
+            reinterpret_cast<Py_intptr_t *>(strides->data()), const_cast<void *>(ptr), flags,
+            nullptr));
         if (!tmp)
             throw error_already_set();
         if (ptr) {
             if (base) {
                 api.PyArray_SetBaseObject_(tmp.ptr(), base.inc_ref().ptr());
             } else {
-                tmp = reinterpret_steal<object>(api.PyArray_NewCopy_(tmp.ptr(), -1 /* any order */));
+                tmp =
+                    reinterpret_steal<object>(api.PyArray_NewCopy_(tmp.ptr(), -1 /* any order */));
             }
         }
         m_ptr = tmp.release().ptr();
     }
 
-    array(const pybind11::dtype &dt, ShapeContainer shape, const void *ptr = nullptr, handle base = handle())
-        : array(dt, std::move(shape), {}, ptr, base) { }
+    array(const pybind11::dtype &dt, ShapeContainer shape, const void *ptr = nullptr,
+          handle base = handle())
+        : array(dt, std::move(shape), {}, ptr, base) {}
 
-    template <typename T, typename = detail::enable_if_t<std::is_integral<T>::value && !std::is_same<bool, T>::value>>
+    template <typename T, typename = detail::enable_if_t<std::is_integral<T>::value &&
+                                                         !std::is_same<bool, T>::value>>
     array(const pybind11::dtype &dt, T count, const void *ptr = nullptr, handle base = handle())
-        : array(dt, {{count}}, ptr, base) { }
+        : array(dt, {{count}}, ptr, base) {}
 
     template <typename T>
     array(ShapeContainer shape, StridesContainer strides, const T *ptr, handle base = handle())
-        : array(pybind11::dtype::of<T>(), std::move(shape), std::move(strides), ptr, base) { }
+        : array(pybind11::dtype::of<T>(), std::move(shape), std::move(strides), ptr, base) {}
 
     template <typename T>
     array(ShapeContainer shape, const T *ptr, handle base = handle())
-        : array(std::move(shape), {}, ptr, base) { }
+        : array(std::move(shape), {}, ptr, base) {}
 
     template <typename T>
-    explicit array(ssize_t count, const T *ptr, handle base = handle()) : array({count}, {}, ptr, base) { }
+    explicit array(ssize_t count, const T *ptr, handle base = handle())
+        : array({count}, {}, ptr, base) {}
 
     explicit array(const buffer_info &info, handle base = handle())
-    : array(pybind11::dtype(info), info.shape, info.strides, info.ptr, base) { }
+        : array(pybind11::dtype(info), info.shape, info.strides, info.ptr, base) {}
 
     /// Array descriptor (dtype)
     pybind11::dtype dtype() const {
@@ -646,7 +670,7 @@ public:
 
     /// Total number of elements
     ssize_t size() const {
-        return std::accumulate(shape(), shape() + ndim(), (ssize_t) 1, std::multiplies<ssize_t>());
+        return std::accumulate(shape(), shape() + ndim(), (ssize_t)1, std::multiplies<ssize_t>());
     }
 
     /// Byte size of a single element
@@ -655,24 +679,16 @@ public:
     }
 
     /// Total number of bytes
-    ssize_t nbytes() const {
-        return size() * itemsize();
-    }
+    ssize_t nbytes() const { return size() * itemsize(); }
 
     /// Number of dimensions
-    ssize_t ndim() const {
-        return detail::array_proxy(m_ptr)->nd;
-    }
+    ssize_t ndim() const { return detail::array_proxy(m_ptr)->nd; }
 
     /// Base object
-    object base() const {
-        return reinterpret_borrow<object>(detail::array_proxy(m_ptr)->base);
-    }
+    object base() const { return reinterpret_borrow<object>(detail::array_proxy(m_ptr)->base); }
 
     /// Dimensions of the array
-    const ssize_t* shape() const {
-        return detail::array_proxy(m_ptr)->dimensions;
-    }
+    const ssize_t *shape() const { return detail::array_proxy(m_ptr)->dimensions; }
 
     /// Dimension along a given axis
     ssize_t shape(ssize_t dim) const {
@@ -682,9 +698,7 @@ public:
     }
 
     /// Strides of the array
-    const ssize_t* strides() const {
-        return detail::array_proxy(m_ptr)->strides;
-    }
+    const ssize_t *strides() const { return detail::array_proxy(m_ptr)->strides; }
 
     /// Stride along a given axis
     ssize_t strides(ssize_t dim) const {
@@ -694,9 +708,7 @@ public:
     }
 
     /// Return the NumPy array flags
-    int flags() const {
-        return detail::array_proxy(m_ptr)->flags;
-    }
+    int flags() const { return detail::array_proxy(m_ptr)->flags; }
 
     /// If set, the array is writeable (otherwise the buffer is read-only)
     bool writeable() const {
@@ -710,22 +722,22 @@ public:
 
     /// Pointer to the contained data. If index is not provided, points to the
     /// beginning of the buffer. May throw if the index would lead to out of bounds access.
-    template<typename... Ix> const void* data(Ix... index) const {
+    template <typename... Ix> const void *data(Ix... index) const {
         return static_cast<const void *>(detail::array_proxy(m_ptr)->data + offset_at(index...));
     }
 
     /// Mutable pointer to the contained data. If index is not provided, points to the
     /// beginning of the buffer. May throw if the index would lead to out of bounds access.
     /// May throw if the array is not writeable.
-    template<typename... Ix> void* mutable_data(Ix... index) {
+    template <typename... Ix> void *mutable_data(Ix... index) {
         check_writeable();
         return static_cast<void *>(detail::array_proxy(m_ptr)->data + offset_at(index...));
     }
 
     /// Byte offset from beginning of the array to a given index (full or partial).
     /// May throw if the index would lead to out of bounds access.
-    template<typename... Ix> ssize_t offset_at(Ix... index) const {
-        if ((ssize_t) sizeof...(index) > ndim())
+    template <typename... Ix> ssize_t offset_at(Ix... index) const {
+        if ((ssize_t)sizeof...(index) > ndim())
             fail_dim_check(sizeof...(index), "too many indices for an array");
         return byte_offset(ssize_t(index)...);
     }
@@ -734,7 +746,7 @@ public:
 
     /// Item count from beginning of the array to a given index (full or partial).
     /// May throw if the index would lead to out of bounds access.
-    template<typename... Ix> ssize_t index_at(Ix... index) const {
+    template <typename... Ix> ssize_t index_at(Ix... index) const {
         return offset_at(index...) / itemsize();
     }
 
@@ -744,30 +756,33 @@ public:
      * care: the array must not be destroyed or reshaped for the duration of the returned object,
      * and the caller must take care not to access invalid dimensions or dimension indices.
      */
-    template <typename T, ssize_t Dims = -1> detail::unchecked_mutable_reference<T, Dims> mutable_unchecked() & {
+    template <typename T, ssize_t Dims = -1>
+    detail::unchecked_mutable_reference<T, Dims> mutable_unchecked() & {
         if (Dims >= 0 && ndim() != Dims)
-            throw std::domain_error("array has incorrect number of dimensions: " + std::to_string(ndim()) +
-                    "; expected " + std::to_string(Dims));
-        return detail::unchecked_mutable_reference<T, Dims>(mutable_data(), shape(), strides(), ndim());
+            throw std::domain_error("array has incorrect number of dimensions: " +
+                                    std::to_string(ndim()) + "; expected " + std::to_string(Dims));
+        return detail::unchecked_mutable_reference<T, Dims>(mutable_data(), shape(), strides(),
+                                                            ndim());
     }
 
     /**
      * Returns a proxy object that provides const access to the array's data without bounds or
      * dimensionality checking.  Unlike `mutable_unchecked()`, this does not require that the
-     * underlying array have the `writable` flag.  Use with care: the array must not be destroyed or
-     * reshaped for the duration of the returned object, and the caller must take care not to access
-     * invalid dimensions or dimension indices.
+     * underlying array have the `writable` flag.  Use with care: the array must not be destroyed
+     * or reshaped for the duration of the returned object, and the caller must take care not to
+     * access invalid dimensions or dimension indices.
      */
-    template <typename T, ssize_t Dims = -1> detail::unchecked_reference<T, Dims> unchecked() const & {
+    template <typename T, ssize_t Dims = -1>
+    detail::unchecked_reference<T, Dims> unchecked() const & {
         if (Dims >= 0 && ndim() != Dims)
-            throw std::domain_error("array has incorrect number of dimensions: " + std::to_string(ndim()) +
-                    "; expected " + std::to_string(Dims));
+            throw std::domain_error("array has incorrect number of dimensions: " +
+                                    std::to_string(ndim()) + "; expected " + std::to_string(Dims));
         return detail::unchecked_reference<T, Dims>(data(), shape(), strides(), ndim());
     }
 
     /// Return a new view with all of the dimensions of length 1 removed
     array squeeze() {
-        auto& api = detail::npy_api::get();
+        auto &api = detail::npy_api::get();
         return reinterpret_steal<array>(api.PyArray_Squeeze_(m_ptr));
     }
 
@@ -777,15 +792,15 @@ public:
     void resize(ShapeContainer new_shape, bool refcheck = true) {
         detail::npy_api::PyArray_Dims d = {
             // Use reinterpret_cast for PyPy on Windows (remove if fixed, checked on 7.3.1)
-            reinterpret_cast<Py_intptr_t*>(new_shape->data()),
-            int(new_shape->size())
-        };
+            reinterpret_cast<Py_intptr_t *>(new_shape->data()), int(new_shape->size())};
         // try to resize, set ordering param to -1 cause it's not used anyway
         auto new_array = reinterpret_steal<object>(
-            detail::npy_api::get().PyArray_Resize_(m_ptr, &d, int(refcheck), -1)
-        );
-        if (!new_array) throw error_already_set();
-        if (isinstance<array>(new_array)) { *this = std::move(new_array); }
+            detail::npy_api::get().PyArray_Resize_(m_ptr, &d, int(refcheck), -1));
+        if (!new_array)
+            throw error_already_set();
+        if (isinstance<array>(new_array)) {
+            *this = std::move(new_array);
+        }
     }
 
     /// Ensure that the argument is a NumPy array
@@ -798,14 +813,14 @@ public:
     }
 
 protected:
-    template<typename, typename> friend struct detail::npy_format_descriptor;
+    template <typename, typename> friend struct detail::npy_format_descriptor;
 
-    void fail_dim_check(ssize_t dim, const std::string& msg) const {
-        throw index_error(msg + ": " + std::to_string(dim) +
-                          " (ndim = " + std::to_string(ndim()) + ")");
+    void fail_dim_check(ssize_t dim, const std::string &msg) const {
+        throw index_error(msg + ": " + std::to_string(dim) + " (ndim = " + std::to_string(ndim()) +
+                          ")");
     }
 
-    template<typename... Ix> ssize_t byte_offset(Ix... index) const {
+    template <typename... Ix> ssize_t byte_offset(Ix... index) const {
         check_dimensions(index...);
         return detail::byte_offset_unsafe(strides(), ssize_t(index)...);
     }
@@ -815,13 +830,14 @@ protected:
             throw std::domain_error("array is not writeable");
     }
 
-    template<typename... Ix> void check_dimensions(Ix... index) const {
+    template <typename... Ix> void check_dimensions(Ix... index) const {
         check_dimensions_impl(ssize_t(0), shape(), ssize_t(index)...);
     }
 
-    void check_dimensions_impl(ssize_t, const ssize_t*) const { }
+    void check_dimensions_impl(ssize_t, const ssize_t *) const {}
 
-    template<typename... Ix> void check_dimensions_impl(ssize_t axis, const ssize_t* shape, ssize_t i, Ix... index) const {
+    template <typename... Ix>
+    void check_dimensions_impl(ssize_t axis, const ssize_t *shape, ssize_t i, Ix... index) const {
         if (i >= *shape) {
             throw index_error(std::string("index ") + std::to_string(i) +
                               " is out of bounds for axis " + std::to_string(axis) +
@@ -845,70 +861,75 @@ template <typename T, int ExtraFlags = array::forcecast> class array_t : public 
 private:
     struct private_ctor {};
     // Delegating constructor needed when both moving and accessing in the same constructor
-    array_t(private_ctor, ShapeContainer &&shape, StridesContainer &&strides, const T *ptr, handle base)
+    array_t(private_ctor, ShapeContainer &&shape, StridesContainer &&strides, const T *ptr,
+            handle base)
         : array(std::move(shape), std::move(strides), ptr, base) {}
+
 public:
     static_assert(!detail::array_info<T>::is_array, "Array types cannot be used with array_t");
 
     using value_type = T;
 
     array_t() : array(0, static_cast<const T *>(nullptr)) {}
-    array_t(handle h, borrowed_t) : array(h, borrowed_t{}) { }
-    array_t(handle h, stolen_t) : array(h, stolen_t{}) { }
+    array_t(handle h, borrowed_t) : array(h, borrowed_t{}) {}
+    array_t(handle h, stolen_t) : array(h, stolen_t{}) {}
 
     PYBIND11_DEPRECATED("Use array_t<T>::ensure() instead")
     array_t(handle h, bool is_borrowed) : array(raw_array_t(h.ptr()), stolen_t{}) {
-        if (!m_ptr) PyErr_Clear();
-        if (!is_borrowed) Py_XDECREF(h.ptr());
+        if (!m_ptr)
+            PyErr_Clear();
+        if (!is_borrowed)
+            Py_XDECREF(h.ptr());
     }
 
     array_t(const object &o) : array(raw_array_t(o.ptr()), stolen_t{}) {
-        if (!m_ptr) throw error_already_set();
+        if (!m_ptr)
+            throw error_already_set();
     }
 
-    explicit array_t(const buffer_info& info, handle base = handle()) : array(info, base) { }
+    explicit array_t(const buffer_info &info, handle base = handle()) : array(info, base) {}
 
-    array_t(ShapeContainer shape, StridesContainer strides, const T *ptr = nullptr, handle base = handle())
-        : array(std::move(shape), std::move(strides), ptr, base) { }
+    array_t(ShapeContainer shape, StridesContainer strides, const T *ptr = nullptr,
+            handle base = handle())
+        : array(std::move(shape), std::move(strides), ptr, base) {}
 
     explicit array_t(ShapeContainer shape, const T *ptr = nullptr, handle base = handle())
         : array_t(private_ctor{}, std::move(shape),
-                ExtraFlags & f_style
-                ? detail::f_strides(*shape, itemsize())
-                : detail::c_strides(*shape, itemsize()),
-                ptr, base) { }
+                  ExtraFlags & f_style ? detail::f_strides(*shape, itemsize())
+                                       : detail::c_strides(*shape, itemsize()),
+                  ptr, base) {}
 
     explicit array_t(ssize_t count, const T *ptr = nullptr, handle base = handle())
-        : array({count}, {}, ptr, base) { }
+        : array({count}, {}, ptr, base) {}
 
-    constexpr ssize_t itemsize() const {
-        return sizeof(T);
-    }
+    constexpr ssize_t itemsize() const { return sizeof(T); }
 
-    template<typename... Ix> ssize_t index_at(Ix... index) const {
+    template <typename... Ix> ssize_t index_at(Ix... index) const {
         return offset_at(index...) / itemsize();
     }
 
-    template<typename... Ix> const T* data(Ix... index) const {
-        return static_cast<const T*>(array::data(index...));
+    template <typename... Ix> const T *data(Ix... index) const {
+        return static_cast<const T *>(array::data(index...));
     }
 
-    template<typename... Ix> T* mutable_data(Ix... index) {
-        return static_cast<T*>(array::mutable_data(index...));
+    template <typename... Ix> T *mutable_data(Ix... index) {
+        return static_cast<T *>(array::mutable_data(index...));
     }
 
     // Reference to element at a given index
-    template<typename... Ix> const T& at(Ix... index) const {
-        if ((ssize_t) sizeof...(index) != ndim())
+    template <typename... Ix> const T &at(Ix... index) const {
+        if ((ssize_t)sizeof...(index) != ndim())
             fail_dim_check(sizeof...(index), "index dimension mismatch");
-        return *(static_cast<const T*>(array::data()) + byte_offset(ssize_t(index)...) / itemsize());
+        return *(static_cast<const T *>(array::data()) +
+                 byte_offset(ssize_t(index)...) / itemsize());
     }
 
     // Mutable reference to element at a given index
-    template<typename... Ix> T& mutable_at(Ix... index) {
-        if ((ssize_t) sizeof...(index) != ndim())
+    template <typename... Ix> T &mutable_at(Ix... index) {
+        if ((ssize_t)sizeof...(index) != ndim())
             fail_dim_check(sizeof...(index), "index dimension mismatch");
-        return *(static_cast<T*>(array::mutable_data()) + byte_offset(ssize_t(index)...) / itemsize());
+        return *(static_cast<T *>(array::mutable_data()) +
+                 byte_offset(ssize_t(index)...) / itemsize());
     }
 
     /**
@@ -917,7 +938,8 @@ public:
      * care: the array must not be destroyed or reshaped for the duration of the returned object,
      * and the caller must take care not to access invalid dimensions or dimension indices.
      */
-    template <ssize_t Dims = -1> detail::unchecked_mutable_reference<T, Dims> mutable_unchecked() & {
+    template <ssize_t Dims = -1>
+    detail::unchecked_mutable_reference<T, Dims> mutable_unchecked() & {
         return array::mutable_unchecked<T, Dims>();
     }
 
@@ -943,9 +965,10 @@ public:
 
     static bool check_(handle h) {
         const auto &api = detail::npy_api::get();
-        return api.PyArray_Check_(h.ptr())
-               && api.PyArray_EquivTypes_(detail::array_proxy(h.ptr())->descr, dtype::of<T>().ptr())
-               && detail::check_flags(h.ptr(), ExtraFlags & (array::c_style | array::f_style));
+        return api.PyArray_Check_(h.ptr()) &&
+               api.PyArray_EquivTypes_(detail::array_proxy(h.ptr())->descr,
+                                       dtype::of<T>().ptr()) &&
+               detail::check_flags(h.ptr(), ExtraFlags & (array::c_style | array::f_style));
     }
 
 protected:
@@ -975,8 +998,7 @@ template <size_t N> struct format_descriptor<std::array<char, N>> {
     static std::string format() { return std::to_string(N) + "s"; }
 };
 
-template <typename T>
-struct format_descriptor<T, detail::enable_if_t<std::is_enum<T>::value>> {
+template <typename T> struct format_descriptor<T, detail::enable_if_t<std::is_enum<T>::value>> {
     static std::string format() {
         return format_descriptor<
             typename std::remove_cv<typename std::underlying_type<T>::type>::type>::format();
@@ -993,8 +1015,7 @@ struct format_descriptor<T, detail::enable_if_t<detail::array_info<T>::is_array>
 };
 
 PYBIND11_NAMESPACE_BEGIN(detail)
-template <typename T, int ExtraFlags>
-struct pyobject_caster<array_t<T, ExtraFlags>> {
+template <typename T, int ExtraFlags> struct pyobject_caster<array_t<T, ExtraFlags>> {
     using type = array_t<T, ExtraFlags>;
 
     bool load(handle src, bool convert) {
@@ -1012,53 +1033,51 @@ struct pyobject_caster<array_t<T, ExtraFlags>> {
 
 template <typename T>
 struct compare_buffer_info<T, detail::enable_if_t<detail::is_pod_struct<T>::value>> {
-    static bool compare(const buffer_info& b) {
+    static bool compare(const buffer_info &b) {
         return npy_api::get().PyArray_EquivTypes_(dtype::of<T>().ptr(), dtype(b).ptr());
     }
 };
 
-template <typename T, typename = void>
-struct npy_format_descriptor_name;
+template <typename T, typename = void> struct npy_format_descriptor_name;
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_integral<T>::value>> {
     static constexpr auto name = _<std::is_same<T, bool>::value>(
-        _("bool"), _<std::is_signed<T>::value>("numpy.int", "numpy.uint") + _<sizeof(T)*8>()
-    );
+        _("bool"), _<std::is_signed<T>::value>("numpy.int", "numpy.uint") + _<sizeof(T) * 8>());
 };
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_floating_point<T>::value>> {
-    static constexpr auto name = _<std::is_same<T, float>::value
-                                   || std::is_same<T, const float>::value
-                                   || std::is_same<T, double>::value
-                                   || std::is_same<T, const double>::value>(
-        _("numpy.float") + _<sizeof(T)*8>(), _("numpy.longdouble")
-    );
+    static constexpr auto name = _ < std::is_same<T, float>::value ||
+                                 std::is_same<T, const float>::value ||
+                                 std::is_same<T, double>::value ||
+                                 std::is_same<T, const double>::value >
+                                     (_("numpy.float") + _<sizeof(T) * 8>(),
+                                      _("numpy.longdouble"));
+};
+
+template <typename T> struct npy_format_descriptor_name<T, enable_if_t<is_complex<T>::value>> {
+    static constexpr auto name = _ < std::is_same<typename T::value_type, float>::value ||
+                                 std::is_same<typename T::value_type, const float>::value ||
+                                 std::is_same<typename T::value_type, double>::value ||
+                                 std::is_same<typename T::value_type, const double>::value >
+                                     (_("numpy.complex") +
+                                          _<sizeof(typename T::value_type) * 16>(),
+                                      _("numpy.longcomplex"));
 };
 
 template <typename T>
-struct npy_format_descriptor_name<T, enable_if_t<is_complex<T>::value>> {
-    static constexpr auto name = _<std::is_same<typename T::value_type, float>::value
-                                   || std::is_same<typename T::value_type, const float>::value
-                                   || std::is_same<typename T::value_type, double>::value
-                                   || std::is_same<typename T::value_type, const double>::value>(
-        _("numpy.complex") + _<sizeof(typename T::value_type)*16>(), _("numpy.longcomplex")
-    );
-};
-
-template <typename T>
-struct npy_format_descriptor<T, enable_if_t<satisfies_any_of<T, std::is_arithmetic, is_complex>::value>>
+struct npy_format_descriptor<
+    T, enable_if_t<satisfies_any_of<T, std::is_arithmetic, is_complex>::value>>
     : npy_format_descriptor_name<T> {
 private:
     // NB: the order here must match the one in common.h
     constexpr static const int values[15] = {
-        npy_api::NPY_BOOL_,
-        npy_api::NPY_BYTE_,   npy_api::NPY_UBYTE_,   npy_api::NPY_INT16_,    npy_api::NPY_UINT16_,
-        npy_api::NPY_INT32_,  npy_api::NPY_UINT32_,  npy_api::NPY_INT64_,    npy_api::NPY_UINT64_,
+        npy_api::NPY_BOOL_,   npy_api::NPY_BYTE_,    npy_api::NPY_UBYTE_,
+        npy_api::NPY_INT16_,  npy_api::NPY_UINT16_,  npy_api::NPY_INT32_,
+        npy_api::NPY_UINT32_, npy_api::NPY_INT64_,   npy_api::NPY_UINT64_,
         npy_api::NPY_FLOAT_,  npy_api::NPY_DOUBLE_,  npy_api::NPY_LONGDOUBLE_,
-        npy_api::NPY_CFLOAT_, npy_api::NPY_CDOUBLE_, npy_api::NPY_CLONGDOUBLE_
-    };
+        npy_api::NPY_CFLOAT_, npy_api::NPY_CDOUBLE_, npy_api::NPY_CLONGDOUBLE_};
 
 public:
     static constexpr int value = values[detail::is_fmt_numeric<T>::index];
@@ -1070,16 +1089,19 @@ public:
     }
 };
 
-#define PYBIND11_DECL_CHAR_FMT \
-    static constexpr auto name = _("S") + _<N>(); \
-    static pybind11::dtype dtype() { return pybind11::dtype(std::string("S") + std::to_string(N)); }
+#define PYBIND11_DECL_CHAR_FMT                                                                    \
+    static constexpr auto name = _("S") + _<N>();                                                 \
+    static pybind11::dtype dtype() {                                                              \
+        return pybind11::dtype(std::string("S") + std::to_string(N));                             \
+    }
 template <size_t N> struct npy_format_descriptor<char[N]> { PYBIND11_DECL_CHAR_FMT };
 template <size_t N> struct npy_format_descriptor<std::array<char, N>> { PYBIND11_DECL_CHAR_FMT };
 #undef PYBIND11_DECL_CHAR_FMT
 
-template<typename T> struct npy_format_descriptor<T, enable_if_t<array_info<T>::is_array>> {
+template <typename T> struct npy_format_descriptor<T, enable_if_t<array_info<T>::is_array>> {
 private:
     using base_descr = npy_format_descriptor<typename array_info<T>::type>;
+
 public:
     static_assert(!array_info<T>::is_empty, "Zero-sized arrays are not supported");
 
@@ -1091,9 +1113,10 @@ public:
     }
 };
 
-template<typename T> struct npy_format_descriptor<T, enable_if_t<std::is_enum<T>::value>> {
+template <typename T> struct npy_format_descriptor<T, enable_if_t<std::is_enum<T>::value>> {
 private:
     using base_descr = npy_format_descriptor<typename std::underlying_type<T>::type>;
+
 public:
     static constexpr auto name = base_descr::name;
     static pybind11::dtype dtype() { return base_descr::dtype(); }
@@ -1107,26 +1130,26 @@ struct field_descriptor {
     dtype descr;
 };
 
-inline PYBIND11_NOINLINE void register_structured_dtype(
-    any_container<field_descriptor> fields,
-    const std::type_info& tinfo, ssize_t itemsize,
-    bool (*direct_converter)(PyObject *, void *&)) {
+inline PYBIND11_NOINLINE void
+register_structured_dtype(any_container<field_descriptor> fields, const std::type_info &tinfo,
+                          ssize_t itemsize, bool (*direct_converter)(PyObject *, void *&)) {
 
-    auto& numpy_internals = get_numpy_internals();
+    auto &numpy_internals = get_numpy_internals();
     if (numpy_internals.get_type_info(tinfo, false))
         pybind11_fail("NumPy: dtype is already registered");
 
     // Use ordered fields because order matters as of NumPy 1.14:
     // https://docs.scipy.org/doc/numpy/release.html#multiple-field-indexing-assignment-of-structured-arrays
     std::vector<field_descriptor> ordered_fields(std::move(fields));
-    std::sort(ordered_fields.begin(), ordered_fields.end(),
+    std::sort(
+        ordered_fields.begin(), ordered_fields.end(),
         [](const field_descriptor &a, const field_descriptor &b) { return a.offset < b.offset; });
 
     list names, formats, offsets;
-    for (auto& field : ordered_fields) {
+    for (auto &field : ordered_fields) {
         if (!field.descr)
-            pybind11_fail(std::string("NumPy: unsupported field dtype: `") +
-                            field.name + "` @ " + tinfo.name());
+            pybind11_fail(std::string("NumPy: unsupported field dtype: `") + field.name + "` @ " +
+                          tinfo.name());
         names.append(PYBIND11_STR_TYPE(field.name));
         formats.append(field.descr);
         offsets.append(pybind11::int_(field.offset));
@@ -1148,7 +1171,7 @@ inline PYBIND11_NOINLINE void register_structured_dtype(
     // overriding the endianness. Putting the ^ in front of individual fields
     // isn't guaranteed to work due to https://github.com/numpy/numpy/issues/9049
     oss << "^T{";
-    for (auto& field : ordered_fields) {
+    for (auto &field : ordered_fields) {
         if (field.offset > offset)
             oss << (field.offset - offset) << 'x';
         oss << field.format << ':' << field.name << ':';
@@ -1160,24 +1183,23 @@ inline PYBIND11_NOINLINE void register_structured_dtype(
     auto format_str = oss.str();
 
     // Sanity check: verify that NumPy properly parses our buffer format string
-    auto& api = npy_api::get();
-    auto arr =  array(buffer_info(nullptr, itemsize, format_str, 1));
+    auto &api = npy_api::get();
+    auto arr = array(buffer_info(nullptr, itemsize, format_str, 1));
     if (!api.PyArray_EquivTypes_(dtype_ptr, arr.dtype().ptr()))
         pybind11_fail("NumPy: invalid buffer descriptor!");
 
     auto tindex = std::type_index(tinfo);
-    numpy_internals.registered_dtypes[tindex] = { dtype_ptr, format_str };
+    numpy_internals.registered_dtypes[tindex] = {dtype_ptr, format_str};
     get_internals().direct_conversions[tindex].push_back(direct_converter);
 }
 
 template <typename T, typename SFINAE> struct npy_format_descriptor {
-    static_assert(is_pod_struct<T>::value, "Attempt to use a non-POD or unimplemented POD type as a numpy dtype");
+    static_assert(is_pod_struct<T>::value,
+                  "Attempt to use a non-POD or unimplemented POD type as a numpy dtype");
 
     static constexpr auto name = make_caster<T>::name;
 
-    static pybind11::dtype dtype() {
-        return reinterpret_borrow<pybind11::dtype>(dtype_ptr());
-    }
+    static pybind11::dtype dtype() { return reinterpret_borrow<pybind11::dtype>(dtype_ptr()); }
 
     static std::string format() {
         static auto format_str = get_numpy_internals().get_type_info<T>(true)->format_str;
@@ -1190,18 +1212,18 @@ template <typename T, typename SFINAE> struct npy_format_descriptor {
     }
 
 private:
-    static PyObject* dtype_ptr() {
-        static PyObject* ptr = get_numpy_internals().get_type_info<T>(true)->dtype_ptr;
+    static PyObject *dtype_ptr() {
+        static PyObject *ptr = get_numpy_internals().get_type_info<T>(true)->dtype_ptr;
         return ptr;
     }
 
-    static bool direct_converter(PyObject *obj, void*& value) {
-        auto& api = npy_api::get();
+    static bool direct_converter(PyObject *obj, void *&value) {
+        auto &api = npy_api::get();
         if (!PyObject_TypeCheck(obj, api.PyVoidArrType_Type_))
             return false;
         if (auto descr = reinterpret_steal<object>(api.PyArray_DescrFromScalar_(obj))) {
             if (api.PyArray_EquivTypes_(dtype_ptr(), descr.ptr())) {
-                value = ((PyVoidScalarObject_Proxy *) obj)->obval;
+                value = ((PyVoidScalarObject_Proxy *)obj)->obval;
                 return true;
             }
         }
@@ -1210,15 +1232,15 @@ private:
 };
 
 #ifdef __CLION_IDE__ // replace heavy macro with dummy code for the IDE (doesn't affect code)
-# define PYBIND11_NUMPY_DTYPE(Type, ...) ((void)0)
-# define PYBIND11_NUMPY_DTYPE_EX(Type, ...) ((void)0)
+#define PYBIND11_NUMPY_DTYPE(Type, ...) ((void)0)
+#define PYBIND11_NUMPY_DTYPE_EX(Type, ...) ((void)0)
 #else
 
-#define PYBIND11_FIELD_DESCRIPTOR_EX(T, Field, Name)                                          \
-    ::pybind11::detail::field_descriptor {                                                    \
-        Name, offsetof(T, Field), sizeof(decltype(std::declval<T>().Field)),                  \
-        ::pybind11::format_descriptor<decltype(std::declval<T>().Field)>::format(),           \
-        ::pybind11::detail::npy_format_descriptor<decltype(std::declval<T>().Field)>::dtype() \
+#define PYBIND11_FIELD_DESCRIPTOR_EX(T, Field, Name)                                              \
+    ::pybind11::detail::field_descriptor {                                                        \
+        Name, offsetof(T, Field), sizeof(decltype(std::declval<T>().Field)),                      \
+            ::pybind11::format_descriptor<decltype(std::declval<T>().Field)>::format(),           \
+            ::pybind11::detail::npy_format_descriptor<decltype(std::declval<T>().Field)>::dtype() \
     }
 
 // Extract name, offset and format descriptor for a struct field
@@ -1227,61 +1249,57 @@ private:
 // The main idea of this macro is borrowed from https://github.com/swansontec/map-macro
 // (C) William Swanson, Paul Fultz
 #define PYBIND11_EVAL0(...) __VA_ARGS__
-#define PYBIND11_EVAL1(...) PYBIND11_EVAL0 (PYBIND11_EVAL0 (PYBIND11_EVAL0 (__VA_ARGS__)))
-#define PYBIND11_EVAL2(...) PYBIND11_EVAL1 (PYBIND11_EVAL1 (PYBIND11_EVAL1 (__VA_ARGS__)))
-#define PYBIND11_EVAL3(...) PYBIND11_EVAL2 (PYBIND11_EVAL2 (PYBIND11_EVAL2 (__VA_ARGS__)))
-#define PYBIND11_EVAL4(...) PYBIND11_EVAL3 (PYBIND11_EVAL3 (PYBIND11_EVAL3 (__VA_ARGS__)))
-#define PYBIND11_EVAL(...)  PYBIND11_EVAL4 (PYBIND11_EVAL4 (PYBIND11_EVAL4 (__VA_ARGS__)))
+#define PYBIND11_EVAL1(...) PYBIND11_EVAL0(PYBIND11_EVAL0(PYBIND11_EVAL0(__VA_ARGS__)))
+#define PYBIND11_EVAL2(...) PYBIND11_EVAL1(PYBIND11_EVAL1(PYBIND11_EVAL1(__VA_ARGS__)))
+#define PYBIND11_EVAL3(...) PYBIND11_EVAL2(PYBIND11_EVAL2(PYBIND11_EVAL2(__VA_ARGS__)))
+#define PYBIND11_EVAL4(...) PYBIND11_EVAL3(PYBIND11_EVAL3(PYBIND11_EVAL3(__VA_ARGS__)))
+#define PYBIND11_EVAL(...) PYBIND11_EVAL4(PYBIND11_EVAL4(PYBIND11_EVAL4(__VA_ARGS__)))
 #define PYBIND11_MAP_END(...)
 #define PYBIND11_MAP_OUT
 #define PYBIND11_MAP_COMMA ,
 #define PYBIND11_MAP_GET_END() 0, PYBIND11_MAP_END
 #define PYBIND11_MAP_NEXT0(test, next, ...) next PYBIND11_MAP_OUT
-#define PYBIND11_MAP_NEXT1(test, next) PYBIND11_MAP_NEXT0 (test, next, 0)
-#define PYBIND11_MAP_NEXT(test, next)  PYBIND11_MAP_NEXT1 (PYBIND11_MAP_GET_END test, next)
-#if defined(_MSC_VER) && !defined(__clang__) // MSVC is not as eager to expand macros, hence this workaround
-#define PYBIND11_MAP_LIST_NEXT1(test, next) \
-    PYBIND11_EVAL0 (PYBIND11_MAP_NEXT0 (test, PYBIND11_MAP_COMMA next, 0))
+#define PYBIND11_MAP_NEXT1(test, next) PYBIND11_MAP_NEXT0(test, next, 0)
+#define PYBIND11_MAP_NEXT(test, next) PYBIND11_MAP_NEXT1(PYBIND11_MAP_GET_END test, next)
+#if defined(_MSC_VER) &&                                                                          \
+    !defined(__clang__) // MSVC is not as eager to expand macros, hence this workaround
+#define PYBIND11_MAP_LIST_NEXT1(test, next)                                                       \
+    PYBIND11_EVAL0(PYBIND11_MAP_NEXT0(test, PYBIND11_MAP_COMMA next, 0))
 #else
-#define PYBIND11_MAP_LIST_NEXT1(test, next) \
-    PYBIND11_MAP_NEXT0 (test, PYBIND11_MAP_COMMA next, 0)
+#define PYBIND11_MAP_LIST_NEXT1(test, next) PYBIND11_MAP_NEXT0(test, PYBIND11_MAP_COMMA next, 0)
 #endif
-#define PYBIND11_MAP_LIST_NEXT(test, next) \
-    PYBIND11_MAP_LIST_NEXT1 (PYBIND11_MAP_GET_END test, next)
-#define PYBIND11_MAP_LIST0(f, t, x, peek, ...) \
-    f(t, x) PYBIND11_MAP_LIST_NEXT (peek, PYBIND11_MAP_LIST1) (f, t, peek, __VA_ARGS__)
-#define PYBIND11_MAP_LIST1(f, t, x, peek, ...) \
-    f(t, x) PYBIND11_MAP_LIST_NEXT (peek, PYBIND11_MAP_LIST0) (f, t, peek, __VA_ARGS__)
+#define PYBIND11_MAP_LIST_NEXT(test, next) PYBIND11_MAP_LIST_NEXT1(PYBIND11_MAP_GET_END test, next)
+#define PYBIND11_MAP_LIST0(f, t, x, peek, ...)                                                    \
+    f(t, x) PYBIND11_MAP_LIST_NEXT(peek, PYBIND11_MAP_LIST1)(f, t, peek, __VA_ARGS__)
+#define PYBIND11_MAP_LIST1(f, t, x, peek, ...)                                                    \
+    f(t, x) PYBIND11_MAP_LIST_NEXT(peek, PYBIND11_MAP_LIST0)(f, t, peek, __VA_ARGS__)
 // PYBIND11_MAP_LIST(f, t, a1, a2, ...) expands to f(t, a1), f(t, a2), ...
-#define PYBIND11_MAP_LIST(f, t, ...) \
-    PYBIND11_EVAL (PYBIND11_MAP_LIST1 (f, t, __VA_ARGS__, (), 0))
+#define PYBIND11_MAP_LIST(f, t, ...) PYBIND11_EVAL(PYBIND11_MAP_LIST1(f, t, __VA_ARGS__, (), 0))
 
-#define PYBIND11_NUMPY_DTYPE(Type, ...) \
-    ::pybind11::detail::npy_format_descriptor<Type>::register_dtype \
-        (::std::vector<::pybind11::detail::field_descriptor> \
-         {PYBIND11_MAP_LIST (PYBIND11_FIELD_DESCRIPTOR, Type, __VA_ARGS__)})
+#define PYBIND11_NUMPY_DTYPE(Type, ...)                                                           \
+    ::pybind11::detail::npy_format_descriptor<Type>::register_dtype(                              \
+        ::std::vector<::pybind11::detail::field_descriptor>{                                      \
+            PYBIND11_MAP_LIST(PYBIND11_FIELD_DESCRIPTOR, Type, __VA_ARGS__)})
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#define PYBIND11_MAP2_LIST_NEXT1(test, next) \
-    PYBIND11_EVAL0 (PYBIND11_MAP_NEXT0 (test, PYBIND11_MAP_COMMA next, 0))
+#define PYBIND11_MAP2_LIST_NEXT1(test, next)                                                      \
+    PYBIND11_EVAL0(PYBIND11_MAP_NEXT0(test, PYBIND11_MAP_COMMA next, 0))
 #else
-#define PYBIND11_MAP2_LIST_NEXT1(test, next) \
-    PYBIND11_MAP_NEXT0 (test, PYBIND11_MAP_COMMA next, 0)
+#define PYBIND11_MAP2_LIST_NEXT1(test, next) PYBIND11_MAP_NEXT0(test, PYBIND11_MAP_COMMA next, 0)
 #endif
-#define PYBIND11_MAP2_LIST_NEXT(test, next) \
-    PYBIND11_MAP2_LIST_NEXT1 (PYBIND11_MAP_GET_END test, next)
-#define PYBIND11_MAP2_LIST0(f, t, x1, x2, peek, ...) \
-    f(t, x1, x2) PYBIND11_MAP2_LIST_NEXT (peek, PYBIND11_MAP2_LIST1) (f, t, peek, __VA_ARGS__)
-#define PYBIND11_MAP2_LIST1(f, t, x1, x2, peek, ...) \
-    f(t, x1, x2) PYBIND11_MAP2_LIST_NEXT (peek, PYBIND11_MAP2_LIST0) (f, t, peek, __VA_ARGS__)
+#define PYBIND11_MAP2_LIST_NEXT(test, next)                                                       \
+    PYBIND11_MAP2_LIST_NEXT1(PYBIND11_MAP_GET_END test, next)
+#define PYBIND11_MAP2_LIST0(f, t, x1, x2, peek, ...)                                              \
+    f(t, x1, x2) PYBIND11_MAP2_LIST_NEXT(peek, PYBIND11_MAP2_LIST1)(f, t, peek, __VA_ARGS__)
+#define PYBIND11_MAP2_LIST1(f, t, x1, x2, peek, ...)                                              \
+    f(t, x1, x2) PYBIND11_MAP2_LIST_NEXT(peek, PYBIND11_MAP2_LIST0)(f, t, peek, __VA_ARGS__)
 // PYBIND11_MAP2_LIST(f, t, a1, a2, ...) expands to f(t, a1, a2), f(t, a3, a4), ...
-#define PYBIND11_MAP2_LIST(f, t, ...) \
-    PYBIND11_EVAL (PYBIND11_MAP2_LIST1 (f, t, __VA_ARGS__, (), 0))
+#define PYBIND11_MAP2_LIST(f, t, ...) PYBIND11_EVAL(PYBIND11_MAP2_LIST1(f, t, __VA_ARGS__, (), 0))
 
-#define PYBIND11_NUMPY_DTYPE_EX(Type, ...) \
-    ::pybind11::detail::npy_format_descriptor<Type>::register_dtype \
-        (::std::vector<::pybind11::detail::field_descriptor> \
-         {PYBIND11_MAP2_LIST (PYBIND11_FIELD_DESCRIPTOR_EX, Type, __VA_ARGS__)})
+#define PYBIND11_NUMPY_DTYPE_EX(Type, ...)                                                        \
+    ::pybind11::detail::npy_format_descriptor<Type>::register_dtype(                              \
+        ::std::vector<::pybind11::detail::field_descriptor>{                                      \
+            PYBIND11_MAP2_LIST(PYBIND11_FIELD_DESCRIPTOR_EX, Type, __VA_ARGS__)})
 
 #endif // __CLION_IDE__
 
@@ -1293,8 +1311,8 @@ public:
 
     common_iterator() : m_strides() {}
 
-    common_iterator(void* ptr, const container_type& strides, const container_type& shape)
-        : p_ptr(reinterpret_cast<char*>(ptr)), m_strides(strides.size()) {
+    common_iterator(void *ptr, const container_type &strides, const container_type &shape)
+        : p_ptr(reinterpret_cast<char *>(ptr)), m_strides(strides.size()) {
         m_strides.back() = static_cast<value_type>(strides.back());
         for (size_type i = m_strides.size() - 1; i != 0; --i) {
             size_type j = i - 1;
@@ -1303,13 +1321,9 @@ public:
         }
     }
 
-    void increment(size_type dim) {
-        p_ptr += m_strides[dim];
-    }
+    void increment(size_type dim) { p_ptr += m_strides[dim]; }
 
-    void* data() const {
-        return p_ptr;
-    }
+    void *data() const { return p_ptr; }
 
 private:
     char *p_ptr{0};
@@ -1320,10 +1334,8 @@ template <size_t N> class multi_array_iterator {
 public:
     using container_type = std::vector<ssize_t>;
 
-    multi_array_iterator(const std::array<buffer_info, N> &buffers,
-                         const container_type &shape)
-        : m_shape(shape.size()), m_index(shape.size(), 0),
-          m_common_iterator() {
+    multi_array_iterator(const std::array<buffer_info, N> &buffers, const container_type &shape)
+        : m_shape(shape.size()), m_index(shape.size(), 0), m_common_iterator() {
 
         // Manual copy to avoid conversion warning if using std::copy
         for (size_t i = 0; i < shape.size(); ++i)
@@ -1334,7 +1346,7 @@ public:
             init_common_iterator(buffers[i], shape, m_common_iterator[i], strides);
     }
 
-    multi_array_iterator& operator++() {
+    multi_array_iterator &operator++() {
         for (size_t j = m_index.size(); j != 0; --j) {
             size_t i = j - 1;
             if (++m_index[i] != m_shape[i]) {
@@ -1346,18 +1358,15 @@ public:
         return *this;
     }
 
-    template <size_t K, class T = void> T* data() const {
-        return reinterpret_cast<T*>(m_common_iterator[K].data());
+    template <size_t K, class T = void> T *data() const {
+        return reinterpret_cast<T *>(m_common_iterator[K].data());
     }
 
 private:
-
     using common_iter = common_iterator;
 
-    void init_common_iterator(const buffer_info &buffer,
-                              const container_type &shape,
-                              common_iter &iterator,
-                              container_type &strides) {
+    void init_common_iterator(const buffer_info &buffer, const container_type &shape,
+                              common_iter &iterator, container_type &strides) {
         auto buffer_shape_iter = buffer.shape.rbegin();
         auto buffer_strides_iter = buffer.strides.rbegin();
         auto shape_iter = shape.rbegin();
@@ -1391,29 +1400,32 @@ private:
 
 enum class broadcast_trivial { non_trivial, c_trivial, f_trivial };
 
-// Populates the shape and number of dimensions for the set of buffers.  Returns a broadcast_trivial
-// enum value indicating whether the broadcast is "trivial"--that is, has each buffer being either a
-// singleton or a full-size, C-contiguous (`c_trivial`) or Fortran-contiguous (`f_trivial`) storage
-// buffer; returns `non_trivial` otherwise.
+// Populates the shape and number of dimensions for the set of buffers.  Returns a
+// broadcast_trivial enum value indicating whether the broadcast is "trivial"--that is, has each
+// buffer being either a singleton or a full-size, C-contiguous (`c_trivial`) or Fortran-contiguous
+// (`f_trivial`) storage buffer; returns `non_trivial` otherwise.
 template <size_t N>
-broadcast_trivial broadcast(const std::array<buffer_info, N> &buffers, ssize_t &ndim, std::vector<ssize_t> &shape) {
-    ndim = std::accumulate(buffers.begin(), buffers.end(), ssize_t(0), [](ssize_t res, const buffer_info &buf) {
-        return std::max(res, buf.ndim);
-    });
+broadcast_trivial broadcast(const std::array<buffer_info, N> &buffers, ssize_t &ndim,
+                            std::vector<ssize_t> &shape) {
+    ndim = std::accumulate(
+        buffers.begin(), buffers.end(), ssize_t(0),
+        [](ssize_t res, const buffer_info &buf) { return std::max(res, buf.ndim); });
 
     shape.clear();
-    shape.resize((size_t) ndim, 1);
+    shape.resize((size_t)ndim, 1);
 
-    // Figure out the output size, and make sure all input arrays conform (i.e. are either size 1 or
-    // the full size).
+    // Figure out the output size, and make sure all input arrays conform (i.e. are either size 1
+    // or the full size).
     for (size_t i = 0; i < N; ++i) {
         auto res_iter = shape.rbegin();
         auto end = buffers[i].shape.rend();
-        for (auto shape_iter = buffers[i].shape.rbegin(); shape_iter != end; ++shape_iter, ++res_iter) {
+        for (auto shape_iter = buffers[i].shape.rbegin(); shape_iter != end;
+             ++shape_iter, ++res_iter) {
             const auto &dim_size_in = *shape_iter;
             auto &dim_size_out = *res_iter;
 
-            // Each input dimension can either be 1 or `n`, but `n` values must match across buffers
+            // Each input dimension can either be 1 or `n`, but `n` values must match across
+            // buffers
             if (dim_size_out == 1)
                 dim_size_out = dim_size_in;
             else if (dim_size_in != 1 && dim_size_in != dim_size_out)
@@ -1439,8 +1451,9 @@ broadcast_trivial broadcast(const std::array<buffer_info, N> &buffers, ssize_t &
         if (trivial_broadcast_c) {
             ssize_t expect_stride = buffers[i].itemsize;
             auto end = buffers[i].shape.crend();
-            for (auto shape_iter = buffers[i].shape.crbegin(), stride_iter = buffers[i].strides.crbegin();
-                    trivial_broadcast_c && shape_iter != end; ++shape_iter, ++stride_iter) {
+            for (auto shape_iter = buffers[i].shape.crbegin(),
+                      stride_iter = buffers[i].strides.crbegin();
+                 trivial_broadcast_c && shape_iter != end; ++shape_iter, ++stride_iter) {
                 if (expect_stride == *stride_iter)
                     expect_stride *= *shape_iter;
                 else
@@ -1452,8 +1465,9 @@ broadcast_trivial broadcast(const std::array<buffer_info, N> &buffers, ssize_t &
         if (trivial_broadcast_f) {
             ssize_t expect_stride = buffers[i].itemsize;
             auto end = buffers[i].shape.cend();
-            for (auto shape_iter = buffers[i].shape.cbegin(), stride_iter = buffers[i].strides.cbegin();
-                    trivial_broadcast_f && shape_iter != end; ++shape_iter, ++stride_iter) {
+            for (auto shape_iter = buffers[i].shape.cbegin(),
+                      stride_iter = buffers[i].strides.cbegin();
+                 trivial_broadcast_f && shape_iter != end; ++shape_iter, ++stride_iter) {
                 if (expect_stride == *stride_iter)
                     expect_stride *= *shape_iter;
                 else
@@ -1462,31 +1476,29 @@ broadcast_trivial broadcast(const std::array<buffer_info, N> &buffers, ssize_t &
         }
     }
 
-    return
-        trivial_broadcast_c ? broadcast_trivial::c_trivial :
-        trivial_broadcast_f ? broadcast_trivial::f_trivial :
-        broadcast_trivial::non_trivial;
+    return trivial_broadcast_c   ? broadcast_trivial::c_trivial
+           : trivial_broadcast_f ? broadcast_trivial::f_trivial
+                                 : broadcast_trivial::non_trivial;
 }
 
-template <typename T>
-struct vectorize_arg {
-    static_assert(!std::is_rvalue_reference<T>::value, "Functions with rvalue reference arguments cannot be vectorized");
+template <typename T> struct vectorize_arg {
+    static_assert(!std::is_rvalue_reference<T>::value,
+                  "Functions with rvalue reference arguments cannot be vectorized");
     // The wrapped function gets called with this type:
     using call_type = remove_reference_t<T>;
     // Is this a vectorized argument?
     static constexpr bool vectorize =
         satisfies_any_of<call_type, std::is_arithmetic, is_complex, is_pod>::value &&
-        satisfies_none_of<call_type, std::is_pointer, std::is_array, is_std_array, std::is_enum>::value &&
+        satisfies_none_of<call_type, std::is_pointer, std::is_array, is_std_array,
+                          std::is_enum>::value &&
         (!std::is_reference<T>::value ||
          (std::is_lvalue_reference<T>::value && std::is_const<call_type>::value));
     // Accept this type: an array for vectorized types, otherwise the type as-is:
     using type = conditional_t<vectorize, array_t<remove_cv_t<call_type>, array::forcecast>, T>;
 };
 
-
 // py::vectorize when a return type is present
-template <typename Func, typename Return, typename... Args>
-struct vectorize_returned_array {
+template <typename Func, typename Return, typename... Args> struct vectorize_returned_array {
     using Type = array_t<Return>;
 
     static Type create(broadcast_trivial trivial, const std::vector<ssize_t> &shape) {
@@ -1495,45 +1507,30 @@ struct vectorize_returned_array {
         return array_t<Return>(shape);
     }
 
-    static Return *mutable_data(Type &array) {
-        return array.mutable_data();
-    }
+    static Return *mutable_data(Type &array) { return array.mutable_data(); }
 
-    static Return call(Func &f, Args &... args) {
-        return f(args...);
-    }
+    static Return call(Func &f, Args &...args) { return f(args...); }
 
-    static void call(Return *out, size_t i, Func &f, Args &... args) {
-        out[i] = f(args...);
-    }
+    static void call(Return *out, size_t i, Func &f, Args &...args) { out[i] = f(args...); }
 };
 
 // py::vectorize when a return type is not present
-template <typename Func, typename... Args>
-struct vectorize_returned_array<Func, void, Args...> {
+template <typename Func, typename... Args> struct vectorize_returned_array<Func, void, Args...> {
     using Type = none;
 
-    static Type create(broadcast_trivial, const std::vector<ssize_t> &) {
-        return none();
-    }
+    static Type create(broadcast_trivial, const std::vector<ssize_t> &) { return none(); }
 
-    static void *mutable_data(Type &) {
-        return nullptr;
-    }
+    static void *mutable_data(Type &) { return nullptr; }
 
-    static detail::void_type call(Func &f, Args &... args) {
+    static detail::void_type call(Func &f, Args &...args) {
         f(args...);
         return {};
     }
 
-    static void call(void *, size_t, Func &f, Args &... args) {
-        f(args...);
-    }
+    static void call(void *, size_t, Func &f, Args &...args) { f(args...); }
 };
 
-
-template <typename Func, typename Return, typename... Args>
-struct vectorize_helper {
+template <typename Func, typename Return, typename... Args> struct vectorize_helper {
 
 // NVCC for some reason breaks if NVectorized is private
 #ifdef __CUDACC__
@@ -1544,16 +1541,15 @@ private:
 
     static constexpr size_t N = sizeof...(Args);
     static constexpr size_t NVectorized = constexpr_sum(vectorize_arg<Args>::vectorize...);
-    static_assert(NVectorized >= 1,
-            "pybind11::vectorize(...) requires a function with at least one vectorizable argument");
+    static_assert(
+        NVectorized >= 1,
+        "pybind11::vectorize(...) requires a function with at least one vectorizable argument");
 
 public:
-    template <typename T>
-    explicit vectorize_helper(T &&f) : f(std::forward<T>(f)) { }
+    template <typename T> explicit vectorize_helper(T &&f) : f(std::forward<T>(f)) {}
 
     object operator()(typename vectorize_arg<Args>::type... args) {
-        return run(args...,
-                   make_index_sequence<N>(),
+        return run(args..., make_index_sequence<N>(),
                    select_indices<vectorize_arg<Args>::vectorize...>(),
                    make_index_sequence<NVectorized>());
     }
@@ -1561,10 +1557,11 @@ public:
 private:
     remove_reference_t<Func> f;
 
-    // Internal compiler error in MSVC 19.16.27025.1 (Visual Studio 2017 15.9.4), when compiling with "/permissive-" flag
-    // when arg_call_types is manually inlined.
+    // Internal compiler error in MSVC 19.16.27025.1 (Visual Studio 2017 15.9.4), when compiling
+    // with "/permissive-" flag when arg_call_types is manually inlined.
     using arg_call_types = std::tuple<typename vectorize_arg<Args>::call_type...>;
-    template <size_t Index> using param_n_t = typename std::tuple_element<Index, arg_call_types>::type;
+    template <size_t Index>
+    using param_n_t = typename std::tuple_element<Index, arg_call_types>::type;
 
     using returned_array = vectorize_returned_array<Func, Return, Args...>;
 
@@ -1575,36 +1572,40 @@ private:
     //     - BIndex is a incremental sequence (beginning at 0) of the same size as VIndex, so that
     //       we can store vectorized buffer_infos in an array (argument VIndex has its buffer at
     //       index BIndex in the array).
-    template <size_t... Index, size_t... VIndex, size_t... BIndex> object run(
-            typename vectorize_arg<Args>::type &...args,
-            index_sequence<Index...> i_seq, index_sequence<VIndex...> vi_seq, index_sequence<BIndex...> bi_seq) {
+    template <size_t... Index, size_t... VIndex, size_t... BIndex>
+    object run(typename vectorize_arg<Args>::type &...args, index_sequence<Index...> i_seq,
+               index_sequence<VIndex...> vi_seq, index_sequence<BIndex...> bi_seq) {
 
         // Pointers to values the function was called with; the vectorized ones set here will start
         // out as array_t<T> pointers, but they will be changed them to T pointers before we make
         // call the wrapped function.  Non-vectorized pointers are left as-is.
-        std::array<void *, N> params{{ &args... }};
+        std::array<void *, N> params{{&args...}};
 
         // The array of `buffer_info`s of vectorized arguments:
-        std::array<buffer_info, NVectorized> buffers{{ reinterpret_cast<array *>(params[VIndex])->request()... }};
+        std::array<buffer_info, NVectorized> buffers{
+            {reinterpret_cast<array *>(params[VIndex])->request()...}};
 
         /* Determine dimensions parameters of output array */
         ssize_t nd = 0;
         std::vector<ssize_t> shape(0);
         auto trivial = broadcast(buffers, nd, shape);
-        auto ndim = (size_t) nd;
+        auto ndim = (size_t)nd;
 
-        size_t size = std::accumulate(shape.begin(), shape.end(), (size_t) 1, std::multiplies<size_t>());
+        size_t size =
+            std::accumulate(shape.begin(), shape.end(), (size_t)1, std::multiplies<size_t>());
 
         // If all arguments are 0-dimension arrays (i.e. single values) return a plain value (i.e.
         // not wrapped in an array).
         if (size == 1 && ndim == 0) {
             PYBIND11_EXPAND_SIDE_EFFECTS(params[VIndex] = buffers[BIndex].ptr);
-            return cast(returned_array::call(f, *reinterpret_cast<param_n_t<Index> *>(params[Index])...));
+            return cast(
+                returned_array::call(f, *reinterpret_cast<param_n_t<Index> *>(params[Index])...));
         }
 
         auto result = returned_array::create(trivial, shape);
 
-        if (size == 0) return std::move(result);
+        if (size == 0)
+            return std::move(result);
 
         /* Call the function */
         auto mutable_data = returned_array::mutable_data(result);
@@ -1618,49 +1619,44 @@ private:
 
     template <size_t... Index, size_t... VIndex, size_t... BIndex>
     void apply_trivial(std::array<buffer_info, NVectorized> &buffers,
-                       std::array<void *, N> &params,
-                       Return *out,
-                       size_t size,
-                       index_sequence<Index...>, index_sequence<VIndex...>, index_sequence<BIndex...>) {
+                       std::array<void *, N> &params, Return *out, size_t size,
+                       index_sequence<Index...>, index_sequence<VIndex...>,
+                       index_sequence<BIndex...>) {
 
         // Initialize an array of mutable byte references and sizes with references set to the
         // appropriate pointer in `params`; as we iterate, we'll increment each pointer by its size
         // (except for singletons, which get an increment of 0).
-        std::array<std::pair<unsigned char *&, const size_t>, NVectorized> vecparams{{
-            std::pair<unsigned char *&, const size_t>(
-                    reinterpret_cast<unsigned char *&>(params[VIndex] = buffers[BIndex].ptr),
-                    buffers[BIndex].size == 1 ? 0 : sizeof(param_n_t<VIndex>)
-            )...
-        }};
+        std::array<std::pair<unsigned char *&, const size_t>, NVectorized> vecparams{
+            {std::pair<unsigned char *&, const size_t>(
+                reinterpret_cast<unsigned char *&>(params[VIndex] = buffers[BIndex].ptr),
+                buffers[BIndex].size == 1 ? 0 : sizeof(param_n_t<VIndex>))...}};
 
         for (size_t i = 0; i < size; ++i) {
-            returned_array::call(out, i, f, *reinterpret_cast<param_n_t<Index> *>(params[Index])...);
-            for (auto &x : vecparams) x.first += x.second;
+            returned_array::call(out, i, f,
+                                 *reinterpret_cast<param_n_t<Index> *>(params[Index])...);
+            for (auto &x : vecparams)
+                x.first += x.second;
         }
     }
 
     template <size_t... Index, size_t... VIndex, size_t... BIndex>
     void apply_broadcast(std::array<buffer_info, NVectorized> &buffers,
-                         std::array<void *, N> &params,
-                         Return *out,
-                         size_t size,
-                         const std::vector<ssize_t> &output_shape,
-                         index_sequence<Index...>, index_sequence<VIndex...>, index_sequence<BIndex...>) {
+                         std::array<void *, N> &params, Return *out, size_t size,
+                         const std::vector<ssize_t> &output_shape, index_sequence<Index...>,
+                         index_sequence<VIndex...>, index_sequence<BIndex...>) {
 
         multi_array_iterator<NVectorized> input_iter(buffers, output_shape);
 
         for (size_t i = 0; i < size; ++i, ++input_iter) {
-            PYBIND11_EXPAND_SIDE_EFFECTS((
-                params[VIndex] = input_iter.template data<BIndex>()
-            ));
-            returned_array::call(out, i, f, *reinterpret_cast<param_n_t<Index> *>(std::get<Index>(params))...);
+            PYBIND11_EXPAND_SIDE_EFFECTS((params[VIndex] = input_iter.template data<BIndex>()));
+            returned_array::call(
+                out, i, f, *reinterpret_cast<param_n_t<Index> *>(std::get<Index>(params))...);
         }
     }
 };
 
 template <typename Func, typename Return, typename... Args>
-vectorize_helper<Func, Return, Args...>
-vectorize_extractor(const Func &f, Return (*) (Args ...)) {
+vectorize_helper<Func, Return, Args...> vectorize_extractor(const Func &f, Return (*)(Args...)) {
     return detail::vectorize_helper<Func, Return, Args...>(f);
 }
 
@@ -1672,28 +1668,33 @@ PYBIND11_NAMESPACE_END(detail)
 
 // Vanilla pointer vectorizer:
 template <typename Return, typename... Args>
-detail::vectorize_helper<Return (*)(Args...), Return, Args...>
-vectorize(Return (*f) (Args ...)) {
+detail::vectorize_helper<Return (*)(Args...), Return, Args...> vectorize(Return (*f)(Args...)) {
     return detail::vectorize_helper<Return (*)(Args...), Return, Args...>(f);
 }
 
 // lambda vectorizer:
 template <typename Func, detail::enable_if_t<detail::is_lambda<Func>::value, int> = 0>
-auto vectorize(Func &&f) -> decltype(
-        detail::vectorize_extractor(std::forward<Func>(f), (detail::function_signature_t<Func> *) nullptr)) {
-    return detail::vectorize_extractor(std::forward<Func>(f), (detail::function_signature_t<Func> *) nullptr);
+auto vectorize(Func &&f)
+    -> decltype(detail::vectorize_extractor(std::forward<Func>(f),
+                                            (detail::function_signature_t<Func> *)nullptr)) {
+    return detail::vectorize_extractor(std::forward<Func>(f),
+                                       (detail::function_signature_t<Func> *)nullptr);
 }
 
 // Vectorize a class method (non-const):
 template <typename Return, typename Class, typename... Args,
-          typename Helper = detail::vectorize_helper<decltype(std::mem_fn(std::declval<Return (Class::*)(Args...)>())), Return, Class *, Args...>>
+          typename Helper = detail::vectorize_helper<
+              decltype(std::mem_fn(std::declval<Return (Class::*)(Args...)>())), Return, Class *,
+              Args...>>
 Helper vectorize(Return (Class::*f)(Args...)) {
     return Helper(std::mem_fn(f));
 }
 
 // Vectorize a class method (const):
 template <typename Return, typename Class, typename... Args,
-          typename Helper = detail::vectorize_helper<decltype(std::mem_fn(std::declval<Return (Class::*)(Args...) const>())), Return, const Class *, Args...>>
+          typename Helper = detail::vectorize_helper<
+              decltype(std::mem_fn(std::declval<Return (Class::*)(Args...) const>())), Return,
+              const Class *, Args...>>
 Helper vectorize(Return (Class::*f)(Args...) const) {
     return Helper(std::mem_fn(f));
 }

--- a/include/pybind11/operators.h
+++ b/include/pybind11/operators.h
@@ -12,10 +12,11 @@
 #include "pybind11.h"
 
 #if defined(__clang__) && !defined(__INTEL_COMPILER)
-#  pragma clang diagnostic ignored "-Wunsequenced" // multiple unsequenced modifications to 'self' (when using def(py::self OP Type()))
+#pragma clang diagnostic ignored "-Wunsequenced" // multiple unsequenced modifications to 'self'
+                                                 // (when using def(py::self OP Type()))
 #elif defined(_MSC_VER)
-#  pragma warning(push)
-#  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
+#pragma warning(push)
+#pragma warning(disable : 4127) // warning C4127: Conditional expression is constant
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
@@ -23,12 +24,50 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 
 /// Enumeration with all supported operator types
 enum op_id : int {
-    op_add, op_sub, op_mul, op_div, op_mod, op_divmod, op_pow, op_lshift,
-    op_rshift, op_and, op_xor, op_or, op_neg, op_pos, op_abs, op_invert,
-    op_int, op_long, op_float, op_str, op_cmp, op_gt, op_ge, op_lt, op_le,
-    op_eq, op_ne, op_iadd, op_isub, op_imul, op_idiv, op_imod, op_ilshift,
-    op_irshift, op_iand, op_ixor, op_ior, op_complex, op_bool, op_nonzero,
-    op_repr, op_truediv, op_itruediv, op_hash
+    op_add,
+    op_sub,
+    op_mul,
+    op_div,
+    op_mod,
+    op_divmod,
+    op_pow,
+    op_lshift,
+    op_rshift,
+    op_and,
+    op_xor,
+    op_or,
+    op_neg,
+    op_pos,
+    op_abs,
+    op_invert,
+    op_int,
+    op_long,
+    op_float,
+    op_str,
+    op_cmp,
+    op_gt,
+    op_ge,
+    op_lt,
+    op_le,
+    op_eq,
+    op_ne,
+    op_iadd,
+    op_isub,
+    op_imul,
+    op_idiv,
+    op_imod,
+    op_ilshift,
+    op_irshift,
+    op_iand,
+    op_ixor,
+    op_ior,
+    op_complex,
+    op_bool,
+    op_nonzero,
+    op_repr,
+    op_truediv,
+    op_itruediv,
+    op_hash
 };
 
 enum op_type : int {
@@ -37,125 +76,131 @@ enum op_type : int {
     op_u  /* unary operator */
 };
 
-struct self_t { };
+struct self_t {};
 static const self_t self = self_t();
 
 /// Type for an unused type slot
-struct undefined_t { };
+struct undefined_t {};
 
 /// Don't warn about an unused variable
 inline self_t __self() { return self; }
 
 /// base template of operator implementations
-template <op_id, op_type, typename B, typename L, typename R> struct op_impl { };
+template <op_id, op_type, typename B, typename L, typename R> struct op_impl {};
 
 /// Operator implementation generator
 template <op_id id, op_type ot, typename L, typename R> struct op_ {
-    template <typename Class, typename... Extra> void execute(Class &cl, const Extra&... extra) const {
+    template <typename Class, typename... Extra>
+    void execute(Class &cl, const Extra &...extra) const {
         using Base = typename Class::type;
         using L_type = conditional_t<std::is_same<L, self_t>::value, Base, L>;
         using R_type = conditional_t<std::is_same<R, self_t>::value, Base, R>;
         using op = op_impl<id, ot, Base, L_type, R_type>;
         cl.def(op::name(), &op::execute, is_operator(), extra...);
-        #if PY_MAJOR_VERSION < 3
+#if PY_MAJOR_VERSION < 3
         if (id == op_truediv || id == op_itruediv)
-            cl.def(id == op_itruediv ? "__idiv__" : ot == op_l ? "__div__" : "__rdiv__",
-                    &op::execute, is_operator(), extra...);
-        #endif
+            cl.def(id == op_itruediv ? "__idiv__"
+                   : ot == op_l      ? "__div__"
+                                     : "__rdiv__",
+                   &op::execute, is_operator(), extra...);
+#endif
     }
-    template <typename Class, typename... Extra> void execute_cast(Class &cl, const Extra&... extra) const {
+    template <typename Class, typename... Extra>
+    void execute_cast(Class &cl, const Extra &...extra) const {
         using Base = typename Class::type;
         using L_type = conditional_t<std::is_same<L, self_t>::value, Base, L>;
         using R_type = conditional_t<std::is_same<R, self_t>::value, Base, R>;
         using op = op_impl<id, ot, Base, L_type, R_type>;
         cl.def(op::name(), &op::execute_cast, is_operator(), extra...);
-        #if PY_MAJOR_VERSION < 3
+#if PY_MAJOR_VERSION < 3
         if (id == op_truediv || id == op_itruediv)
-            cl.def(id == op_itruediv ? "__idiv__" : ot == op_l ? "__div__" : "__rdiv__",
-                    &op::execute, is_operator(), extra...);
-        #endif
+            cl.def(id == op_itruediv ? "__idiv__"
+                   : ot == op_l      ? "__div__"
+                                     : "__rdiv__",
+                   &op::execute, is_operator(), extra...);
+#endif
     }
 };
 
-#define PYBIND11_BINARY_OPERATOR(id, rid, op, expr)                                    \
-template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L, R> { \
-    static char const* name() { return "__" #id "__"; }                                \
-    static auto execute(const L &l, const R &r) -> decltype(expr) { return (expr); }   \
-    static B execute_cast(const L &l, const R &r) { return B(expr); }                  \
-};                                                                                     \
-template <typename B, typename L, typename R> struct op_impl<op_##id, op_r, B, L, R> { \
-    static char const* name() { return "__" #rid "__"; }                               \
-    static auto execute(const R &r, const L &l) -> decltype(expr) { return (expr); }   \
-    static B execute_cast(const R &r, const L &l) { return B(expr); }                  \
-};                                                                                     \
-inline op_<op_##id, op_l, self_t, self_t> op(const self_t &, const self_t &) {         \
-    return op_<op_##id, op_l, self_t, self_t>();                                       \
-}                                                                                      \
-template <typename T> op_<op_##id, op_l, self_t, T> op(const self_t &, const T &) {    \
-    return op_<op_##id, op_l, self_t, T>();                                            \
-}                                                                                      \
-template <typename T> op_<op_##id, op_r, T, self_t> op(const T &, const self_t &) {    \
-    return op_<op_##id, op_r, T, self_t>();                                            \
-}
+#define PYBIND11_BINARY_OPERATOR(id, rid, op, expr)                                               \
+    template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L, R> {        \
+        static char const *name() { return "__" #id "__"; }                                       \
+        static auto execute(const L &l, const R &r) -> decltype(expr) { return (expr); }          \
+        static B execute_cast(const L &l, const R &r) { return B(expr); }                         \
+    };                                                                                            \
+    template <typename B, typename L, typename R> struct op_impl<op_##id, op_r, B, L, R> {        \
+        static char const *name() { return "__" #rid "__"; }                                      \
+        static auto execute(const R &r, const L &l) -> decltype(expr) { return (expr); }          \
+        static B execute_cast(const R &r, const L &l) { return B(expr); }                         \
+    };                                                                                            \
+    inline op_<op_##id, op_l, self_t, self_t> op(const self_t &, const self_t &) {                \
+        return op_<op_##id, op_l, self_t, self_t>();                                              \
+    }                                                                                             \
+    template <typename T> op_<op_##id, op_l, self_t, T> op(const self_t &, const T &) {           \
+        return op_<op_##id, op_l, self_t, T>();                                                   \
+    }                                                                                             \
+    template <typename T> op_<op_##id, op_r, T, self_t> op(const T &, const self_t &) {           \
+        return op_<op_##id, op_r, T, self_t>();                                                   \
+    }
 
-#define PYBIND11_INPLACE_OPERATOR(id, op, expr)                                        \
-template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L, R> { \
-    static char const* name() { return "__" #id "__"; }                                \
-    static auto execute(L &l, const R &r) -> decltype(expr) { return expr; }           \
-    static B execute_cast(L &l, const R &r) { return B(expr); }                        \
-};                                                                                     \
-template <typename T> op_<op_##id, op_l, self_t, T> op(const self_t &, const T &) {    \
-    return op_<op_##id, op_l, self_t, T>();                                            \
-}
+#define PYBIND11_INPLACE_OPERATOR(id, op, expr)                                                   \
+    template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L, R> {        \
+        static char const *name() { return "__" #id "__"; }                                       \
+        static auto execute(L &l, const R &r) -> decltype(expr) { return expr; }                  \
+        static B execute_cast(L &l, const R &r) { return B(expr); }                               \
+    };                                                                                            \
+    template <typename T> op_<op_##id, op_l, self_t, T> op(const self_t &, const T &) {           \
+        return op_<op_##id, op_l, self_t, T>();                                                   \
+    }
 
-#define PYBIND11_UNARY_OPERATOR(id, op, expr)                                          \
-template <typename B, typename L> struct op_impl<op_##id, op_u, B, L, undefined_t> {   \
-    static char const* name() { return "__" #id "__"; }                                \
-    static auto execute(const L &l) -> decltype(expr) { return expr; }                 \
-    static B execute_cast(const L &l) { return B(expr); }                              \
-};                                                                                     \
-inline op_<op_##id, op_u, self_t, undefined_t> op(const self_t &) {                    \
-    return op_<op_##id, op_u, self_t, undefined_t>();                                  \
-}
+#define PYBIND11_UNARY_OPERATOR(id, op, expr)                                                     \
+    template <typename B, typename L> struct op_impl<op_##id, op_u, B, L, undefined_t> {          \
+        static char const *name() { return "__" #id "__"; }                                       \
+        static auto execute(const L &l) -> decltype(expr) { return expr; }                        \
+        static B execute_cast(const L &l) { return B(expr); }                                     \
+    };                                                                                            \
+    inline op_<op_##id, op_u, self_t, undefined_t> op(const self_t &) {                           \
+        return op_<op_##id, op_u, self_t, undefined_t>();                                         \
+    }
 
-PYBIND11_BINARY_OPERATOR(sub,       rsub,         operator-,    l - r)
-PYBIND11_BINARY_OPERATOR(add,       radd,         operator+,    l + r)
-PYBIND11_BINARY_OPERATOR(mul,       rmul,         operator*,    l * r)
-PYBIND11_BINARY_OPERATOR(truediv,   rtruediv,     operator/,    l / r)
-PYBIND11_BINARY_OPERATOR(mod,       rmod,         operator%,    l % r)
-PYBIND11_BINARY_OPERATOR(lshift,    rlshift,      operator<<,   l << r)
-PYBIND11_BINARY_OPERATOR(rshift,    rrshift,      operator>>,   l >> r)
-PYBIND11_BINARY_OPERATOR(and,       rand,         operator&,    l & r)
-PYBIND11_BINARY_OPERATOR(xor,       rxor,         operator^,    l ^ r)
-PYBIND11_BINARY_OPERATOR(eq,        eq,           operator==,   l == r)
-PYBIND11_BINARY_OPERATOR(ne,        ne,           operator!=,   l != r)
-PYBIND11_BINARY_OPERATOR(or,        ror,          operator|,    l | r)
-PYBIND11_BINARY_OPERATOR(gt,        lt,           operator>,    l > r)
-PYBIND11_BINARY_OPERATOR(ge,        le,           operator>=,   l >= r)
-PYBIND11_BINARY_OPERATOR(lt,        gt,           operator<,    l < r)
-PYBIND11_BINARY_OPERATOR(le,        ge,           operator<=,   l <= r)
-//PYBIND11_BINARY_OPERATOR(pow,       rpow,         pow,          std::pow(l,  r))
-PYBIND11_INPLACE_OPERATOR(iadd,     operator+=,   l += r)
-PYBIND11_INPLACE_OPERATOR(isub,     operator-=,   l -= r)
-PYBIND11_INPLACE_OPERATOR(imul,     operator*=,   l *= r)
-PYBIND11_INPLACE_OPERATOR(itruediv, operator/=,   l /= r)
-PYBIND11_INPLACE_OPERATOR(imod,     operator%=,   l %= r)
-PYBIND11_INPLACE_OPERATOR(ilshift,  operator<<=,  l <<= r)
-PYBIND11_INPLACE_OPERATOR(irshift,  operator>>=,  l >>= r)
-PYBIND11_INPLACE_OPERATOR(iand,     operator&=,   l &= r)
-PYBIND11_INPLACE_OPERATOR(ixor,     operator^=,   l ^= r)
-PYBIND11_INPLACE_OPERATOR(ior,      operator|=,   l |= r)
-PYBIND11_UNARY_OPERATOR(neg,        operator-,    -l)
-PYBIND11_UNARY_OPERATOR(pos,        operator+,    +l)
+PYBIND11_BINARY_OPERATOR(sub, rsub, operator-, l - r)
+PYBIND11_BINARY_OPERATOR(add, radd, operator+, l + r)
+PYBIND11_BINARY_OPERATOR(mul, rmul, operator*, l *r)
+PYBIND11_BINARY_OPERATOR(truediv, rtruediv, operator/, l / r)
+PYBIND11_BINARY_OPERATOR(mod, rmod, operator%, l % r)
+PYBIND11_BINARY_OPERATOR(lshift, rlshift, operator<<, l << r)
+PYBIND11_BINARY_OPERATOR(rshift, rrshift, operator>>, l >> r)
+PYBIND11_BINARY_OPERATOR(and, rand, operator&, l &r)
+PYBIND11_BINARY_OPERATOR(xor, rxor, operator^, l ^ r)
+PYBIND11_BINARY_OPERATOR(eq, eq, operator==, l == r)
+PYBIND11_BINARY_OPERATOR(ne, ne, operator!=, l != r)
+PYBIND11_BINARY_OPERATOR(or, ror, operator|, l | r)
+PYBIND11_BINARY_OPERATOR(gt, lt, operator>, l > r)
+PYBIND11_BINARY_OPERATOR(ge, le, operator>=, l >= r)
+PYBIND11_BINARY_OPERATOR(lt, gt, operator<, l < r)
+PYBIND11_BINARY_OPERATOR(le, ge, operator<=, l <= r)
+// PYBIND11_BINARY_OPERATOR(pow,       rpow,         pow,          std::pow(l,  r))
+PYBIND11_INPLACE_OPERATOR(iadd, operator+=, l += r)
+PYBIND11_INPLACE_OPERATOR(isub, operator-=, l -= r)
+PYBIND11_INPLACE_OPERATOR(imul, operator*=, l *= r)
+PYBIND11_INPLACE_OPERATOR(itruediv, operator/=, l /= r)
+PYBIND11_INPLACE_OPERATOR(imod, operator%=, l %= r)
+PYBIND11_INPLACE_OPERATOR(ilshift, operator<<=, l <<= r)
+PYBIND11_INPLACE_OPERATOR(irshift, operator>>=, l >>= r)
+PYBIND11_INPLACE_OPERATOR(iand, operator&=, l &= r)
+PYBIND11_INPLACE_OPERATOR(ixor, operator^=, l ^= r)
+PYBIND11_INPLACE_OPERATOR(ior, operator|=, l |= r)
+PYBIND11_UNARY_OPERATOR(neg, operator-, -l)
+PYBIND11_UNARY_OPERATOR(pos, operator+, +l)
 // WARNING: This usage of `abs` should only be done for existing STL overloads.
 // Adding overloads directly in to the `std::` namespace is advised against:
 // https://en.cppreference.com/w/cpp/language/extending_std
-PYBIND11_UNARY_OPERATOR(abs,        abs,          std::abs(l))
-PYBIND11_UNARY_OPERATOR(hash,       hash,         std::hash<L>()(l))
-PYBIND11_UNARY_OPERATOR(invert,     operator~,    (~l))
-PYBIND11_UNARY_OPERATOR(bool,       operator!,    !!l)
-PYBIND11_UNARY_OPERATOR(int,        int_,         (int) l)
-PYBIND11_UNARY_OPERATOR(float,      float_,       (double) l)
+PYBIND11_UNARY_OPERATOR(abs, abs, std::abs(l))
+PYBIND11_UNARY_OPERATOR(hash, hash, std::hash<L>()(l))
+PYBIND11_UNARY_OPERATOR(invert, operator~, (~l))
+PYBIND11_UNARY_OPERATOR(bool, operator!, !!l)
+PYBIND11_UNARY_OPERATOR(int, int_, (int)l)
+PYBIND11_UNARY_OPERATOR(float, float_, (double)l)
 
 #undef PYBIND11_BINARY_OPERATOR
 #undef PYBIND11_INPLACE_OPERATOR
@@ -169,5 +214,5 @@ using detail::hash;
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
 
 #if defined(_MSC_VER)
-#  pragma warning(pop)
+#pragma warning(pop)
 #endif

--- a/include/pybind11/options.h
+++ b/include/pybind11/options.h
@@ -15,43 +15,54 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 class options {
 public:
-
     // Default RAII constructor, which leaves settings as they currently are.
     options() : previous_state(global_state()) {}
 
     // Class is non-copyable.
-    options(const options&) = delete;
-    options& operator=(const options&) = delete;
+    options(const options &) = delete;
+    options &operator=(const options &) = delete;
 
     // Destructor, which restores settings that were in effect before.
-    ~options() {
-        global_state() = previous_state;
-    }
+    ~options() { global_state() = previous_state; }
 
     // Setter methods (affect the global state):
 
-    options& disable_user_defined_docstrings() & { global_state().show_user_defined_docstrings = false; return *this; }
+    options &disable_user_defined_docstrings() & {
+        global_state().show_user_defined_docstrings = false;
+        return *this;
+    }
 
-    options& enable_user_defined_docstrings() & { global_state().show_user_defined_docstrings = true; return *this; }
+    options &enable_user_defined_docstrings() & {
+        global_state().show_user_defined_docstrings = true;
+        return *this;
+    }
 
-    options& disable_function_signatures() & { global_state().show_function_signatures = false; return *this; }
+    options &disable_function_signatures() & {
+        global_state().show_function_signatures = false;
+        return *this;
+    }
 
-    options& enable_function_signatures() & { global_state().show_function_signatures = true; return *this; }
+    options &enable_function_signatures() & {
+        global_state().show_function_signatures = true;
+        return *this;
+    }
 
     // Getter methods (return the global state):
 
-    static bool show_user_defined_docstrings() { return global_state().show_user_defined_docstrings; }
+    static bool show_user_defined_docstrings() {
+        return global_state().show_user_defined_docstrings;
+    }
 
     static bool show_function_signatures() { return global_state().show_function_signatures; }
 
     // This type is not meant to be allocated on the heap.
-    void* operator new(size_t) = delete;
+    void *operator new(size_t) = delete;
 
 private:
-
     struct state {
-        bool show_user_defined_docstrings = true;  //< Include user-supplied texts in docstrings.
-        bool show_function_signatures = true;      //< Include auto-generated function signatures in docstrings.
+        bool show_user_defined_docstrings = true; //< Include user-supplied texts in docstrings.
+        bool show_function_signatures =
+            true; //< Include auto-generated function signatures in docstrings.
     };
 
     static state &global_state() {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -956,11 +956,13 @@ public:
 #endif
     }
 
+    // clang-format off
     /** \rst
         Create Python binding for a new function within the module scope. ``Func``
         can be a plain C++ function, a function pointer, or a lambda function. For
         details on the ``Extra&& ... extra`` argument, see section :ref:`extras`.
     \endrst */
+    // clang-format on
     template <typename Func, typename... Extra>
     module_ &def(const char *name_, Func &&f, const Extra& ... extra) {
         cpp_function func(std::forward<Func>(f), name(name_), scope(*this),
@@ -971,6 +973,7 @@ public:
         return *this;
     }
 
+    // clang-format off
     /** \rst
         Create and return a new Python submodule with the given name and docstring.
         This also works recursively, i.e.
@@ -981,6 +984,7 @@ public:
             py::module_ m2 = m.def_submodule("sub", "A submodule of 'example'");
             py::module_ m3 = m2.def_submodule("subsub", "A submodule of 'example.sub'");
     \endrst */
+    // clang-format on
     module_ def_submodule(const char *name, const char *doc = nullptr) {
         std::string full_name = std::string(PyModule_GetName(m_ptr))
             + std::string(".") + std::string(name);
@@ -1007,6 +1011,7 @@ public:
         *this = reinterpret_steal<module_>(obj);
     }
 
+    // clang-format off
     /** \rst
         Adds an object to the module using the given name.  Throws if an object with the given name
         already exists.
@@ -1014,6 +1019,7 @@ public:
         ``overwrite`` should almost always be false: attempting to overwrite objects that pybind11 has
         established will, in most cases, break things.
     \endrst */
+    // clang-format on
     PYBIND11_NOINLINE void add_object(const char *name, handle obj, bool overwrite = false) {
         if (!overwrite && hasattr(*this, name))
             pybind11_fail("Error during initialization: multiple incompatible definitions with name \"" +
@@ -1028,12 +1034,14 @@ public:
     struct module_def {};
 #endif
 
+    // clang-format off
     /** \rst
         Create a new top-level module that can be used as the main module of a C extension.
 
         For Python 3, ``def`` should point to a statically allocated module_def.
         For Python 2, ``def`` can be a nullptr and is completely ignored.
     \endrst */
+    // clang-format on
     static module_ create_extension_module(const char *name, const char *doc, module_def *def) {
 #if PY_MAJOR_VERSION >= 3
         // module_def is PyModuleDef
@@ -2173,6 +2181,7 @@ inline function get_type_override(const void *this_ptr, const type_info *this_ty
 }
 PYBIND11_NAMESPACE_END(detail)
 
+// clang-format off
 /** \rst
   Try to retrieve a python method by the provided name from the instance pointed to by the this_ptr.
 
@@ -2180,7 +2189,8 @@ PYBIND11_NAMESPACE_END(detail)
              the first non-trampoline class encountered in the inheritance chain.
   :name: The name of the overridden Python method to retrieve.
   :return: The Python method by this name from the object or an empty function wrapper.
- \endrst */
+\endrst */
+// clang-format on
 template <class T> function get_override(const T *this_ptr, const char *name) {
     auto tinfo = detail::get_type_info(typeid(T));
     return tinfo ? detail::get_type_override(this_ptr, tinfo, name) : function();
@@ -2201,6 +2211,7 @@ template <class T> function get_override(const T *this_ptr, const char *name) {
         }                                                                                         \
     } while (false)
 
+// clang-format off
 /** \rst
     Macro to populate the virtual method in the trampoline class. This macro tries to look up a method named 'fn'
     from the Python side, deals with the :ref:`gil` and necessary argument conversions to call this method and return
@@ -2218,22 +2229,26 @@ template <class T> function get_override(const T *this_ptr, const char *name) {
         );
       }
 \endrst */
+// clang-format on
 #define PYBIND11_OVERRIDE_NAME(ret_type, cname, name, fn, ...) \
     do { \
         PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__); \
         return cname::fn(__VA_ARGS__); \
     } while (false)
 
+// clang-format off
 /** \rst
     Macro for pure virtual functions, this function is identical to :c:macro:`PYBIND11_OVERRIDE_NAME`, except that it
     throws if no override can be found.
 \endrst */
+// clang-format on
 #define PYBIND11_OVERRIDE_PURE_NAME(ret_type, cname, name, fn, ...) \
     do { \
         PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__); \
         pybind11::pybind11_fail("Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\""); \
     } while (false)
 
+// clang-format off
 /** \rst
     Macro to populate the virtual method in the trampoline class. This macro tries to look up the method
     from the Python side, deals with the :ref:`gil` and necessary argument conversions to call this method and return
@@ -2258,13 +2273,16 @@ template <class T> function get_override(const T *this_ptr, const char *name) {
           }
       };
 \endrst */
+// clang-format on
 #define PYBIND11_OVERRIDE(ret_type, cname, fn, ...) \
     PYBIND11_OVERRIDE_NAME(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), #fn, fn, __VA_ARGS__)
 
+// clang-format off
 /** \rst
     Macro for pure virtual functions, this function is identical to :c:macro:`PYBIND11_OVERRIDE`, except that it throws
     if no override can be found.
 \endrst */
+// clang-format on
 #define PYBIND11_OVERRIDE_PURE(ret_type, cname, fn, ...) \
     PYBIND11_OVERRIDE_PURE_NAME(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), #fn, fn, __VA_ARGS__)
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -11,50 +11,56 @@
 #pragma once
 
 #if defined(__INTEL_COMPILER)
-#  pragma warning push
-#  pragma warning disable 68    // integer conversion resulted in a change of sign
-#  pragma warning disable 186   // pointless comparison of unsigned integer with zero
-#  pragma warning disable 878   // incompatible exception specifications
-#  pragma warning disable 1334  // the "template" keyword used for syntactic disambiguation may only be used within a template
-#  pragma warning disable 1682  // implicit conversion of a 64-bit integral type to a smaller integral type (potential portability problem)
-#  pragma warning disable 1786  // function "strdup" was declared deprecated
-#  pragma warning disable 1875  // offsetof applied to non-POD (Plain Old Data) types is nonstandard
-#  pragma warning disable 2196  // warning #2196: routine is both "inline" and "noinline"
+#pragma warning push
+#pragma warning disable 68   // integer conversion resulted in a change of sign
+#pragma warning disable 186  // pointless comparison of unsigned integer with zero
+#pragma warning disable 878  // incompatible exception specifications
+#pragma warning disable 1334 // the "template" keyword used for syntactic disambiguation may only
+                             // be used within a template
+#pragma warning disable 1682 // implicit conversion of a 64-bit integral type to a smaller integral
+                             // type (potential portability problem)
+#pragma warning disable 1786 // function "strdup" was declared deprecated
+#pragma warning disable 1875 // offsetof applied to non-POD (Plain Old Data) types is nonstandard
+#pragma warning disable 2196 // warning #2196: routine is both "inline" and "noinline"
 #elif defined(_MSC_VER)
-#  pragma warning(push)
-#  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
-#  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
-#  pragma warning(disable: 4512) // warning C4512: Assignment operator was implicitly defined as deleted
-#  pragma warning(disable: 4800) // warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
-#  pragma warning(disable: 4996) // warning C4996: The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name
-#  pragma warning(disable: 4702) // warning C4702: unreachable code
-#  pragma warning(disable: 4522) // warning C4522: multiple assignment operators specified
-#  pragma warning(disable: 4505) // warning C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
+#pragma warning(push)
+#pragma warning(disable : 4100) // warning C4100: Unreferenced formal parameter
+#pragma warning(disable : 4127) // warning C4127: Conditional expression is constant
+#pragma warning(                                                                                  \
+    disable : 4512) // warning C4512: Assignment operator was implicitly defined as deleted
+#pragma warning(disable : 4800) // warning C4800: 'int': forcing value to bool 'true' or 'false'
+                                // (performance warning)
+#pragma warning(disable : 4996) // warning C4996: The POSIX name for this item is deprecated.
+                                // Instead, use the ISO C and C++ conformant name
+#pragma warning(disable : 4702) // warning C4702: unreachable code
+#pragma warning(disable : 4522) // warning C4522: multiple assignment operators specified
+#pragma warning(disable : 4505) // warning C4505: 'PySlice_GetIndicesEx': unreferenced local
+                                // function has been removed (PyPy only)
 #elif defined(__GNUG__) && !defined(__clang__)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
-#  pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#  pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#  pragma GCC diagnostic ignored "-Wattributes"
-#  if __GNUC__ >= 7
-#    pragma GCC diagnostic ignored "-Wnoexcept-type"
-#  endif
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic ignored "-Wattributes"
+#if __GNUC__ >= 7
+#pragma GCC diagnostic ignored "-Wnoexcept-type"
+#endif
 #endif
 
 #include "attr.h"
-#include "gil.h"
-#include "options.h"
 #include "detail/class.h"
 #include "detail/init.h"
+#include "gil.h"
+#include "options.h"
 
 #include <memory>
-#include <vector>
 #include <string>
 #include <utility>
+#include <vector>
 
 #if defined(__GNUG__) && !defined(__clang__)
-#  include <cxxabi.h>
+#include <cxxabi.h>
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
@@ -63,52 +69,53 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 class cpp_function : public function {
 public:
     cpp_function() = default;
-    cpp_function(std::nullptr_t) { }
+    cpp_function(std::nullptr_t) {}
 
     /// Construct a cpp_function from a vanilla function pointer
     template <typename Return, typename... Args, typename... Extra>
-    cpp_function(Return (*f)(Args...), const Extra&... extra) {
+    cpp_function(Return (*f)(Args...), const Extra &...extra) {
         initialize(f, f, extra...);
     }
 
     /// Construct a cpp_function from a lambda function (possibly with internal state)
     template <typename Func, typename... Extra,
               typename = detail::enable_if_t<detail::is_lambda<Func>::value>>
-    cpp_function(Func &&f, const Extra&... extra) {
-        initialize(std::forward<Func>(f),
-                   (detail::function_signature_t<Func> *) nullptr, extra...);
+    cpp_function(Func &&f, const Extra &...extra) {
+        initialize(std::forward<Func>(f), (detail::function_signature_t<Func> *)nullptr, extra...);
     }
 
     /// Construct a cpp_function from a class method (non-const, no ref-qualifier)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
-    cpp_function(Return (Class::*f)(Arg...), const Extra&... extra) {
-        initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
-                   (Return (*) (Class *, Arg...)) nullptr, extra...);
+    cpp_function(Return (Class::*f)(Arg...), const Extra &...extra) {
+        initialize(
+            [f](Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
+            (Return(*)(Class *, Arg...)) nullptr, extra...);
     }
 
     /// Construct a cpp_function from a class method (non-const, lvalue ref-qualifier)
     /// A copy of the overload for non-const functions without explicit ref-qualifier
     /// but with an added `&`.
     template <typename Return, typename Class, typename... Arg, typename... Extra>
-    cpp_function(Return (Class::*f)(Arg...)&, const Extra&... extra) {
+    cpp_function(Return (Class::*f)(Arg...) &, const Extra &...extra) {
         initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(args...); },
-                   (Return (*) (Class *, Arg...)) nullptr, extra...);
+                   (Return(*)(Class *, Arg...)) nullptr, extra...);
     }
 
     /// Construct a cpp_function from a class method (const, no ref-qualifier)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
-    cpp_function(Return (Class::*f)(Arg...) const, const Extra&... extra) {
-        initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
-                   (Return (*)(const Class *, Arg ...)) nullptr, extra...);
+    cpp_function(Return (Class::*f)(Arg...) const, const Extra &...extra) {
+        initialize([f](const Class *c,
+                       Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
+                   (Return(*)(const Class *, Arg...)) nullptr, extra...);
     }
 
     /// Construct a cpp_function from a class method (const, lvalue ref-qualifier)
     /// A copy of the overload for const functions without explicit ref-qualifier
     /// but with an added `&`.
     template <typename Return, typename Class, typename... Arg, typename... Extra>
-    cpp_function(Return (Class::*f)(Arg...) const&, const Extra&... extra) {
+    cpp_function(Return (Class::*f)(Arg...) const &, const Extra &...extra) {
         initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(args...); },
-                   (Return (*)(const Class *, Arg ...)) nullptr, extra...);
+                   (Return(*)(const Class *, Arg...)) nullptr, extra...);
     }
 
     /// Return the function name
@@ -118,9 +125,10 @@ protected:
     struct InitializingFunctionRecordDeleter {
         // `destruct(function_record, false)`: `initialize_generic` copies strings and
         // takes care of cleaning up in case of exceptions. So pass `false` to `free_strings`.
-        void operator()(detail::function_record * rec) { destruct(rec, false); }
+        void operator()(detail::function_record *rec) { destruct(rec, false); }
     };
-    using unique_function_record = std::unique_ptr<detail::function_record, InitializingFunctionRecordDeleter>;
+    using unique_function_record =
+        std::unique_ptr<detail::function_record, InitializingFunctionRecordDeleter>;
 
     /// Space optimization: don't inline this frequently instantiated fragment
     PYBIND11_NOINLINE unique_function_record make_function_record() {
@@ -129,11 +137,14 @@ protected:
 
     /// Special internal constructor for functors, lambda functions, etc.
     template <typename Func, typename Return, typename... Args, typename... Extra>
-    void initialize(Func &&f, Return (*)(Args...), const Extra&... extra) {
+    void initialize(Func &&f, Return (*)(Args...), const Extra &...extra) {
         using namespace detail;
-        struct capture { remove_reference_t<Func> f; };
+        struct capture {
+            remove_reference_t<Func> f;
+        };
 
-        /* Store the function including any extra state it might have (e.g. a lambda capture object) */
+        /* Store the function including any extra state it might have (e.g. a lambda capture
+         * object) */
         // The unique_ptr makes sure nothing is leaked in case of an exception.
         auto unique_rec = make_function_record();
         auto rec = unique_rec.get();
@@ -144,28 +155,28 @@ protected:
                enough space to use the placement new operator. However, the
                'if' statement above ensures that this is the case. */
 #if defined(__GNUG__) && __GNUC__ >= 6 && !defined(__clang__) && !defined(__INTEL_COMPILER)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wplacement-new"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wplacement-new"
 #endif
-            new ((capture *) &rec->data) capture { std::forward<Func>(f) };
+            new ((capture *)&rec->data) capture{std::forward<Func>(f)};
 #if defined(__GNUG__) && __GNUC__ >= 6 && !defined(__clang__) && !defined(__INTEL_COMPILER)
-#  pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif
             if (!std::is_trivially_destructible<Func>::value)
-                rec->free_data = [](function_record *r) { ((capture *) &r->data)->~capture(); };
+                rec->free_data = [](function_record *r) { ((capture *)&r->data)->~capture(); };
         } else {
-            rec->data[0] = new capture { std::forward<Func>(f) };
-            rec->free_data = [](function_record *r) { delete ((capture *) r->data[0]); };
+            rec->data[0] = new capture{std::forward<Func>(f)};
+            rec->free_data = [](function_record *r) { delete ((capture *)r->data[0]); };
         }
 
         /* Type casters for the function arguments and return value */
         using cast_in = argument_loader<Args...>;
-        using cast_out = make_caster<
-            conditional_t<std::is_void<Return>::value, void_type, Return>
-        >;
+        using cast_out =
+            make_caster<conditional_t<std::is_void<Return>::value, void_type, Return>>;
 
-        static_assert(expected_num_args<Extra...>(sizeof...(Args), cast_in::has_args, cast_in::has_kwargs),
-                      "The number of argument annotations does not match the number of function arguments");
+        static_assert(
+            expected_num_args<Extra...>(sizeof...(Args), cast_in::has_args, cast_in::has_kwargs),
+            "The number of argument annotations does not match the number of function arguments");
 
         /* Dispatch code which converts function arguments and performs the actual function call */
         rec->impl = [](function_call &call) -> handle {
@@ -179,19 +190,21 @@ protected:
             process_attributes<Extra...>::precall(call);
 
             /* Get a pointer to the capture object */
-            auto data = (sizeof(capture) <= sizeof(call.func.data)
-                         ? &call.func.data : call.func.data[0]);
+            auto data =
+                (sizeof(capture) <= sizeof(call.func.data) ? &call.func.data : call.func.data[0]);
             auto *cap = const_cast<capture *>(reinterpret_cast<const capture *>(data));
 
             /* Override policy for rvalues -- usually to enforce rvp::move on an rvalue */
-            return_value_policy policy = return_value_policy_override<Return>::policy(call.func.policy);
+            return_value_policy policy =
+                return_value_policy_override<Return>::policy(call.func.policy);
 
             /* Function scope guard -- defaults to the compile-to-nothing `void_type` */
             using Guard = extract_guard_t<Extra...>;
 
             /* Perform the function call */
-            handle result = cast_out::cast(
-                std::move(args_converter).template call<Return, Guard>(cap->f), policy, call.parent);
+            handle result =
+                cast_out::cast(std::move(args_converter).template call<Return, Guard>(cap->f),
+                               policy, call.parent);
 
             /* Invoke call policy post-call hook */
             process_attributes<Extra...>::postcall(call, result);
@@ -207,35 +220,44 @@ protected:
                            has_pos_only_args = any_of<std::is_same<pos_only, Extra>...>::value,
                            has_args = any_of<std::is_same<args, Args>...>::value,
                            has_arg_annotations = any_of<is_keyword<Extra>...>::value;
-            static_assert(has_arg_annotations || !has_kw_only_args, "py::kw_only requires the use of argument annotations");
-            static_assert(has_arg_annotations || !has_pos_only_args, "py::pos_only requires the use of argument annotations (for docstrings and aligning the annotations to the argument)");
-            static_assert(!(has_args && has_kw_only_args), "py::kw_only cannot be combined with a py::args argument");
+            static_assert(has_arg_annotations || !has_kw_only_args,
+                          "py::kw_only requires the use of argument annotations");
+            static_assert(has_arg_annotations || !has_pos_only_args,
+                          "py::pos_only requires the use of argument annotations (for docstrings "
+                          "and aligning the annotations to the argument)");
+            static_assert(!(has_args && has_kw_only_args),
+                          "py::kw_only cannot be combined with a py::args argument");
         }
 
-        /* Generate a readable signature describing the function's arguments and return value types */
-        static constexpr auto signature = _("(") + cast_in::arg_names + _(") -> ") + cast_out::name;
+        /* Generate a readable signature describing the function's arguments and return value types
+         */
+        static constexpr auto signature =
+            _("(") + cast_in::arg_names + _(") -> ") + cast_out::name;
         PYBIND11_DESCR_CONSTEXPR auto types = decltype(signature)::types();
 
         /* Register the function with Python from generic (non-templated) code */
         // Pass on the ownership over the `unique_rec` to `initialize_generic`. `rec` stays valid.
         initialize_generic(std::move(unique_rec), signature.text, types.data(), sizeof...(Args));
 
-        if (cast_in::has_args) rec->has_args = true;
-        if (cast_in::has_kwargs) rec->has_kwargs = true;
+        if (cast_in::has_args)
+            rec->has_args = true;
+        if (cast_in::has_kwargs)
+            rec->has_kwargs = true;
 
         /* Stash some additional information used by an important optimization in 'functional.h' */
         using FunctionType = Return (*)(Args...);
         constexpr bool is_function_ptr =
-            std::is_convertible<Func, FunctionType>::value &&
-            sizeof(capture) == sizeof(void *);
+            std::is_convertible<Func, FunctionType>::value && sizeof(capture) == sizeof(void *);
         if (is_function_ptr) {
             rec->is_stateless = true;
-            rec->data[1] = const_cast<void *>(reinterpret_cast<const void *>(&typeid(FunctionType)));
+            rec->data[1] =
+                const_cast<void *>(reinterpret_cast<const void *>(&typeid(FunctionType)));
         }
     }
 
-    // Utility class that keeps track of all duplicated strings, and cleans them up in its destructor,
-    // unless they are released. Basically a RAII-solution to deal with exceptions along the way.
+    // Utility class that keeps track of all duplicated strings, and cleans them up in its
+    // destructor, unless they are released. Basically a RAII-solution to deal with exceptions
+    // along the way.
     class strdup_guard {
     public:
         ~strdup_guard() {
@@ -247,9 +269,8 @@ protected:
             strings.push_back(t);
             return t;
         }
-        void release() {
-            strings.clear();
-        }
+        void release() { strings.clear(); }
+
     private:
         std::vector<char *> strings;
     };
@@ -258,21 +279,24 @@ protected:
     void initialize_generic(unique_function_record &&unique_rec, const char *text,
                             const std::type_info *const *types, size_t args) {
         // Do NOT receive `unique_rec` by value. If this function fails to move out the unique_ptr,
-        // we do not want this to destuct the pointer. `initialize` (the caller) still relies on the
-        // pointee being alive after this call. Only move out if a `capsule` is going to keep it alive.
+        // we do not want this to destuct the pointer. `initialize` (the caller) still relies on
+        // the pointee being alive after this call. Only move out if a `capsule` is going to keep
+        // it alive.
         auto rec = unique_rec.get();
 
         // Keep track of strdup'ed strings, and clean them up as long as the function's capsule
         // has not taken ownership yet (when `unique_rec.release()` is called).
-        // Note: This cannot easily be fixed by a `unique_ptr` with custom deleter, because the strings
-        // are only referenced before strdup'ing. So only *after* the following block could `destruct`
-        // safely be called, but even then, `repr` could still throw in the middle of copying all strings.
+        // Note: This cannot easily be fixed by a `unique_ptr` with custom deleter, because the
+        // strings are only referenced before strdup'ing. So only *after* the following block could
+        // `destruct` safely be called, but even then, `repr` could still throw in the middle of
+        // copying all strings.
         strdup_guard guarded_strdup;
 
         /* Create copies of all referenced C-style strings */
         rec->name = guarded_strdup(rec->name ? rec->name : "");
-        if (rec->doc) rec->doc = guarded_strdup(rec->doc);
-        for (auto &a: rec->args) {
+        if (rec->doc)
+            rec->doc = guarded_strdup(rec->doc);
+        for (auto &a : rec->args) {
             if (a.name)
                 a.name = guarded_strdup(a.name);
             if (a.descr)
@@ -285,15 +309,19 @@ protected:
 
 #if !defined(NDEBUG) && !defined(PYBIND11_DISABLE_NEW_STYLE_INIT_WARNING)
         if (rec->is_constructor && !rec->is_new_style_constructor) {
-            const auto class_name = detail::get_fully_qualified_tp_name((PyTypeObject *) rec->scope.ptr());
+            const auto class_name =
+                detail::get_fully_qualified_tp_name((PyTypeObject *)rec->scope.ptr());
             const auto func_name = std::string(rec->name);
-            PyErr_WarnEx(
-                PyExc_FutureWarning,
-                ("pybind11-bound class '" + class_name + "' is using an old-style "
-                 "placement-new '" + func_name + "' which has been deprecated. See "
-                 "the upgrade guide in pybind11's docs. This message is only visible "
-                 "when compiled in debug mode.").c_str(), 0
-            );
+            PyErr_WarnEx(PyExc_FutureWarning,
+                         ("pybind11-bound class '" + class_name +
+                          "' is using an old-style "
+                          "placement-new '" +
+                          func_name +
+                          "' which has been deprecated. See "
+                          "the upgrade guide in pybind11's docs. This message is only visible "
+                          "when compiled in debug mode.")
+                             .c_str(),
+                         0);
         }
 #endif
 
@@ -335,16 +363,16 @@ protected:
                 if (!t)
                     pybind11_fail("Internal error while parsing type signature (1)");
                 if (auto tinfo = detail::get_type_info(*t)) {
-                    handle th((PyObject *) tinfo->type);
-                    signature +=
-                        th.attr("__module__").cast<std::string>() + "." +
-                        th.attr("__qualname__").cast<std::string>(); // Python 3.3+, but we backport it to earlier versions
+                    handle th((PyObject *)tinfo->type);
+                    signature += th.attr("__module__").cast<std::string>() + "." +
+                                 th.attr("__qualname__")
+                                     .cast<std::string>(); // Python 3.3+, but we backport it to
+                                                           // earlier versions
                 } else if (rec->is_new_style_constructor && arg_index == 0) {
                     // A new-style `__init__` takes `self` as `value_and_holder`.
                     // Rewrite it to the proper class type.
-                    signature +=
-                        rec->scope.attr("__module__").cast<std::string>() + "." +
-                        rec->scope.attr("__qualname__").cast<std::string>();
+                    signature += rec->scope.attr("__module__").cast<std::string>() + "." +
+                                 rec->scope.attr("__qualname__").cast<std::string>();
                 } else {
                     std::string tname(t->name());
                     detail::clean_type_id(tname);
@@ -369,7 +397,7 @@ protected:
 #endif
         rec->signature = guarded_strdup(signature.c_str());
         rec->args.shrink_to_fit();
-        rec->nargs = (std::uint16_t) args;
+        rec->nargs = (std::uint16_t)args;
 
         if (rec->sibling && PYBIND11_INSTANCE_METHOD_CHECK(rec->sibling.ptr()))
             rec->sibling = PYBIND11_INSTANCE_METHOD_GET_FUNCTION(rec->sibling.ptr());
@@ -377,17 +405,19 @@ protected:
         detail::function_record *chain = nullptr, *chain_start = rec;
         if (rec->sibling) {
             if (PyCFunction_Check(rec->sibling.ptr())) {
-                auto rec_capsule = reinterpret_borrow<capsule>(PyCFunction_GET_SELF(rec->sibling.ptr()));
-                chain = (detail::function_record *) rec_capsule;
+                auto rec_capsule =
+                    reinterpret_borrow<capsule>(PyCFunction_GET_SELF(rec->sibling.ptr()));
+                chain = (detail::function_record *)rec_capsule;
                 /* Never append a method to an overload chain of a parent class;
                    instead, hide the parent's overloads in this case */
                 if (!chain->scope.is(rec->scope))
                     chain = nullptr;
             }
-            // Don't trigger for things like the default __init__, which are wrapper_descriptors that we are intentionally replacing
+            // Don't trigger for things like the default __init__, which are wrapper_descriptors
+            // that we are intentionally replacing
             else if (!rec->sibling.is_none() && rec->name[0] != '_')
-                pybind11_fail("Cannot overload existing non-function object \"" + std::string(rec->name) +
-                        "\" with a function of the same name");
+                pybind11_fail("Cannot overload existing non-function object \"" +
+                              std::string(rec->name) + "\" with a function of the same name");
         }
 
         if (!chain) {
@@ -395,13 +425,12 @@ protected:
             rec->def = new PyMethodDef();
             std::memset(rec->def, 0, sizeof(PyMethodDef));
             rec->def->ml_name = rec->name;
-            rec->def->ml_meth
-                = reinterpret_cast<PyCFunction>(reinterpret_cast<void (*)()>(dispatcher));
+            rec->def->ml_meth =
+                reinterpret_cast<PyCFunction>(reinterpret_cast<void (*)()>(dispatcher));
             rec->def->ml_flags = METH_VARARGS | METH_KEYWORDS;
 
-            capsule rec_capsule(unique_rec.release(), [](void *ptr) {
-                destruct((detail::function_record *) ptr);
-            });
+            capsule rec_capsule(unique_rec.release(),
+                                [](void *ptr) { destruct((detail::function_record *)ptr); });
             guarded_strdup.release();
 
             object scope_module;
@@ -421,13 +450,16 @@ protected:
             m_ptr = rec->sibling.ptr();
             inc_ref();
             if (chain->is_method != rec->is_method)
-                pybind11_fail("overloading a method with both static and instance methods is not supported; "
-                    #if defined(NDEBUG)
-                        "compile in debug mode for more details"
-                    #else
-                        "error while attempting to bind " + std::string(rec->is_method ? "instance" : "static") + " method " +
-                        std::string(pybind11::str(rec->scope.attr("__name__"))) + "." + std::string(rec->name) + signature
-                    #endif
+                pybind11_fail(
+                    "overloading a method with both static and instance methods is not supported; "
+#if defined(NDEBUG)
+                    "compile in debug mode for more details"
+#else
+                    "error while attempting to bind " +
+                    std::string(rec->is_method ? "instance" : "static") + " method " +
+                    std::string(pybind11::str(rec->scope.attr("__name__"))) + "." +
+                    std::string(rec->name) + signature
+#endif
                 );
 
             if (rec->prepend) {
@@ -436,7 +468,8 @@ protected:
                 // chain.
                 chain_start = rec;
                 rec->next = chain;
-                auto rec_capsule = reinterpret_borrow<capsule>(((PyCFunctionObject *) m_ptr)->m_self);
+                auto rec_capsule =
+                    reinterpret_borrow<capsule>(((PyCFunctionObject *)m_ptr)->m_self);
                 rec_capsule.set_pointer(unique_rec.release());
                 guarded_strdup.release();
             } else {
@@ -463,7 +496,8 @@ protected:
         bool first_user_def = true;
         for (auto it = chain_start; it != nullptr; it = it->next) {
             if (options::show_function_signatures()) {
-                if (index > 0) signatures += "\n";
+                if (index > 0)
+                    signatures += "\n";
                 if (chain)
                     signatures += std::to_string(++index) + ". ";
                 signatures += rec->name;
@@ -471,20 +505,24 @@ protected:
                 signatures += "\n";
             }
             if (it->doc && it->doc[0] != '\0' && options::show_user_defined_docstrings()) {
-                // If we're appending another docstring, and aren't printing function signatures, we
-                // need to append a newline first:
+                // If we're appending another docstring, and aren't printing function signatures,
+                // we need to append a newline first:
                 if (!options::show_function_signatures()) {
-                    if (first_user_def) first_user_def = false;
-                    else signatures += "\n";
+                    if (first_user_def)
+                        first_user_def = false;
+                    else
+                        signatures += "\n";
                 }
-                if (options::show_function_signatures()) signatures += "\n";
+                if (options::show_function_signatures())
+                    signatures += "\n";
                 signatures += it->doc;
-                if (options::show_function_signatures()) signatures += "\n";
+                if (options::show_function_signatures())
+                    signatures += "\n";
             }
         }
 
         /* Install docstring */
-        auto *func = (PyCFunctionObject *) m_ptr;
+        auto *func = (PyCFunctionObject *)m_ptr;
         std::free(const_cast<char *>(func->m_ml->ml_doc));
         // Install docstring if it's non-empty (when at least one option is enabled)
         func->m_ml->ml_doc = signatures.empty() ? nullptr : strdup(signatures.c_str());
@@ -492,18 +530,19 @@ protected:
         if (rec->is_method) {
             m_ptr = PYBIND11_INSTANCE_METHOD_NEW(m_ptr, rec->scope.ptr());
             if (!m_ptr)
-                pybind11_fail("cpp_function::cpp_function(): Could not allocate instance method object");
+                pybind11_fail(
+                    "cpp_function::cpp_function(): Could not allocate instance method object");
             Py_DECREF(func);
         }
     }
 
     /// When a cpp_function is GCed, release any memory allocated by pybind11
     static void destruct(detail::function_record *rec, bool free_strings = true) {
-        // If on Python 3.9, check the interpreter "MICRO" (patch) version.
-        // If this is running on 3.9.0, we have to work around a bug.
-        #if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 9
-            static bool is_zero = Py_GetVersion()[4] == '0';
-        #endif
+// If on Python 3.9, check the interpreter "MICRO" (patch) version.
+// If this is running on 3.9.0, we have to work around a bug.
+#if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 9
+        static bool is_zero = Py_GetVersion()[4] == '0';
+#endif
 
         while (rec) {
             detail::function_record *next = rec->next;
@@ -513,27 +552,27 @@ protected:
             // so they cannot be freed. Once the function has been created, they can.
             // Check `make_function_record` for more details.
             if (free_strings) {
-                std::free((char *) rec->name);
-                std::free((char *) rec->doc);
-                std::free((char *) rec->signature);
-                for (auto &arg: rec->args) {
+                std::free((char *)rec->name);
+                std::free((char *)rec->doc);
+                std::free((char *)rec->signature);
+                for (auto &arg : rec->args) {
                     std::free(const_cast<char *>(arg.name));
                     std::free(const_cast<char *>(arg.descr));
                 }
             }
-            for (auto &arg: rec->args)
+            for (auto &arg : rec->args)
                 arg.value.dec_ref();
             if (rec->def) {
                 std::free(const_cast<char *>(rec->def->ml_doc));
-                // Python 3.9.0 decref's these in the wrong order; rec->def
-                // If loaded on 3.9.0, let these leak (use Python 3.9.1 at runtime to fix)
-                // See https://github.com/python/cpython/pull/22670
-                #if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 9
-                    if (!is_zero)
-                        delete rec->def;
-                #else
+// Python 3.9.0 decref's these in the wrong order; rec->def
+// If loaded on 3.9.0, let these leak (use Python 3.9.1 at runtime to fix)
+// See https://github.com/python/cpython/pull/22670
+#if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 9
+                if (!is_zero)
                     delete rec->def;
-                #endif
+#else
+                delete rec->def;
+#endif
             }
             delete rec;
             rec = next;
@@ -545,23 +584,27 @@ protected:
         using namespace detail;
 
         /* Iterator over the list of potentially admissible overloads */
-        const function_record *overloads = (function_record *) PyCapsule_GetPointer(self, nullptr),
+        const function_record *overloads = (function_record *)PyCapsule_GetPointer(self, nullptr),
                               *it = overloads;
 
-        /* Need to know how many arguments + keyword arguments there are to pick the right overload */
-        const auto n_args_in = (size_t) PyTuple_GET_SIZE(args_in);
+        /* Need to know how many arguments + keyword arguments there are to pick the right overload
+         */
+        const auto n_args_in = (size_t)PyTuple_GET_SIZE(args_in);
 
         handle parent = n_args_in > 0 ? PyTuple_GET_ITEM(args_in, 0) : nullptr,
                result = PYBIND11_TRY_NEXT_OVERLOAD;
 
         auto self_value_and_holder = value_and_holder();
         if (overloads->is_constructor) {
-            if (!parent || !PyObject_TypeCheck(parent.ptr(), (PyTypeObject *) overloads->scope.ptr())) {
-                PyErr_SetString(PyExc_TypeError, "__init__(self, ...) called with invalid or missing `self` argument");
+            if (!parent ||
+                !PyObject_TypeCheck(parent.ptr(), (PyTypeObject *)overloads->scope.ptr())) {
+                PyErr_SetString(
+                    PyExc_TypeError,
+                    "__init__(self, ...) called with invalid or missing `self` argument");
                 return nullptr;
             }
 
-            const auto tinfo = get_type_info((PyTypeObject *) overloads->scope.ptr());
+            const auto tinfo = get_type_info((PyTypeObject *)overloads->scope.ptr());
             const auto pi = reinterpret_cast<instance *>(parent.ptr());
             self_value_and_holder = pi->get_value_and_holder(tinfo, true);
 
@@ -587,36 +630,40 @@ protected:
                    1. Copy all positional arguments we were given, also checking to make sure that
                       named positional arguments weren't *also* specified via kwarg.
                    2. If we weren't given enough, try to make up the omitted ones by checking
-                      whether they were provided by a kwarg matching the `py::arg("name")` name.  If
+                      whether they were provided by a kwarg matching the `py::arg("name")` name. If
                       so, use it (and remove it from kwargs; if not, see if the function binding
                       provided a default that we can use.
-                   3. Ensure that either all keyword arguments were "consumed", or that the function
-                      takes a kwargs argument to accept unconsumed kwargs.
+                   3. Ensure that either all keyword arguments were "consumed", or that the
+                   function takes a kwargs argument to accept unconsumed kwargs.
                    4. Any positional arguments still left get put into a tuple (for args), and any
                       leftover kwargs get put into a dict.
                    5. Pack everything into a vector; if we have py::args or py::kwargs, they are an
                       extra tuple or dict at the end of the positional arguments.
                    6. Call the function call dispatcher (function_record::impl)
 
-                   If one of these fail, move on to the next overload and keep trying until we get a
-                   result other than PYBIND11_TRY_NEXT_OVERLOAD.
+                   If one of these fail, move on to the next overload and keep trying until we get
+                   a result other than PYBIND11_TRY_NEXT_OVERLOAD.
                  */
 
                 const function_record &func = *it;
-                size_t num_args = func.nargs;    // Number of positional arguments that we need
-                if (func.has_args) --num_args;   // (but don't count py::args
-                if (func.has_kwargs) --num_args; //  or py::kwargs)
+                size_t num_args = func.nargs; // Number of positional arguments that we need
+                if (func.has_args)
+                    --num_args; // (but don't count py::args
+                if (func.has_kwargs)
+                    --num_args; //  or py::kwargs)
                 size_t pos_args = num_args - func.nargs_kw_only;
 
                 if (!func.has_args && n_args_in > pos_args)
                     continue; // Too many positional arguments for this overload
 
                 if (n_args_in < pos_args && func.args.size() < pos_args)
-                    continue; // Not enough positional arguments given, and not enough defaults to fill in the blanks
+                    continue; // Not enough positional arguments given, and not enough defaults to
+                              // fill in the blanks
 
                 function_call call(func, parent);
 
-                size_t args_to_copy = (std::min)(pos_args, n_args_in); // Protect std::min with parentheses
+                size_t args_to_copy =
+                    (std::min)(pos_args, n_args_in); // Protect std::min with parentheses
                 size_t args_copied = 0;
 
                 // 0. Inject new-style `self` argument
@@ -635,8 +682,10 @@ protected:
                 // 1. Copy any position arguments given.
                 bool bad_arg = false;
                 for (; args_copied < args_to_copy; ++args_copied) {
-                    const argument_record *arg_rec = args_copied < func.args.size() ? &func.args[args_copied] : nullptr;
-                    if (kwargs_in && arg_rec && arg_rec->name && dict_getitemstring(kwargs_in, arg_rec->name)) {
+                    const argument_record *arg_rec =
+                        args_copied < func.args.size() ? &func.args[args_copied] : nullptr;
+                    if (kwargs_in && arg_rec && arg_rec->name &&
+                        dict_getitemstring(kwargs_in, arg_rec->name)) {
                         bad_arg = true;
                         break;
                     }
@@ -706,13 +755,13 @@ protected:
                         if (value) {
                             call.args.push_back(value);
                             call.args_convert.push_back(arg_rec.convert);
-                        }
-                        else
+                        } else
                             break;
                     }
 
                     if (args_copied < num_args)
-                        continue; // Not enough arguments, defaults, or kwargs to fill the positional arguments
+                        continue; // Not enough arguments, defaults, or kwargs to fill the
+                                  // positional arguments
                 }
 
                 // 3. Check everything was consumed (unless we have a kwargs arg)
@@ -749,12 +798,13 @@ protected:
                     call.kwargs_ref = std::move(kwargs);
                 }
 
-                // 5. Put everything in a vector.  Not technically step 5, we've been building it
-                // in `call.args` all along.
-                #if !defined(NDEBUG)
+// 5. Put everything in a vector.  Not technically step 5, we've been building it
+// in `call.args` all along.
+#if !defined(NDEBUG)
                 if (call.args.size() != func.nargs || call.args_convert.size() != func.nargs)
-                    pybind11_fail("Internal error: function call dispatcher inserted wrong number of arguments!");
-                #endif
+                    pybind11_fail("Internal error: function call dispatcher inserted wrong number "
+                                  "of arguments!");
+#endif
 
                 std::vector<bool> second_pass_convert;
                 if (overloaded) {
@@ -793,7 +843,8 @@ protected:
             }
 
             if (overloaded && !second_pass.empty() && result.ptr() == PYBIND11_TRY_NEXT_OVERLOAD) {
-                // The no-conversion pass finished without success, try again with conversion allowed
+                // The no-conversion pass finished without success, try again with conversion
+                // allowed
                 for (auto &call : second_pass) {
                     try {
                         loader_life_support guard{};
@@ -815,7 +866,7 @@ protected:
             e.restore();
             return nullptr;
 #ifdef __GLIBCXX__
-        } catch ( abi::__forced_unwind& ) {
+        } catch (abi::__forced_unwind &) {
             throw;
 #endif
         } catch (...) {
@@ -828,11 +879,13 @@ protected:
                 - catch the exception and call PyErr_SetString or PyErr_SetObject
                   to set a standard (or custom) Python exception, or
                 - do nothing and let the exception fall through to the next translator, or
-                - delegate translation to the next translator by throwing a new type of exception. */
+                - delegate translation to the next translator by throwing a new type of exception.
+             */
 
             auto last_exception = std::current_exception();
-            auto &registered_exception_translators = get_internals().registered_exception_translators;
-            for (auto& translator : registered_exception_translators) {
+            auto &registered_exception_translators =
+                get_internals().registered_exception_translators;
+            for (auto &translator : registered_exception_translators) {
                 try {
                     translator(last_exception);
                 } catch (...) {
@@ -841,7 +894,8 @@ protected:
                 }
                 return nullptr;
             }
-            PyErr_SetString(PyExc_SystemError, "Exception escaped from default exception translator!");
+            PyErr_SetString(PyExc_SystemError,
+                            "Exception escaped from default exception translator!");
             return nullptr;
         }
 
@@ -860,16 +914,17 @@ protected:
                 return handle(Py_NotImplemented).inc_ref().ptr();
 
             std::string msg = std::string(overloads->name) + "(): incompatible " +
-                std::string(overloads->is_constructor ? "constructor" : "function") +
-                " arguments. The following argument types are supported:\n";
+                              std::string(overloads->is_constructor ? "constructor" : "function") +
+                              " arguments. The following argument types are supported:\n";
 
             int ctr = 0;
             for (const function_record *it2 = overloads; it2 != nullptr; it2 = it2->next) {
-                msg += "    "+ std::to_string(++ctr) + ". ";
+                msg += "    " + std::to_string(++ctr) + ". ";
 
                 bool wrote_sig = false;
                 if (overloads->is_constructor) {
-                    // For a constructor, rewrite `(self: Object, arg0, ...) -> NoneType` as `Object(arg0, ...)`
+                    // For a constructor, rewrite `(self: Object, arg0, ...) -> NoneType` as
+                    // `Object(arg0, ...)`
                     std::string sig = it2->signature;
                     size_t start = sig.find('(') + 7; // skip "(self: "
                     if (start < sig.size()) {
@@ -877,7 +932,8 @@ protected:
                         size_t end = sig.find(", "), next = end + 2;
                         size_t ret = sig.rfind(" -> ");
                         // Or the ), if there is no comma:
-                        if (end >= sig.size()) next = end = sig.find(')');
+                        if (end >= sig.size())
+                            next = end = sig.find(')');
                         if (start < end && next < sig.size()) {
                             msg.append(sig, start, end - start);
                             msg += '(';
@@ -886,7 +942,8 @@ protected:
                         }
                     }
                 }
-                if (!wrote_sig) msg += it2->signature;
+                if (!wrote_sig)
+                    msg += it2->signature;
 
                 msg += "\n";
             }
@@ -894,27 +951,32 @@ protected:
             auto args_ = reinterpret_borrow<tuple>(args_in);
             bool some_args = false;
             for (size_t ti = overloads->is_constructor ? 1 : 0; ti < args_.size(); ++ti) {
-                if (!some_args) some_args = true;
-                else msg += ", ";
+                if (!some_args)
+                    some_args = true;
+                else
+                    msg += ", ";
                 try {
                     msg += pybind11::repr(args_[ti]);
-                } catch (const error_already_set&) {
+                } catch (const error_already_set &) {
                     msg += "<repr raised Error>";
                 }
             }
             if (kwargs_in) {
                 auto kwargs = reinterpret_borrow<dict>(kwargs_in);
                 if (!kwargs.empty()) {
-                    if (some_args) msg += "; ";
+                    if (some_args)
+                        msg += "; ";
                     msg += "kwargs: ";
                     bool first = true;
                     for (auto kwarg : kwargs) {
-                        if (first) first = false;
-                        else msg += ", ";
+                        if (first)
+                            first = false;
+                        else
+                            msg += ", ";
                         msg += pybind11::str("{}=").format(kwarg.first);
                         try {
                             msg += pybind11::repr(kwarg.second);
-                        } catch (const error_already_set&) {
+                        } catch (const error_already_set &) {
                             msg += "<repr raised Error>";
                         }
                     }
@@ -964,11 +1026,12 @@ public:
     \endrst */
     // clang-format on
     template <typename Func, typename... Extra>
-    module_ &def(const char *name_, Func &&f, const Extra& ... extra) {
+    module_ &def(const char *name_, Func &&f, const Extra &...extra) {
         cpp_function func(std::forward<Func>(f), name(name_), scope(*this),
                           sibling(getattr(*this, name_, none())), extra...);
         // NB: allow overwriting here because cpp_function sets up a chain with the intention of
-        // overwriting (and has already checked internally that it isn't overwriting non-functions).
+        // overwriting (and has already checked internally that it isn't overwriting
+        // non-functions).
         add_object(name_, func, true /* overwrite */);
         return *this;
     }
@@ -986,8 +1049,8 @@ public:
     \endrst */
     // clang-format on
     module_ def_submodule(const char *name, const char *doc = nullptr) {
-        std::string full_name = std::string(PyModule_GetName(m_ptr))
-            + std::string(".") + std::string(name);
+        std::string full_name =
+            std::string(PyModule_GetName(m_ptr)) + std::string(".") + std::string(name);
         auto result = reinterpret_borrow<module_>(PyImport_AddModule(full_name.c_str()));
         if (doc && options::show_user_defined_docstrings())
             result.attr("__doc__") = pybind11::str(doc);
@@ -1022,8 +1085,9 @@ public:
     // clang-format on
     PYBIND11_NOINLINE void add_object(const char *name, handle obj, bool overwrite = false) {
         if (!overwrite && hasattr(*this, name))
-            pybind11_fail("Error during initialization: multiple incompatible definitions with name \"" +
-                    std::string(name) + "\"");
+            pybind11_fail(
+                "Error during initialization: multiple incompatible definitions with name \"" +
+                std::string(name) + "\"");
 
         PyModule_AddObject(ptr(), name, obj.inc_ref().ptr() /* steals a reference */);
     }
@@ -1045,29 +1109,31 @@ public:
     static module_ create_extension_module(const char *name, const char *doc, module_def *def) {
 #if PY_MAJOR_VERSION >= 3
         // module_def is PyModuleDef
-        def = new (def) PyModuleDef {  // Placement new (not an allocation).
-            /* m_base */     PyModuleDef_HEAD_INIT,
-            /* m_name */     name,
-            /* m_doc */      options::show_user_defined_docstrings() ? doc : nullptr,
-            /* m_size */     -1,
-            /* m_methods */  nullptr,
-            /* m_slots */    nullptr,
-            /* m_traverse */ nullptr,
-            /* m_clear */    nullptr,
-            /* m_free */     nullptr
-        };
+        def = new (def)
+            PyModuleDef{// Placement new (not an allocation).
+                        /* m_base */ PyModuleDef_HEAD_INIT,
+                        /* m_name */ name,
+                        /* m_doc */ options::show_user_defined_docstrings() ? doc : nullptr,
+                        /* m_size */ -1,
+                        /* m_methods */ nullptr,
+                        /* m_slots */ nullptr,
+                        /* m_traverse */ nullptr,
+                        /* m_clear */ nullptr,
+                        /* m_free */ nullptr};
         auto m = PyModule_Create(def);
 #else
         // Ignore module_def *def; only necessary for Python 3
-        (void) def;
-        auto m = Py_InitModule3(name, nullptr, options::show_user_defined_docstrings() ? doc : nullptr);
+        (void)def;
+        auto m =
+            Py_InitModule3(name, nullptr, options::show_user_defined_docstrings() ? doc : nullptr);
 #endif
         if (m == nullptr) {
             if (PyErr_Occurred())
                 throw error_already_set();
             pybind11_fail("Internal error in module_::create_extension_module()");
         }
-        // TODO: Should be reinterpret_steal for Python 3, but Python also steals it again when returned from PyInit_...
+        // TODO: Should be reinterpret_steal for Python 3, but Python also steals it again when
+        // returned from PyInit_...
         //       For Python 2, reinterpret_borrow is correct.
         return reinterpret_borrow<module_>(m);
     }
@@ -1093,7 +1159,8 @@ public:
     PYBIND11_OBJECT_DEFAULT(generic_type, object, PyType_Check)
 protected:
     void initialize(const type_record &rec) {
-        if (rec.scope && hasattr(rec.scope, "__dict__") && rec.scope.attr("__dict__").contains(rec.name))
+        if (rec.scope && hasattr(rec.scope, "__dict__") &&
+            rec.scope.attr("__dict__").contains(rec.name))
             pybind11_fail("generic_type: cannot initialize type \"" + std::string(rec.name) +
                           "\": an object with that name is already defined");
 
@@ -1105,7 +1172,7 @@ protected:
 
         /* Register supplemental type information in C++ dict */
         auto *tinfo = new detail::type_info();
-        tinfo->type = (PyTypeObject *) m_ptr;
+        tinfo->type = (PyTypeObject *)m_ptr;
         tinfo->cpptype = rec.type;
         tinfo->type_size = rec.type_size;
         tinfo->type_align = rec.type_align;
@@ -1125,14 +1192,13 @@ protected:
             registered_local_types_cpp()[tindex] = tinfo;
         else
             internals.registered_types_cpp[tindex] = tinfo;
-        internals.registered_types_py[(PyTypeObject *) m_ptr] = { tinfo };
+        internals.registered_types_py[(PyTypeObject *)m_ptr] = {tinfo};
 
         if (rec.bases.size() > 1 || rec.multiple_inheritance) {
             mark_parents_nonsimple(tinfo->type);
             tinfo->simple_ancestors = false;
-        }
-        else if (rec.bases.size() == 1) {
-            auto parent_tinfo = get_type_info((PyTypeObject *) rec.bases[0].ptr());
+        } else if (rec.bases.size() == 1) {
+            auto parent_tinfo = get_type_info((PyTypeObject *)rec.bases[0].ptr());
             tinfo->simple_ancestors = parent_tinfo->simple_ancestors;
         }
 
@@ -1147,86 +1213,94 @@ protected:
     void mark_parents_nonsimple(PyTypeObject *value) {
         auto t = reinterpret_borrow<tuple>(value->tp_bases);
         for (handle h : t) {
-            auto tinfo2 = get_type_info((PyTypeObject *) h.ptr());
+            auto tinfo2 = get_type_info((PyTypeObject *)h.ptr());
             if (tinfo2)
                 tinfo2->simple_type = false;
-            mark_parents_nonsimple((PyTypeObject *) h.ptr());
+            mark_parents_nonsimple((PyTypeObject *)h.ptr());
         }
     }
 
-    void install_buffer_funcs(
-            buffer_info *(*get_buffer)(PyObject *, void *),
-            void *get_buffer_data) {
-        auto *type = (PyHeapTypeObject*) m_ptr;
+    void install_buffer_funcs(buffer_info *(*get_buffer)(PyObject *, void *),
+                              void *get_buffer_data) {
+        auto *type = (PyHeapTypeObject *)m_ptr;
         auto tinfo = detail::get_type_info(&type->ht_type);
 
         if (!type->ht_type.tp_as_buffer)
-            pybind11_fail(
-                "To be able to register buffer protocol support for the type '" +
-                get_fully_qualified_tp_name(tinfo->type) +
-                "' the associated class<>(..) invocation must "
-                "include the pybind11::buffer_protocol() annotation!");
+            pybind11_fail("To be able to register buffer protocol support for the type '" +
+                          get_fully_qualified_tp_name(tinfo->type) +
+                          "' the associated class<>(..) invocation must "
+                          "include the pybind11::buffer_protocol() annotation!");
 
         tinfo->get_buffer = get_buffer;
         tinfo->get_buffer_data = get_buffer_data;
     }
 
     // rec_func must be set for either fget or fset.
-    void def_property_static_impl(const char *name,
-                                  handle fget, handle fset,
+    void def_property_static_impl(const char *name, handle fget, handle fset,
                                   detail::function_record *rec_func) {
         const auto is_static = rec_func && !(rec_func->is_method && rec_func->scope);
-        const auto has_doc = rec_func && rec_func->doc && pybind11::options::show_user_defined_docstrings();
-        auto property = handle((PyObject *) (is_static ? get_internals().static_property_type
-                                                       : &PyProperty_Type));
-        attr(name) = property(fget.ptr() ? fget : none(),
-                              fset.ptr() ? fset : none(),
-                              /*deleter*/none(),
-                              pybind11::str(has_doc ? rec_func->doc : ""));
+        const auto has_doc =
+            rec_func && rec_func->doc && pybind11::options::show_user_defined_docstrings();
+        auto property = handle(
+            (PyObject *)(is_static ? get_internals().static_property_type : &PyProperty_Type));
+        attr(name) = property(fget.ptr() ? fget : none(), fset.ptr() ? fset : none(),
+                              /*deleter*/ none(), pybind11::str(has_doc ? rec_func->doc : ""));
     }
 };
 
 /// Set the pointer to operator new if it exists. The cast is needed because it can be overloaded.
 template <typename T, typename = void_t<decltype(static_cast<void *(*)(size_t)>(T::operator new))>>
-void set_operator_new(type_record *r) { r->operator_new = &T::operator new; }
-
-template <typename> void set_operator_new(...) { }
-
-template <typename T, typename SFINAE = void> struct has_operator_delete : std::false_type { };
-template <typename T> struct has_operator_delete<T, void_t<decltype(static_cast<void (*)(void *)>(T::operator delete))>>
-    : std::true_type { };
-template <typename T, typename SFINAE = void> struct has_operator_delete_size : std::false_type { };
-template <typename T> struct has_operator_delete_size<T, void_t<decltype(static_cast<void (*)(void *, size_t)>(T::operator delete))>>
-    : std::true_type { };
-/// Call class-specific delete if it exists or global otherwise. Can also be an overload set.
-template <typename T, enable_if_t<has_operator_delete<T>::value, int> = 0>
-void call_operator_delete(T *p, size_t, size_t) { T::operator delete(p); }
-template <typename T, enable_if_t<!has_operator_delete<T>::value && has_operator_delete_size<T>::value, int> = 0>
-void call_operator_delete(T *p, size_t s, size_t) { T::operator delete(p, s); }
-
-inline void call_operator_delete(void *p, size_t s, size_t a) {
-    (void)s; (void)a;
-    #if defined(__cpp_aligned_new) && (!defined(_MSC_VER) || _MSC_VER >= 1912)
-        if (a > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
-            #ifdef __cpp_sized_deallocation
-                ::operator delete(p, s, std::align_val_t(a));
-            #else
-                ::operator delete(p, std::align_val_t(a));
-            #endif
-            return;
-        }
-    #endif
-    #ifdef __cpp_sized_deallocation
-        ::operator delete(p, s);
-    #else
-        ::operator delete(p);
-    #endif
+void set_operator_new(type_record *r) {
+    r->operator_new = &T::operator new;
 }
 
-inline void add_class_method(object& cls, const char *name_, const cpp_function &cf) {
+template <typename> void set_operator_new(...) {}
+
+template <typename T, typename SFINAE = void> struct has_operator_delete : std::false_type {};
+template <typename T>
+struct has_operator_delete<T, void_t<decltype(static_cast<void (*)(void *)>(T::operator delete))>>
+    : std::true_type {};
+template <typename T, typename SFINAE = void> struct has_operator_delete_size : std::false_type {};
+template <typename T>
+struct has_operator_delete_size<
+    T, void_t<decltype(static_cast<void (*)(void *, size_t)>(T::operator delete))>>
+    : std::true_type {};
+/// Call class-specific delete if it exists or global otherwise. Can also be an overload set.
+template <typename T, enable_if_t<has_operator_delete<T>::value, int> = 0>
+void call_operator_delete(T *p, size_t, size_t) {
+    T::operator delete(p);
+}
+template <
+    typename T,
+    enable_if_t<!has_operator_delete<T>::value && has_operator_delete_size<T>::value, int> = 0>
+void call_operator_delete(T *p, size_t s, size_t) {
+    T::operator delete(p, s);
+}
+
+inline void call_operator_delete(void *p, size_t s, size_t a) {
+    (void)s;
+    (void)a;
+#if defined(__cpp_aligned_new) && (!defined(_MSC_VER) || _MSC_VER >= 1912)
+    if (a > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
+#ifdef __cpp_sized_deallocation
+        ::operator delete(p, s, std::align_val_t(a));
+#else
+        ::operator delete(p, std::align_val_t(a));
+#endif
+        return;
+    }
+#endif
+#ifdef __cpp_sized_deallocation
+    ::operator delete(p, s);
+#else
+    ::operator delete(p);
+#endif
+}
+
+inline void add_class_method(object &cls, const char *name_, const cpp_function &cf) {
     cls.attr(cf.name()) = cf;
     if (strcmp(name_, "__eq__") == 0 && !cls.attr("__dict__").contains("__hash__")) {
-      cls.attr("__hash__") = none();
+        cls.attr("__hash__") = none();
     }
 }
 
@@ -1235,30 +1309,33 @@ PYBIND11_NAMESPACE_END(detail)
 /// Given a pointer to a member function, cast it to its `Derived` version.
 /// Forward everything else unchanged.
 template <typename /*Derived*/, typename F>
-auto method_adaptor(F &&f) -> decltype(std::forward<F>(f)) { return std::forward<F>(f); }
+auto method_adaptor(F &&f) -> decltype(std::forward<F>(f)) {
+    return std::forward<F>(f);
+}
 
 template <typename Derived, typename Return, typename Class, typename... Args>
 auto method_adaptor(Return (Class::*pmf)(Args...)) -> Return (Derived::*)(Args...) {
-    static_assert(detail::is_accessible_base_of<Class, Derived>::value,
+    static_assert(
+        detail::is_accessible_base_of<Class, Derived>::value,
         "Cannot bind an inaccessible base class method; use a lambda definition instead");
     return pmf;
 }
 
 template <typename Derived, typename Return, typename Class, typename... Args>
 auto method_adaptor(Return (Class::*pmf)(Args...) const) -> Return (Derived::*)(Args...) const {
-    static_assert(detail::is_accessible_base_of<Class, Derived>::value,
+    static_assert(
+        detail::is_accessible_base_of<Class, Derived>::value,
         "Cannot bind an inaccessible base class method; use a lambda definition instead");
     return pmf;
 }
 
-template <typename type_, typename... options>
-class class_ : public detail::generic_type {
+template <typename type_, typename... options> class class_ : public detail::generic_type {
     template <typename T> using is_holder = detail::is_holder_type<type_, T>;
     template <typename T> using is_subtype = detail::is_strict_base_of<type_, T>;
     template <typename T> using is_base = detail::is_strict_base_of<T, type_>;
     // struct instead of using here to help MSVC:
-    template <typename T> struct is_valid_class_option :
-        detail::any_of<is_holder<T>, is_subtype<T>, is_base<T>> {};
+    template <typename T>
+    struct is_valid_class_option : detail::any_of<is_holder<T>, is_subtype<T>, is_base<T>> {};
 
 public:
     using type = type_;
@@ -1267,23 +1344,23 @@ public:
     using holder_type = detail::exactly_one_t<is_holder, std::unique_ptr<type>, options...>;
 
     static_assert(detail::all_of<is_valid_class_option<options>...>::value,
-            "Unknown/invalid class_ template parameters provided");
+                  "Unknown/invalid class_ template parameters provided");
 
     static_assert(!has_alias || std::is_polymorphic<type>::value,
-            "Cannot use an alias class with a non-polymorphic type");
+                  "Cannot use an alias class with a non-polymorphic type");
 
     PYBIND11_OBJECT(class_, generic_type, PyType_Check)
 
-    template <typename... Extra>
-    class_(handle scope, const char *name, const Extra &... extra) {
+    template <typename... Extra> class_(handle scope, const char *name, const Extra &...extra) {
         using namespace detail;
 
         // MI can only be specified via class_ template options, not constructor parameters
         static_assert(
             none_of<is_pyobject<Extra>...>::value || // no base class arguments, or:
-            (   constexpr_sum(is_pyobject<Extra>::value...) == 1 && // Exactly one base
-                constexpr_sum(is_base<options>::value...)   == 0 && // no template option bases
-                none_of<std::is_same<multiple_inheritance, Extra>...>::value), // no multiple_inheritance attr
+                (constexpr_sum(is_pyobject<Extra>::value...) == 1 && // Exactly one base
+                 constexpr_sum(is_base<options>::value...) == 0 &&   // no template option bases
+                 none_of<std::is_same<multiple_inheritance,
+                                      Extra>...>::value), // no multiple_inheritance attr
             "Error: multiple inheritance bases must be specified via class_ template options");
 
         type_record record;
@@ -1291,7 +1368,7 @@ public:
         record.name = name;
         record.type = &typeid(type);
         record.type_size = sizeof(conditional_t<has_alias, type_alias, type>);
-        record.type_align = alignof(conditional_t<has_alias, type_alias, type>&);
+        record.type_align = alignof(conditional_t<has_alias, type_alias, type> &);
         record.holder_size = sizeof(holder_type);
         record.init_instance = init_instance;
         record.dealloc = dealloc;
@@ -1308,8 +1385,10 @@ public:
         generic_type::initialize(record);
 
         if (has_alias) {
-            auto &instances = record.module_local ? registered_local_types_cpp() : get_internals().registered_types_cpp;
-            instances[std::type_index(typeid(type_alias))] = instances[std::type_index(typeid(type))];
+            auto &instances = record.module_local ? registered_local_types_cpp()
+                                                  : get_internals().registered_types_cpp;
+            instances[std::type_index(typeid(type_alias))] =
+                instances[std::type_index(typeid(type))];
         }
     }
 
@@ -1321,20 +1400,20 @@ public:
     }
 
     template <typename Base, detail::enable_if_t<!is_base<Base>::value, int> = 0>
-    static void add_base(detail::type_record &) { }
+    static void add_base(detail::type_record &) {}
 
     template <typename Func, typename... Extra>
-    class_ &def(const char *name_, Func&& f, const Extra&... extra) {
+    class_ &def(const char *name_, Func &&f, const Extra &...extra) {
         cpp_function cf(method_adaptor<type>(std::forward<Func>(f)), name(name_), is_method(*this),
                         sibling(getattr(*this, name_, none())), extra...);
         add_class_method(*this, name_, cf);
         return *this;
     }
 
-    template <typename Func, typename... Extra> class_ &
-    def_static(const char *name_, Func &&f, const Extra&... extra) {
+    template <typename Func, typename... Extra>
+    class_ &def_static(const char *name_, Func &&f, const Extra &...extra) {
         static_assert(!std::is_member_function_pointer<Func>::value,
-                "def_static(...) called with a non-static member function pointer");
+                      "def_static(...) called with a non-static member function pointer");
         cpp_function cf(std::forward<Func>(f), name(name_), scope(*this),
                         sibling(getattr(*this, name_, none())), extra...);
         attr(cf.name()) = staticmethod(cf);
@@ -1342,31 +1421,31 @@ public:
     }
 
     template <detail::op_id id, detail::op_type ot, typename L, typename R, typename... Extra>
-    class_ &def(const detail::op_<id, ot, L, R> &op, const Extra&... extra) {
+    class_ &def(const detail::op_<id, ot, L, R> &op, const Extra &...extra) {
         op.execute(*this, extra...);
         return *this;
     }
 
     template <detail::op_id id, detail::op_type ot, typename L, typename R, typename... Extra>
-    class_ & def_cast(const detail::op_<id, ot, L, R> &op, const Extra&... extra) {
+    class_ &def_cast(const detail::op_<id, ot, L, R> &op, const Extra &...extra) {
         op.execute_cast(*this, extra...);
         return *this;
     }
 
     template <typename... Args, typename... Extra>
-    class_ &def(const detail::initimpl::constructor<Args...> &init, const Extra&... extra) {
+    class_ &def(const detail::initimpl::constructor<Args...> &init, const Extra &...extra) {
         init.execute(*this, extra...);
         return *this;
     }
 
     template <typename... Args, typename... Extra>
-    class_ &def(const detail::initimpl::alias_constructor<Args...> &init, const Extra&... extra) {
+    class_ &def(const detail::initimpl::alias_constructor<Args...> &init, const Extra &...extra) {
         init.execute(*this, extra...);
         return *this;
     }
 
     template <typename... Args, typename... Extra>
-    class_ &def(detail::initimpl::factory<Args...> &&init, const Extra&... extra) {
+    class_ &def(detail::initimpl::factory<Args...> &&init, const Extra &...extra) {
         std::move(init).execute(*this, extra...);
         return *this;
     }
@@ -1377,52 +1456,58 @@ public:
         return *this;
     }
 
-    template <typename Func>
-    class_& def_buffer(Func &&func) {
-        struct capture { Func func; };
-        auto *ptr = new capture { std::forward<Func>(func) };
-        install_buffer_funcs([](PyObject *obj, void *ptr) -> buffer_info* {
-            detail::make_caster<type> caster;
-            if (!caster.load(obj, false))
-                return nullptr;
-            return new buffer_info(((capture *) ptr)->func(caster));
-        }, ptr);
+    template <typename Func> class_ &def_buffer(Func &&func) {
+        struct capture {
+            Func func;
+        };
+        auto *ptr = new capture{std::forward<Func>(func)};
+        install_buffer_funcs(
+            [](PyObject *obj, void *ptr) -> buffer_info * {
+                detail::make_caster<type> caster;
+                if (!caster.load(obj, false))
+                    return nullptr;
+                return new buffer_info(((capture *)ptr)->func(caster));
+            },
+            ptr);
         weakref(m_ptr, cpp_function([ptr](handle wr) {
-            delete ptr;
-            wr.dec_ref();
-        })).release();
+                    delete ptr;
+                    wr.dec_ref();
+                }))
+            .release();
         return *this;
     }
 
     template <typename Return, typename Class, typename... Args>
     class_ &def_buffer(Return (Class::*func)(Args...)) {
-        return def_buffer([func] (type &obj) { return (obj.*func)(); });
+        return def_buffer([func](type &obj) { return (obj.*func)(); });
     }
 
     template <typename Return, typename Class, typename... Args>
     class_ &def_buffer(Return (Class::*func)(Args...) const) {
-        return def_buffer([func] (const type &obj) { return (obj.*func)(); });
+        return def_buffer([func](const type &obj) { return (obj.*func)(); });
     }
 
     template <typename C, typename D, typename... Extra>
-    class_ &def_readwrite(const char *name, D C::*pm, const Extra&... extra) {
-        static_assert(std::is_same<C, type>::value || std::is_base_of<C, type>::value, "def_readwrite() requires a class member (or base class member)");
-        cpp_function fget([pm](const type &c) -> const D &{ return c.*pm; }, is_method(*this)),
-                     fset([pm](type &c, const D &value) { c.*pm = value; }, is_method(*this));
+    class_ &def_readwrite(const char *name, D C::*pm, const Extra &...extra) {
+        static_assert(std::is_same<C, type>::value || std::is_base_of<C, type>::value,
+                      "def_readwrite() requires a class member (or base class member)");
+        cpp_function fget([pm](const type &c) -> const D & { return c.*pm; }, is_method(*this)),
+            fset([pm](type &c, const D &value) { c.*pm = value; }, is_method(*this));
         def_property(name, fget, fset, return_value_policy::reference_internal, extra...);
         return *this;
     }
 
     template <typename C, typename D, typename... Extra>
-    class_ &def_readonly(const char *name, const D C::*pm, const Extra& ...extra) {
-        static_assert(std::is_same<C, type>::value || std::is_base_of<C, type>::value, "def_readonly() requires a class member (or base class member)");
-        cpp_function fget([pm](const type &c) -> const D &{ return c.*pm; }, is_method(*this));
+    class_ &def_readonly(const char *name, const D C::*pm, const Extra &...extra) {
+        static_assert(std::is_same<C, type>::value || std::is_base_of<C, type>::value,
+                      "def_readonly() requires a class member (or base class member)");
+        cpp_function fget([pm](const type &c) -> const D & { return c.*pm; }, is_method(*this));
         def_property_readonly(name, fget, return_value_policy::reference_internal, extra...);
         return *this;
     }
 
     template <typename D, typename... Extra>
-    class_ &def_readwrite_static(const char *name, D *pm, const Extra& ...extra) {
+    class_ &def_readwrite_static(const char *name, D *pm, const Extra &...extra) {
         cpp_function fget([pm](const object &) -> const D & { return *pm; }, scope(*this)),
             fset([pm](const object &, const D &value) { *pm = value; }, scope(*this));
         def_property_static(name, fget, fset, return_value_policy::reference, extra...);
@@ -1430,7 +1515,7 @@ public:
     }
 
     template <typename D, typename... Extra>
-    class_ &def_readonly_static(const char *name, const D *pm, const Extra& ...extra) {
+    class_ &def_readonly_static(const char *name, const D *pm, const Extra &...extra) {
         cpp_function fget([pm](const object &) -> const D & { return *pm; }, scope(*this));
         def_property_readonly_static(name, fget, return_value_policy::reference, extra...);
         return *this;
@@ -1438,66 +1523,78 @@ public:
 
     /// Uses return_value_policy::reference_internal by default
     template <typename Getter, typename... Extra>
-    class_ &def_property_readonly(const char *name, const Getter &fget, const Extra& ...extra) {
+    class_ &def_property_readonly(const char *name, const Getter &fget, const Extra &...extra) {
         return def_property_readonly(name, cpp_function(method_adaptor<type>(fget)),
                                      return_value_policy::reference_internal, extra...);
     }
 
     /// Uses cpp_function's return_value_policy by default
     template <typename... Extra>
-    class_ &def_property_readonly(const char *name, const cpp_function &fget, const Extra& ...extra) {
+    class_ &def_property_readonly(const char *name, const cpp_function &fget,
+                                  const Extra &...extra) {
         return def_property(name, fget, nullptr, extra...);
     }
 
     /// Uses return_value_policy::reference by default
     template <typename Getter, typename... Extra>
-    class_ &def_property_readonly_static(const char *name, const Getter &fget, const Extra& ...extra) {
-        return def_property_readonly_static(name, cpp_function(fget), return_value_policy::reference, extra...);
+    class_ &def_property_readonly_static(const char *name, const Getter &fget,
+                                         const Extra &...extra) {
+        return def_property_readonly_static(name, cpp_function(fget),
+                                            return_value_policy::reference, extra...);
     }
 
     /// Uses cpp_function's return_value_policy by default
     template <typename... Extra>
-    class_ &def_property_readonly_static(const char *name, const cpp_function &fget, const Extra& ...extra) {
+    class_ &def_property_readonly_static(const char *name, const cpp_function &fget,
+                                         const Extra &...extra) {
         return def_property_static(name, fget, nullptr, extra...);
     }
 
     /// Uses return_value_policy::reference_internal by default
     template <typename Getter, typename Setter, typename... Extra>
-    class_ &def_property(const char *name, const Getter &fget, const Setter &fset, const Extra& ...extra) {
+    class_ &def_property(const char *name, const Getter &fget, const Setter &fset,
+                         const Extra &...extra) {
         return def_property(name, fget, cpp_function(method_adaptor<type>(fset)), extra...);
     }
     template <typename Getter, typename... Extra>
-    class_ &def_property(const char *name, const Getter &fget, const cpp_function &fset, const Extra& ...extra) {
+    class_ &def_property(const char *name, const Getter &fget, const cpp_function &fset,
+                         const Extra &...extra) {
         return def_property(name, cpp_function(method_adaptor<type>(fget)), fset,
                             return_value_policy::reference_internal, extra...);
     }
 
     /// Uses cpp_function's return_value_policy by default
     template <typename... Extra>
-    class_ &def_property(const char *name, const cpp_function &fget, const cpp_function &fset, const Extra& ...extra) {
+    class_ &def_property(const char *name, const cpp_function &fget, const cpp_function &fset,
+                         const Extra &...extra) {
         return def_property_static(name, fget, fset, is_method(*this), extra...);
     }
 
     /// Uses return_value_policy::reference by default
     template <typename Getter, typename... Extra>
-    class_ &def_property_static(const char *name, const Getter &fget, const cpp_function &fset, const Extra& ...extra) {
-        return def_property_static(name, cpp_function(fget), fset, return_value_policy::reference, extra...);
+    class_ &def_property_static(const char *name, const Getter &fget, const cpp_function &fset,
+                                const Extra &...extra) {
+        return def_property_static(name, cpp_function(fget), fset, return_value_policy::reference,
+                                   extra...);
     }
 
     /// Uses cpp_function's return_value_policy by default
     template <typename... Extra>
-    class_ &def_property_static(const char *name, const cpp_function &fget, const cpp_function &fset, const Extra& ...extra) {
-        static_assert( 0 == detail::constexpr_sum(std::is_base_of<arg, Extra>::value...),
+    class_ &def_property_static(const char *name, const cpp_function &fget,
+                                const cpp_function &fset, const Extra &...extra) {
+        static_assert(0 == detail::constexpr_sum(std::is_base_of<arg, Extra>::value...),
                       "Argument annotations are not allowed for properties");
         auto rec_fget = get_function_record(fget), rec_fset = get_function_record(fset);
         auto *rec_active = rec_fget;
         if (rec_fget) {
-           char *doc_prev = rec_fget->doc; /* 'extra' field may include a property-specific documentation string */
-           detail::process_attributes<Extra...>::init(extra..., rec_fget);
-           if (rec_fget->doc && rec_fget->doc != doc_prev) {
-              free(doc_prev);
-              rec_fget->doc = strdup(rec_fget->doc);
-           }
+            char *doc_prev =
+                rec_fget
+                    ->doc; /* 'extra' field may include a property-specific documentation string */
+            detail::process_attributes<Extra...>::init(extra..., rec_fget);
+            if (rec_fget->doc && rec_fget->doc != doc_prev) {
+                free(doc_prev);
+                rec_fget->doc = strdup(rec_fget->doc);
+            }
         }
         if (rec_fset) {
             char *doc_prev = rec_fset->doc;
@@ -1506,7 +1603,8 @@ public:
                 free(doc_prev);
                 rec_fset->doc = strdup(rec_fset->doc);
             }
-            if (! rec_active) rec_active = rec_fset;
+            if (!rec_active)
+                rec_active = rec_fset;
         }
         def_property_static_impl(name, fget, fset, rec_active);
         return *this;
@@ -1516,10 +1614,11 @@ private:
     /// Initialize holder object, variant 1: object derives from enable_shared_from_this
     template <typename T>
     static void init_holder(detail::instance *inst, detail::value_and_holder &v_h,
-            const holder_type * /* unused */, const std::enable_shared_from_this<T> * /* dummy */) {
+                            const holder_type * /* unused */,
+                            const std::enable_shared_from_this<T> * /* dummy */) {
 
         auto sh = std::dynamic_pointer_cast<typename holder_type::element_type>(
-                detail::try_get_shared_from_this(v_h.value_ptr<type>()));
+            detail::try_get_shared_from_this(v_h.value_ptr<type>()));
         if (sh) {
             new (std::addressof(v_h.holder<holder_type>())) holder_type(std::move(sh));
             v_h.set_holder_constructed();
@@ -1532,18 +1631,24 @@ private:
     }
 
     static void init_holder_from_existing(const detail::value_and_holder &v_h,
-            const holder_type *holder_ptr, std::true_type /*is_copy_constructible*/) {
-        new (std::addressof(v_h.holder<holder_type>())) holder_type(*reinterpret_cast<const holder_type *>(holder_ptr));
+                                          const holder_type *holder_ptr,
+                                          std::true_type /*is_copy_constructible*/) {
+        new (std::addressof(v_h.holder<holder_type>()))
+            holder_type(*reinterpret_cast<const holder_type *>(holder_ptr));
     }
 
     static void init_holder_from_existing(const detail::value_and_holder &v_h,
-            const holder_type *holder_ptr, std::false_type /*is_copy_constructible*/) {
-        new (std::addressof(v_h.holder<holder_type>())) holder_type(std::move(*const_cast<holder_type *>(holder_ptr)));
+                                          const holder_type *holder_ptr,
+                                          std::false_type /*is_copy_constructible*/) {
+        new (std::addressof(v_h.holder<holder_type>()))
+            holder_type(std::move(*const_cast<holder_type *>(holder_ptr)));
     }
 
-    /// Initialize holder object, variant 2: try to construct from existing holder object, if possible
+    /// Initialize holder object, variant 2: try to construct from existing holder object, if
+    /// possible
     static void init_holder(detail::instance *inst, detail::value_and_holder &v_h,
-            const holder_type *holder_ptr, const void * /* dummy -- not enable_shared_from_this<T>) */) {
+                            const holder_type *holder_ptr,
+                            const void * /* dummy -- not enable_shared_from_this<T>) */) {
         if (holder_ptr) {
             init_holder_from_existing(v_h, holder_ptr, std::is_copy_constructible<holder_type>());
             v_h.set_holder_constructed();
@@ -1554,8 +1659,8 @@ private:
     }
 
     /// Performs instance initialization including constructing a holder and registering the known
-    /// instance.  Should be called as soon as the `type` value_ptr is set for an instance.  Takes an
-    /// optional pointer to an existing holder to use; if not specified and the instance is
+    /// instance.  Should be called as soon as the `type` value_ptr is set for an instance.  Takes
+    /// an optional pointer to an existing holder to use; if not specified and the instance is
     /// `.owned`, a new holder will be constructed to manage the value pointer.
     static void init_instance(detail::instance *inst, const void *holder_ptr) {
         auto v_h = inst->get_value_and_holder(detail::get_type_info(typeid(type)));
@@ -1563,7 +1668,7 @@ private:
             register_instance(inst, v_h.value_ptr(), v_h.type);
             v_h.set_instance_registered();
         }
-        init_holder(inst, v_h, (const holder_type *) holder_ptr, v_h.value_ptr<type>());
+        init_holder(inst, v_h, (const holder_type *)holder_ptr, v_h.value_ptr<type>());
     }
 
     /// Deallocates an instance; via holder, if constructed; otherwise via operator delete.
@@ -1578,19 +1683,17 @@ private:
         if (v_h.holder_constructed()) {
             v_h.holder<holder_type>().~holder_type();
             v_h.set_holder_constructed(false);
-        }
-        else {
-            detail::call_operator_delete(v_h.value_ptr<type>(),
-                v_h.type->type_size,
-                v_h.type->type_align
-            );
+        } else {
+            detail::call_operator_delete(v_h.value_ptr<type>(), v_h.type->type_size,
+                                         v_h.type->type_align);
         }
         v_h.value_ptr() = nullptr;
     }
 
     static detail::function_record *get_function_record(handle h) {
         h = detail::get_function(h);
-        return h ? (detail::function_record *) reinterpret_borrow<capsule>(PyCFunction_GET_SELF(h.ptr()))
+        return h ? (detail::function_record *)reinterpret_borrow<capsule>(
+                       PyCFunction_GET_SELF(h.ptr()))
                  : nullptr;
     }
 };
@@ -1599,14 +1702,18 @@ private:
 template <typename... Args> detail::initimpl::constructor<Args...> init() { return {}; }
 /// Like `init<Args...>()`, but the instance is always constructed through the alias class (even
 /// when not inheriting on the Python side).
-template <typename... Args> detail::initimpl::alias_constructor<Args...> init_alias() { return {}; }
+template <typename... Args> detail::initimpl::alias_constructor<Args...> init_alias() {
+    return {};
+}
 
 /// Binds a factory function as a constructor
-template <typename Func, typename Ret = detail::initimpl::factory<Func>>
-Ret init(Func &&f) { return {std::forward<Func>(f)}; }
+template <typename Func, typename Ret = detail::initimpl::factory<Func>> Ret init(Func &&f) {
+    return {std::forward<Func>(f)};
+}
 
-/// Dual-argument factory function: the first function is called when no alias is needed, the second
-/// when an alias is needed (i.e. due to python-side inheritance).  Arguments must be identical.
+/// Dual-argument factory function: the first function is called when no alias is needed, the
+/// second when an alias is needed (i.e. due to python-side inheritance).  Arguments must be
+/// identical.
 template <typename CFunc, typename AFunc, typename Ret = detail::initimpl::factory<CFunc, AFunc>>
 Ret init(CFunc &&c, AFunc &&a) {
     return {std::forward<CFunc>(c), std::forward<AFunc>(a)};
@@ -1631,12 +1738,12 @@ inline str enum_name(handle arg) {
 }
 
 struct enum_base {
-    enum_base(handle base, handle parent) : m_base(base), m_parent(parent) { }
+    enum_base(handle base, handle parent) : m_base(base), m_parent(parent) {}
 
     PYBIND11_NOINLINE void init(bool is_arithmetic, bool is_convertible) {
         m_base.attr("__entries") = dict();
-        auto property = handle((PyObject *) &PyProperty_Type);
-        auto static_property = handle((PyObject *) get_internals().static_property_type);
+        auto property = handle((PyObject *)&PyProperty_Type);
+        auto static_property = handle((PyObject *)get_internals().static_property_type);
 
         m_base.attr("__repr__") = cpp_function(
             [](const object &arg) -> str {
@@ -1644,8 +1751,7 @@ struct enum_base {
                 object type_name = type.attr("__name__");
                 return pybind11::str("<{}.{}: {}>").format(type_name, enum_name(arg), int_(arg));
             },
-            name("__repr__"),
-            is_method(m_base));
+            name("__repr__"), is_method(m_base));
 
         m_base.attr("name") = property(cpp_function(&enum_name, name("name"), is_method(m_base)));
 
@@ -1653,35 +1759,39 @@ struct enum_base {
             [](handle arg) -> str {
                 object type_name = type::handle_of(arg).attr("__name__");
                 return pybind11::str("{}.{}").format(type_name, enum_name(arg));
-            }, name("name"), is_method(m_base)
-        );
+            },
+            name("name"), is_method(m_base));
 
-        m_base.attr("__doc__") = static_property(cpp_function(
-            [](handle arg) -> std::string {
-                std::string docstring;
-                dict entries = arg.attr("__entries");
-                if (((PyTypeObject *) arg.ptr())->tp_doc)
-                    docstring += std::string(((PyTypeObject *) arg.ptr())->tp_doc) + "\n\n";
-                docstring += "Members:";
-                for (auto kv : entries) {
-                    auto key = std::string(pybind11::str(kv.first));
-                    auto comment = kv.second[int_(1)];
-                    docstring += "\n\n  " + key;
-                    if (!comment.is_none())
-                        docstring += " : " + (std::string) pybind11::str(comment);
-                }
-                return docstring;
-            }, name("__doc__")
-        ), none(), none(), "");
+        m_base.attr("__doc__") = static_property(
+            cpp_function(
+                [](handle arg) -> std::string {
+                    std::string docstring;
+                    dict entries = arg.attr("__entries");
+                    if (((PyTypeObject *)arg.ptr())->tp_doc)
+                        docstring += std::string(((PyTypeObject *)arg.ptr())->tp_doc) + "\n\n";
+                    docstring += "Members:";
+                    for (auto kv : entries) {
+                        auto key = std::string(pybind11::str(kv.first));
+                        auto comment = kv.second[int_(1)];
+                        docstring += "\n\n  " + key;
+                        if (!comment.is_none())
+                            docstring += " : " + (std::string)pybind11::str(comment);
+                    }
+                    return docstring;
+                },
+                name("__doc__")),
+            none(), none(), "");
 
         m_base.attr("__members__") = static_property(cpp_function(
-            [](handle arg) -> dict {
-                dict entries = arg.attr("__entries"), m;
-                for (auto kv : entries)
-                    m[kv.first] = kv.second[int_(0)];
-                return m;
-            }, name("__members__")), none(), none(), ""
-        );
+                                                         [](handle arg) -> dict {
+                                                             dict entries = arg.attr("__entries"),
+                                                                  m;
+                                                             for (auto kv : entries)
+                                                                 m[kv.first] = kv.second[int_(0)];
+                                                             return m;
+                                                         },
+                                                         name("__members__")),
+                                                     none(), none(), "");
 
 #define PYBIND11_ENUM_OP_STRICT(op, expr, strict_behavior)                                        \
     m_base.attr(op) = cpp_function(                                                               \
@@ -1690,9 +1800,7 @@ struct enum_base {
                 strict_behavior;                                                                  \
             return expr;                                                                          \
         },                                                                                        \
-        name(op),                                                                                 \
-        is_method(m_base),                                                                        \
-        arg("other"))
+        name(op), is_method(m_base), arg("other"))
 
 #define PYBIND11_ENUM_OP_CONV(op, expr)                                                           \
     m_base.attr(op) = cpp_function(                                                               \
@@ -1700,9 +1808,7 @@ struct enum_base {
             int_ a(a_), b(b_);                                                                    \
             return expr;                                                                          \
         },                                                                                        \
-        name(op),                                                                                 \
-        is_method(m_base),                                                                        \
-        arg("other"))
+        name(op), is_method(m_base), arg("other"))
 
 #define PYBIND11_ENUM_OP_CONV_LHS(op, expr)                                                       \
     m_base.attr(op) = cpp_function(                                                               \
@@ -1710,61 +1816,59 @@ struct enum_base {
             int_ a(a_);                                                                           \
             return expr;                                                                          \
         },                                                                                        \
-        name(op),                                                                                 \
-        is_method(m_base),                                                                        \
-        arg("other"))
+        name(op), is_method(m_base), arg("other"))
 
         if (is_convertible) {
-            PYBIND11_ENUM_OP_CONV_LHS("__eq__", !b.is_none() &&  a.equal(b));
-            PYBIND11_ENUM_OP_CONV_LHS("__ne__",  b.is_none() || !a.equal(b));
+            PYBIND11_ENUM_OP_CONV_LHS("__eq__", !b.is_none() && a.equal(b));
+            PYBIND11_ENUM_OP_CONV_LHS("__ne__", b.is_none() || !a.equal(b));
 
             if (is_arithmetic) {
-                PYBIND11_ENUM_OP_CONV("__lt__",   a <  b);
-                PYBIND11_ENUM_OP_CONV("__gt__",   a >  b);
-                PYBIND11_ENUM_OP_CONV("__le__",   a <= b);
-                PYBIND11_ENUM_OP_CONV("__ge__",   a >= b);
-                PYBIND11_ENUM_OP_CONV("__and__",  a &  b);
-                PYBIND11_ENUM_OP_CONV("__rand__", a &  b);
-                PYBIND11_ENUM_OP_CONV("__or__",   a |  b);
-                PYBIND11_ENUM_OP_CONV("__ror__",  a |  b);
-                PYBIND11_ENUM_OP_CONV("__xor__",  a ^  b);
-                PYBIND11_ENUM_OP_CONV("__rxor__", a ^  b);
-                m_base.attr("__invert__")
-                    = cpp_function([](const object &arg) { return ~(int_(arg)); },
-                                   name("__invert__"),
-                                   is_method(m_base));
+                PYBIND11_ENUM_OP_CONV("__lt__", a < b);
+                PYBIND11_ENUM_OP_CONV("__gt__", a > b);
+                PYBIND11_ENUM_OP_CONV("__le__", a <= b);
+                PYBIND11_ENUM_OP_CONV("__ge__", a >= b);
+                PYBIND11_ENUM_OP_CONV("__and__", a & b);
+                PYBIND11_ENUM_OP_CONV("__rand__", a & b);
+                PYBIND11_ENUM_OP_CONV("__or__", a | b);
+                PYBIND11_ENUM_OP_CONV("__ror__", a | b);
+                PYBIND11_ENUM_OP_CONV("__xor__", a ^ b);
+                PYBIND11_ENUM_OP_CONV("__rxor__", a ^ b);
+                m_base.attr("__invert__") =
+                    cpp_function([](const object &arg) { return ~(int_(arg)); },
+                                 name("__invert__"), is_method(m_base));
             }
         } else {
-            PYBIND11_ENUM_OP_STRICT("__eq__",  int_(a).equal(int_(b)), return false);
+            PYBIND11_ENUM_OP_STRICT("__eq__", int_(a).equal(int_(b)), return false);
             PYBIND11_ENUM_OP_STRICT("__ne__", !int_(a).equal(int_(b)), return true);
 
             if (is_arithmetic) {
-                #define PYBIND11_THROW throw type_error("Expected an enumeration of matching type!");
-                PYBIND11_ENUM_OP_STRICT("__lt__", int_(a) <  int_(b), PYBIND11_THROW);
-                PYBIND11_ENUM_OP_STRICT("__gt__", int_(a) >  int_(b), PYBIND11_THROW);
+#define PYBIND11_THROW throw type_error("Expected an enumeration of matching type!");
+                PYBIND11_ENUM_OP_STRICT("__lt__", int_(a) < int_(b), PYBIND11_THROW);
+                PYBIND11_ENUM_OP_STRICT("__gt__", int_(a) > int_(b), PYBIND11_THROW);
                 PYBIND11_ENUM_OP_STRICT("__le__", int_(a) <= int_(b), PYBIND11_THROW);
                 PYBIND11_ENUM_OP_STRICT("__ge__", int_(a) >= int_(b), PYBIND11_THROW);
-                #undef PYBIND11_THROW
+#undef PYBIND11_THROW
             }
         }
 
-        #undef PYBIND11_ENUM_OP_CONV_LHS
-        #undef PYBIND11_ENUM_OP_CONV
-        #undef PYBIND11_ENUM_OP_STRICT
+#undef PYBIND11_ENUM_OP_CONV_LHS
+#undef PYBIND11_ENUM_OP_CONV
+#undef PYBIND11_ENUM_OP_STRICT
 
-        m_base.attr("__getstate__") = cpp_function(
-            [](const object &arg) { return int_(arg); }, name("__getstate__"), is_method(m_base));
+        m_base.attr("__getstate__") = cpp_function([](const object &arg) { return int_(arg); },
+                                                   name("__getstate__"), is_method(m_base));
 
-        m_base.attr("__hash__") = cpp_function(
-            [](const object &arg) { return int_(arg); }, name("__hash__"), is_method(m_base));
+        m_base.attr("__hash__") = cpp_function([](const object &arg) { return int_(arg); },
+                                               name("__hash__"), is_method(m_base));
     }
 
-    PYBIND11_NOINLINE void value(char const* name_, object value, const char *doc = nullptr) {
+    PYBIND11_NOINLINE void value(char const *name_, object value, const char *doc = nullptr) {
         dict entries = m_base.attr("__entries");
         str name(name_);
         if (entries.contains(name)) {
-            std::string type_name = (std::string) str(m_base.attr("__name__"));
-            throw value_error(type_name + ": element \"" + std::string(name_) + "\" already exists!");
+            std::string type_name = (std::string)str(m_base.attr("__name__"));
+            throw value_error(type_name + ": element \"" + std::string(name_) +
+                              "\" already exists!");
         }
 
         entries[name] = std::make_pair(value, doc);
@@ -1787,45 +1891,46 @@ PYBIND11_NAMESPACE_END(detail)
 template <typename Type> class enum_ : public class_<Type> {
 public:
     using Base = class_<Type>;
-    using Base::def;
     using Base::attr;
+    using Base::def;
     using Base::def_property_readonly;
     using Base::def_property_readonly_static;
     using Scalar = typename std::underlying_type<Type>::type;
 
     template <typename... Extra>
-    enum_(const handle &scope, const char *name, const Extra&... extra)
-      : class_<Type>(scope, name, extra...), m_base(*this, scope) {
+    enum_(const handle &scope, const char *name, const Extra &...extra)
+        : class_<Type>(scope, name, extra...), m_base(*this, scope) {
         constexpr bool is_arithmetic = detail::any_of<std::is_same<arithmetic, Extra>...>::value;
         constexpr bool is_convertible = std::is_convertible<Type, Scalar>::value;
         m_base.init(is_arithmetic, is_convertible);
 
         def(init([](Scalar i) { return static_cast<Type>(i); }), arg("value"));
-        def_property_readonly("value", [](Type value) { return (Scalar) value; });
-        def("__int__", [](Type value) { return (Scalar) value; });
-        #if PY_MAJOR_VERSION < 3
-            def("__long__", [](Type value) { return (Scalar) value; });
-        #endif
-        #if PY_MAJOR_VERSION > 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 8)
-            def("__index__", [](Type value) { return (Scalar) value; });
-        #endif
+        def_property_readonly("value", [](Type value) { return (Scalar)value; });
+        def("__int__", [](Type value) { return (Scalar)value; });
+#if PY_MAJOR_VERSION < 3
+        def("__long__", [](Type value) { return (Scalar)value; });
+#endif
+#if PY_MAJOR_VERSION > 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 8)
+        def("__index__", [](Type value) { return (Scalar)value; });
+#endif
 
         attr("__setstate__") = cpp_function(
             [](detail::value_and_holder &v_h, Scalar arg) {
                 detail::initimpl::setstate<Base>(v_h, static_cast<Type>(arg),
-                        Py_TYPE(v_h.inst) != v_h.type->type); },
-            detail::is_new_style_constructor(),
-            pybind11::name("__setstate__"), is_method(*this), arg("state"));
+                                                 Py_TYPE(v_h.inst) != v_h.type->type);
+            },
+            detail::is_new_style_constructor(), pybind11::name("__setstate__"), is_method(*this),
+            arg("state"));
     }
 
     /// Export enumeration entries into the parent scope
-    enum_& export_values() {
+    enum_ &export_values() {
         m_base.export_values();
         return *this;
     }
 
     /// Add an enumeration entry
-    enum_& value(char const* name, Type value, const char *doc = nullptr) {
+    enum_ &value(char const *name, Type value, const char *doc = nullptr) {
         m_base.value(name, pybind11::cast(value, return_value_policy::copy), doc);
         return *this;
     }
@@ -1835,7 +1940,6 @@ private:
 };
 
 PYBIND11_NAMESPACE_BEGIN(detail)
-
 
 inline void keep_alive_impl(handle nurse, handle patient) {
     if (!nurse || !patient)
@@ -1849,22 +1953,24 @@ inline void keep_alive_impl(handle nurse, handle patient) {
         /* It's a pybind-registered type, so we can store the patient in the
          * internal list. */
         add_patient(nurse.ptr(), patient.ptr());
-    }
-    else {
+    } else {
         /* Fall back to clever approach based on weak references taken from
          * Boost.Python. This is not used for pybind-registered types because
          * the objects can be destroyed out-of-order in a GC pass. */
-        cpp_function disable_lifesupport(
-            [patient](handle weakref) { patient.dec_ref(); weakref.dec_ref(); });
+        cpp_function disable_lifesupport([patient](handle weakref) {
+            patient.dec_ref();
+            weakref.dec_ref();
+        });
 
         weakref wr(nurse, disable_lifesupport);
 
         patient.inc_ref(); /* reference patient and leak the weak reference */
-        (void) wr.release();
+        (void)wr.release();
     }
 }
 
-PYBIND11_NOINLINE inline void keep_alive_impl(size_t Nurse, size_t Patient, function_call &call, handle ret) {
+PYBIND11_NOINLINE inline void keep_alive_impl(size_t Nurse, size_t Patient, function_call &call,
+                                              handle ret) {
     auto get_arg = [&](size_t n) {
         if (n == 0)
             return ret;
@@ -1878,20 +1984,23 @@ PYBIND11_NOINLINE inline void keep_alive_impl(size_t Nurse, size_t Patient, func
     keep_alive_impl(get_arg(Nurse), get_arg(Patient));
 }
 
-inline std::pair<decltype(internals::registered_types_py)::iterator, bool> all_type_info_get_cache(PyTypeObject *type) {
-    auto res = get_internals().registered_types_py
+inline std::pair<decltype(internals::registered_types_py)::iterator, bool>
+all_type_info_get_cache(PyTypeObject *type) {
+    auto res = get_internals()
+                   .registered_types_py
 #ifdef __cpp_lib_unordered_map_try_emplace
-        .try_emplace(type);
+                   .try_emplace(type);
 #else
-        .emplace(type, std::vector<detail::type_info *>());
+                   .emplace(type, std::vector<detail::type_info *>());
 #endif
     if (res.second) {
         // New cache entry created; set up a weak reference to automatically remove it if the type
         // gets destroyed:
-        weakref((PyObject *) type, cpp_function([type](handle wr) {
-            get_internals().registered_types_py.erase(type);
-            wr.dec_ref();
-        })).release();
+        weakref((PyObject *)type, cpp_function([type](handle wr) {
+                    get_internals().registered_types_py.erase(type);
+                    wr.dec_ref();
+                }))
+            .release();
     }
 
     return res;
@@ -1907,30 +2016,32 @@ struct iterator_state {
 PYBIND11_NAMESPACE_END(detail)
 
 /// Makes a python iterator from a first and past-the-end C++ InputIterator.
-template <return_value_policy Policy = return_value_policy::reference_internal,
-          typename Iterator,
+template <return_value_policy Policy = return_value_policy::reference_internal, typename Iterator,
           typename Sentinel,
-#ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Issue in breathe 4.26.1
           typename ValueType = decltype(*std::declval<Iterator>()),
 #endif
           typename... Extra>
-iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
+iterator make_iterator(Iterator first, Sentinel last, Extra &&...extra) {
     using state = detail::iterator_state<Iterator, Sentinel, false, Policy>;
 
     if (!detail::get_type_info(typeid(state), false)) {
         class_<state>(handle(), "iterator", pybind11::module_local())
-            .def("__iter__", [](state &s) -> state& { return s; })
-            .def("__next__", [](state &s) -> ValueType {
-                if (!s.first_or_done)
-                    ++s.it;
-                else
-                    s.first_or_done = false;
-                if (s.it == s.end) {
-                    s.first_or_done = true;
-                    throw stop_iteration();
-                }
-                return *s.it;
-            }, std::forward<Extra>(extra)..., Policy);
+            .def("__iter__", [](state &s) -> state & { return s; })
+            .def(
+                "__next__",
+                [](state &s) -> ValueType {
+                    if (!s.first_or_done)
+                        ++s.it;
+                    else
+                        s.first_or_done = false;
+                    if (s.it == s.end) {
+                        s.first_or_done = true;
+                        throw stop_iteration();
+                    }
+                    return *s.it;
+                },
+                std::forward<Extra>(extra)..., Policy);
     }
 
     return cast(state{first, last, true});
@@ -1938,30 +2049,32 @@ iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
 
 /// Makes an python iterator over the keys (`.first`) of a iterator over pairs from a
 /// first and past-the-end InputIterator.
-template <return_value_policy Policy = return_value_policy::reference_internal,
-          typename Iterator,
+template <return_value_policy Policy = return_value_policy::reference_internal, typename Iterator,
           typename Sentinel,
-#ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Issue in breathe 4.26.1
           typename KeyType = decltype((*std::declval<Iterator>()).first),
 #endif
           typename... Extra>
-iterator make_key_iterator(Iterator first, Sentinel last, Extra &&... extra) {
+iterator make_key_iterator(Iterator first, Sentinel last, Extra &&...extra) {
     using state = detail::iterator_state<Iterator, Sentinel, true, Policy>;
 
     if (!detail::get_type_info(typeid(state), false)) {
         class_<state>(handle(), "iterator", pybind11::module_local())
-            .def("__iter__", [](state &s) -> state& { return s; })
-            .def("__next__", [](state &s) -> KeyType {
-                if (!s.first_or_done)
-                    ++s.it;
-                else
-                    s.first_or_done = false;
-                if (s.it == s.end) {
-                    s.first_or_done = true;
-                    throw stop_iteration();
-                }
-                return (*s.it).first;
-            }, std::forward<Extra>(extra)..., Policy);
+            .def("__iter__", [](state &s) -> state & { return s; })
+            .def(
+                "__next__",
+                [](state &s) -> KeyType {
+                    if (!s.first_or_done)
+                        ++s.it;
+                    else
+                        s.first_or_done = false;
+                    if (s.it == s.end) {
+                        s.first_or_done = true;
+                        throw stop_iteration();
+                    }
+                    return (*s.it).first;
+                },
+                std::forward<Extra>(extra)..., Policy);
     }
 
     return cast(state{first, last, true});
@@ -1969,15 +2082,17 @@ iterator make_key_iterator(Iterator first, Sentinel last, Extra &&... extra) {
 
 /// Makes an iterator over values of an stl container or other container supporting
 /// `std::begin()`/`std::end()`
-template <return_value_policy Policy = return_value_policy::reference_internal,
-          typename Type, typename... Extra> iterator make_iterator(Type &value, Extra&&... extra) {
+template <return_value_policy Policy = return_value_policy::reference_internal, typename Type,
+          typename... Extra>
+iterator make_iterator(Type &value, Extra &&...extra) {
     return make_iterator<Policy>(std::begin(value), std::end(value), extra...);
 }
 
 /// Makes an iterator over the keys (`.first`) of a stl map-like container supporting
 /// `std::begin()`/`std::end()`
-template <return_value_policy Policy = return_value_policy::reference_internal,
-          typename Type, typename... Extra> iterator make_key_iterator(Type &value, Extra&&... extra) {
+template <return_value_policy Policy = return_value_policy::reference_internal, typename Type,
+          typename... Extra>
+iterator make_key_iterator(Type &value, Extra &&...extra) {
     return make_key_iterator<Policy>(std::begin(value), std::end(value), extra...);
 }
 
@@ -1996,7 +2111,7 @@ template <typename InputType, typename OutputType> void implicitly_convertible()
             return nullptr;
         tuple args(1);
         args[0] = obj;
-        PyObject *result = PyObject_Call((PyObject *) type, args.ptr(), nullptr);
+        PyObject *result = PyObject_Call((PyObject *)type, args.ptr(), nullptr);
         if (result == nullptr)
             PyErr_Clear();
         return result;
@@ -2009,7 +2124,7 @@ template <typename InputType, typename OutputType> void implicitly_convertible()
 }
 
 template <typename ExceptionTranslator>
-void register_exception_translator(ExceptionTranslator&& translator) {
+void register_exception_translator(ExceptionTranslator &&translator) {
     detail::get_internals().registered_exception_translators.push_front(
         std::forward<ExceptionTranslator>(translator));
 }
@@ -2021,32 +2136,32 @@ void register_exception_translator(ExceptionTranslator&& translator) {
  * It is not (yet) possible to use as a py::base.
  * Template type argument is reserved for future use.
  */
-template <typename type>
-class exception : public object {
+template <typename type> class exception : public object {
 public:
     exception() = default;
     exception(handle scope, const char *name, handle base = PyExc_Exception) {
-        std::string full_name = scope.attr("__name__").cast<std::string>() +
-                                std::string(".") + name;
+        std::string full_name =
+            scope.attr("__name__").cast<std::string>() + std::string(".") + name;
         m_ptr = PyErr_NewException(const_cast<char *>(full_name.c_str()), base.ptr(), NULL);
         if (hasattr(scope, "__dict__") && scope.attr("__dict__").contains(name))
             pybind11_fail("Error during initialization: multiple incompatible "
-                          "definitions with name \"" + std::string(name) + "\"");
+                          "definitions with name \"" +
+                          std::string(name) + "\"");
         scope.attr(name) = *this;
     }
 
     // Sets the current python exception to this exception object with the given message
-    void operator()(const char *message) {
-        PyErr_SetString(m_ptr, message);
-    }
+    void operator()(const char *message) { PyErr_SetString(m_ptr, message); }
 };
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 // Returns a reference to a function-local static exception object used in the simple
 // register_exception approach below.  (It would be simpler to have the static local variable
 // directly in register_exception, but that makes clang <3.5 segfault - issue #1349).
-template <typename CppException>
-exception<CppException> &get_exception_object() { static exception<CppException> ex; return ex; }
+template <typename CppException> exception<CppException> &get_exception_object() {
+    static exception<CppException> ex;
+    return ex;
+}
 PYBIND11_NAMESPACE_END(detail)
 
 /**
@@ -2056,14 +2171,15 @@ PYBIND11_NAMESPACE_END(detail)
  * exception object and translator directly.
  */
 template <typename CppException>
-exception<CppException> &register_exception(handle scope,
-                                            const char *name,
+exception<CppException> &register_exception(handle scope, const char *name,
                                             handle base = PyExc_Exception) {
     auto &ex = detail::get_exception_object<CppException>();
-    if (!ex) ex = exception<CppException>(scope, name, base);
+    if (!ex)
+        ex = exception<CppException>(scope, name, base);
 
     register_exception_translator([](std::exception_ptr p) {
-        if (!p) return;
+        if (!p)
+            return;
         try {
             std::rethrow_exception(p);
         } catch (const CppException &e) {
@@ -2123,7 +2239,8 @@ error_already_set::~error_already_set() {
 }
 
 PYBIND11_NAMESPACE_BEGIN(detail)
-inline function get_type_override(const void *this_ptr, const type_info *this_type, const char *name)  {
+inline function get_type_override(const void *this_ptr, const type_info *this_type,
+                                  const char *name) {
     handle self = get_object_handle(this_ptr, this_type);
     if (!self)
         return function();
@@ -2146,11 +2263,11 @@ inline function get_type_override(const void *this_ptr, const type_info *this_ty
        Unfortunately this doesn't work on PyPy. */
 #if !defined(PYPY_VERSION)
     PyFrameObject *frame = PyThreadState_Get()->frame;
-    if (frame && (std::string) str(frame->f_code->co_name) == name &&
+    if (frame && (std::string)str(frame->f_code->co_name) == name &&
         frame->f_code->co_argcount > 0) {
         PyFrame_FastToLocals(frame);
-        PyObject *self_caller = dict_getitem(
-            frame->f_locals, PyTuple_GET_ITEM(frame->f_code->co_varnames, 0));
+        PyObject *self_caller =
+            dict_getitem(frame->f_locals, PyTuple_GET_ITEM(frame->f_code->co_varnames, 0));
         if (self_caller == self.ptr())
             return function();
     }
@@ -2158,18 +2275,20 @@ inline function get_type_override(const void *this_ptr, const type_info *this_ty
     /* PyPy currently doesn't provide a detailed cpyext emulation of
        frame objects, so we have to emulate this using Python. This
        is going to be slow..*/
-    dict d; d["self"] = self; d["name"] = pybind11::str(name);
-    PyObject *result = PyRun_String(
-        "import inspect\n"
-        "frame = inspect.currentframe()\n"
-        "if frame is not None:\n"
-        "    frame = frame.f_back\n"
-        "    if frame is not None and str(frame.f_code.co_name) == name and "
-        "frame.f_code.co_argcount > 0:\n"
-        "        self_caller = frame.f_locals[frame.f_code.co_varnames[0]]\n"
-        "        if self_caller == self:\n"
-        "            self = None\n",
-        Py_file_input, d.ptr(), d.ptr());
+    dict d;
+    d["self"] = self;
+    d["name"] = pybind11::str(name);
+    PyObject *result =
+        PyRun_String("import inspect\n"
+                     "frame = inspect.currentframe()\n"
+                     "if frame is not None:\n"
+                     "    frame = frame.f_back\n"
+                     "    if frame is not None and str(frame.f_code.co_name) == name and "
+                     "frame.f_code.co_argcount > 0:\n"
+                     "        self_caller = frame.f_locals[frame.f_code.co_varnames[0]]\n"
+                     "        if self_caller == self:\n"
+                     "            self = None\n",
+                     Py_file_input, d.ptr(), d.ptr());
     if (result == nullptr)
         throw error_already_set();
     if (d["self"].is_none())
@@ -2199,8 +2318,8 @@ template <class T> function get_override(const T *this_ptr, const char *name) {
 #define PYBIND11_OVERRIDE_IMPL(ret_type, cname, name, ...)                                        \
     do {                                                                                          \
         pybind11::gil_scoped_acquire gil;                                                         \
-        pybind11::function override                                                               \
-            = pybind11::get_override(static_cast<const cname *>(this), name);                     \
+        pybind11::function override =                                                             \
+            pybind11::get_override(static_cast<const cname *>(this), name);                       \
         if (override) {                                                                           \
             auto o = override(__VA_ARGS__);                                                       \
             if (pybind11::detail::cast_is_temporary_value_reference<ret_type>::value) {           \
@@ -2230,10 +2349,10 @@ template <class T> function get_override(const T *this_ptr, const char *name) {
       }
 \endrst */
 // clang-format on
-#define PYBIND11_OVERRIDE_NAME(ret_type, cname, name, fn, ...) \
-    do { \
+#define PYBIND11_OVERRIDE_NAME(ret_type, cname, name, fn, ...)                                    \
+    do {                                                                                          \
         PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__); \
-        return cname::fn(__VA_ARGS__); \
+        return cname::fn(__VA_ARGS__);                                                            \
     } while (false)
 
 // clang-format off
@@ -2242,10 +2361,11 @@ template <class T> function get_override(const T *this_ptr, const char *name) {
     throws if no override can be found.
 \endrst */
 // clang-format on
-#define PYBIND11_OVERRIDE_PURE_NAME(ret_type, cname, name, fn, ...) \
-    do { \
+#define PYBIND11_OVERRIDE_PURE_NAME(ret_type, cname, name, fn, ...)                               \
+    do {                                                                                          \
         PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__); \
-        pybind11::pybind11_fail("Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\""); \
+        pybind11::pybind11_fail(                                                                  \
+            "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
     } while (false)
 
 // clang-format off
@@ -2274,7 +2394,7 @@ template <class T> function get_override(const T *this_ptr, const char *name) {
       };
 \endrst */
 // clang-format on
-#define PYBIND11_OVERRIDE(ret_type, cname, fn, ...) \
+#define PYBIND11_OVERRIDE(ret_type, cname, fn, ...)                                               \
     PYBIND11_OVERRIDE_NAME(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), #fn, fn, __VA_ARGS__)
 
 // clang-format off
@@ -2283,37 +2403,38 @@ template <class T> function get_override(const T *this_ptr, const char *name) {
     if no override can be found.
 \endrst */
 // clang-format on
-#define PYBIND11_OVERRIDE_PURE(ret_type, cname, fn, ...) \
-    PYBIND11_OVERRIDE_PURE_NAME(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), #fn, fn, __VA_ARGS__)
-
+#define PYBIND11_OVERRIDE_PURE(ret_type, cname, fn, ...)                                          \
+    PYBIND11_OVERRIDE_PURE_NAME(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), #fn, fn,           \
+                                __VA_ARGS__)
 
 // Deprecated versions
 
 PYBIND11_DEPRECATED("get_type_overload has been deprecated")
-inline function get_type_overload(const void *this_ptr, const detail::type_info *this_type, const char *name) {
+inline function get_type_overload(const void *this_ptr, const detail::type_info *this_type,
+                                  const char *name) {
     return detail::get_type_override(this_ptr, this_type, name);
 }
 
-template <class T>
-inline function get_overload(const T *this_ptr, const char *name) {
+template <class T> inline function get_overload(const T *this_ptr, const char *name) {
     return get_override(this_ptr, name);
 }
 
-#define PYBIND11_OVERLOAD_INT(ret_type, cname, name, ...) \
+#define PYBIND11_OVERLOAD_INT(ret_type, cname, name, ...)                                         \
     PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__)
-#define PYBIND11_OVERLOAD_NAME(ret_type, cname, name, fn, ...) \
+#define PYBIND11_OVERLOAD_NAME(ret_type, cname, name, fn, ...)                                    \
     PYBIND11_OVERRIDE_NAME(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, fn, __VA_ARGS__)
-#define PYBIND11_OVERLOAD_PURE_NAME(ret_type, cname, name, fn, ...) \
-    PYBIND11_OVERRIDE_PURE_NAME(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, fn, __VA_ARGS__);
-#define PYBIND11_OVERLOAD(ret_type, cname, fn, ...) \
+#define PYBIND11_OVERLOAD_PURE_NAME(ret_type, cname, name, fn, ...)                               \
+    PYBIND11_OVERRIDE_PURE_NAME(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, fn,          \
+                                __VA_ARGS__);
+#define PYBIND11_OVERLOAD(ret_type, cname, fn, ...)                                               \
     PYBIND11_OVERRIDE(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), fn, __VA_ARGS__)
-#define PYBIND11_OVERLOAD_PURE(ret_type, cname, fn, ...) \
+#define PYBIND11_OVERLOAD_PURE(ret_type, cname, fn, ...)                                          \
     PYBIND11_OVERRIDE_PURE(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), fn, __VA_ARGS__);
 
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
 
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-#  pragma warning(pop)
+#pragma warning(pop)
 #elif defined(__GNUG__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
-#  pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -47,54 +47,65 @@ using tuple_accessor = accessor<accessor_policies::tuple_item>;
 class pyobject_tag { };
 template <typename T> using is_pyobject = std::is_base_of<pyobject_tag, remove_reference_t<T>>;
 
+// clang-format off
 /** \rst
     A mixin class which adds common functions to `handle`, `object` and various accessors.
     The only requirement for `Derived` is to implement ``PyObject *Derived::ptr() const``.
 \endrst */
+// clang-format on
 template <typename Derived>
 class object_api : public pyobject_tag {
     const Derived &derived() const { return static_cast<const Derived &>(*this); }
 
 public:
+    // clang-format off
     /** \rst
         Return an iterator equivalent to calling ``iter()`` in Python. The object
         must be a collection which supports the iteration protocol.
     \endrst */
+    // clang-format on
     iterator begin() const;
     /// Return a sentinel which ends iteration.
     iterator end() const;
 
+    // clang-format off
     /** \rst
         Return an internal functor to invoke the object's sequence protocol. Casting
         the returned ``detail::item_accessor`` instance to a `handle` or `object`
         subclass causes a corresponding call to ``__getitem__``. Assigning a `handle`
         or `object` subclass causes a call to ``__setitem__``.
     \endrst */
+    // clang-format on
     item_accessor operator[](handle key) const;
     /// See above (the only difference is that they key is provided as a string literal)
     item_accessor operator[](const char *key) const;
 
+    // clang-format off
     /** \rst
         Return an internal functor to access the object's attributes. Casting the
         returned ``detail::obj_attr_accessor`` instance to a `handle` or `object`
         subclass causes a corresponding call to ``getattr``. Assigning a `handle`
         or `object` subclass causes a call to ``setattr``.
     \endrst */
+    // clang-format on
     obj_attr_accessor attr(handle key) const;
     /// See above (the only difference is that they key is provided as a string literal)
     str_attr_accessor attr(const char *key) const;
 
+    // clang-format off
     /** \rst
         Matches * unpacking in Python, e.g. to unpack arguments out of a ``tuple``
         or ``list`` for a function call. Applying another * to the result yields
         ** unpacking, e.g. to unpack a dict as function keyword arguments.
         See :ref:`calling_python_functions`.
     \endrst */
+    // clang-format on
     args_proxy operator*() const;
 
     /// Check if the given item is contained within this object, i.e. ``item in obj``.
     template <typename T> bool contains(T &&item) const;
 
+    // clang-format off
     /** \rst
         Assuming the Python object is a function or implements the ``__call__``
         protocol, ``operator()`` invokes the underlying function, passing an
@@ -105,6 +116,7 @@ public:
         function will throw a `cast_error` exception. When the Python function
         call fails, a `error_already_set` exception is thrown.
     \endrst */
+    // clang-format on
     template <return_value_policy policy = return_value_policy::automatic_reference, typename... Args>
     object operator()(Args &&...args) const;
     template <return_value_policy policy = return_value_policy::automatic_reference, typename... Args>
@@ -162,6 +174,7 @@ private:
 
 PYBIND11_NAMESPACE_END(detail)
 
+// clang-format off
 /** \rst
     Holds a reference to a Python object (no reference counting)
 
@@ -173,6 +186,7 @@ PYBIND11_NAMESPACE_END(detail)
         The `object` class inherits from `handle` and adds automatic reference
         counting features.
 \endrst */
+// clang-format on
 class handle : public detail::object_api<handle> {
 public:
     /// The default constructor creates a handle with a ``nullptr``-valued pointer
@@ -184,31 +198,39 @@ public:
     PyObject *ptr() const { return m_ptr; }
     PyObject *&ptr() { return m_ptr; }
 
+    // clang-format off
     /** \rst
         Manually increase the reference count of the Python object. Usually, it is
         preferable to use the `object` class which derives from `handle` and calls
         this function automatically. Returns a reference to itself.
     \endrst */
+    // clang-format on
     const handle& inc_ref() const & { Py_XINCREF(m_ptr); return *this; }
 
+    // clang-format off
     /** \rst
         Manually decrease the reference count of the Python object. Usually, it is
         preferable to use the `object` class which derives from `handle` and calls
         this function automatically. Returns a reference to itself.
     \endrst */
+    // clang-format on
     const handle& dec_ref() const & { Py_XDECREF(m_ptr); return *this; }
 
+    // clang-format off
     /** \rst
         Attempt to cast the Python object into the given C++ type. A `cast_error`
         will be throw upon failure.
     \endrst */
+    // clang-format on
     template <typename T> T cast() const;
     /// Return ``true`` when the `handle` wraps a valid Python object
     explicit operator bool() const { return m_ptr != nullptr; }
+    // clang-format off
     /** \rst
         Deprecated: Check that the underlying pointers are the same.
         Equivalent to ``obj1 is obj2`` in Python.
     \endrst */
+    // clang-format on
     PYBIND11_DEPRECATED("Use obj1.is(obj2) instead")
     bool operator==(const handle &h) const { return m_ptr == h.m_ptr; }
     PYBIND11_DEPRECATED("Use !obj1.is(obj2) instead")
@@ -219,6 +241,7 @@ protected:
     PyObject *m_ptr = nullptr;
 };
 
+// clang-format off
 /** \rst
     Holds a reference to a Python object (with reference counting)
 
@@ -229,6 +252,7 @@ protected:
     scope and is destructed. When using `object` instances consistently, it is much
     easier to get reference counting right at the first attempt.
 \endrst */
+// clang-format on
 class object : public handle {
 public:
     object() = default;
@@ -241,11 +265,13 @@ public:
     /// Destructor; automatically calls `handle::dec_ref()`
     ~object() { dec_ref(); }
 
+    // clang-format off
     /** \rst
         Resets the internal pointer to ``nullptr`` without decreasing the
         object's reference count. The function returns a raw handle to the original
         Python object.
     \endrst */
+    // clang-format on
     handle release() {
       PyObject *tmp = m_ptr;
       m_ptr = nullptr;
@@ -290,6 +316,7 @@ public:
     object(handle h, stolen_t) : handle(h) { }
 };
 
+// clang-format off
 /** \rst
     Declare that a `handle` or ``PyObject *`` is a certain type and borrow the reference.
     The target type ``T`` must be `object` or one of its derived classes. The function
@@ -303,8 +330,10 @@ public:
         // or
         py::tuple t = reinterpret_borrow<py::tuple>(p); // <-- `p` must be already be a `tuple`
 \endrst */
+// clang-format on
 template <typename T> T reinterpret_borrow(handle h) { return {h, object::borrowed_t{}}; }
 
+// clang-format off
 /** \rst
     Like `reinterpret_borrow`, but steals the reference.
 
@@ -313,6 +342,7 @@ template <typename T> T reinterpret_borrow(handle h) { return {h, object::borrow
         PyObject *p = PyObject_Str(obj);
         py::str s = reinterpret_steal<py::str>(p); // <-- `p` must be already be a `str`
 \endrst */
+// clang-format on
 template <typename T> T reinterpret_steal(handle h) { return {h, object::stolen_t{}}; }
 
 PYBIND11_NAMESPACE_BEGIN(detail)
@@ -384,11 +414,13 @@ private:
     as their Python counterparts.
  */
 
+// clang-format off
 /** \ingroup python_builtins
     \rst
     Return true if ``obj`` is an instance of ``T``. Type ``T`` must be a subclass of
     `object` or a class which was exposed to Python as ``py::class_<T>``.
 \endrst */
+// clang-format on
 template <typename T, detail::enable_if_t<std::is_base_of<object, T>::value, int> = 0>
 bool isinstance(handle obj) { return T::check_(obj); }
 
@@ -884,6 +916,7 @@ PYBIND11_NAMESPACE_END(detail)
 /// \addtogroup pytypes
 /// @{
 
+// clang-format off
 /** \rst
     Wraps a Python iterator so that it can also be used as a C++ input iterator
 
@@ -892,6 +925,7 @@ PYBIND11_NAMESPACE_END(detail)
     operator. This iterator should only be used to retrieve the current
     value using ``operator*()``.
 \endrst */
+// clang-format on
 class iterator : public object {
 public:
     using iterator_category = std::input_iterator_tag;
@@ -923,6 +957,7 @@ public:
 
     pointer operator->() const { operator*(); return &value; }
 
+    // clang-format off
     /** \rst
          The value which marks the end of the iteration. ``it == iterator::sentinel()``
          is equivalent to catching ``StopIteration`` in Python.
@@ -936,6 +971,7 @@ public:
                  }
              }
     \endrst */
+    // clang-format on
     static iterator sentinel() { return {}; }
 
     friend bool operator==(const iterator &a, const iterator &b) { return a->ptr() == b->ptr(); }
@@ -1003,10 +1039,12 @@ public:
 
     explicit str(const bytes &b);
 
+    // clang-format off
     /** \rst
         Return a string representation of the object. This is analogous to
         the ``str()`` function in Python.
     \endrst */
+    // clang-format on
     explicit str(handle h) : object(raw_str(h.ptr()), stolen_t{}) { if (!m_ptr) throw error_already_set(); }
 
     operator std::string() const {
@@ -1043,9 +1081,11 @@ private:
 /// @} pytypes
 
 inline namespace literals {
+// clang-format off
 /** \rst
     String literal version of `str`
- \endrst */
+\endrst */
+// clang-format on
 inline str operator"" _s(const char *s, size_t size) { return {s, size}; }
 } // namespace literals
 
@@ -1487,6 +1527,7 @@ class memoryview : public object {
 public:
     PYBIND11_OBJECT_CVT(memoryview, object, PyMemoryView_Check, PyMemoryView_FromObject)
 
+    // clang-format off
     /** \rst
         Creates ``memoryview`` from ``buffer_info``.
 
@@ -1495,7 +1536,8 @@ public:
 
         For creating a ``memoryview`` from objects that support buffer protocol,
         use ``memoryview(const object& obj)`` instead of this constructor.
-     \endrst */
+    \endrst */
+    // clang-format on
     explicit memoryview(const buffer_info& info) {
         if (!info.view())
             pybind11_fail("Prohibited to create memoryview without Py_buffer");
@@ -1507,6 +1549,7 @@ public:
             pybind11_fail("Unable to create memoryview from buffer descriptor");
     }
 
+    // clang-format off
     /** \rst
         Creates ``memoryview`` from static buffer.
 
@@ -1529,7 +1572,8 @@ public:
             per dimension).
         :param readonly: Flag to indicate if the underlying storage may be
             written to.
-     \endrst */
+    \endrst */
+    // clang-format on
     static memoryview from_buffer(
         void *ptr, ssize_t itemsize, const char *format,
         detail::any_container<ssize_t> shape,
@@ -1561,6 +1605,7 @@ public:
     }
 
 #if PY_MAJOR_VERSION >= 3
+    // clang-format off
     /** \rst
         Creates ``memoryview`` from static memory.
 
@@ -1573,7 +1618,8 @@ public:
         See also: Python C API documentation for `PyMemoryView_FromBuffer`_.
 
         .. _PyMemoryView_FromMemory: https://docs.python.org/c-api/memoryview.html#c.PyMemoryView_FromMemory
-     \endrst */
+    \endrst */
+    // clang-format on
     static memoryview from_memory(void *mem, ssize_t size, bool readonly = false) {
         PyObject* ptr = PyMemoryView_FromMemory(
             reinterpret_cast<char*>(mem), size,

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -9,18 +9,21 @@
 
 #pragma once
 
-#include "detail/common.h"
 #include "buffer_info.h"
-#include <utility>
+#include "detail/common.h"
 #include <type_traits>
+#include <utility>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 /* A few forward declarations */
-class handle; class object;
-class str; class iterator;
+class handle;
+class object;
+class str;
+class iterator;
 class type;
-struct arg; struct arg_v;
+struct arg;
+struct arg_v;
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 class args_proxy;
@@ -29,12 +32,12 @@ inline bool isinstance_generic(handle obj, const std::type_info &tp);
 // Accessor forward declarations
 template <typename Policy> class accessor;
 namespace accessor_policies {
-    struct obj_attr;
-    struct str_attr;
-    struct generic_item;
-    struct sequence_item;
-    struct list_item;
-    struct tuple_item;
+struct obj_attr;
+struct str_attr;
+struct generic_item;
+struct sequence_item;
+struct list_item;
+struct tuple_item;
 } // namespace accessor_policies
 using obj_attr_accessor = accessor<accessor_policies::obj_attr>;
 using str_attr_accessor = accessor<accessor_policies::str_attr>;
@@ -44,7 +47,7 @@ using list_accessor = accessor<accessor_policies::list_item>;
 using tuple_accessor = accessor<accessor_policies::tuple_item>;
 
 /// Tag and check to identify a class which implements the Python object API
-class pyobject_tag { };
+class pyobject_tag {};
 template <typename T> using is_pyobject = std::is_base_of<pyobject_tag, remove_reference_t<T>>;
 
 // clang-format off
@@ -53,8 +56,7 @@ template <typename T> using is_pyobject = std::is_base_of<pyobject_tag, remove_r
     The only requirement for `Derived` is to implement ``PyObject *Derived::ptr() const``.
 \endrst */
 // clang-format on
-template <typename Derived>
-class object_api : public pyobject_tag {
+template <typename Derived> class object_api : public pyobject_tag {
     const Derived &derived() const { return static_cast<const Derived &>(*this); }
 
 public:
@@ -117,22 +119,24 @@ public:
         call fails, a `error_already_set` exception is thrown.
     \endrst */
     // clang-format on
-    template <return_value_policy policy = return_value_policy::automatic_reference, typename... Args>
+    template <return_value_policy policy = return_value_policy::automatic_reference,
+              typename... Args>
     object operator()(Args &&...args) const;
-    template <return_value_policy policy = return_value_policy::automatic_reference, typename... Args>
+    template <return_value_policy policy = return_value_policy::automatic_reference,
+              typename... Args>
     PYBIND11_DEPRECATED("call(...) was deprecated in favor of operator()(...)")
-        object call(Args&&... args) const;
+    object call(Args &&...args) const;
 
     /// Equivalent to ``obj is other`` in Python.
-    bool is(object_api const& other) const { return derived().ptr() == other.derived().ptr(); }
+    bool is(object_api const &other) const { return derived().ptr() == other.derived().ptr(); }
     /// Equivalent to ``obj is None`` in Python.
     bool is_none() const { return derived().ptr() == Py_None; }
     /// Equivalent to obj == other in Python
-    bool equal(object_api const &other) const      { return rich_compare(other, Py_EQ); }
-    bool not_equal(object_api const &other) const  { return rich_compare(other, Py_NE); }
-    bool operator<(object_api const &other) const  { return rich_compare(other, Py_LT); }
+    bool equal(object_api const &other) const { return rich_compare(other, Py_EQ); }
+    bool not_equal(object_api const &other) const { return rich_compare(other, Py_NE); }
+    bool operator<(object_api const &other) const { return rich_compare(other, Py_LT); }
     bool operator<=(object_api const &other) const { return rich_compare(other, Py_LE); }
-    bool operator>(object_api const &other) const  { return rich_compare(other, Py_GT); }
+    bool operator>(object_api const &other) const { return rich_compare(other, Py_GT); }
     bool operator>=(object_api const &other) const { return rich_compare(other, Py_GE); }
 
     object operator-() const;
@@ -165,7 +169,8 @@ public:
     /// Return the object's current reference count
     int ref_count() const { return static_cast<int>(Py_REFCNT(derived().ptr())); }
 
-    // TODO PYBIND11_DEPRECATED("Call py::type::handle_of(h) or py::type::of(h) instead of h.get_type()")
+    // TODO PYBIND11_DEPRECATED("Call py::type::handle_of(h) or py::type::of(h) instead of
+    // h.get_type()")
     handle get_type() const;
 
 private:
@@ -192,7 +197,7 @@ public:
     /// The default constructor creates a handle with a ``nullptr``-valued pointer
     handle() = default;
     /// Creates a ``handle`` from the given raw Python object pointer
-    handle(PyObject *ptr) : m_ptr(ptr) { } // Allow implicit conversion from PyObject*
+    handle(PyObject *ptr) : m_ptr(ptr) {} // Allow implicit conversion from PyObject*
 
     /// Return the underlying ``PyObject *`` pointer
     PyObject *ptr() const { return m_ptr; }
@@ -205,7 +210,10 @@ public:
         this function automatically. Returns a reference to itself.
     \endrst */
     // clang-format on
-    const handle& inc_ref() const & { Py_XINCREF(m_ptr); return *this; }
+    const handle &inc_ref() const & {
+        Py_XINCREF(m_ptr);
+        return *this;
+    }
 
     // clang-format off
     /** \rst
@@ -214,7 +222,10 @@ public:
         this function automatically. Returns a reference to itself.
     \endrst */
     // clang-format on
-    const handle& dec_ref() const & { Py_XDECREF(m_ptr); return *this; }
+    const handle &dec_ref() const & {
+        Py_XDECREF(m_ptr);
+        return *this;
+    }
 
     // clang-format off
     /** \rst
@@ -237,6 +248,7 @@ public:
     bool operator!=(const handle &h) const { return m_ptr != h.m_ptr; }
     PYBIND11_DEPRECATED("Use handle::operator bool() instead")
     bool check() const { return m_ptr != nullptr; }
+
 protected:
     PyObject *m_ptr = nullptr;
 };
@@ -257,11 +269,17 @@ class object : public handle {
 public:
     object() = default;
     PYBIND11_DEPRECATED("Use reinterpret_borrow<object>() or reinterpret_steal<object>()")
-    object(handle h, bool is_borrowed) : handle(h) { if (is_borrowed) inc_ref(); }
+    object(handle h, bool is_borrowed) : handle(h) {
+        if (is_borrowed)
+            inc_ref();
+    }
     /// Copy constructor; always increases the reference count
     object(const object &o) : handle(o) { inc_ref(); }
     /// Move constructor; steals the object from ``other`` and preserves its reference count
-    object(object &&other) noexcept { m_ptr = other.m_ptr; other.m_ptr = nullptr; }
+    object(object &&other) noexcept {
+        m_ptr = other.m_ptr;
+        other.m_ptr = nullptr;
+    }
     /// Destructor; automatically calls `handle::dec_ref()`
     ~object() { dec_ref(); }
 
@@ -273,19 +291,19 @@ public:
     \endrst */
     // clang-format on
     handle release() {
-      PyObject *tmp = m_ptr;
-      m_ptr = nullptr;
-      return handle(tmp);
+        PyObject *tmp = m_ptr;
+        m_ptr = nullptr;
+        return handle(tmp);
     }
 
-    object& operator=(const object &other) {
+    object &operator=(const object &other) {
         other.inc_ref();
         dec_ref();
         m_ptr = other.m_ptr;
         return *this;
     }
 
-    object& operator=(object &&other) noexcept {
+    object &operator=(object &&other) noexcept {
         if (this != &other) {
             handle temp(m_ptr);
             m_ptr = other.m_ptr;
@@ -302,10 +320,10 @@ public:
 
 protected:
     // Tags for choosing constructors from raw PyObject *
-    struct borrowed_t { };
-    struct stolen_t { };
+    struct borrowed_t {};
+    struct stolen_t {};
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Issue in breathe 4.26.1
     template <typename T> friend T reinterpret_borrow(handle);
     template <typename T> friend T reinterpret_steal(handle);
 #endif
@@ -313,7 +331,7 @@ protected:
 public:
     // Only accessible from derived classes and the reinterpret_* functions
     object(handle h, borrowed_t) : handle(h) { inc_ref(); }
-    object(handle h, stolen_t) : handle(h) { }
+    object(handle h, stolen_t) : handle(h) {}
 };
 
 // clang-format off
@@ -350,8 +368,10 @@ inline std::string error_string();
 PYBIND11_NAMESPACE_END(detail)
 
 #if defined(_MSC_VER)
-#  pragma warning(push)
-#  pragma warning(disable: 4275 4251) // warning C4275: An exported class was derived from a class that wasn't exported. Can be ignored when derived from a STL class.
+#pragma warning(push)
+#pragma warning(                                                                                  \
+    disable : 4275 4251) // warning C4275: An exported class was derived from a class that wasn't
+                         // exported. Can be ignored when derived from a STL class.
 #endif
 /// Fetch and hold an error which was already set in Python.  An instance of this is typically
 /// thrown to propagate python-side errors back through C++ which can either be caught manually or
@@ -373,13 +393,15 @@ public:
     /// Give the currently-held error back to Python, if any.  If there is currently a Python error
     /// already set it is cleared first.  After this call, the current object no longer stores the
     /// error variables (but the `.what()` string is still available).
-    void restore() { PyErr_Restore(m_type.release().ptr(), m_value.release().ptr(), m_trace.release().ptr()); }
+    void restore() {
+        PyErr_Restore(m_type.release().ptr(), m_value.release().ptr(), m_trace.release().ptr());
+    }
 
     /// If it is impossible to raise the currently-held error, such as in destructor, we can write
     /// it out using Python's unraisable hook (sys.unraisablehook). The error context should be
     /// some object whose repr() helps identify the location of the error. Python already knows the
-    /// type and value of the error, so there is no need to repeat that. For example, __func__ could
-    /// be helpful. After this call, the current object no longer stores the error variables,
+    /// type and value of the error, so there is no need to repeat that. For example, __func__
+    /// could be helpful. After this call, the current object no longer stores the error variables,
     /// and neither does Python.
     void discard_as_unraisable(object err_context) {
         restore();
@@ -398,15 +420,15 @@ public:
     /// the given tuple.
     bool matches(handle exc) const { return PyErr_GivenExceptionMatches(m_type.ptr(), exc.ptr()); }
 
-    const object& type() const { return m_type; }
-    const object& value() const { return m_value; }
-    const object& trace() const { return m_trace; }
+    const object &type() const { return m_type; }
+    const object &value() const { return m_value; }
+    const object &trace() const { return m_trace; }
 
 private:
     object m_type, m_value, m_trace;
 };
 #if defined(_MSC_VER)
-#  pragma warning(pop)
+#pragma warning(pop)
 #endif
 
 /** \defgroup python_builtins _
@@ -422,10 +444,14 @@ private:
 \endrst */
 // clang-format on
 template <typename T, detail::enable_if_t<std::is_base_of<object, T>::value, int> = 0>
-bool isinstance(handle obj) { return T::check_(obj); }
+bool isinstance(handle obj) {
+    return T::check_(obj);
+}
 
 template <typename T, detail::enable_if_t<!std::is_base_of<object, T>::value, int> = 0>
-bool isinstance(handle obj) { return detail::isinstance_generic(obj, typeid(T)); }
+bool isinstance(handle obj) {
+    return detail::isinstance_generic(obj, typeid(T));
+}
 
 template <> inline bool isinstance<handle>(handle) = delete;
 template <> inline bool isinstance<object>(handle obj) { return obj.ptr() != nullptr; }
@@ -450,22 +476,30 @@ inline bool hasattr(handle obj, const char *name) {
 }
 
 inline void delattr(handle obj, handle name) {
-    if (PyObject_DelAttr(obj.ptr(), name.ptr()) != 0) { throw error_already_set(); }
+    if (PyObject_DelAttr(obj.ptr(), name.ptr()) != 0) {
+        throw error_already_set();
+    }
 }
 
 inline void delattr(handle obj, const char *name) {
-    if (PyObject_DelAttrString(obj.ptr(), name) != 0) { throw error_already_set(); }
+    if (PyObject_DelAttrString(obj.ptr(), name) != 0) {
+        throw error_already_set();
+    }
 }
 
 inline object getattr(handle obj, handle name) {
     PyObject *result = PyObject_GetAttr(obj.ptr(), name.ptr());
-    if (!result) { throw error_already_set(); }
+    if (!result) {
+        throw error_already_set();
+    }
     return reinterpret_steal<object>(result);
 }
 
 inline object getattr(handle obj, const char *name) {
     PyObject *result = PyObject_GetAttrString(obj.ptr(), name);
-    if (!result) { throw error_already_set(); }
+    if (!result) {
+        throw error_already_set();
+    }
     return reinterpret_steal<object>(result);
 }
 
@@ -486,16 +520,22 @@ inline object getattr(handle obj, const char *name, handle default_) {
 }
 
 inline void setattr(handle obj, handle name, handle value) {
-    if (PyObject_SetAttr(obj.ptr(), name.ptr(), value.ptr()) != 0) { throw error_already_set(); }
+    if (PyObject_SetAttr(obj.ptr(), name.ptr(), value.ptr()) != 0) {
+        throw error_already_set();
+    }
 }
 
 inline void setattr(handle obj, const char *name, handle value) {
-    if (PyObject_SetAttrString(obj.ptr(), name, value.ptr()) != 0) { throw error_already_set(); }
+    if (PyObject_SetAttrString(obj.ptr(), name, value.ptr()) != 0) {
+        throw error_already_set();
+    }
 }
 
 inline ssize_t hash(handle obj) {
     auto h = PyObject_Hash(obj.ptr());
-    if (h == -1) { throw error_already_set(); }
+    if (h == -1) {
+        throw error_already_set();
+    }
     return h;
 }
 
@@ -509,7 +549,7 @@ inline handle get_function(handle value) {
             value = PyInstanceMethod_GET_FUNCTION(value.ptr());
         else
 #endif
-        if (PyMethod_Check(value.ptr()))
+            if (PyMethod_Check(value.ptr()))
             value = PyMethod_GET_FUNCTION(value.ptr());
     }
     return value;
@@ -519,8 +559,7 @@ inline handle get_function(handle value) {
 // aren't swallowed (see #2862)
 
 // copied from cpython _PyDict_GetItemStringWithError
-inline PyObject * dict_getitemstring(PyObject *v, const char *key)
-{
+inline PyObject *dict_getitemstring(PyObject *v, const char *key) {
 #if PY_MAJOR_VERSION >= 3
     PyObject *kv, *rv;
     kv = PyUnicode_FromString(key);
@@ -539,8 +578,7 @@ inline PyObject * dict_getitemstring(PyObject *v, const char *key)
 #endif
 }
 
-inline PyObject * dict_getitem(PyObject *v, PyObject *key)
-{
+inline PyObject *dict_getitem(PyObject *v, PyObject *key) {
 #if PY_MAJOR_VERSION >= 3
     PyObject *rv = PyDict_GetItemWithError(v, key);
     if (rv == NULL && PyErr_Occurred()) {
@@ -552,28 +590,28 @@ inline PyObject * dict_getitem(PyObject *v, PyObject *key)
 #endif
 }
 
-// Helper aliases/functions to support implicit casting of values given to python accessors/methods.
-// When given a pyobject, this simply returns the pyobject as-is; for other C++ type, the value goes
-// through pybind11::cast(obj) to convert it to an `object`.
+// Helper aliases/functions to support implicit casting of values given to python
+// accessors/methods. When given a pyobject, this simply returns the pyobject as-is; for other C++
+// type, the value goes through pybind11::cast(obj) to convert it to an `object`.
 template <typename T, enable_if_t<is_pyobject<T>::value, int> = 0>
-auto object_or_cast(T &&o) -> decltype(std::forward<T>(o)) { return std::forward<T>(o); }
+auto object_or_cast(T &&o) -> decltype(std::forward<T>(o)) {
+    return std::forward<T>(o);
+}
 // The following casting version is implemented in cast.h:
-template <typename T, enable_if_t<!is_pyobject<T>::value, int> = 0>
-object object_or_cast(T &&o);
+template <typename T, enable_if_t<!is_pyobject<T>::value, int> = 0> object object_or_cast(T &&o);
 // Match a PyObject*, which we want to convert directly to handle via its converting constructor
 inline handle object_or_cast(PyObject *ptr) { return ptr; }
 
-template <typename Policy>
-class accessor : public object_api<accessor<Policy>> {
+template <typename Policy> class accessor : public object_api<accessor<Policy>> {
     using key_type = typename Policy::key_type;
 
 public:
-    accessor(handle obj, key_type key) : obj(obj), key(std::move(key)) { }
+    accessor(handle obj, key_type key) : obj(obj), key(std::move(key)) {}
     accessor(const accessor &) = default;
     accessor(accessor &&) noexcept = default;
 
-    // accessor overload required to override default assignment operator (templates are not allowed
-    // to replace default compiler-generated assignments).
+    // accessor overload required to override default assignment operator (templates are not
+    // allowed to replace default compiler-generated assignments).
     void operator=(const accessor &a) && { std::move(*this).operator=(handle(a)); }
     void operator=(const accessor &a) & { operator=(handle(a)); }
 
@@ -585,14 +623,18 @@ public:
     }
 
     template <typename T = Policy>
-    PYBIND11_DEPRECATED("Use of obj.attr(...) as bool is deprecated in favor of pybind11::hasattr(obj, ...)")
-    explicit operator enable_if_t<std::is_same<T, accessor_policies::str_attr>::value ||
-            std::is_same<T, accessor_policies::obj_attr>::value, bool>() const {
+    PYBIND11_DEPRECATED(
+        "Use of obj.attr(...) as bool is deprecated in favor of pybind11::hasattr(obj, ...)")
+    explicit
+    operator enable_if_t<std::is_same<T, accessor_policies::str_attr>::value ||
+                             std::is_same<T, accessor_policies::obj_attr>::value,
+                         bool>() const {
         return hasattr(obj, key);
     }
     template <typename T = Policy>
     PYBIND11_DEPRECATED("Use of obj[key] as bool is deprecated in favor of obj.contains(key)")
-    explicit operator enable_if_t<std::is_same<T, accessor_policies::generic_item>::value, bool>() const {
+    explicit
+    operator enable_if_t<std::is_same<T, accessor_policies::generic_item>::value, bool>() const {
         return obj.contains(key);
     }
 
@@ -602,7 +644,9 @@ public:
 
 private:
     object &get_cache() const {
-        if (!cache) { cache = Policy::get(obj, key); }
+        if (!cache) {
+            cache = Policy::get(obj, key);
+        }
         return cache;
     }
 
@@ -630,12 +674,16 @@ struct generic_item {
 
     static object get(handle obj, handle key) {
         PyObject *result = PyObject_GetItem(obj.ptr(), key.ptr());
-        if (!result) { throw error_already_set(); }
+        if (!result) {
+            throw error_already_set();
+        }
         return reinterpret_steal<object>(result);
     }
 
     static void set(handle obj, handle key, handle val) {
-        if (PyObject_SetItem(obj.ptr(), key.ptr(), val.ptr()) != 0) { throw error_already_set(); }
+        if (PyObject_SetItem(obj.ptr(), key.ptr(), val.ptr()) != 0) {
+            throw error_already_set();
+        }
     }
 };
 
@@ -644,7 +692,9 @@ struct sequence_item {
 
     static object get(handle obj, size_t index) {
         PyObject *result = PySequence_GetItem(obj.ptr(), static_cast<ssize_t>(index));
-        if (!result) { throw error_already_set(); }
+        if (!result) {
+            throw error_already_set();
+        }
         return reinterpret_steal<object>(result);
     }
 
@@ -661,7 +711,9 @@ struct list_item {
 
     static object get(handle obj, size_t index) {
         PyObject *result = PyList_GetItem(obj.ptr(), static_cast<ssize_t>(index));
-        if (!result) { throw error_already_set(); }
+        if (!result) {
+            throw error_already_set();
+        }
         return reinterpret_borrow<object>(result);
     }
 
@@ -678,7 +730,9 @@ struct tuple_item {
 
     static object get(handle obj, size_t index) {
         PyObject *result = PyTuple_GetItem(obj.ptr(), static_cast<ssize_t>(index));
-        if (!result) { throw error_already_set(); }
+        if (!result) {
+            throw error_already_set();
+        }
         return reinterpret_borrow<object>(result);
     }
 
@@ -692,8 +746,7 @@ struct tuple_item {
 PYBIND11_NAMESPACE_END(accessor_policies)
 
 /// STL iterator template used for tuple, list, sequence and dict
-template <typename Policy>
-class generic_iterator : public Policy {
+template <typename Policy> class generic_iterator : public Policy {
     using It = generic_iterator;
 
 public:
@@ -704,39 +757,64 @@ public:
     using pointer = typename Policy::pointer;
 
     generic_iterator() = default;
-    generic_iterator(handle seq, ssize_t index) : Policy(seq, index) { }
+    generic_iterator(handle seq, ssize_t index) : Policy(seq, index) {}
 
     reference operator*() const { return Policy::dereference(); }
     reference operator[](difference_type n) const { return *(*this + n); }
     pointer operator->() const { return **this; }
 
-    It &operator++() { Policy::increment(); return *this; }
-    It operator++(int) { auto copy = *this; Policy::increment(); return copy; }
-    It &operator--() { Policy::decrement(); return *this; }
-    It operator--(int) { auto copy = *this; Policy::decrement(); return copy; }
-    It &operator+=(difference_type n) { Policy::advance(n); return *this; }
-    It &operator-=(difference_type n) { Policy::advance(-n); return *this; }
+    It &operator++() {
+        Policy::increment();
+        return *this;
+    }
+    It operator++(int) {
+        auto copy = *this;
+        Policy::increment();
+        return copy;
+    }
+    It &operator--() {
+        Policy::decrement();
+        return *this;
+    }
+    It operator--(int) {
+        auto copy = *this;
+        Policy::decrement();
+        return copy;
+    }
+    It &operator+=(difference_type n) {
+        Policy::advance(n);
+        return *this;
+    }
+    It &operator-=(difference_type n) {
+        Policy::advance(-n);
+        return *this;
+    }
 
-    friend It operator+(const It &a, difference_type n) { auto copy = a; return copy += n; }
+    friend It operator+(const It &a, difference_type n) {
+        auto copy = a;
+        return copy += n;
+    }
     friend It operator+(difference_type n, const It &b) { return b + n; }
-    friend It operator-(const It &a, difference_type n) { auto copy = a; return copy -= n; }
+    friend It operator-(const It &a, difference_type n) {
+        auto copy = a;
+        return copy -= n;
+    }
     friend difference_type operator-(const It &a, const It &b) { return a.distance_to(b); }
 
     friend bool operator==(const It &a, const It &b) { return a.equal(b); }
     friend bool operator!=(const It &a, const It &b) { return !(a == b); }
-    friend bool operator< (const It &a, const It &b) { return b - a > 0; }
-    friend bool operator> (const It &a, const It &b) { return b < a; }
+    friend bool operator<(const It &a, const It &b) { return b - a > 0; }
+    friend bool operator>(const It &a, const It &b) { return b < a; }
     friend bool operator>=(const It &a, const It &b) { return !(a < b); }
     friend bool operator<=(const It &a, const It &b) { return !(a > b); }
 };
 
 PYBIND11_NAMESPACE_BEGIN(iterator_policies)
 /// Quick proxy class needed to implement ``operator->`` for iterators which can't return pointers
-template <typename T>
-struct arrow_proxy {
+template <typename T> struct arrow_proxy {
     T value;
 
-    arrow_proxy(T &&value) : value(std::move(value)) { }
+    arrow_proxy(T &&value) : value(std::move(value)) {}
     T *operator->() const { return &value; }
 };
 
@@ -748,7 +826,7 @@ protected:
     using reference = const handle;
     using pointer = arrow_proxy<const handle>;
 
-    sequence_fast_readonly(handle obj, ssize_t n) : ptr(PySequence_Fast_ITEMS(obj.ptr()) + n) { }
+    sequence_fast_readonly(handle obj, ssize_t n) : ptr(PySequence_Fast_ITEMS(obj.ptr()) + n) {}
 
     reference dereference() const { return *ptr; }
     void increment() { ++ptr; }
@@ -769,7 +847,7 @@ protected:
     using reference = sequence_accessor;
     using pointer = arrow_proxy<const sequence_accessor>;
 
-    sequence_slow_readwrite(handle obj, ssize_t index) : obj(obj), index(index) { }
+    sequence_slow_readwrite(handle obj, ssize_t index) : obj(obj), index(index) {}
 
     reference dereference() const { return {obj, static_cast<size_t>(index)}; }
     void increment() { ++index; }
@@ -795,7 +873,11 @@ protected:
     dict_readonly(handle obj, ssize_t pos) : obj(obj), pos(pos) { increment(); }
 
     reference dereference() const { return {key, value}; }
-    void increment() { if (!PyDict_Next(obj.ptr(), &pos, &key, &value)) { pos = -1; } }
+    void increment() {
+        if (!PyDict_Next(obj.ptr(), &pos, &key, &value)) {
+            pos = -1;
+        }
+    }
     bool equal(const dict_readonly &b) const { return pos == b.pos; }
 
 private:
@@ -830,7 +912,9 @@ inline bool PyNone_Check(PyObject *o) { return o == Py_None; }
 inline bool PyEllipsis_Check(PyObject *o) { return o == Py_Ellipsis; }
 
 #ifdef PYBIND11_STR_LEGACY_PERMISSIVE
-inline bool PyUnicode_Check_Permissive(PyObject *o) { return PyUnicode_Check(o) || PYBIND11_BYTES_CHECK(o); }
+inline bool PyUnicode_Check_Permissive(PyObject *o) {
+    return PyUnicode_Check(o) || PYBIND11_BYTES_CHECK(o);
+}
 #define PYBIND11_STR_CHECK_FUN detail::PyUnicode_Check_Permissive
 #else
 #define PYBIND11_STR_CHECK_FUN PyUnicode_Check
@@ -840,22 +924,21 @@ inline bool PyStaticMethod_Check(PyObject *o) { return o->ob_type == &PyStaticMe
 
 class kwargs_proxy : public handle {
 public:
-    explicit kwargs_proxy(handle h) : handle(h) { }
+    explicit kwargs_proxy(handle h) : handle(h) {}
 };
 
 class args_proxy : public handle {
 public:
-    explicit args_proxy(handle h) : handle(h) { }
+    explicit args_proxy(handle h) : handle(h) {}
     kwargs_proxy operator*() const { return kwargs_proxy(*this); }
 };
 
 /// Python argument categories (using PEP 448 terms)
 template <typename T> using is_keyword = std::is_base_of<arg, T>;
-template <typename T> using is_s_unpacking = std::is_same<args_proxy, T>; // * unpacking
+template <typename T> using is_s_unpacking = std::is_same<args_proxy, T>;    // * unpacking
 template <typename T> using is_ds_unpacking = std::is_same<kwargs_proxy, T>; // ** unpacking
-template <typename T> using is_positional = satisfies_none_of<T,
-    is_keyword, is_s_unpacking, is_ds_unpacking
->;
+template <typename T>
+using is_positional = satisfies_none_of<T, is_keyword, is_s_unpacking, is_ds_unpacking>;
 template <typename T> using is_keyword_or_ds = satisfies_any_of<T, is_keyword, is_ds_unpacking>;
 
 // Call argument collector forward declarations
@@ -870,48 +953,56 @@ PYBIND11_NAMESPACE_END(detail)
 //       inheriting ctors: `using Parent::Parent`. It's not an option right now because
 //       the `using` statement triggers the parent deprecation warning even if the ctor
 //       isn't even used.
-#define PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun) \
-    public: \
-        PYBIND11_DEPRECATED("Use reinterpret_borrow<"#Name">() or reinterpret_steal<"#Name">()") \
-        Name(handle h, bool is_borrowed) : Parent(is_borrowed ? Parent(h, borrowed_t{}) : Parent(h, stolen_t{})) { } \
-        Name(handle h, borrowed_t) : Parent(h, borrowed_t{}) { } \
-        Name(handle h, stolen_t) : Parent(h, stolen_t{}) { } \
-        PYBIND11_DEPRECATED("Use py::isinstance<py::python_type>(obj) instead") \
-        bool check() const { return m_ptr != nullptr && (bool) CheckFun(m_ptr); } \
-        static bool check_(handle h) { return h.ptr() != nullptr && CheckFun(h.ptr()); } \
-        template <typename Policy_> \
-        Name(const ::pybind11::detail::accessor<Policy_> &a) : Name(object(a)) { }
+#define PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun)                                            \
+public:                                                                                           \
+    PYBIND11_DEPRECATED("Use reinterpret_borrow<" #Name ">() or reinterpret_steal<" #Name ">()")  \
+    Name(handle h, bool is_borrowed)                                                              \
+        : Parent(is_borrowed ? Parent(h, borrowed_t{}) : Parent(h, stolen_t{})) {}                \
+    Name(handle h, borrowed_t) : Parent(h, borrowed_t{}) {}                                       \
+    Name(handle h, stolen_t) : Parent(h, stolen_t{}) {}                                           \
+    PYBIND11_DEPRECATED("Use py::isinstance<py::python_type>(obj) instead")                       \
+    bool check() const { return m_ptr != nullptr && (bool)CheckFun(m_ptr); }                      \
+    static bool check_(handle h) { return h.ptr() != nullptr && CheckFun(h.ptr()); }              \
+    template <typename Policy_>                                                                   \
+    Name(const ::pybind11::detail::accessor<Policy_> &a) : Name(object(a)) {}
 
-#define PYBIND11_OBJECT_CVT(Name, Parent, CheckFun, ConvertFun) \
-    PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun) \
-    /* This is deliberately not 'explicit' to allow implicit conversion from object: */ \
-    Name(const object &o) \
-    : Parent(check_(o) ? o.inc_ref().ptr() : ConvertFun(o.ptr()), stolen_t{}) \
-    { if (!m_ptr) throw error_already_set(); } \
-    Name(object &&o) \
-    : Parent(check_(o) ? o.release().ptr() : ConvertFun(o.ptr()), stolen_t{}) \
-    { if (!m_ptr) throw error_already_set(); }
+#define PYBIND11_OBJECT_CVT(Name, Parent, CheckFun, ConvertFun)                                   \
+    PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun)                                                \
+    /* This is deliberately not 'explicit' to allow implicit conversion from object: */           \
+    Name(const object &o)                                                                         \
+        : Parent(check_(o) ? o.inc_ref().ptr() : ConvertFun(o.ptr()), stolen_t{}) {               \
+        if (!m_ptr)                                                                               \
+            throw error_already_set();                                                            \
+    }                                                                                             \
+    Name(object &&o) : Parent(check_(o) ? o.release().ptr() : ConvertFun(o.ptr()), stolen_t{}) {  \
+        if (!m_ptr)                                                                               \
+            throw error_already_set();                                                            \
+    }
 
-#define PYBIND11_OBJECT_CVT_DEFAULT(Name, Parent, CheckFun, ConvertFun) \
-    PYBIND11_OBJECT_CVT(Name, Parent, CheckFun, ConvertFun) \
-    Name() : Parent() { }
+#define PYBIND11_OBJECT_CVT_DEFAULT(Name, Parent, CheckFun, ConvertFun)                           \
+    PYBIND11_OBJECT_CVT(Name, Parent, CheckFun, ConvertFun)                                       \
+    Name() : Parent() {}
 
-#define PYBIND11_OBJECT_CHECK_FAILED(Name, o_ptr) \
-    ::pybind11::type_error("Object of type '" + \
-                           ::pybind11::detail::get_fully_qualified_tp_name(Py_TYPE(o_ptr)) + \
+#define PYBIND11_OBJECT_CHECK_FAILED(Name, o_ptr)                                                 \
+    ::pybind11::type_error("Object of type '" +                                                   \
+                           ::pybind11::detail::get_fully_qualified_tp_name(Py_TYPE(o_ptr)) +      \
                            "' is not an instance of '" #Name "'")
 
-#define PYBIND11_OBJECT(Name, Parent, CheckFun) \
-    PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun) \
-    /* This is deliberately not 'explicit' to allow implicit conversion from object: */ \
-    Name(const object &o) : Parent(o) \
-    { if (m_ptr && !check_(m_ptr)) throw PYBIND11_OBJECT_CHECK_FAILED(Name, m_ptr); } \
-    Name(object &&o) : Parent(std::move(o)) \
-    { if (m_ptr && !check_(m_ptr)) throw PYBIND11_OBJECT_CHECK_FAILED(Name, m_ptr); }
+#define PYBIND11_OBJECT(Name, Parent, CheckFun)                                                   \
+    PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun)                                                \
+    /* This is deliberately not 'explicit' to allow implicit conversion from object: */           \
+    Name(const object &o) : Parent(o) {                                                           \
+        if (m_ptr && !check_(m_ptr))                                                              \
+            throw PYBIND11_OBJECT_CHECK_FAILED(Name, m_ptr);                                      \
+    }                                                                                             \
+    Name(object &&o) : Parent(std::move(o)) {                                                     \
+        if (m_ptr && !check_(m_ptr))                                                              \
+            throw PYBIND11_OBJECT_CHECK_FAILED(Name, m_ptr);                                      \
+    }
 
-#define PYBIND11_OBJECT_DEFAULT(Name, Parent, CheckFun) \
-    PYBIND11_OBJECT(Name, Parent, CheckFun) \
-    Name() : Parent() { }
+#define PYBIND11_OBJECT_DEFAULT(Name, Parent, CheckFun)                                           \
+    PYBIND11_OBJECT(Name, Parent, CheckFun)                                                       \
+    Name() : Parent() {}
 
 /// \addtogroup pytypes
 /// @{
@@ -936,7 +1027,7 @@ public:
 
     PYBIND11_OBJECT_DEFAULT(iterator, object, PyIter_Check)
 
-    iterator& operator++() {
+    iterator &operator++() {
         advance();
         return *this;
     }
@@ -949,13 +1040,16 @@ public:
 
     reference operator*() const {
         if (m_ptr && !value.ptr()) {
-            auto& self = const_cast<iterator &>(*this);
+            auto &self = const_cast<iterator &>(*this);
             self.advance();
         }
         return value;
     }
 
-    pointer operator->() const { operator*(); return &value; }
+    pointer operator->() const {
+        operator*();
+        return &value;
+    }
 
     // clang-format off
     /** \rst
@@ -980,21 +1074,21 @@ public:
 private:
     void advance() {
         value = reinterpret_steal<object>(PyIter_Next(m_ptr));
-        if (PyErr_Occurred()) { throw error_already_set(); }
+        if (PyErr_Occurred()) {
+            throw error_already_set();
+        }
     }
 
 private:
     object value = {};
 };
 
-
-
 class type : public object {
 public:
     PYBIND11_OBJECT(type, object, PyType_Check)
 
     /// Return a type handle from a handle or an object
-    static handle handle_of(handle h) { return handle((PyObject*) Py_TYPE(h.ptr())); }
+    static handle handle_of(handle h) { return handle((PyObject *)Py_TYPE(h.ptr())); }
 
     /// Return a type object from a handle or an object
     static type of(handle h) { return type(type::handle_of(h), borrowed_t{}); }
@@ -1003,14 +1097,12 @@ public:
     /// Convert C++ type to handle if previously registered. Does not convert
     /// standard types, like int, float. etc. yet.
     /// See https://github.com/pybind/pybind11/issues/2486
-    template<typename T>
-    static handle handle_of();
+    template <typename T> static handle handle_of();
 
     /// Convert C++ type to type if previously registered. Does not convert
     /// standard types, like int, float. etc. yet.
     /// See https://github.com/pybind/pybind11/issues/2486
-    template<typename T>
-    static type of() {return type(type::handle_of<T>(), borrowed_t{}); }
+    template <typename T> static type of() { return type(type::handle_of<T>(), borrowed_t{}); }
 };
 
 class iterable : public object {
@@ -1024,18 +1116,19 @@ class str : public object {
 public:
     PYBIND11_OBJECT_CVT(str, object, PYBIND11_STR_CHECK_FUN, raw_str)
 
-    str(const char *c, size_t n)
-        : object(PyUnicode_FromStringAndSize(c, (ssize_t) n), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate string object!");
+    str(const char *c, size_t n) : object(PyUnicode_FromStringAndSize(c, (ssize_t)n), stolen_t{}) {
+        if (!m_ptr)
+            pybind11_fail("Could not allocate string object!");
     }
 
-    // 'explicit' is explicitly omitted from the following constructors to allow implicit conversion to py::str from C++ string-like objects
-    str(const char *c = "")
-        : object(PyUnicode_FromString(c), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate string object!");
+    // 'explicit' is explicitly omitted from the following constructors to allow implicit
+    // conversion to py::str from C++ string-like objects
+    str(const char *c = "") : object(PyUnicode_FromString(c), stolen_t{}) {
+        if (!m_ptr)
+            pybind11_fail("Could not allocate string object!");
     }
 
-    str(const std::string &s) : str(s.data(), s.size()) { }
+    str(const std::string &s) : str(s.data(), s.size()) {}
 
     explicit str(const bytes &b);
 
@@ -1045,7 +1138,10 @@ public:
         the ``str()`` function in Python.
     \endrst */
     // clang-format on
-    explicit str(handle h) : object(raw_str(h.ptr()), stolen_t{}) { if (!m_ptr) throw error_already_set(); }
+    explicit str(handle h) : object(raw_str(h.ptr()), stolen_t{}) {
+        if (!m_ptr)
+            throw error_already_set();
+    }
 
     operator std::string() const {
         object temp = *this;
@@ -1058,11 +1154,10 @@ public:
         ssize_t length;
         if (PYBIND11_BYTES_AS_STRING_AND_SIZE(temp.ptr(), &buffer, &length))
             pybind11_fail("Unable to extract string contents! (invalid type)");
-        return std::string(buffer, (size_t) length);
+        return std::string(buffer, (size_t)length);
     }
 
-    template <typename... Args>
-    str format(Args &&...args) const {
+    template <typename... Args> str format(Args &&...args) const {
         return attr("format")(std::forward<Args>(args)...);
     }
 
@@ -1071,9 +1166,11 @@ private:
     static PyObject *raw_str(PyObject *op) {
         PyObject *str_value = PyObject_Str(op);
 #if PY_MAJOR_VERSION < 3
-        if (!str_value) throw error_already_set();
+        if (!str_value)
+            throw error_already_set();
         PyObject *unicode = PyUnicode_FromEncodedObject(str_value, "utf-8", nullptr);
-        Py_XDECREF(str_value); str_value = unicode;
+        Py_XDECREF(str_value);
+        str_value = unicode;
 #endif
         return str_value;
     }
@@ -1096,18 +1193,19 @@ public:
     PYBIND11_OBJECT(bytes, object, PYBIND11_BYTES_CHECK)
 
     // Allow implicit conversion:
-    bytes(const char *c = "")
-        : object(PYBIND11_BYTES_FROM_STRING(c), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate bytes object!");
+    bytes(const char *c = "") : object(PYBIND11_BYTES_FROM_STRING(c), stolen_t{}) {
+        if (!m_ptr)
+            pybind11_fail("Could not allocate bytes object!");
     }
 
     bytes(const char *c, size_t n)
-        : object(PYBIND11_BYTES_FROM_STRING_AND_SIZE(c, (ssize_t) n), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate bytes object!");
+        : object(PYBIND11_BYTES_FROM_STRING_AND_SIZE(c, (ssize_t)n), stolen_t{}) {
+        if (!m_ptr)
+            pybind11_fail("Could not allocate bytes object!");
     }
 
     // Allow implicit conversion:
-    bytes(const std::string &s) : bytes(s.data(), s.size()) { }
+    bytes(const std::string &s) : bytes(s.data(), s.size()) {}
 
     explicit bytes(const pybind11::str &s);
 
@@ -1116,7 +1214,7 @@ public:
         ssize_t length;
         if (PYBIND11_BYTES_AS_STRING_AND_SIZE(m_ptr, &buffer, &length))
             pybind11_fail("Unable to extract bytes contents!");
-        return std::string(buffer, (size_t) length);
+        return std::string(buffer, (size_t)length);
     }
 };
 // Note: breathe >= 4.17.0 will fail to build docs if the below two constructors
@@ -1140,12 +1238,12 @@ inline bytes::bytes(const pybind11::str &s) {
     m_ptr = obj.release().ptr();
 }
 
-inline str::str(const bytes& b) {
+inline str::str(const bytes &b) {
     char *buffer;
     ssize_t length;
     if (PYBIND11_BYTES_AS_STRING_AND_SIZE(b.ptr(), &buffer, &length))
         pybind11_fail("Unable to extract bytes contents!");
-    auto obj = reinterpret_steal<object>(PyUnicode_FromStringAndSize(buffer, (ssize_t) length));
+    auto obj = reinterpret_steal<object>(PyUnicode_FromStringAndSize(buffer, (ssize_t)length));
     if (!obj)
         pybind11_fail("Could not allocate string object!");
     m_ptr = obj.release().ptr();
@@ -1158,14 +1256,14 @@ public:
     PYBIND11_OBJECT_CVT(bytearray, object, PyByteArray_Check, PyByteArray_FromObject)
 
     bytearray(const char *c, size_t n)
-        : object(PyByteArray_FromStringAndSize(c, (ssize_t) n), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate bytearray object!");
+        : object(PyByteArray_FromStringAndSize(c, (ssize_t)n), stolen_t{}) {
+        if (!m_ptr)
+            pybind11_fail("Could not allocate bytearray object!");
     }
 
-    bytearray()
-        : bytearray("", 0) {}
+    bytearray() : bytearray("", 0) {}
 
-    explicit bytearray(const std::string &s) : bytearray(s.data(), s.size()) { }
+    explicit bytearray(const std::string &s) : bytearray(s.data(), s.size()) {}
 
     size_t size() const { return static_cast<size_t>(PyByteArray_Size(m_ptr)); }
 
@@ -1184,28 +1282,29 @@ public:
 class none : public object {
 public:
     PYBIND11_OBJECT(none, object, detail::PyNone_Check)
-    none() : object(Py_None, borrowed_t{}) { }
+    none() : object(Py_None, borrowed_t{}) {}
 };
 
 class ellipsis : public object {
 public:
     PYBIND11_OBJECT(ellipsis, object, detail::PyEllipsis_Check)
-    ellipsis() : object(Py_Ellipsis, borrowed_t{}) { }
+    ellipsis() : object(Py_Ellipsis, borrowed_t{}) {}
 };
 
 class bool_ : public object {
 public:
     PYBIND11_OBJECT_CVT(bool_, object, PyBool_Check, raw_bool)
-    bool_() : object(Py_False, borrowed_t{}) { }
+    bool_() : object(Py_False, borrowed_t{}) {}
     // Allow implicit conversion from and to `bool`:
-    bool_(bool value) : object(value ? Py_True : Py_False, borrowed_t{}) { }
+    bool_(bool value) : object(value ? Py_True : Py_False, borrowed_t{}) {}
     operator bool() const { return m_ptr && PyLong_AsLong(m_ptr) != 0; }
 
 private:
     /// Return the truth value of an object -- always returns a new reference
     static PyObject *raw_bool(PyObject *op) {
         const auto value = PyObject_IsTrue(op);
-        if (value == -1) return nullptr;
+        if (value == -1)
+            return nullptr;
         return handle(value ? Py_True : Py_False).inc_ref().ptr();
     }
 };
@@ -1215,51 +1314,46 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 // otherwise you get back the unsigned long or unsigned long long value cast to (Unsigned).
 // (The distinction is critically important when casting a returned -1 error value to some other
 // unsigned type: (A)-1 != (B)-1 when A and B are unsigned types of different sizes).
-template <typename Unsigned>
-Unsigned as_unsigned(PyObject *o) {
+template <typename Unsigned> Unsigned as_unsigned(PyObject *o) {
     if (sizeof(Unsigned) <= sizeof(unsigned long)
 #if PY_VERSION_HEX < 0x03000000
-            || PyInt_Check(o)
+        || PyInt_Check(o)
 #endif
     ) {
         unsigned long v = PyLong_AsUnsignedLong(o);
-        return v == (unsigned long) -1 && PyErr_Occurred() ? (Unsigned) -1 : (Unsigned) v;
+        return v == (unsigned long)-1 && PyErr_Occurred() ? (Unsigned)-1 : (Unsigned)v;
     }
     unsigned long long v = PyLong_AsUnsignedLongLong(o);
-    return v == (unsigned long long) -1 && PyErr_Occurred() ? (Unsigned) -1 : (Unsigned) v;
+    return v == (unsigned long long)-1 && PyErr_Occurred() ? (Unsigned)-1 : (Unsigned)v;
 }
 PYBIND11_NAMESPACE_END(detail)
 
 class int_ : public object {
 public:
     PYBIND11_OBJECT_CVT(int_, object, PYBIND11_LONG_CHECK, PyNumber_Long)
-    int_() : object(PyLong_FromLong(0), stolen_t{}) { }
+    int_() : object(PyLong_FromLong(0), stolen_t{}) {}
     // Allow implicit conversion from C++ integral types:
-    template <typename T,
-              detail::enable_if_t<std::is_integral<T>::value, int> = 0>
-    int_(T value) {
+    template <typename T, detail::enable_if_t<std::is_integral<T>::value, int> = 0> int_(T value) {
         if (sizeof(T) <= sizeof(long)) {
             if (std::is_signed<T>::value)
-                m_ptr = PyLong_FromLong((long) value);
+                m_ptr = PyLong_FromLong((long)value);
             else
-                m_ptr = PyLong_FromUnsignedLong((unsigned long) value);
+                m_ptr = PyLong_FromUnsignedLong((unsigned long)value);
         } else {
             if (std::is_signed<T>::value)
-                m_ptr = PyLong_FromLongLong((long long) value);
+                m_ptr = PyLong_FromLongLong((long long)value);
             else
-                m_ptr = PyLong_FromUnsignedLongLong((unsigned long long) value);
+                m_ptr = PyLong_FromUnsignedLongLong((unsigned long long)value);
         }
-        if (!m_ptr) pybind11_fail("Could not allocate int object!");
+        if (!m_ptr)
+            pybind11_fail("Could not allocate int object!");
     }
 
-    template <typename T,
-              detail::enable_if_t<std::is_integral<T>::value, int> = 0>
+    template <typename T, detail::enable_if_t<std::is_integral<T>::value, int> = 0>
     operator T() const {
-        return std::is_unsigned<T>::value
-            ? detail::as_unsigned<T>(m_ptr)
-            : sizeof(T) <= sizeof(long)
-              ? (T) PyLong_AsLong(m_ptr)
-              : (T) PYBIND11_LONG_AS_LONGLONG(m_ptr);
+        return std::is_unsigned<T>::value  ? detail::as_unsigned<T>(m_ptr)
+               : sizeof(T) <= sizeof(long) ? (T)PyLong_AsLong(m_ptr)
+                                           : (T)PYBIND11_LONG_AS_LONGLONG(m_ptr);
     }
 };
 
@@ -1267,14 +1361,16 @@ class float_ : public object {
 public:
     PYBIND11_OBJECT_CVT(float_, object, PyFloat_Check, PyNumber_Float)
     // Allow implicit conversion from float/double:
-    float_(float value) : object(PyFloat_FromDouble((double) value), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate float object!");
+    float_(float value) : object(PyFloat_FromDouble((double)value), stolen_t{}) {
+        if (!m_ptr)
+            pybind11_fail("Could not allocate float object!");
     }
-    float_(double value = .0) : object(PyFloat_FromDouble((double) value), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate float object!");
+    float_(double value = .0) : object(PyFloat_FromDouble((double)value), stolen_t{}) {
+        if (!m_ptr)
+            pybind11_fail("Could not allocate float object!");
     }
-    operator float() const { return (float) PyFloat_AsDouble(m_ptr); }
-    operator double() const { return (double) PyFloat_AsDouble(m_ptr); }
+    operator float() const { return (float)PyFloat_AsDouble(m_ptr); }
+    operator double() const { return (double)PyFloat_AsDouble(m_ptr); }
 };
 
 class weakref : public object {
@@ -1282,13 +1378,12 @@ public:
     PYBIND11_OBJECT_CVT_DEFAULT(weakref, object, PyWeakref_Check, raw_weakref)
     explicit weakref(handle obj, handle callback = {})
         : object(PyWeakref_NewRef(obj.ptr(), callback.ptr()), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate weak reference!");
+        if (!m_ptr)
+            pybind11_fail("Could not allocate weak reference!");
     }
 
 private:
-    static PyObject *raw_weakref(PyObject *o) {
-        return PyWeakref_NewRef(o, nullptr);
-    }
+    static PyObject *raw_weakref(PyObject *o) { return PyWeakref_NewRef(o, nullptr); }
 };
 
 class slice : public object {
@@ -1297,21 +1392,19 @@ public:
     slice(ssize_t start_, ssize_t stop_, ssize_t step_) {
         int_ start(start_), stop(stop_), step(step_);
         m_ptr = PySlice_New(start.ptr(), stop.ptr(), step.ptr());
-        if (!m_ptr) pybind11_fail("Could not allocate slice object!");
+        if (!m_ptr)
+            pybind11_fail("Could not allocate slice object!");
     }
     bool compute(size_t length, size_t *start, size_t *stop, size_t *step,
                  size_t *slicelength) const {
-        return PySlice_GetIndicesEx((PYBIND11_SLICE_OBJECT *) m_ptr,
-                                    (ssize_t) length, (ssize_t *) start,
-                                    (ssize_t *) stop, (ssize_t *) step,
-                                    (ssize_t *) slicelength) == 0;
+        return PySlice_GetIndicesEx((PYBIND11_SLICE_OBJECT *)m_ptr, (ssize_t)length,
+                                    (ssize_t *)start, (ssize_t *)stop, (ssize_t *)step,
+                                    (ssize_t *)slicelength) == 0;
     }
     bool compute(ssize_t length, ssize_t *start, ssize_t *stop, ssize_t *step,
-      ssize_t *slicelength) const {
-      return PySlice_GetIndicesEx((PYBIND11_SLICE_OBJECT *) m_ptr,
-          length, start,
-          stop, step,
-          slicelength) == 0;
+                 ssize_t *slicelength) const {
+        return PySlice_GetIndicesEx((PYBIND11_SLICE_OBJECT *)m_ptr, length, start, stop, step,
+                                    slicelength) == 0;
     }
 };
 
@@ -1319,9 +1412,11 @@ class capsule : public object {
 public:
     PYBIND11_OBJECT_DEFAULT(capsule, object, PyCapsule_CheckExact)
     PYBIND11_DEPRECATED("Use reinterpret_borrow<capsule>() or reinterpret_steal<capsule>()")
-    capsule(PyObject *ptr, bool is_borrowed) : object(is_borrowed ? object(ptr, borrowed_t{}) : object(ptr, stolen_t{})) { }
+    capsule(PyObject *ptr, bool is_borrowed)
+        : object(is_borrowed ? object(ptr, borrowed_t{}) : object(ptr, stolen_t{})) {}
 
-    explicit capsule(const void *value, const char *name = nullptr, void (*destructor)(PyObject *) = nullptr)
+    explicit capsule(const void *value, const char *name = nullptr,
+                     void (*destructor)(PyObject *) = nullptr)
         : object(PyCapsule_New(const_cast<void *>(value), name, destructor), stolen_t{}) {
         if (!m_ptr)
             pybind11_fail("Could not allocate capsule object!");
@@ -1329,7 +1424,7 @@ public:
 
     PYBIND11_DEPRECATED("Please pass a destructor that takes a void pointer as input")
     capsule(const void *value, void (*destruct)(PyObject *))
-        : object(PyCapsule_New(const_cast<void*>(value), nullptr, destruct), stolen_t{}) {
+        : object(PyCapsule_New(const_cast<void *>(value), nullptr, destruct), stolen_t{}) {
         if (!m_ptr)
             pybind11_fail("Could not allocate capsule object!");
     }
@@ -1344,7 +1439,7 @@ public:
         if (!m_ptr)
             pybind11_fail("Could not allocate capsule object!");
 
-        if (PyCapsule_SetContext(m_ptr, (void *) destructor) != 0)
+        if (PyCapsule_SetContext(m_ptr, (void *)destructor) != 0)
             pybind11_fail("Could not set capsule context!");
     }
 
@@ -1358,16 +1453,14 @@ public:
             pybind11_fail("Could not allocate capsule object!");
     }
 
-    template <typename T> operator T *() const {
-        return get_pointer<T>();
-    }
+    template <typename T> operator T *() const { return get_pointer<T>(); }
 
     /// Get the pointer the capsule holds.
-    template<typename T = void>
-    T* get_pointer() const {
+    template <typename T = void> T *get_pointer() const {
         auto name = this->name();
         T *result = static_cast<T *>(PyCapsule_GetPointer(m_ptr, name));
-        if (!result) pybind11_fail("Unable to extract capsule contents!");
+        if (!result)
+            pybind11_fail("Unable to extract capsule contents!");
         return result;
     }
 
@@ -1383,10 +1476,11 @@ public:
 class tuple : public object {
 public:
     PYBIND11_OBJECT_CVT(tuple, object, PyTuple_Check, PySequence_Tuple)
-    explicit tuple(size_t size = 0) : object(PyTuple_New((ssize_t) size), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate tuple object!");
+    explicit tuple(size_t size = 0) : object(PyTuple_New((ssize_t)size), stolen_t{}) {
+        if (!m_ptr)
+            pybind11_fail("Could not allocate tuple object!");
     }
-    size_t size() const { return (size_t) PyTuple_Size(m_ptr); }
+    size_t size() const { return (size_t)PyTuple_Size(m_ptr); }
     bool empty() const { return size() == 0; }
     detail::tuple_accessor operator[](size_t index) const { return {*this, index}; }
     detail::item_accessor operator[](handle h) const { return object::operator[](h); }
@@ -1397,25 +1491,24 @@ public:
 // We need to put this into a separate function because the Intel compiler
 // fails to compile enable_if_t<all_of<is_keyword_or_ds<Args>...>::value> part below
 // (tested with ICC 2021.1 Beta 20200827).
-template <typename... Args>
-constexpr bool args_are_all_keyword_or_ds()
-{
-  return detail::all_of<detail::is_keyword_or_ds<Args>...>::value;
+template <typename... Args> constexpr bool args_are_all_keyword_or_ds() {
+    return detail::all_of<detail::is_keyword_or_ds<Args>...>::value;
 }
 
 class dict : public object {
 public:
     PYBIND11_OBJECT_CVT(dict, object, PyDict_Check, raw_dict)
     dict() : object(PyDict_New(), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate dict object!");
+        if (!m_ptr)
+            pybind11_fail("Could not allocate dict object!");
     }
-    template <typename... Args,
-              typename = detail::enable_if_t<args_are_all_keyword_or_ds<Args...>()>,
-              // MSVC workaround: it can't compile an out-of-line definition, so defer the collector
-              typename collector = detail::deferred_t<detail::unpacking_collector<>, Args...>>
-    explicit dict(Args &&...args) : dict(collector(std::forward<Args>(args)...).kwargs()) { }
+    template <
+        typename... Args, typename = detail::enable_if_t<args_are_all_keyword_or_ds<Args...>()>,
+        // MSVC workaround: it can't compile an out-of-line definition, so defer the collector
+        typename collector = detail::deferred_t<detail::unpacking_collector<>, Args...>>
+    explicit dict(Args &&...args) : dict(collector(std::forward<Args>(args)...).kwargs()) {}
 
-    size_t size() const { return (size_t) PyDict_Size(m_ptr); }
+    size_t size() const { return (size_t)PyDict_Size(m_ptr); }
     bool empty() const { return size() == 0; }
     detail::dict_iterator begin() const { return {*this, 0}; }
     detail::dict_iterator end() const { return {}; }
@@ -1429,7 +1522,7 @@ private:
     static PyObject *raw_dict(PyObject *op) {
         if (PyDict_Check(op))
             return handle(op).inc_ref().ptr();
-        return PyObject_CallFunctionObjArgs((PyObject *) &PyDict_Type, op, nullptr);
+        return PyObject_CallFunctionObjArgs((PyObject *)&PyDict_Type, op, nullptr);
     }
 };
 
@@ -1440,7 +1533,7 @@ public:
         ssize_t result = PySequence_Size(m_ptr);
         if (result == -1)
             throw error_already_set();
-        return (size_t) result;
+        return (size_t)result;
     }
     bool empty() const { return size() == 0; }
     detail::sequence_accessor operator[](size_t index) const { return {*this, index}; }
@@ -1452,10 +1545,11 @@ public:
 class list : public object {
 public:
     PYBIND11_OBJECT_CVT(list, object, PyList_Check, PySequence_List)
-    explicit list(size_t size = 0) : object(PyList_New((ssize_t) size), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate list object!");
+    explicit list(size_t size = 0) : object(PyList_New((ssize_t)size), stolen_t{}) {
+        if (!m_ptr)
+            pybind11_fail("Could not allocate list object!");
     }
-    size_t size() const { return (size_t) PyList_Size(m_ptr); }
+    size_t size() const { return (size_t)PyList_Size(m_ptr); }
     bool empty() const { return size() == 0; }
     detail::list_accessor operator[](size_t index) const { return {*this, index}; }
     detail::item_accessor operator[](handle h) const { return object::operator[](h); }
@@ -1466,20 +1560,25 @@ public:
     }
     template <typename T> void insert(size_t index, T &&val) const {
         PyList_Insert(m_ptr, static_cast<ssize_t>(index),
-            detail::object_or_cast(std::forward<T>(val)).ptr());
+                      detail::object_or_cast(std::forward<T>(val)).ptr());
     }
 };
 
-class args : public tuple { PYBIND11_OBJECT_DEFAULT(args, tuple, PyTuple_Check) };
-class kwargs : public dict { PYBIND11_OBJECT_DEFAULT(kwargs, dict, PyDict_Check)  };
+class args : public tuple {
+    PYBIND11_OBJECT_DEFAULT(args, tuple, PyTuple_Check)
+};
+class kwargs : public dict {
+    PYBIND11_OBJECT_DEFAULT(kwargs, dict, PyDict_Check)
+};
 
 class set : public object {
 public:
     PYBIND11_OBJECT_CVT(set, object, PySet_Check, PySet_New)
     set() : object(PySet_New(nullptr), stolen_t{}) {
-        if (!m_ptr) pybind11_fail("Could not allocate set object!");
+        if (!m_ptr)
+            pybind11_fail("Could not allocate set object!");
     }
-    size_t size() const { return (size_t) PySet_Size(m_ptr); }
+    size_t size() const { return (size_t)PySet_Size(m_ptr); }
     bool empty() const { return size() == 0; }
     template <typename T> bool add(T &&val) const {
         return PySet_Add(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 0;
@@ -1499,7 +1598,7 @@ public:
             return fun;
         return handle();
     }
-    bool is_cpp_function() const { return (bool) cpp_function(); }
+    bool is_cpp_function() const { return (bool)cpp_function(); }
 };
 
 class staticmethod : public object {
@@ -1513,7 +1612,8 @@ public:
 
     buffer_info request(bool writable = false) const {
         int flags = PyBUF_STRIDES | PyBUF_FORMAT;
-        if (writable) flags |= PyBUF_WRITABLE;
+        if (writable)
+            flags |= PyBUF_WRITABLE;
         auto *view = new Py_buffer();
         if (PyObject_GetBuffer(m_ptr, view, flags) != 0) {
             delete view;
@@ -1538,13 +1638,12 @@ public:
         use ``memoryview(const object& obj)`` instead of this constructor.
     \endrst */
     // clang-format on
-    explicit memoryview(const buffer_info& info) {
+    explicit memoryview(const buffer_info &info) {
         if (!info.view())
             pybind11_fail("Prohibited to create memoryview without Py_buffer");
         // Note: PyMemoryView_FromBuffer never increments obj reference.
-        m_ptr = (info.view()->obj) ?
-            PyMemoryView_FromObject(info.view()->obj) :
-            PyMemoryView_FromBuffer(info.view());
+        m_ptr = (info.view()->obj) ? PyMemoryView_FromObject(info.view()->obj)
+                                   : PyMemoryView_FromBuffer(info.view());
         if (!m_ptr)
             pybind11_fail("Unable to create memoryview from buffer descriptor");
     }
@@ -1574,34 +1673,28 @@ public:
             written to.
     \endrst */
     // clang-format on
-    static memoryview from_buffer(
-        void *ptr, ssize_t itemsize, const char *format,
-        detail::any_container<ssize_t> shape,
-        detail::any_container<ssize_t> strides, bool readonly = false);
+    static memoryview from_buffer(void *ptr, ssize_t itemsize, const char *format,
+                                  detail::any_container<ssize_t> shape,
+                                  detail::any_container<ssize_t> strides, bool readonly = false);
 
-    static memoryview from_buffer(
-        const void *ptr, ssize_t itemsize, const char *format,
-        detail::any_container<ssize_t> shape,
-        detail::any_container<ssize_t> strides) {
-        return memoryview::from_buffer(
-            const_cast<void *>(ptr), itemsize, format, std::move(shape), std::move(strides), true);
+    static memoryview from_buffer(const void *ptr, ssize_t itemsize, const char *format,
+                                  detail::any_container<ssize_t> shape,
+                                  detail::any_container<ssize_t> strides) {
+        return memoryview::from_buffer(const_cast<void *>(ptr), itemsize, format, std::move(shape),
+                                       std::move(strides), true);
     }
 
-    template<typename T>
-    static memoryview from_buffer(
-        T *ptr, detail::any_container<ssize_t> shape,
-        detail::any_container<ssize_t> strides, bool readonly = false) {
-        return memoryview::from_buffer(
-            reinterpret_cast<void*>(ptr), sizeof(T),
-            format_descriptor<T>::value, shape, strides, readonly);
+    template <typename T>
+    static memoryview from_buffer(T *ptr, detail::any_container<ssize_t> shape,
+                                  detail::any_container<ssize_t> strides, bool readonly = false) {
+        return memoryview::from_buffer(reinterpret_cast<void *>(ptr), sizeof(T),
+                                       format_descriptor<T>::value, shape, strides, readonly);
     }
 
-    template<typename T>
-    static memoryview from_buffer(
-        const T *ptr, detail::any_container<ssize_t> shape,
-        detail::any_container<ssize_t> strides) {
-        return memoryview::from_buffer(
-            const_cast<T*>(ptr), shape, strides, true);
+    template <typename T>
+    static memoryview from_buffer(const T *ptr, detail::any_container<ssize_t> shape,
+                                  detail::any_container<ssize_t> strides) {
+        return memoryview::from_buffer(const_cast<T *>(ptr), shape, strides, true);
     }
 
 #if PY_MAJOR_VERSION >= 3
@@ -1621,25 +1714,23 @@ public:
     \endrst */
     // clang-format on
     static memoryview from_memory(void *mem, ssize_t size, bool readonly = false) {
-        PyObject* ptr = PyMemoryView_FromMemory(
-            reinterpret_cast<char*>(mem), size,
-            (readonly) ? PyBUF_READ : PyBUF_WRITE);
+        PyObject *ptr = PyMemoryView_FromMemory(reinterpret_cast<char *>(mem), size,
+                                                (readonly) ? PyBUF_READ : PyBUF_WRITE);
         if (!ptr)
             pybind11_fail("Could not allocate memoryview object!");
         return memoryview(object(ptr, stolen_t{}));
     }
 
     static memoryview from_memory(const void *mem, ssize_t size) {
-        return memoryview::from_memory(const_cast<void*>(mem), size, true);
+        return memoryview::from_memory(const_cast<void *>(mem), size, true);
     }
 #endif
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-inline memoryview memoryview::from_buffer(
-    void *ptr, ssize_t itemsize, const char* format,
-    detail::any_container<ssize_t> shape,
-    detail::any_container<ssize_t> strides, bool readonly) {
+inline memoryview memoryview::from_buffer(void *ptr, ssize_t itemsize, const char *format,
+                                          detail::any_container<ssize_t> shape,
+                                          detail::any_container<ssize_t> strides, bool readonly) {
     size_t ndim = shape->size();
     if (ndim != strides->size())
         pybind11_fail("memoryview: shape length doesn't match strides length");
@@ -1652,18 +1743,18 @@ inline memoryview memoryview::from_buffer(
     view.len = size * itemsize;
     view.readonly = static_cast<int>(readonly);
     view.itemsize = itemsize;
-    view.format = const_cast<char*>(format);
+    view.format = const_cast<char *>(format);
     view.ndim = static_cast<int>(ndim);
     view.shape = shape->data();
     view.strides = strides->data();
     view.suboffsets = nullptr;
     view.internal = nullptr;
-    PyObject* obj = PyMemoryView_FromBuffer(&view);
+    PyObject *obj = PyMemoryView_FromBuffer(&view);
     if (!obj)
         throw error_already_set();
     return memoryview(object(obj, stolen_t{}));
 }
-#endif  // DOXYGEN_SHOULD_SKIP_THIS
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 /// @} pytypes
 
 /// \addtogroup python_builtins
@@ -1674,7 +1765,7 @@ inline size_t len(handle h) {
     ssize_t result = PyObject_Length(h.ptr());
     if (result < 0)
         throw error_already_set();
-    return (size_t) result;
+    return (size_t)result;
 }
 
 /// Get the length hint of a Python object.
@@ -1691,23 +1782,28 @@ inline size_t len_hint(handle h) {
         PyErr_Clear();
         return 0;
     }
-    return (size_t) result;
+    return (size_t)result;
 }
 
 inline str repr(handle h) {
     PyObject *str_value = PyObject_Repr(h.ptr());
-    if (!str_value) throw error_already_set();
+    if (!str_value)
+        throw error_already_set();
 #if PY_MAJOR_VERSION < 3
     PyObject *unicode = PyUnicode_FromEncodedObject(str_value, "utf-8", nullptr);
-    Py_XDECREF(str_value); str_value = unicode;
-    if (!str_value) throw error_already_set();
+    Py_XDECREF(str_value);
+    str_value = unicode;
+    if (!str_value)
+        throw error_already_set();
 #endif
     return reinterpret_steal<str>(str_value);
 }
 
 inline iterator iter(handle obj) {
     PyObject *result = PyObject_GetIter(obj.ptr());
-    if (!result) { throw error_already_set(); }
+    if (!result) {
+        throw error_already_set();
+    }
     return reinterpret_steal<iterator>(result);
 }
 /// @} python_builtins
@@ -1734,60 +1830,54 @@ template <typename D> template <typename T> bool object_api<D>::contains(T &&ite
     return attr("__contains__")(std::forward<T>(item)).template cast<bool>();
 }
 
-template <typename D>
-pybind11::str object_api<D>::str() const { return pybind11::str(derived()); }
+template <typename D> pybind11::str object_api<D>::str() const { return pybind11::str(derived()); }
 
-template <typename D>
-str_attr_accessor object_api<D>::doc() const { return attr("__doc__"); }
+template <typename D> str_attr_accessor object_api<D>::doc() const { return attr("__doc__"); }
 
-template <typename D>
-handle object_api<D>::get_type() const { return type::handle_of(derived()); }
+template <typename D> handle object_api<D>::get_type() const { return type::handle_of(derived()); }
 
-template <typename D>
-bool object_api<D>::rich_compare(object_api const &other, int value) const {
+template <typename D> bool object_api<D>::rich_compare(object_api const &other, int value) const {
     int rv = PyObject_RichCompareBool(derived().ptr(), other.derived().ptr(), value);
     if (rv == -1)
         throw error_already_set();
     return rv == 1;
 }
 
-#define PYBIND11_MATH_OPERATOR_UNARY(op, fn)                                   \
-    template <typename D> object object_api<D>::op() const {                   \
-        object result = reinterpret_steal<object>(fn(derived().ptr()));        \
-        if (!result.ptr())                                                     \
-            throw error_already_set();                                         \
-        return result;                                                         \
+#define PYBIND11_MATH_OPERATOR_UNARY(op, fn)                                                      \
+    template <typename D> object object_api<D>::op() const {                                      \
+        object result = reinterpret_steal<object>(fn(derived().ptr()));                           \
+        if (!result.ptr())                                                                        \
+            throw error_already_set();                                                            \
+        return result;                                                                            \
     }
 
-#define PYBIND11_MATH_OPERATOR_BINARY(op, fn)                                  \
-    template <typename D>                                                      \
-    object object_api<D>::op(object_api const &other) const {                  \
-        object result = reinterpret_steal<object>(                             \
-            fn(derived().ptr(), other.derived().ptr()));                       \
-        if (!result.ptr())                                                     \
-            throw error_already_set();                                         \
-        return result;                                                         \
+#define PYBIND11_MATH_OPERATOR_BINARY(op, fn)                                                     \
+    template <typename D> object object_api<D>::op(object_api const &other) const {               \
+        object result = reinterpret_steal<object>(fn(derived().ptr(), other.derived().ptr()));    \
+        if (!result.ptr())                                                                        \
+            throw error_already_set();                                                            \
+        return result;                                                                            \
     }
 
-PYBIND11_MATH_OPERATOR_UNARY (operator~,   PyNumber_Invert)
-PYBIND11_MATH_OPERATOR_UNARY (operator-,   PyNumber_Negative)
-PYBIND11_MATH_OPERATOR_BINARY(operator+,   PyNumber_Add)
-PYBIND11_MATH_OPERATOR_BINARY(operator+=,  PyNumber_InPlaceAdd)
-PYBIND11_MATH_OPERATOR_BINARY(operator-,   PyNumber_Subtract)
-PYBIND11_MATH_OPERATOR_BINARY(operator-=,  PyNumber_InPlaceSubtract)
-PYBIND11_MATH_OPERATOR_BINARY(operator*,   PyNumber_Multiply)
-PYBIND11_MATH_OPERATOR_BINARY(operator*=,  PyNumber_InPlaceMultiply)
-PYBIND11_MATH_OPERATOR_BINARY(operator/,   PyNumber_TrueDivide)
-PYBIND11_MATH_OPERATOR_BINARY(operator/=,  PyNumber_InPlaceTrueDivide)
-PYBIND11_MATH_OPERATOR_BINARY(operator|,   PyNumber_Or)
-PYBIND11_MATH_OPERATOR_BINARY(operator|=,  PyNumber_InPlaceOr)
-PYBIND11_MATH_OPERATOR_BINARY(operator&,   PyNumber_And)
-PYBIND11_MATH_OPERATOR_BINARY(operator&=,  PyNumber_InPlaceAnd)
-PYBIND11_MATH_OPERATOR_BINARY(operator^,   PyNumber_Xor)
-PYBIND11_MATH_OPERATOR_BINARY(operator^=,  PyNumber_InPlaceXor)
-PYBIND11_MATH_OPERATOR_BINARY(operator<<,  PyNumber_Lshift)
+PYBIND11_MATH_OPERATOR_UNARY(operator~, PyNumber_Invert)
+PYBIND11_MATH_OPERATOR_UNARY(operator-, PyNumber_Negative)
+PYBIND11_MATH_OPERATOR_BINARY(operator+, PyNumber_Add)
+PYBIND11_MATH_OPERATOR_BINARY(operator+=, PyNumber_InPlaceAdd)
+PYBIND11_MATH_OPERATOR_BINARY(operator-, PyNumber_Subtract)
+PYBIND11_MATH_OPERATOR_BINARY(operator-=, PyNumber_InPlaceSubtract)
+PYBIND11_MATH_OPERATOR_BINARY(operator*, PyNumber_Multiply)
+PYBIND11_MATH_OPERATOR_BINARY(operator*=, PyNumber_InPlaceMultiply)
+PYBIND11_MATH_OPERATOR_BINARY(operator/, PyNumber_TrueDivide)
+PYBIND11_MATH_OPERATOR_BINARY(operator/=, PyNumber_InPlaceTrueDivide)
+PYBIND11_MATH_OPERATOR_BINARY(operator|, PyNumber_Or)
+PYBIND11_MATH_OPERATOR_BINARY(operator|=, PyNumber_InPlaceOr)
+PYBIND11_MATH_OPERATOR_BINARY(operator&, PyNumber_And)
+PYBIND11_MATH_OPERATOR_BINARY(operator&=, PyNumber_InPlaceAnd)
+PYBIND11_MATH_OPERATOR_BINARY(operator^, PyNumber_Xor)
+PYBIND11_MATH_OPERATOR_BINARY(operator^=, PyNumber_InPlaceXor)
+PYBIND11_MATH_OPERATOR_BINARY(operator<<, PyNumber_Lshift)
 PYBIND11_MATH_OPERATOR_BINARY(operator<<=, PyNumber_InPlaceLshift)
-PYBIND11_MATH_OPERATOR_BINARY(operator>>,  PyNumber_Rshift)
+PYBIND11_MATH_OPERATOR_BINARY(operator>>, PyNumber_Rshift)
 PYBIND11_MATH_OPERATOR_BINARY(operator>>=, PyNumber_InPlaceRshift)
 
 #undef PYBIND11_MATH_OPERATOR_UNARY

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -10,42 +10,42 @@
 #pragma once
 
 #include "pybind11.h"
-#include <set>
-#include <unordered_set>
-#include <map>
-#include <unordered_map>
+#include <deque>
 #include <iostream>
 #include <list>
-#include <deque>
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
 #include <valarray>
 
 #if defined(_MSC_VER)
 #pragma warning(push)
-#pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
+#pragma warning(disable : 4127) // warning C4127: Conditional expression is constant
 #endif
 
 #ifdef __has_include
 // std::optional (but including it in c++14 mode isn't allowed)
-#  if defined(PYBIND11_CPP17) && __has_include(<optional>)
-#    include <optional>
-#    define PYBIND11_HAS_OPTIONAL 1
-#  endif
+#if defined(PYBIND11_CPP17) && __has_include(<optional>)
+#include <optional>
+#define PYBIND11_HAS_OPTIONAL 1
+#endif
 // std::experimental::optional (but not allowed in c++11 mode)
-#  if defined(PYBIND11_CPP14) && (__has_include(<experimental/optional>) && \
+#if defined(PYBIND11_CPP14) && (__has_include(<experimental/optional>) && \
                                  !__has_include(<optional>))
-#    include <experimental/optional>
-#    define PYBIND11_HAS_EXP_OPTIONAL 1
-#  endif
+#include <experimental/optional>
+#define PYBIND11_HAS_EXP_OPTIONAL 1
+#endif
 // std::variant
-#  if defined(PYBIND11_CPP17) && __has_include(<variant>)
-#    include <variant>
-#    define PYBIND11_HAS_VARIANT 1
-#  endif
+#if defined(PYBIND11_CPP17) && __has_include(<variant>)
+#include <variant>
+#define PYBIND11_HAS_VARIANT 1
+#endif
 #elif defined(_MSC_VER) && defined(PYBIND11_CPP17)
-#  include <optional>
-#  include <variant>
-#  define PYBIND11_HAS_OPTIONAL 1
-#  define PYBIND11_HAS_VARIANT 1
+#include <optional>
+#include <variant>
+#define PYBIND11_HAS_OPTIONAL 1
+#define PYBIND11_HAS_VARIANT 1
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
@@ -54,13 +54,12 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 /// Extracts an const lvalue reference or rvalue reference for U based on the type of T (e.g. for
 /// forwarding a container element).  Typically used indirect via forwarded_type(), below.
 template <typename T, typename U>
-using forwarded_type = conditional_t<
-    std::is_lvalue_reference<T>::value, remove_reference_t<U> &, remove_reference_t<U> &&>;
+using forwarded_type = conditional_t<std::is_lvalue_reference<T>::value, remove_reference_t<U> &,
+                                     remove_reference_t<U> &&>;
 
 /// Forwards a value U as rvalue or lvalue according to whether T is rvalue or lvalue; typically
 /// used for forwarding a container's elements.
-template <typename T, typename U>
-forwarded_type<T, U> forward_like(U &&u) {
+template <typename T, typename U> forwarded_type<T, U> forward_like(U &&u) {
     return std::forward<detail::forwarded_type<T, U>>(std::forward<U>(u));
 }
 
@@ -82,13 +81,13 @@ template <typename Type, typename Key> struct set_caster {
         return true;
     }
 
-    template <typename T>
-    static handle cast(T &&src, return_value_policy policy, handle parent) {
+    template <typename T> static handle cast(T &&src, return_value_policy policy, handle parent) {
         if (!std::is_lvalue_reference<T>::value)
             policy = return_value_policy_override<Key>::policy(policy);
         pybind11::set s;
         for (auto &&value : src) {
-            auto value_ = reinterpret_steal<object>(key_conv::cast(forward_like<T>(value), policy, parent));
+            auto value_ =
+                reinterpret_steal<object>(key_conv::cast(forward_like<T>(value), policy, parent));
             if (!value_ || !s.add(value_))
                 return handle();
         }
@@ -99,7 +98,7 @@ template <typename Type, typename Key> struct set_caster {
 };
 
 template <typename Type, typename Key, typename Value> struct map_caster {
-    using key_conv   = make_caster<Key>;
+    using key_conv = make_caster<Key>;
     using value_conv = make_caster<Value>;
 
     bool load(handle src, bool convert) {
@@ -110,16 +109,14 @@ template <typename Type, typename Key, typename Value> struct map_caster {
         for (auto it : d) {
             key_conv kconv;
             value_conv vconv;
-            if (!kconv.load(it.first.ptr(), convert) ||
-                !vconv.load(it.second.ptr(), convert))
+            if (!kconv.load(it.first.ptr(), convert) || !vconv.load(it.second.ptr(), convert))
                 return false;
             value.emplace(cast_op<Key &&>(std::move(kconv)), cast_op<Value &&>(std::move(vconv)));
         }
         return true;
     }
 
-    template <typename T>
-    static handle cast(T &&src, return_value_policy policy, handle parent) {
+    template <typename T> static handle cast(T &&src, return_value_policy policy, handle parent) {
         dict d;
         return_value_policy policy_key = policy;
         return_value_policy policy_value = policy;
@@ -128,8 +125,10 @@ template <typename Type, typename Key, typename Value> struct map_caster {
             policy_value = return_value_policy_override<Value>::policy(policy_value);
         }
         for (auto &&kv : src) {
-            auto key = reinterpret_steal<object>(key_conv::cast(forward_like<T>(kv.first), policy_key, parent));
-            auto value = reinterpret_steal<object>(value_conv::cast(forward_like<T>(kv.second), policy_value, parent));
+            auto key = reinterpret_steal<object>(
+                key_conv::cast(forward_like<T>(kv.first), policy_key, parent));
+            auto value = reinterpret_steal<object>(
+                value_conv::cast(forward_like<T>(kv.second), policy_value, parent));
             if (!key || !value)
                 return handle();
             d[key] = value;
@@ -160,7 +159,7 @@ template <typename Type, typename Value> struct list_caster {
 
 private:
     template <
-        typename T                                                                          = Type,
+        typename T = Type,
         enable_if_t<std::is_same<decltype(std::declval<T>().reserve(0)), void>::value, int> = 0>
     void reserve_maybe(const sequence &s, Type *) {
         value.reserve(s.size());
@@ -168,17 +167,18 @@ private:
     void reserve_maybe(const sequence &, void *) {}
 
 public:
-    template <typename T>
-    static handle cast(T &&src, return_value_policy policy, handle parent) {
+    template <typename T> static handle cast(T &&src, return_value_policy policy, handle parent) {
         if (!std::is_lvalue_reference<T>::value)
             policy = return_value_policy_override<Value>::policy(policy);
         list l(src.size());
         size_t index = 0;
         for (auto &&value : src) {
-            auto value_ = reinterpret_steal<object>(value_conv::cast(forward_like<T>(value), policy, parent));
+            auto value_ = reinterpret_steal<object>(
+                value_conv::cast(forward_like<T>(value), policy, parent));
             if (!value_)
                 return handle();
-            PyList_SET_ITEM(l.ptr(), (ssize_t) index++, value_.release().ptr()); // steals a reference
+            PyList_SET_ITEM(l.ptr(), (ssize_t)index++,
+                            value_.release().ptr()); // steals a reference
         }
         return l.release();
     }
@@ -186,27 +186,26 @@ public:
     PYBIND11_TYPE_CASTER(Type, _("List[") + value_conv::name + _("]"));
 };
 
-template <typename Type, typename Alloc> struct type_caster<std::vector<Type, Alloc>>
- : list_caster<std::vector<Type, Alloc>, Type> { };
+template <typename Type, typename Alloc>
+struct type_caster<std::vector<Type, Alloc>> : list_caster<std::vector<Type, Alloc>, Type> {};
 
-template <typename Type, typename Alloc> struct type_caster<std::deque<Type, Alloc>>
- : list_caster<std::deque<Type, Alloc>, Type> { };
+template <typename Type, typename Alloc>
+struct type_caster<std::deque<Type, Alloc>> : list_caster<std::deque<Type, Alloc>, Type> {};
 
-template <typename Type, typename Alloc> struct type_caster<std::list<Type, Alloc>>
- : list_caster<std::list<Type, Alloc>, Type> { };
+template <typename Type, typename Alloc>
+struct type_caster<std::list<Type, Alloc>> : list_caster<std::list<Type, Alloc>, Type> {};
 
-template <typename ArrayType, typename Value, bool Resizable, size_t Size = 0> struct array_caster {
+template <typename ArrayType, typename Value, bool Resizable, size_t Size = 0>
+struct array_caster {
     using value_conv = make_caster<Value>;
 
 private:
-    template <bool R = Resizable>
-    bool require_size(enable_if_t<R, size_t> size) {
+    template <bool R = Resizable> bool require_size(enable_if_t<R, size_t> size) {
         if (value.size() != size)
             value.resize(size);
         return true;
     }
-    template <bool R = Resizable>
-    bool require_size(enable_if_t<!R, size_t> size) {
+    template <bool R = Resizable> bool require_size(enable_if_t<!R, size_t> size) {
         return size == Size;
     }
 
@@ -227,42 +226,49 @@ public:
         return true;
     }
 
-    template <typename T>
-    static handle cast(T &&src, return_value_policy policy, handle parent) {
+    template <typename T> static handle cast(T &&src, return_value_policy policy, handle parent) {
         list l(src.size());
         size_t index = 0;
         for (auto &&value : src) {
-            auto value_ = reinterpret_steal<object>(value_conv::cast(forward_like<T>(value), policy, parent));
+            auto value_ = reinterpret_steal<object>(
+                value_conv::cast(forward_like<T>(value), policy, parent));
             if (!value_)
                 return handle();
-            PyList_SET_ITEM(l.ptr(), (ssize_t) index++, value_.release().ptr()); // steals a reference
+            PyList_SET_ITEM(l.ptr(), (ssize_t)index++,
+                            value_.release().ptr()); // steals a reference
         }
         return l.release();
     }
 
-    PYBIND11_TYPE_CASTER(ArrayType, _("List[") + value_conv::name + _<Resizable>(_(""), _("[") + _<Size>() + _("]")) + _("]"));
+    PYBIND11_TYPE_CASTER(ArrayType, _("List[") + value_conv::name +
+                                        _<Resizable>(_(""), _("[") + _<Size>() + _("]")) + _("]"));
 };
 
-template <typename Type, size_t Size> struct type_caster<std::array<Type, Size>>
- : array_caster<std::array<Type, Size>, Type, false, Size> { };
+template <typename Type, size_t Size>
+struct type_caster<std::array<Type, Size>>
+    : array_caster<std::array<Type, Size>, Type, false, Size> {};
 
-template <typename Type> struct type_caster<std::valarray<Type>>
- : array_caster<std::valarray<Type>, Type, true> { };
+template <typename Type>
+struct type_caster<std::valarray<Type>> : array_caster<std::valarray<Type>, Type, true> {};
 
-template <typename Key, typename Compare, typename Alloc> struct type_caster<std::set<Key, Compare, Alloc>>
-  : set_caster<std::set<Key, Compare, Alloc>, Key> { };
+template <typename Key, typename Compare, typename Alloc>
+struct type_caster<std::set<Key, Compare, Alloc>>
+    : set_caster<std::set<Key, Compare, Alloc>, Key> {};
 
-template <typename Key, typename Hash, typename Equal, typename Alloc> struct type_caster<std::unordered_set<Key, Hash, Equal, Alloc>>
-  : set_caster<std::unordered_set<Key, Hash, Equal, Alloc>, Key> { };
+template <typename Key, typename Hash, typename Equal, typename Alloc>
+struct type_caster<std::unordered_set<Key, Hash, Equal, Alloc>>
+    : set_caster<std::unordered_set<Key, Hash, Equal, Alloc>, Key> {};
 
-template <typename Key, typename Value, typename Compare, typename Alloc> struct type_caster<std::map<Key, Value, Compare, Alloc>>
-  : map_caster<std::map<Key, Value, Compare, Alloc>, Key, Value> { };
+template <typename Key, typename Value, typename Compare, typename Alloc>
+struct type_caster<std::map<Key, Value, Compare, Alloc>>
+    : map_caster<std::map<Key, Value, Compare, Alloc>, Key, Value> {};
 
-template <typename Key, typename Value, typename Hash, typename Equal, typename Alloc> struct type_caster<std::unordered_map<Key, Value, Hash, Equal, Alloc>>
-  : map_caster<std::unordered_map<Key, Value, Hash, Equal, Alloc>, Key, Value> { };
+template <typename Key, typename Value, typename Hash, typename Equal, typename Alloc>
+struct type_caster<std::unordered_map<Key, Value, Hash, Equal, Alloc>>
+    : map_caster<std::unordered_map<Key, Value, Hash, Equal, Alloc>, Key, Value> {};
 
 // This type caster is intended to be used for std::optional and std::experimental::optional
-template<typename T> struct optional_caster {
+template <typename T> struct optional_caster {
     using value_conv = make_caster<typename T::value_type>;
 
     template <typename T_>
@@ -280,7 +286,7 @@ template<typename T> struct optional_caster {
             return false;
         }
         if (src.is_none()) {
-            return true;  // default-constructed value is already empty
+            return true; // default-constructed value is already empty
         }
         value_conv inner_caster;
         if (!inner_caster.load(src, convert))
@@ -294,18 +300,19 @@ template<typename T> struct optional_caster {
 };
 
 #if defined(PYBIND11_HAS_OPTIONAL)
-template<typename T> struct type_caster<std::optional<T>>
-    : public optional_caster<std::optional<T>> {};
+template <typename T>
+struct type_caster<std::optional<T>> : public optional_caster<std::optional<T>> {};
 
-template<> struct type_caster<std::nullopt_t>
-    : public void_caster<std::nullopt_t> {};
+template <> struct type_caster<std::nullopt_t> : public void_caster<std::nullopt_t> {};
 #endif
 
 #if defined(PYBIND11_HAS_EXP_OPTIONAL)
-template<typename T> struct type_caster<std::experimental::optional<T>>
+template <typename T>
+struct type_caster<std::experimental::optional<T>>
     : public optional_caster<std::experimental::optional<T>> {};
 
-template<> struct type_caster<std::experimental::nullopt_t>
+template <>
+struct type_caster<std::experimental::nullopt_t>
     : public void_caster<std::experimental::nullopt_t> {};
 #endif
 
@@ -316,8 +323,7 @@ struct variant_caster_visitor {
 
     using result_type = handle; // required by boost::variant in C++11
 
-    template <typename T>
-    result_type operator()(T &&src) const {
+    template <typename T> result_type operator()(T &&src) const {
         return make_caster<T>::cast(std::forward<T>(src), policy, parent);
     }
 };
@@ -326,8 +332,7 @@ struct variant_caster_visitor {
 /// `namespace::variant` types which provide a `namespace::visit()` function are handled here
 /// automatically using argument-dependent lookup. Users can provide specializations for other
 /// variant-like classes, e.g. `boost::variant` and `boost::apply_visitor`.
-template <template<typename...> class Variant>
-struct visit_helper {
+template <template <typename...> class Variant> struct visit_helper {
     template <typename... Args>
     static auto call(Args &&...args) -> decltype(visit(std::forward<Args>(args)...)) {
         return visit(std::forward<Args>(args)...);
@@ -337,8 +342,7 @@ struct visit_helper {
 /// Generic variant caster
 template <typename Variant> struct variant_caster;
 
-template <template<typename...> class V, typename... Ts>
-struct variant_caster<V<Ts...>> {
+template <template <typename...> class V, typename... Ts> struct variant_caster<V<Ts...>> {
     static_assert(sizeof...(Ts) > 0, "Variant must consist of at least one alternative.");
 
     template <typename U, typename... Us>
@@ -375,7 +379,7 @@ struct variant_caster<V<Ts...>> {
 
 #if defined(PYBIND11_HAS_VARIANT)
 template <typename... Ts>
-struct type_caster<std::variant<Ts...>> : variant_caster<std::variant<Ts...>> { };
+struct type_caster<std::variant<Ts...>> : variant_caster<std::variant<Ts...>> {};
 #endif
 
 PYBIND11_NAMESPACE_END(detail)
@@ -384,7 +388,7 @@ inline std::ostream &operator<<(std::ostream &os, const handle &obj) {
 #ifdef PYBIND11_HAS_STRING_VIEW
     os << str(obj).cast<std::string_view>();
 #else
-    os << (std::string) str(obj);
+    os << (std::string)str(obj);
 #endif
     return os;
 }

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -14,44 +14,44 @@
 #include <string>
 
 #ifdef __has_include
-#  if defined(PYBIND11_CPP17) && __has_include(<filesystem>) && \
+#if defined(PYBIND11_CPP17) && __has_include(<filesystem>) && \
       PY_VERSION_HEX >= 0x03060000
-#    include <filesystem>
-#    define PYBIND11_HAS_FILESYSTEM 1
-#  endif
+#include <filesystem>
+#define PYBIND11_HAS_FILESYSTEM 1
+#endif
 #endif
 
 #if !defined(PYBIND11_HAS_FILESYSTEM) && !defined(PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL)
-#    error                                                                                        \
-        "#include <filesystem> is not available. (Use -DPYBIND11_HAS_FILESYSTEM_IS_OPTIONAL to ignore.)"
+#error                                                                                            \
+    "#include <filesystem> is not available. (Use -DPYBIND11_HAS_FILESYSTEM_IS_OPTIONAL to ignore.)"
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 #if defined(PYBIND11_HAS_FILESYSTEM)
-template<typename T> struct path_caster {
+template <typename T> struct path_caster {
 
 private:
-    static PyObject* unicode_from_fs_native(const std::string& w) {
+    static PyObject *unicode_from_fs_native(const std::string &w) {
 #if !defined(PYPY_VERSION)
         return PyUnicode_DecodeFSDefaultAndSize(w.c_str(), ssize_t(w.size()));
 #else
         // PyPy mistakenly declares the first parameter as non-const.
-        return PyUnicode_DecodeFSDefaultAndSize(
-            const_cast<char*>(w.c_str()), ssize_t(w.size()));
+        return PyUnicode_DecodeFSDefaultAndSize(const_cast<char *>(w.c_str()), ssize_t(w.size()));
 #endif
     }
 
-    static PyObject* unicode_from_fs_native(const std::wstring& w) {
+    static PyObject *unicode_from_fs_native(const std::wstring &w) {
         return PyUnicode_FromWideChar(w.c_str(), ssize_t(w.size()));
     }
 
 public:
-    static handle cast(const T& path, return_value_policy, handle) {
+    static handle cast(const T &path, return_value_policy, handle) {
         if (auto py_str = unicode_from_fs_native(path.native())) {
-            return module_::import("pathlib").attr("Path")(reinterpret_steal<object>(py_str))
-                   .release();
+            return module_::import("pathlib")
+                .attr("Path")(reinterpret_steal<object>(py_str))
+                .release();
         }
         return nullptr;
     }
@@ -60,12 +60,12 @@ public:
         // PyUnicode_FSConverter and PyUnicode_FSDecoder normally take care of
         // calling PyOS_FSPath themselves, but that's broken on PyPy (PyPy
         // issue #3168) so we do it ourselves instead.
-        PyObject* buf = PyOS_FSPath(handle.ptr());
+        PyObject *buf = PyOS_FSPath(handle.ptr());
         if (!buf) {
             PyErr_Clear();
             return false;
         }
-        PyObject* native = nullptr;
+        PyObject *native = nullptr;
         if constexpr (std::is_same_v<typename T::value_type, char>) {
             if (PyUnicode_FSConverter(buf, &native)) {
                 if (auto c_str = PyBytes_AsString(native)) {
@@ -78,7 +78,7 @@ public:
             if (PyUnicode_FSDecoder(buf, &native)) {
                 if (auto c_str = PyUnicode_AsWideCharString(native, nullptr)) {
                     // AsWideCharString returns a new string that must be free'd.
-                    value = c_str;  // Copies the string.
+                    value = c_str; // Copies the string.
                     PyMem_Free(c_str);
                 }
             }
@@ -95,8 +95,8 @@ public:
     PYBIND11_TYPE_CASTER(T, _("os.PathLike"));
 };
 
-template<> struct type_caster<std::filesystem::path>
-    : public path_caster<std::filesystem::path> {};
+template <>
+struct type_caster<std::filesystem::path> : public path_caster<std::filesystem::path> {};
 #endif // PYBIND11_HAS_FILESYSTEM
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -19,73 +19,74 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 /* SFINAE helper class used by 'is_comparable */
-template <typename T>  struct container_traits {
-    template <typename T2> static std::true_type test_comparable(decltype(std::declval<const T2 &>() == std::declval<const T2 &>())*);
+template <typename T> struct container_traits {
+    template <typename T2>
+    static std::true_type
+    test_comparable(decltype(std::declval<const T2 &>() == std::declval<const T2 &>()) *);
     template <typename T2> static std::false_type test_comparable(...);
     template <typename T2> static std::true_type test_value(typename T2::value_type *);
     template <typename T2> static std::false_type test_value(...);
-    template <typename T2> static std::true_type test_pair(typename T2::first_type *, typename T2::second_type *);
+    template <typename T2>
+    static std::true_type test_pair(typename T2::first_type *, typename T2::second_type *);
     template <typename T2> static std::false_type test_pair(...);
 
-    static constexpr const bool is_comparable = std::is_same<std::true_type, decltype(test_comparable<T>(nullptr))>::value;
-    static constexpr const bool is_pair = std::is_same<std::true_type, decltype(test_pair<T>(nullptr, nullptr))>::value;
-    static constexpr const bool is_vector = std::is_same<std::true_type, decltype(test_value<T>(nullptr))>::value;
+    static constexpr const bool is_comparable =
+        std::is_same<std::true_type, decltype(test_comparable<T>(nullptr))>::value;
+    static constexpr const bool is_pair =
+        std::is_same<std::true_type, decltype(test_pair<T>(nullptr, nullptr))>::value;
+    static constexpr const bool is_vector =
+        std::is_same<std::true_type, decltype(test_value<T>(nullptr))>::value;
     static constexpr const bool is_element = !is_pair && !is_vector;
 };
 
 /* Default: is_comparable -> std::false_type */
-template <typename T, typename SFINAE = void>
-struct is_comparable : std::false_type { };
+template <typename T, typename SFINAE = void> struct is_comparable : std::false_type {};
 
 /* For non-map data structures, check whether operator== can be instantiated */
 template <typename T>
 struct is_comparable<
-    T, enable_if_t<container_traits<T>::is_element &&
-                   container_traits<T>::is_comparable>>
-    : std::true_type { };
+    T, enable_if_t<container_traits<T>::is_element && container_traits<T>::is_comparable>>
+    : std::true_type {};
 
-/* For a vector/map data structure, recursively check the value type (which is std::pair for maps) */
-template <typename T>
-struct is_comparable<T, enable_if_t<container_traits<T>::is_vector>> {
-    static constexpr const bool value =
-        is_comparable<typename T::value_type>::value;
+/* For a vector/map data structure, recursively check the value type (which is std::pair for maps)
+ */
+template <typename T> struct is_comparable<T, enable_if_t<container_traits<T>::is_vector>> {
+    static constexpr const bool value = is_comparable<typename T::value_type>::value;
 };
 
 /* For pairs, recursively check the two data types */
-template <typename T>
-struct is_comparable<T, enable_if_t<container_traits<T>::is_pair>> {
-    static constexpr const bool value =
-        is_comparable<typename T::first_type>::value &&
-        is_comparable<typename T::second_type>::value;
+template <typename T> struct is_comparable<T, enable_if_t<container_traits<T>::is_pair>> {
+    static constexpr const bool value = is_comparable<typename T::first_type>::value &&
+                                        is_comparable<typename T::second_type>::value;
 };
 
 /* Fallback functions */
-template <typename, typename, typename... Args> void vector_if_copy_constructible(const Args &...) { }
-template <typename, typename, typename... Args> void vector_if_equal_operator(const Args &...) { }
-template <typename, typename, typename... Args> void vector_if_insertion_operator(const Args &...) { }
-template <typename, typename, typename... Args> void vector_modifiers(const Args &...) { }
+template <typename, typename, typename... Args>
+void vector_if_copy_constructible(const Args &...) {}
+template <typename, typename, typename... Args> void vector_if_equal_operator(const Args &...) {}
+template <typename, typename, typename... Args>
+void vector_if_insertion_operator(const Args &...) {}
+template <typename, typename, typename... Args> void vector_modifiers(const Args &...) {}
 
-template<typename Vector, typename Class_>
+template <typename Vector, typename Class_>
 void vector_if_copy_constructible(enable_if_t<is_copy_constructible<Vector>::value, Class_> &cl) {
     cl.def(init<const Vector &>(), "Copy constructor");
 }
 
-template<typename Vector, typename Class_>
+template <typename Vector, typename Class_>
 void vector_if_equal_operator(enable_if_t<is_comparable<Vector>::value, Class_> &cl) {
     using T = typename Vector::value_type;
 
     cl.def(self == self);
     cl.def(self != self);
 
-    cl.def("count",
-        [](const Vector &v, const T &x) {
-            return std::count(v.begin(), v.end(), x);
-        },
-        arg("x"),
-        "Return the number of times ``x`` appears in the list"
-    );
+    cl.def(
+        "count", [](const Vector &v, const T &x) { return std::count(v.begin(), v.end(), x); },
+        arg("x"), "Return the number of times ``x`` appears in the list");
 
-    cl.def("remove", [](Vector &v, const T &x) {
+    cl.def(
+        "remove",
+        [](Vector &v, const T &x) {
             auto p = std::find(v.begin(), v.end(), x);
             if (p != v.end())
                 v.erase(p);
@@ -94,23 +95,20 @@ void vector_if_equal_operator(enable_if_t<is_comparable<Vector>::value, Class_> 
         },
         arg("x"),
         "Remove the first item from the list whose value is x. "
-        "It is an error if there is no such item."
-    );
+        "It is an error if there is no such item.");
 
-    cl.def("__contains__",
-        [](const Vector &v, const T &x) {
-            return std::find(v.begin(), v.end(), x) != v.end();
-        },
-        arg("x"),
-        "Return true the container contains ``x``"
-    );
+    cl.def(
+        "__contains__",
+        [](const Vector &v, const T &x) { return std::find(v.begin(), v.end(), x) != v.end(); },
+        arg("x"), "Return true the container contains ``x``");
 }
 
 // Vector modifiers -- requires a copyable vector_type:
-// (Technically, some of these (pop and __delitem__) don't actually require copyability, but it seems
-// silly to allow deletion but not insertion, so include them here too.)
+// (Technically, some of these (pop and __delitem__) don't actually require copyability, but it
+// seems silly to allow deletion but not insertion, so include them here too.)
 template <typename Vector, typename Class_>
-void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_type>::value, Class_> &cl) {
+void vector_modifiers(
+    enable_if_t<is_copy_constructible<typename Vector::value_type>::value, Class_> &cl) {
     using T = typename Vector::value_type;
     using SizeType = typename Vector::size_type;
     using DiffType = typename Vector::difference_type;
@@ -123,10 +121,9 @@ void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_t
         return i;
     };
 
-    cl.def("append",
-           [](Vector &v, const T &value) { v.push_back(value); },
-           arg("x"),
-           "Add an item to the end of the list");
+    cl.def(
+        "append", [](Vector &v, const T &value) { v.push_back(value); }, arg("x"),
+        "Add an item to the end of the list");
 
     cl.def(init([](const iterable &it) {
         auto v = std::unique_ptr<Vector>(new Vector());
@@ -136,20 +133,12 @@ void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_t
         return v.release();
     }));
 
-    cl.def("clear",
-        [](Vector &v) {
-            v.clear();
-        },
-        "Clear the contents"
-    );
+    cl.def(
+        "clear", [](Vector &v) { v.clear(); }, "Clear the contents");
 
-    cl.def("extend",
-       [](Vector &v, const Vector &src) {
-           v.insert(v.end(), src.begin(), src.end());
-       },
-       arg("L"),
-       "Extend the list by appending all the items in the given list"
-    );
+    cl.def(
+        "extend", [](Vector &v, const Vector &src) { v.insert(v.end(), src.begin(), src.end()); },
+        arg("L"), "Extend the list by appending all the items in the given list");
 
     cl.def(
         "extend",
@@ -171,10 +160,10 @@ void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_t
                 throw;
             }
         },
-        arg("L"),
-        "Extend the list by appending all the items in the given list");
+        arg("L"), "Extend the list by appending all the items in the given list");
 
-    cl.def("insert",
+    cl.def(
+        "insert",
         [](Vector &v, DiffType i, const T &x) {
             // Can't use wrap_i; i == v.size() is OK
             if (i < 0)
@@ -183,11 +172,10 @@ void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_t
                 throw index_error();
             v.insert(v.begin() + i, x);
         },
-        arg("i") , arg("x"),
-        "Insert an item at a given position."
-    );
+        arg("i"), arg("x"), "Insert an item at a given position.");
 
-    cl.def("pop",
+    cl.def(
+        "pop",
         [](Vector &v) {
             if (v.empty())
                 throw index_error();
@@ -195,29 +183,26 @@ void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_t
             v.pop_back();
             return t;
         },
-        "Remove and return the last item"
-    );
+        "Remove and return the last item");
 
-    cl.def("pop",
+    cl.def(
+        "pop",
         [wrap_i](Vector &v, DiffType i) {
             i = wrap_i(i, v.size());
-            T t = v[(SizeType) i];
+            T t = v[(SizeType)i];
             v.erase(v.begin() + i);
             return t;
         },
-        arg("i"),
-        "Remove and return the item at index ``i``"
-    );
+        arg("i"), "Remove and return the item at index ``i``");
 
-    cl.def("__setitem__",
-        [wrap_i](Vector &v, DiffType i, const T &t) {
-            i = wrap_i(i, v.size());
-            v[(SizeType)i] = t;
-        }
-    );
+    cl.def("__setitem__", [wrap_i](Vector &v, DiffType i, const T &t) {
+        i = wrap_i(i, v.size());
+        v[(SizeType)i] = t;
+    });
 
     /// Slicing protocol
-    cl.def("__getitem__",
+    cl.def(
+        "__getitem__",
         [](const Vector &v, slice slice) -> Vector * {
             size_t start, stop, step, slicelength;
 
@@ -225,44 +210,44 @@ void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_t
                 throw error_already_set();
 
             auto *seq = new Vector();
-            seq->reserve((size_t) slicelength);
+            seq->reserve((size_t)slicelength);
 
-            for (size_t i=0; i<slicelength; ++i) {
+            for (size_t i = 0; i < slicelength; ++i) {
                 seq->push_back(v[start]);
                 start += step;
             }
             return seq;
         },
-        arg("s"),
-        "Retrieve list elements using a slice object"
-    );
+        arg("s"), "Retrieve list elements using a slice object");
 
-    cl.def("__setitem__",
-        [](Vector &v, slice slice,  const Vector &value) {
+    cl.def(
+        "__setitem__",
+        [](Vector &v, slice slice, const Vector &value) {
             size_t start, stop, step, slicelength;
             if (!slice.compute(v.size(), &start, &stop, &step, &slicelength))
                 throw error_already_set();
 
             if (slicelength != value.size())
-                throw std::runtime_error("Left and right hand size of slice assignment have different sizes!");
+                throw std::runtime_error(
+                    "Left and right hand size of slice assignment have different sizes!");
 
-            for (size_t i=0; i<slicelength; ++i) {
+            for (size_t i = 0; i < slicelength; ++i) {
                 v[start] = value[i];
                 start += step;
             }
         },
-        "Assign list elements using a slice object"
-    );
+        "Assign list elements using a slice object");
 
-    cl.def("__delitem__",
+    cl.def(
+        "__delitem__",
         [wrap_i](Vector &v, DiffType i) {
             i = wrap_i(i, v.size());
             v.erase(v.begin() + i);
         },
-        "Delete the list elements at index ``i``"
-    );
+        "Delete the list elements at index ``i``");
 
-    cl.def("__delitem__",
+    cl.def(
+        "__delitem__",
         [](Vector &v, slice slice) {
             size_t start, stop, step, slicelength;
 
@@ -270,7 +255,7 @@ void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_t
                 throw error_already_set();
 
             if (step == 1 && false) {
-                v.erase(v.begin() + (DiffType) start, v.begin() + DiffType(start + slicelength));
+                v.erase(v.begin() + (DiffType)start, v.begin() + DiffType(start + slicelength));
             } else {
                 for (size_t i = 0; i < slicelength; ++i) {
                     v.erase(v.begin() + DiffType(start));
@@ -278,15 +263,15 @@ void vector_modifiers(enable_if_t<is_copy_constructible<typename Vector::value_t
                 }
             }
         },
-        "Delete list elements using a slice object"
-    );
-
+        "Delete list elements using a slice object");
 }
 
 // If the type has an operator[] that doesn't return a reference (most notably std::vector<bool>),
 // we have to access by copying; otherwise we return by reference.
-template <typename Vector> using vector_needs_copy = negation<
-    std::is_same<decltype(std::declval<Vector>()[typename Vector::size_type()]), typename Vector::value_type &>>;
+template <typename Vector>
+using vector_needs_copy =
+    negation<std::is_same<decltype(std::declval<Vector>()[typename Vector::size_type()]),
+                          typename Vector::value_type &>>;
 
 // The usual case: access and iterate by reference
 template <typename Vector, typename Class_>
@@ -294,7 +279,7 @@ void vector_accessor(enable_if_t<!vector_needs_copy<Vector>::value, Class_> &cl)
     using T = typename Vector::value_type;
     using SizeType = typename Vector::size_type;
     using DiffType = typename Vector::difference_type;
-    using ItType   = typename Vector::iterator;
+    using ItType = typename Vector::iterator;
 
     auto wrap_i = [](DiffType i, SizeType n) {
         if (i < 0)
@@ -304,7 +289,8 @@ void vector_accessor(enable_if_t<!vector_needs_copy<Vector>::value, Class_> &cl)
         return i;
     };
 
-    cl.def("__getitem__",
+    cl.def(
+        "__getitem__",
         [wrap_i](Vector &v, DiffType i) -> T & {
             i = wrap_i(i, v.size());
             return v[(SizeType)i];
@@ -312,13 +298,13 @@ void vector_accessor(enable_if_t<!vector_needs_copy<Vector>::value, Class_> &cl)
         return_value_policy::reference_internal // ref + keepalive
     );
 
-    cl.def("__iter__",
-           [](Vector &v) {
-               return make_iterator<
-                   return_value_policy::reference_internal, ItType, ItType, T&>(
-                   v.begin(), v.end());
-           },
-           keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
+    cl.def(
+        "__iter__",
+        [](Vector &v) {
+            return make_iterator<return_value_policy::reference_internal, ItType, ItType, T &>(
+                v.begin(), v.end());
+        },
+        keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
     );
 }
 
@@ -328,36 +314,36 @@ void vector_accessor(enable_if_t<vector_needs_copy<Vector>::value, Class_> &cl) 
     using T = typename Vector::value_type;
     using SizeType = typename Vector::size_type;
     using DiffType = typename Vector::difference_type;
-    using ItType   = typename Vector::iterator;
-    cl.def("__getitem__",
-        [](const Vector &v, DiffType i) -> T {
-            if (i < 0 && (i += v.size()) < 0)
-                throw index_error();
-            if ((SizeType)i >= v.size())
-                throw index_error();
-            return v[(SizeType)i];
-        }
-    );
+    using ItType = typename Vector::iterator;
+    cl.def("__getitem__", [](const Vector &v, DiffType i) -> T {
+        if (i < 0 && (i += v.size()) < 0)
+            throw index_error();
+        if ((SizeType)i >= v.size())
+            throw index_error();
+        return v[(SizeType)i];
+    });
 
-    cl.def("__iter__",
-           [](Vector &v) {
-               return make_iterator<
-                   return_value_policy::copy, ItType, ItType, T>(
-                   v.begin(), v.end());
-           },
-           keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
+    cl.def(
+        "__iter__",
+        [](Vector &v) {
+            return make_iterator<return_value_policy::copy, ItType, ItType, T>(v.begin(), v.end());
+        },
+        keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
     );
 }
 
-template <typename Vector, typename Class_> auto vector_if_insertion_operator(Class_ &cl, std::string const &name)
-    -> decltype(std::declval<std::ostream&>() << std::declval<typename Vector::value_type>(), void()) {
+template <typename Vector, typename Class_>
+auto vector_if_insertion_operator(Class_ &cl, std::string const &name)
+    -> decltype(std::declval<std::ostream &>() << std::declval<typename Vector::value_type>(),
+                void()) {
     using size_type = typename Vector::size_type;
 
-    cl.def("__repr__",
-           [name](Vector &v) {
+    cl.def(
+        "__repr__",
+        [name](Vector &v) {
             std::ostringstream s;
             s << name << '[';
-            for (size_type i=0; i < v.size(); ++i) {
+            for (size_type i = 0; i < v.size(); ++i) {
                 s << v[i];
                 if (i != v.size() - 1)
                     s << ", ";
@@ -365,22 +351,24 @@ template <typename Vector, typename Class_> auto vector_if_insertion_operator(Cl
             s << ']';
             return s.str();
         },
-        "Return the canonical string representation of this list."
-    );
+        "Return the canonical string representation of this list.");
 }
 
 // Provide the buffer interface for vectors if we have data() and we have a format for it
-// GCC seems to have "void std::vector<bool>::data()" - doing SFINAE on the existence of data() is insufficient, we need to check it returns an appropriate pointer
-template <typename Vector, typename = void>
-struct vector_has_data_and_format : std::false_type {};
+// GCC seems to have "void std::vector<bool>::data()" - doing SFINAE on the existence of data() is
+// insufficient, we need to check it returns an appropriate pointer
+template <typename Vector, typename = void> struct vector_has_data_and_format : std::false_type {};
 template <typename Vector>
-struct vector_has_data_and_format<Vector, enable_if_t<std::is_same<decltype(format_descriptor<typename Vector::value_type>::format(), std::declval<Vector>().data()), typename Vector::value_type*>::value>> : std::true_type {};
+struct vector_has_data_and_format<
+    Vector,
+    enable_if_t<std::is_same<decltype(format_descriptor<typename Vector::value_type>::format(),
+                                      std::declval<Vector>().data()),
+                             typename Vector::value_type *>::value>> : std::true_type {};
 
 // [workaround(intel)] Separate function required here
 // Workaround as the Intel compiler does not compile the enable_if_t part below
 // (tested with icc (ICC) 2021.1 Beta 20200827)
-template <typename... Args>
-constexpr bool args_any_are_buffer() {
+template <typename... Args> constexpr bool args_any_are_buffer() {
     return detail::any_of<std::is_same<Args, buffer_protocol>...>::value;
 }
 
@@ -389,48 +377,51 @@ constexpr bool args_any_are_buffer() {
 
 // Add the buffer interface to a vector
 template <typename Vector, typename Class_, typename... Args>
-void vector_buffer_impl(Class_& cl, std::true_type) {
+void vector_buffer_impl(Class_ &cl, std::true_type) {
     using T = typename Vector::value_type;
 
-    static_assert(vector_has_data_and_format<Vector>::value, "There is not an appropriate format descriptor for this vector");
+    static_assert(vector_has_data_and_format<Vector>::value,
+                  "There is not an appropriate format descriptor for this vector");
 
-    // numpy.h declares this for arbitrary types, but it may raise an exception and crash hard at runtime if PYBIND11_NUMPY_DTYPE hasn't been called, so check here
+    // numpy.h declares this for arbitrary types, but it may raise an exception and crash hard at
+    // runtime if PYBIND11_NUMPY_DTYPE hasn't been called, so check here
     format_descriptor<T>::format();
 
-    cl.def_buffer([](Vector& v) -> buffer_info {
-        return buffer_info(v.data(), static_cast<ssize_t>(sizeof(T)), format_descriptor<T>::format(), 1, {v.size()}, {sizeof(T)});
+    cl.def_buffer([](Vector &v) -> buffer_info {
+        return buffer_info(v.data(), static_cast<ssize_t>(sizeof(T)),
+                           format_descriptor<T>::format(), 1, {v.size()}, {sizeof(T)});
     });
 
     cl.def(init([](const buffer &buf) {
         auto info = buf.request();
         if (info.ndim != 1 || info.strides[0] % static_cast<ssize_t>(sizeof(T)))
             throw type_error("Only valid 1D buffers can be copied to a vector");
-        if (!detail::compare_buffer_info<T>::compare(info) || (ssize_t) sizeof(T) != info.itemsize)
-            throw type_error("Format mismatch (Python: " + info.format + " C++: " + format_descriptor<T>::format() + ")");
+        if (!detail::compare_buffer_info<T>::compare(info) || (ssize_t)sizeof(T) != info.itemsize)
+            throw type_error("Format mismatch (Python: " + info.format +
+                             " C++: " + format_descriptor<T>::format() + ")");
 
-        T *p = static_cast<T*>(info.ptr);
+        T *p = static_cast<T *>(info.ptr);
         ssize_t step = info.strides[0] / static_cast<ssize_t>(sizeof(T));
         T *end = p + info.shape[0] * step;
         if (step == 1) {
             return Vector(p, end);
         }
         Vector vec;
-        vec.reserve((size_t) info.shape[0]);
+        vec.reserve((size_t)info.shape[0]);
         for (; p != end; p += step)
             vec.push_back(*p);
         return vec;
-
     }));
 
     return;
 }
 
 template <typename Vector, typename Class_, typename... Args>
-void vector_buffer_impl(Class_&, std::false_type) {}
+void vector_buffer_impl(Class_ &, std::false_type) {}
 
-template <typename Vector, typename Class_, typename... Args>
-void vector_buffer(Class_& cl) {
-    vector_buffer_impl<Vector, Class_, Args...>(cl, detail::any_of<std::is_same<Args, buffer_protocol>...>{});
+template <typename Vector, typename Class_, typename... Args> void vector_buffer(Class_ &cl) {
+    vector_buffer_impl<Vector, Class_, Args...>(
+        cl, detail::any_of<std::is_same<Args, buffer_protocol>...>{});
 }
 
 PYBIND11_NAMESPACE_END(detail)
@@ -439,7 +430,7 @@ PYBIND11_NAMESPACE_END(detail)
 // std::vector
 //
 template <typename Vector, typename holder_type = std::unique_ptr<Vector>, typename... Args>
-class_<Vector, holder_type> bind_vector(handle scope, std::string const &name, Args&&... args) {
+class_<Vector, holder_type> bind_vector(handle scope, std::string const &name, Args &&...args) {
     using Class_ = class_<Vector, holder_type>;
 
     // If the value_type is unregistered (e.g. a converting type) or is itself registered
@@ -470,17 +461,11 @@ class_<Vector, holder_type> bind_vector(handle scope, std::string const &name, A
     // Accessor and iterator; return by value if copyable, otherwise we return by ref + keep-alive
     detail::vector_accessor<Vector, Class_>(cl);
 
-    cl.def("__bool__",
-        [](const Vector &v) -> bool {
-            return !v.empty();
-        },
-        "Check whether the list is nonempty"
-    );
+    cl.def(
+        "__bool__", [](const Vector &v) -> bool { return !v.empty(); },
+        "Check whether the list is nonempty");
 
     cl.def("__len__", &Vector::size);
-
-
-
 
 #if 0
     // C++ style functions deprecated, leaving it here as an example
@@ -525,8 +510,6 @@ class_<Vector, holder_type> bind_vector(handle scope, std::string const &name, A
     return cl;
 }
 
-
-
 //
 // std::map, std::unordered_map
 //
@@ -534,52 +517,55 @@ class_<Vector, holder_type> bind_vector(handle scope, std::string const &name, A
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 /* Fallback functions */
-template <typename, typename, typename... Args> void map_if_insertion_operator(const Args &...) { }
-template <typename, typename, typename... Args> void map_assignment(const Args &...) { }
+template <typename, typename, typename... Args> void map_if_insertion_operator(const Args &...) {}
+template <typename, typename, typename... Args> void map_assignment(const Args &...) {}
 
 // Map assignment when copy-assignable: just copy the value
 template <typename Map, typename Class_>
-void map_assignment(enable_if_t<is_copy_assignable<typename Map::mapped_type>::value, Class_> &cl) {
+void map_assignment(
+    enable_if_t<is_copy_assignable<typename Map::mapped_type>::value, Class_> &cl) {
     using KeyType = typename Map::key_type;
     using MappedType = typename Map::mapped_type;
 
-    cl.def("__setitem__",
-           [](Map &m, const KeyType &k, const MappedType &v) {
-               auto it = m.find(k);
-               if (it != m.end()) it->second = v;
-               else m.emplace(k, v);
-           }
-    );
+    cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v) {
+        auto it = m.find(k);
+        if (it != m.end())
+            it->second = v;
+        else
+            m.emplace(k, v);
+    });
 }
 
-// Not copy-assignable, but still copy-constructible: we can update the value by erasing and reinserting
-template<typename Map, typename Class_>
-void map_assignment(enable_if_t<
-        !is_copy_assignable<typename Map::mapped_type>::value &&
-        is_copy_constructible<typename Map::mapped_type>::value,
-        Class_> &cl) {
+// Not copy-assignable, but still copy-constructible: we can update the value by erasing and
+// reinserting
+template <typename Map, typename Class_>
+void map_assignment(enable_if_t<!is_copy_assignable<typename Map::mapped_type>::value &&
+                                    is_copy_constructible<typename Map::mapped_type>::value,
+                                Class_> &cl) {
     using KeyType = typename Map::key_type;
     using MappedType = typename Map::mapped_type;
 
-    cl.def("__setitem__",
-           [](Map &m, const KeyType &k, const MappedType &v) {
-               // We can't use m[k] = v; because value type might not be default constructable
-               auto r = m.emplace(k, v);
-               if (!r.second) {
-                   // value type is not copy assignable so the only way to insert it is to erase it first...
-                   m.erase(r.first);
-                   m.emplace(k, v);
-               }
-           }
-    );
+    cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v) {
+        // We can't use m[k] = v; because value type might not be default constructable
+        auto r = m.emplace(k, v);
+        if (!r.second) {
+            // value type is not copy assignable so the only way to insert it is to erase it
+            // first...
+            m.erase(r.first);
+            m.emplace(k, v);
+        }
+    });
 }
 
+template <typename Map, typename Class_>
+auto map_if_insertion_operator(Class_ &cl, std::string const &name)
+    -> decltype(std::declval<std::ostream &>() << std::declval<typename Map::key_type>()
+                                               << std::declval<typename Map::mapped_type>(),
+                void()) {
 
-template <typename Map, typename Class_> auto map_if_insertion_operator(Class_ &cl, std::string const &name)
--> decltype(std::declval<std::ostream&>() << std::declval<typename Map::key_type>() << std::declval<typename Map::mapped_type>(), void()) {
-
-    cl.def("__repr__",
-           [name](Map &m) {
+    cl.def(
+        "__repr__",
+        [name](Map &m) {
             std::ostringstream s;
             s << name << '{';
             bool f = false;
@@ -592,15 +578,13 @@ template <typename Map, typename Class_> auto map_if_insertion_operator(Class_ &
             s << '}';
             return s.str();
         },
-        "Return the canonical string representation of this map."
-    );
+        "Return the canonical string representation of this map.");
 }
-
 
 PYBIND11_NAMESPACE_END(detail)
 
 template <typename Map, typename holder_type = std::unique_ptr<Map>, typename... Args>
-class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args&&... args) {
+class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args &&...args) {
     using KeyType = typename Map::key_type;
     using MappedType = typename Map::mapped_type;
     using Class_ = class_<Map, holder_type>;
@@ -622,51 +606,47 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args&&.
     // Register stream insertion operator (if possible)
     detail::map_if_insertion_operator<Map, Class_>(cl, name);
 
-    cl.def("__bool__",
-        [](const Map &m) -> bool { return !m.empty(); },
-        "Check whether the map is nonempty"
+    cl.def(
+        "__bool__", [](const Map &m) -> bool { return !m.empty(); },
+        "Check whether the map is nonempty");
+
+    cl.def(
+        "__iter__", [](Map &m) { return make_key_iterator(m.begin(), m.end()); },
+        keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
     );
 
-    cl.def("__iter__",
-           [](Map &m) { return make_key_iterator(m.begin(), m.end()); },
-           keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
+    cl.def(
+        "items", [](Map &m) { return make_iterator(m.begin(), m.end()); },
+        keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
     );
 
-    cl.def("items",
-           [](Map &m) { return make_iterator(m.begin(), m.end()); },
-           keep_alive<0, 1>() /* Essential: keep list alive while iterator exists */
-    );
-
-    cl.def("__getitem__",
+    cl.def(
+        "__getitem__",
         [](Map &m, const KeyType &k) -> MappedType & {
             auto it = m.find(k);
             if (it == m.end())
-              throw key_error();
-           return it->second;
+                throw key_error();
+            return it->second;
         },
         return_value_policy::reference_internal // ref + keepalive
     );
 
-    cl.def("__contains__",
-        [](Map &m, const KeyType &k) -> bool {
-            auto it = m.find(k);
-            if (it == m.end())
-              return false;
-           return true;
-        }
-    );
+    cl.def("__contains__", [](Map &m, const KeyType &k) -> bool {
+        auto it = m.find(k);
+        if (it == m.end())
+            return false;
+        return true;
+    });
 
     // Assignment provided only if the type is copyable
     detail::map_assignment<Map, Class_>(cl);
 
-    cl.def("__delitem__",
-           [](Map &m, const KeyType &k) {
-               auto it = m.find(k);
-               if (it == m.end())
-                   throw key_error();
-               m.erase(it);
-           }
-    );
+    cl.def("__delitem__", [](Map &m, const KeyType &k) {
+        auto it = m.find(k);
+        if (it == m.end())
+            throw key_error();
+        m.erase(it);
+    });
 
     cl.def("__len__", &Map::size);
 

--- a/tests/cross_module_gil_utils.cpp
+++ b/tests/cross_module_gil_utils.cpp
@@ -6,8 +6,8 @@
     All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file.
 */
-#include <pybind11/pybind11.h>
 #include <cstdint>
+#include <pybind11/pybind11.h>
 
 // This file mimics a DSO that makes pybind11 calls but does not define a
 // PYBIND11_MODULE. The purpose is to test that such a DSO can create a
@@ -26,33 +26,24 @@ constexpr char kModuleName[] = "cross_module_gil_utils";
 
 #if PY_MAJOR_VERSION >= 3
 struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    kModuleName,
-    NULL,
-    0,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
+    PyModuleDef_HEAD_INIT, kModuleName, NULL, 0, NULL, NULL, NULL, NULL, NULL};
 #else
-PyMethodDef module_methods[] = {
-    {NULL, NULL, 0, NULL}
-};
+PyMethodDef module_methods[] = {{NULL, NULL, 0, NULL}};
 #endif
 
-}  // namespace
+} // namespace
 
 extern "C" PYBIND11_EXPORT
 #if PY_MAJOR_VERSION >= 3
-PyObject* PyInit_cross_module_gil_utils()
+    PyObject *
+    PyInit_cross_module_gil_utils()
 #else
-void initcross_module_gil_utils()
+    void
+    initcross_module_gil_utils()
 #endif
 {
 
-    PyObject* m =
+    PyObject *m =
 #if PY_MAJOR_VERSION >= 3
         PyModule_Create(&moduledef);
 #else
@@ -60,11 +51,10 @@ void initcross_module_gil_utils()
 #endif
 
     if (m != NULL) {
-        static_assert(
-            sizeof(&gil_acquire) == sizeof(void*),
-            "Function pointer must have the same size as void*");
+        static_assert(sizeof(&gil_acquire) == sizeof(void *),
+                      "Function pointer must have the same size as void*");
         PyModule_AddObject(m, "gil_acquire_funcaddr",
-                           PyLong_FromVoidPtr(reinterpret_cast<void*>(&gil_acquire)));
+                           PyLong_FromVoidPtr(reinterpret_cast<void *>(&gil_acquire)));
     }
 
 #if PY_MAJOR_VERSION >= 3

--- a/tests/local_bindings.h
+++ b/tests/local_bindings.h
@@ -6,7 +6,7 @@
 /// Simple class used to test py::local:
 template <int> class LocalBase {
 public:
-    LocalBase(int i) : i(i) { }
+    LocalBase(int i) : i(i) {}
     int i = -1;
 };
 
@@ -39,17 +39,15 @@ PYBIND11_MAKE_OPAQUE(LocalVec);
 PYBIND11_MAKE_OPAQUE(LocalVec2);
 PYBIND11_MAKE_OPAQUE(LocalMap);
 PYBIND11_MAKE_OPAQUE(NonLocalVec);
-//PYBIND11_MAKE_OPAQUE(NonLocalVec2); // same type as LocalVec2
+// PYBIND11_MAKE_OPAQUE(NonLocalVec2); // same type as LocalVec2
 PYBIND11_MAKE_OPAQUE(NonLocalMap);
 PYBIND11_MAKE_OPAQUE(NonLocalMap2);
 
-
 // Simple bindings (used with the above):
-template <typename T, int Adjust = 0, typename... Args>
-py::class_<T> bind_local(Args && ...args) {
-    return py::class_<T>(std::forward<Args>(args)...)
-        .def(py::init<int>())
-        .def("get", [](T &i) { return i.i + Adjust; });
+template <typename T, int Adjust = 0, typename... Args> py::class_<T> bind_local(Args &&...args) {
+    return py::class_<T>(std::forward<Args>(args)...).def(py::init<int>()).def("get", [](T &i) {
+        return i.i + Adjust;
+    });
 };
 
 // Simulate a foreign library base class (to match the example in the docs):
@@ -62,5 +60,11 @@ public:
 };
 } // namespace pets
 
-struct MixGL { int i; MixGL(int i) : i{i} {} };
-struct MixGL2 { int i; MixGL2(int i) : i{i} {} };
+struct MixGL {
+    int i;
+    MixGL(int i) : i{i} {}
+};
+struct MixGL2 {
+    int i;
+    MixGL2(int i) : i{i} {}
+};

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -7,11 +7,11 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "local_bindings.h"
+#include "pybind11_tests.h"
 #include "test_exceptions.h"
-#include <pybind11/stl_bind.h>
 #include <numeric>
+#include <pybind11/stl_bind.h>
 
 PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.doc() = "pybind11 cross-module test module";
@@ -26,24 +26,31 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     bind_local<ExternalType2>(m, "ExternalType2", py::module_local());
 
     // test_exceptions.py
-    m.def("raise_runtime_error", []() { PyErr_SetString(PyExc_RuntimeError, "My runtime error"); throw py::error_already_set(); });
-    m.def("raise_value_error", []() { PyErr_SetString(PyExc_ValueError, "My value error"); throw py::error_already_set(); });
+    m.def("raise_runtime_error", []() {
+        PyErr_SetString(PyExc_RuntimeError, "My runtime error");
+        throw py::error_already_set();
+    });
+    m.def("raise_value_error", []() {
+        PyErr_SetString(PyExc_ValueError, "My value error");
+        throw py::error_already_set();
+    });
     m.def("throw_pybind_value_error", []() { throw py::value_error("pybind11 value error"); });
     m.def("throw_pybind_type_error", []() { throw py::type_error("pybind11 type error"); });
     m.def("throw_stop_iteration", []() { throw py::stop_iteration(); });
     py::register_exception_translator([](std::exception_ptr p) {
-      try {
-          if (p) std::rethrow_exception(p);
-      } catch (const shared_exception &e) {
-          PyErr_SetString(PyExc_KeyError, e.what());
-      }
+        try {
+            if (p)
+                std::rethrow_exception(p);
+        } catch (const shared_exception &e) {
+            PyErr_SetString(PyExc_KeyError, e.what());
+        }
     });
 
     // test_local_bindings.py
     // Local to both:
-    bind_local<LocalType, 1>(m, "LocalType", py::module_local())
-        .def("get2", [](LocalType &t) { return t.i + 2; })
-        ;
+    bind_local<LocalType, 1>(m, "LocalType", py::module_local()).def("get2", [](LocalType &t) {
+        return t.i + 2;
+    });
 
     // Can only be called with our python type:
     m.def("local_value", [](LocalType &l) { return l.i; });
@@ -51,9 +58,7 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     // test_nonlocal_failure
     // This registration will fail (global registration when LocalFail is already registered
     // globally in the main test module):
-    m.def("register_nonlocal", [m]() {
-        bind_local<NonLocalType, 0>(m, "NonLocalType");
-    });
+    m.def("register_nonlocal", [m]() { bind_local<NonLocalType, 0>(m, "NonLocalType"); });
 
     // test_stl_bind_local
     // stl_bind.h binders defaults to py::module_local if the types are local or converting:
@@ -63,27 +68,21 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     // test_stl_bind_global
     // and global if the type (or one of the types, for the map) is global (so these will fail,
     // assuming pybind11_tests is already loaded):
-    m.def("register_nonlocal_vec", [m]() {
-        py::bind_vector<NonLocalVec>(m, "NonLocalVec");
-    });
-    m.def("register_nonlocal_map", [m]() {
-        py::bind_map<NonLocalMap>(m, "NonLocalMap");
-    });
+    m.def("register_nonlocal_vec", [m]() { py::bind_vector<NonLocalVec>(m, "NonLocalVec"); });
+    m.def("register_nonlocal_map", [m]() { py::bind_map<NonLocalMap>(m, "NonLocalMap"); });
     // The default can, however, be overridden to global using `py::module_local()` or
     // `py::module_local(false)`.
     // Explicitly made local:
     py::bind_vector<NonLocalVec2>(m, "NonLocalVec2", py::module_local());
     // Explicitly made global (and so will fail to bind):
-    m.def("register_nonlocal_map2", [m]() {
-        py::bind_map<NonLocalMap2>(m, "NonLocalMap2", py::module_local(false));
-    });
+    m.def("register_nonlocal_map2",
+          [m]() { py::bind_map<NonLocalMap2>(m, "NonLocalMap2", py::module_local(false)); });
 
     // test_mixed_local_global
     // We try this both with the global type registered first and vice versa (the order shouldn't
     // matter).
-    m.def("register_mixed_global_local", [m]() {
-        bind_local<MixedGlobalLocal, 200>(m, "MixedGlobalLocal", py::module_local());
-    });
+    m.def("register_mixed_global_local",
+          [m]() { bind_local<MixedGlobalLocal, 200>(m, "MixedGlobalLocal", py::module_local()); });
     m.def("register_mixed_local_global", [m]() {
         bind_local<MixedLocalGlobal, 2000>(m, "MixedLocalGlobal", py::module_local(false));
     });
@@ -91,14 +90,14 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.def("get_mixed_lg", [](int i) { return MixedLocalGlobal(i); });
 
     // test_internal_locals_differ
-    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::registered_local_types_cpp(); });
+    m.def("local_cpp_types_addr",
+          []() { return (uintptr_t)&py::detail::registered_local_types_cpp(); });
 
     // test_stl_caster_vs_stl_bind
     py::bind_vector<std::vector<int>>(m, "VectorInt");
 
-    m.def("load_vector_via_binding", [](std::vector<int> &v) {
-        return std::accumulate(v.begin(), v.end(), 0);
-    });
+    m.def("load_vector_via_binding",
+          [](std::vector<int> &v) { return std::accumulate(v.begin(), v.end(), 0); });
 
     // test_cross_module_calls
     m.def("return_self", [](LocalVec *v) { return v; });
@@ -110,11 +109,9 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
         // NOLINTNEXTLINE
         Dog(std::string name) : Pet(name) {}
     };
-    py::class_<pets::Pet>(m, "Pet", py::module_local())
-        .def("name", &pets::Pet::name);
+    py::class_<pets::Pet>(m, "Pet", py::module_local()).def("name", &pets::Pet::name);
     // Binding for local extending class:
-    py::class_<Dog, pets::Pet>(m, "Dog")
-        .def(py::init<std::string>());
+    py::class_<Dog, pets::Pet>(m, "Dog").def(py::init<std::string>());
     m.def("pet_name", [](pets::Pet &p) { return p.name(); });
 
     py::class_<MixGL>(m, "MixGL", py::module_local()).def(py::init<int>());
@@ -132,6 +129,6 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     // The main module already includes stl.h, but we need to test the error message
     // which appears when this header is missing.
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("missing_header_arg", [](std::vector<float>) { });
+    m.def("missing_header_arg", [](std::vector<float>) {});
     m.def("missing_header_return", []() { return std::vector<float>(); });
 }

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -104,9 +104,12 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.def("return_self", [](LocalVec *v) { return v; });
     m.def("return_copy", [](const LocalVec &v) { return LocalVec(v); });
 
-    // Changing this broke things with pygrep. TODO fix
-    // NOLINTNEXTLINE
-    class Dog : public pets::Pet { public: Dog(std::string name) : Pet(name) {}; };
+    class Dog : public pets::Pet {
+    public:
+        // Changing this broke things with pygrep. TODO fix
+        // NOLINTNEXTLINE
+        Dog(std::string name) : Pet(name) {}
+    };
     py::class_<pets::Pet>(m, "Pet", py::module_local())
         .def("name", &pets::Pet::name);
     // Binding for local extending class:

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -31,9 +31,7 @@ std::list<std::function<void(py::module_ &)>> &initializers() {
     return inits;
 }
 
-test_initializer::test_initializer(Initializer init) {
-    initializers().emplace_back(init);
-}
+test_initializer::test_initializer(Initializer init) { initializers().emplace_back(init); }
 
 test_initializer::test_initializer(const char *submodule_name, Initializer init) {
     initializers().emplace_back([=](py::module_ &parent) {
@@ -51,15 +49,15 @@ void bind_ConstructorStats(py::module_ &m) {
         .def_readwrite("move_assignments", &ConstructorStats::move_assignments)
         .def_readwrite("copy_constructions", &ConstructorStats::copy_constructions)
         .def_readwrite("move_constructions", &ConstructorStats::move_constructions)
-        .def_static("get", (ConstructorStats &(*)(py::object)) &ConstructorStats::get, py::return_value_policy::reference_internal)
+        .def_static("get", (ConstructorStats & (*)(py::object)) & ConstructorStats::get,
+                    py::return_value_policy::reference_internal)
 
-        // Not exactly ConstructorStats, but related: expose the internal pybind number of registered instances
-        // to allow instance cleanup checks (invokes a GC first)
+        // Not exactly ConstructorStats, but related: expose the internal pybind number of
+        // registered instances to allow instance cleanup checks (invokes a GC first)
         .def_static("detail_reg_inst", []() {
             ConstructorStats::gc();
             return py::detail::get_internals().registered_instances.size();
-        })
-        ;
+        });
 }
 
 PYBIND11_MODULE(pybind11_tests, m) {
@@ -79,12 +77,12 @@ PYBIND11_MODULE(pybind11_tests, m) {
         .def("get_value", &UserType::value, "Get value using a method")
         .def("set_value", &UserType::set, "Set value using a method")
         .def_property("value", &UserType::value, &UserType::set, "Get/set value using a property")
-        .def("__repr__", [](const UserType& u) { return "UserType({})"_s.format(u.value()); });
+        .def("__repr__", [](const UserType &u) { return "UserType({})"_s.format(u.value()); });
 
     py::class_<IncType, UserType>(m, "IncType")
         .def(py::init<>())
         .def(py::init<int>())
-        .def("__repr__", [](const IncType& u) { return "IncType({})"_s.format(u.value()); });
+        .def("__repr__", [](const IncType &u) { return "IncType({})"_s.format(u.value()); });
 
     for (const auto &initializer : initializers())
         initializer(m);

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -8,7 +8,8 @@
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
 // We get some really long type names here which causes MSVC 2015 to emit warnings
-#  pragma warning(disable: 4503) // warning C4503: decorated name length exceeded, name was truncated
+#    pragma warning(                                                                              \
+        disable : 4503) // warning C4503: decorated name length exceeded, name was truncated
 #endif
 
 namespace py = pybind11;

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -1,5 +1,9 @@
 #pragma once
+
+// This must be kept first for MSVC 2015.
+// Do not remove the empty line between the #includes.
 #include <pybind11/pybind11.h>
+
 #include <pybind11/eval.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1910

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -8,8 +8,8 @@
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
 // We get some really long type names here which causes MSVC 2015 to emit warnings
-#    pragma warning(                                                                              \
-        disable : 4503) // warning C4503: decorated name length exceeded, name was truncated
+#pragma warning(                                                                                  \
+    disable : 4503) // warning C4503: decorated name length exceeded, name was truncated
 #endif
 
 namespace py = pybind11;
@@ -23,20 +23,19 @@ public:
     test_initializer(const char *submodule_name, Initializer init);
 };
 
-#define TEST_SUBMODULE(name, variable)                   \
-    void test_submodule_##name(py::module_ &);            \
-    test_initializer name(#name, test_submodule_##name); \
+#define TEST_SUBMODULE(name, variable)                                                            \
+    void test_submodule_##name(py::module_ &);                                                    \
+    test_initializer name(#name, test_submodule_##name);                                          \
     void test_submodule_##name(py::module_ &variable)
 
-
 /// Dummy type which is not exported anywhere -- something to trigger a conversion error
-struct UnregisteredType { };
+struct UnregisteredType {};
 
 /// A user-defined type which is exported and can be used by any test
 class UserType {
 public:
     UserType() = default;
-    UserType(int i) : i(i) { }
+    UserType(int i) : i(i) {}
 
     int value() const { return i; }
     void set(int set) { i = set; }
@@ -50,7 +49,7 @@ class IncType : public UserType {
 public:
     using UserType::UserType;
     IncType() = default;
-    IncType(const IncType &other) : IncType(other.value() + 1) { }
+    IncType(const IncType &other) : IncType(other.value() + 1) {}
     IncType(IncType &&) = delete;
     IncType &operator=(const IncType &) = delete;
     IncType &operator=(IncType &&) = delete;
@@ -62,22 +61,25 @@ union IntFloat {
     float f;
 };
 
-/// Custom cast-only type that casts to a string "rvalue" or "lvalue" depending on the cast context.
-/// Used to test recursive casters (e.g. std::tuple, stl containers).
+/// Custom cast-only type that casts to a string "rvalue" or "lvalue" depending on the cast
+/// context. Used to test recursive casters (e.g. std::tuple, stl containers).
 struct RValueCaster {};
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
-template<> class type_caster<RValueCaster> {
+template <> class type_caster<RValueCaster> {
 public:
     PYBIND11_TYPE_CASTER(RValueCaster, _("RValueCaster"));
-    static handle cast(RValueCaster &&, return_value_policy, handle) { return py::str("rvalue").release(); }
-    static handle cast(const RValueCaster &, return_value_policy, handle) { return py::str("lvalue").release(); }
+    static handle cast(RValueCaster &&, return_value_policy, handle) {
+        return py::str("rvalue").release();
+    }
+    static handle cast(const RValueCaster &, return_value_policy, handle) {
+        return py::str("lvalue").release();
+    }
 };
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(pybind11)
 
-template <typename F>
-void ignoreOldStyleInitWarnings(F &&body) {
+template <typename F> void ignoreOldStyleInitWarnings(F &&body) {
     py::exec(R"(
     message = "pybind11-bound class '.+' is using an old-style placement-new '(?:__init__|__setstate__)' which has been deprecated"
 
@@ -85,5 +87,6 @@ void ignoreOldStyleInitWarnings(F &&body) {
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=message, category=FutureWarning)
         body()
-    )", py::dict(py::arg("body") = py::cpp_function(body)));
+    )",
+             py::dict(py::arg("body") = py::cpp_function(body)));
 }

--- a/tests/test_async.cpp
+++ b/tests/test_async.cpp
@@ -11,12 +11,11 @@
 
 TEST_SUBMODULE(async_module, m) {
     struct DoesNotSupportAsync {};
-    py::class_<DoesNotSupportAsync>(m, "DoesNotSupportAsync")
-        .def(py::init<>());
+    py::class_<DoesNotSupportAsync>(m, "DoesNotSupportAsync").def(py::init<>());
     struct SupportsAsync {};
     py::class_<SupportsAsync>(m, "SupportsAsync")
         .def(py::init<>())
-        .def("__await__", [](const SupportsAsync& self) -> py::object {
+        .def("__await__", [](const SupportsAsync &self) -> py::object {
             static_cast<void>(self);
             py::object loop = py::module_::import("asyncio.events").attr("get_event_loop")();
             py::object f = loop.attr("create_future")();

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -155,7 +155,7 @@ TEST_SUBMODULE(buffers, m) {
                                    py::format_descriptor<int32_t>::format(), 1);
         }
 
-        ConstBuffer() : value(new int32_t{0}) { };
+        ConstBuffer() : value(new int32_t{0}) {}
     };
     py::class_<ConstBuffer>(m, "ConstBuffer", py::buffer_protocol())
         .def(py::init<>())

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -7,8 +7,8 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 #include <pybind11/stl.h>
 
 TEST_SUBMODULE(buffers, m) {
@@ -17,14 +17,15 @@ TEST_SUBMODULE(buffers, m) {
     public:
         Matrix(py::ssize_t rows, py::ssize_t cols) : m_rows(rows), m_cols(cols) {
             print_created(this, std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
-            m_data = new float[(size_t) (rows*cols)];
-            memset(m_data, 0, sizeof(float) * (size_t) (rows * cols));
+            m_data = new float[(size_t)(rows * cols)];
+            memset(m_data, 0, sizeof(float) * (size_t)(rows * cols));
         }
 
         Matrix(const Matrix &s) : m_rows(s.m_rows), m_cols(s.m_cols) {
-            print_copy_created(this, std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
-            m_data = new float[(size_t) (m_rows * m_cols)];
-            memcpy(m_data, s.m_data, sizeof(float) * (size_t) (m_rows * m_cols));
+            print_copy_created(this,
+                               std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
+            m_data = new float[(size_t)(m_rows * m_cols)];
+            memcpy(m_data, s.m_data, sizeof(float) * (size_t)(m_rows * m_cols));
         }
 
         Matrix(Matrix &&s) noexcept : m_rows(s.m_rows), m_cols(s.m_cols), m_data(s.m_data) {
@@ -35,42 +36,50 @@ TEST_SUBMODULE(buffers, m) {
         }
 
         ~Matrix() {
-            print_destroyed(this, std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
+            print_destroyed(this,
+                            std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
             delete[] m_data;
         }
 
         Matrix &operator=(const Matrix &s) {
-            print_copy_assigned(this, std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
+            print_copy_assigned(this,
+                                std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
             delete[] m_data;
             m_rows = s.m_rows;
             m_cols = s.m_cols;
-            m_data = new float[(size_t) (m_rows * m_cols)];
-            memcpy(m_data, s.m_data, sizeof(float) * (size_t) (m_rows * m_cols));
+            m_data = new float[(size_t)(m_rows * m_cols)];
+            memcpy(m_data, s.m_data, sizeof(float) * (size_t)(m_rows * m_cols));
             return *this;
         }
 
         Matrix &operator=(Matrix &&s) noexcept {
-            print_move_assigned(this, std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
+            print_move_assigned(this,
+                                std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
             if (&s != this) {
                 delete[] m_data;
-                m_rows = s.m_rows; m_cols = s.m_cols; m_data = s.m_data;
-                s.m_rows = 0; s.m_cols = 0; s.m_data = nullptr;
+                m_rows = s.m_rows;
+                m_cols = s.m_cols;
+                m_data = s.m_data;
+                s.m_rows = 0;
+                s.m_cols = 0;
+                s.m_data = nullptr;
             }
             return *this;
         }
 
         float operator()(py::ssize_t i, py::ssize_t j) const {
-            return m_data[(size_t) (i*m_cols + j)];
+            return m_data[(size_t)(i * m_cols + j)];
         }
 
         float &operator()(py::ssize_t i, py::ssize_t j) {
-            return m_data[(size_t) (i*m_cols + j)];
+            return m_data[(size_t)(i * m_cols + j)];
         }
 
         float *data() { return m_data; }
 
         py::ssize_t rows() const { return m_rows; }
         py::ssize_t cols() const { return m_cols; }
+
     private:
         py::ssize_t m_rows;
         py::ssize_t m_cols;
@@ -86,7 +95,7 @@ TEST_SUBMODULE(buffers, m) {
                 throw std::runtime_error("Incompatible buffer format!");
 
             auto v = new Matrix(info.shape[0], info.shape[1]);
-            memcpy(v->data(), info.ptr, sizeof(float) * (size_t) (v->rows() * v->cols()));
+            memcpy(v->data(), info.ptr, sizeof(float) * (size_t)(v->rows() * v->cols()));
             return v;
         }))
 
@@ -109,22 +118,19 @@ TEST_SUBMODULE(buffers, m) {
         /// Provide buffer access
         .def_buffer([](Matrix &m) -> py::buffer_info {
             return py::buffer_info(
-                m.data(),                               /* Pointer to buffer */
-                { m.rows(), m.cols() },                 /* Buffer dimensions */
-                { sizeof(float) * size_t(m.cols()),     /* Strides (in bytes) for each index */
-                  sizeof(float) }
-            );
+                m.data(),                          /* Pointer to buffer */
+                {m.rows(), m.cols()},              /* Buffer dimensions */
+                {sizeof(float) * size_t(m.cols()), /* Strides (in bytes) for each index */
+                 sizeof(float)});
         });
 
     // test_inherited_protocol
     class SquareMatrix : public Matrix {
     public:
-        SquareMatrix(py::ssize_t n) : Matrix(n, n) { }
+        SquareMatrix(py::ssize_t n) : Matrix(n, n) {}
     };
     // Derived classes inherit the buffer protocol and the buffer access function
-    py::class_<SquareMatrix, Matrix>(m, "SquareMatrix")
-        .def(py::init<py::ssize_t>());
-
+    py::class_<SquareMatrix, Matrix>(m, "SquareMatrix").def(py::init<py::ssize_t>());
 
     // test_pointer_to_member_fn
     // Tests that passing a pointer to member to the base class works in
@@ -133,15 +139,14 @@ TEST_SUBMODULE(buffers, m) {
         int32_t value = 0;
 
         py::buffer_info get_buffer_info() {
-            return py::buffer_info(&value, sizeof(value),
-                                   py::format_descriptor<int32_t>::format(), 1);
+            return py::buffer_info(&value, sizeof(value), py::format_descriptor<int32_t>::format(),
+                                   1);
         }
     };
     py::class_<Buffer>(m, "Buffer", py::buffer_protocol())
         .def(py::init<>())
         .def_readwrite("value", &Buffer::value)
         .def_buffer(&Buffer::get_buffer_info);
-
 
     class ConstBuffer {
         std::unique_ptr<int32_t> value;
@@ -162,19 +167,17 @@ TEST_SUBMODULE(buffers, m) {
         .def_property("value", &ConstBuffer::get_value, &ConstBuffer::set_value)
         .def_buffer(&ConstBuffer::get_buffer_info);
 
-    struct DerivedBuffer : public Buffer { };
+    struct DerivedBuffer : public Buffer {};
     py::class_<DerivedBuffer>(m, "DerivedBuffer", py::buffer_protocol())
         .def(py::init<>())
-        .def_readwrite("value", (int32_t DerivedBuffer::*) &DerivedBuffer::value)
+        .def_readwrite("value", (int32_t DerivedBuffer::*)&DerivedBuffer::value)
         .def_buffer(&DerivedBuffer::get_buffer_info);
 
     struct BufferReadOnly {
         const uint8_t value = 0;
-        BufferReadOnly(uint8_t value): value(value) {}
+        BufferReadOnly(uint8_t value) : value(value) {}
 
-        py::buffer_info get_buffer_info() {
-            return py::buffer_info(&value, 1);
-        }
+        py::buffer_info get_buffer_info() { return py::buffer_info(&value, 1); }
     };
     py::class_<BufferReadOnly>(m, "BufferReadOnly", py::buffer_protocol())
         .def(py::init<uint8_t>())
@@ -184,9 +187,7 @@ TEST_SUBMODULE(buffers, m) {
         uint8_t value = 0;
         bool readonly = false;
 
-        py::buffer_info get_buffer_info() {
-            return py::buffer_info(&value, 1, readonly);
-        }
+        py::buffer_info get_buffer_info() { return py::buffer_info(&value, 1, readonly); }
     };
     py::class_<BufferReadOnlySelect>(m, "BufferReadOnlySelect", py::buffer_protocol())
         .def(py::init<>())
@@ -205,9 +206,11 @@ TEST_SUBMODULE(buffers, m) {
         .def_readonly("strides", &py::buffer_info::strides)
         .def_readonly("readonly", &py::buffer_info::readonly)
         .def("__repr__", [](py::handle self) {
-             return py::str("itemsize={0.itemsize!r}, size={0.size!r}, format={0.format!r}, ndim={0.ndim!r}, shape={0.shape!r}, strides={0.strides!r}, readonly={0.readonly!r}").format(self);
-        })
-        ;
+            return py::str("itemsize={0.itemsize!r}, size={0.size!r}, format={0.format!r}, "
+                           "ndim={0.ndim!r}, shape={0.shape!r}, strides={0.strides!r}, "
+                           "readonly={0.readonly!r}")
+                .format(self);
+        });
 
     m.def("get_buffer_info", [](const py::buffer &buffer) { return buffer.request(); });
 }

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -151,10 +151,13 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("int_passthrough_noconvert", [](int arg) { return arg; }, py::arg{}.noconvert());
 
     // test_tuple
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("pair_passthrough", [](std::pair<bool, std::string> input) {
-        return std::make_pair(input.second, input.first);
-    }, "Return a pair in reversed order");
+    m.def(
+        "pair_passthrough",
+        // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        [](std::pair<bool, std::string> input) {
+            return std::make_pair(input.second, input.first);
+        },
+        "Return a pair in reversed order");
     m.def("tuple_passthrough", [](std::tuple<bool, std::string, int> input) {
         return std::make_tuple(std::get<2>(input), std::get<1>(input), std::get<0>(input));
     }, "Return a triple in reversed order");

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -11,53 +11,65 @@
 #include <pybind11/complex.h>
 
 #if defined(_MSC_VER)
-#  pragma warning(push)
-#  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
+#pragma warning(push)
+#pragma warning(disable : 4127) // warning C4127: Conditional expression is constant
 #endif
 
 struct ConstRefCasted {
-  int tag;
+    int tag;
 };
 
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
-template <>
-class type_caster<ConstRefCasted> {
- public:
-  static constexpr auto name = _<ConstRefCasted>();
+template <> class type_caster<ConstRefCasted> {
+public:
+    static constexpr auto name = _<ConstRefCasted>();
 
-  // Input is unimportant, a new value will always be constructed based on the
-  // cast operator.
-  bool load(handle, bool) { return true; }
+    // Input is unimportant, a new value will always be constructed based on the
+    // cast operator.
+    bool load(handle, bool) { return true; }
 
-  operator ConstRefCasted &&() {
-      value = {1};
-      // NOLINTNEXTLINE(performance-move-const-arg)
-      return std::move(value);
-  }
-  operator ConstRefCasted&() { value = {2}; return value; }
-  operator ConstRefCasted*() { value = {3}; return &value; }
+    operator ConstRefCasted &&() {
+        value = {1};
+        // NOLINTNEXTLINE(performance-move-const-arg)
+        return std::move(value);
+    }
+    operator ConstRefCasted &() {
+        value = {2};
+        return value;
+    }
+    operator ConstRefCasted *() {
+        value = {3};
+        return &value;
+    }
 
-  operator const ConstRefCasted&() { value = {4}; return value; }
-  operator const ConstRefCasted*() { value = {5}; return &value; }
+    operator const ConstRefCasted &() {
+        value = {4};
+        return value;
+    }
+    operator const ConstRefCasted *() {
+        value = {5};
+        return &value;
+    }
 
-  // custom cast_op to explicitly propagate types to the conversion operators.
-  template <typename T_>
-  using cast_op_type =
-      /// const
-      conditional_t<
-          std::is_same<remove_reference_t<T_>, const ConstRefCasted*>::value, const ConstRefCasted*,
-      conditional_t<
-          std::is_same<T_, const ConstRefCasted&>::value, const ConstRefCasted&,
-      /// non-const
-      conditional_t<
-          std::is_same<remove_reference_t<T_>, ConstRefCasted*>::value, ConstRefCasted*,
-      conditional_t<
-          std::is_same<T_, ConstRefCasted&>::value, ConstRefCasted&,
-          /* else */ConstRefCasted&&>>>>;
+    // custom cast_op to explicitly propagate types to the conversion operators.
+    template <typename T_>
+    using cast_op_type =
+        /// const
+        conditional_t<
+            std::is_same<remove_reference_t<T_>, const ConstRefCasted *>::value,
+            const ConstRefCasted *,
+            conditional_t<
+                std::is_same<T_, const ConstRefCasted &>::value, const ConstRefCasted &,
+                /// non-const
+                conditional_t<
+                    std::is_same<remove_reference_t<T_>, ConstRefCasted *>::value,
+                    ConstRefCasted *,
+                    conditional_t<std::is_same<T_, ConstRefCasted &>::value, ConstRefCasted &,
+                                  /* else */ ConstRefCasted &&>>>>;
 
- private:
-  ConstRefCasted value = {0};
+private:
+    ConstRefCasted value = {0};
 };
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(pybind11)
@@ -67,27 +79,47 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("string_roundtrip", [](const char *s) { return s; });
 
     // test_unicode_conversion
-    // Some test characters in utf16 and utf32 encodings.  The last one (the 𝐀) contains a null byte
-    char32_t a32 = 0x61 /*a*/, z32 = 0x7a /*z*/, ib32 = 0x203d /*‽*/, cake32 = 0x1f382 /*🎂*/,              mathbfA32 = 0x1d400 /*𝐀*/;
-    char16_t b16 = 0x62 /*b*/, z16 = 0x7a,       ib16 = 0x203d,       cake16_1 = 0xd83c, cake16_2 = 0xdf82, mathbfA16_1 = 0xd835, mathbfA16_2 = 0xdc00;
+    // Some test characters in utf16 and utf32 encodings.  The last one (the 𝐀) contains a null
+    // byte
+    char32_t a32 = 0x61 /*a*/, z32 = 0x7a /*z*/, ib32 = 0x203d /*‽*/, cake32 = 0x1f382 /*🎂*/,
+             mathbfA32 = 0x1d400 /*𝐀*/;
+    char16_t b16 = 0x62 /*b*/, z16 = 0x7a, ib16 = 0x203d, cake16_1 = 0xd83c, cake16_2 = 0xdf82,
+             mathbfA16_1 = 0xd835, mathbfA16_2 = 0xdc00;
     std::wstring wstr;
-    wstr.push_back(0x61); // a
+    wstr.push_back(0x61);   // a
     wstr.push_back(0x2e18); // ⸘
-    if (sizeof(wchar_t) == 2) { wstr.push_back(mathbfA16_1); wstr.push_back(mathbfA16_2); } // 𝐀, utf16
-    else { wstr.push_back((wchar_t) mathbfA32); } // 𝐀, utf32
+    if (sizeof(wchar_t) == 2) {
+        wstr.push_back(mathbfA16_1);
+        wstr.push_back(mathbfA16_2);
+    } // 𝐀, utf16
+    else {
+        wstr.push_back((wchar_t)mathbfA32);
+    }                     // 𝐀, utf32
     wstr.push_back(0x7a); // z
 
-    m.def("good_utf8_string", []() { return std::string((const char*)u8"Say utf8\u203d \U0001f382 \U0001d400"); }); // Say utf8‽ 🎂 𝐀
-    m.def("good_utf16_string", [=]() { return std::u16string({ b16, ib16, cake16_1, cake16_2, mathbfA16_1, mathbfA16_2, z16 }); }); // b‽🎂𝐀z
-    m.def("good_utf32_string", [=]() { return std::u32string({ a32, mathbfA32, cake32, ib32, z32 }); }); // a𝐀🎂‽z
+    m.def("good_utf8_string", []() {
+        return std::string((const char *)u8"Say utf8\u203d \U0001f382 \U0001d400");
+    }); // Say utf8‽ 🎂 𝐀
+    m.def("good_utf16_string", [=]() {
+        return std::u16string({b16, ib16, cake16_1, cake16_2, mathbfA16_1, mathbfA16_2, z16});
+    }); // b‽🎂𝐀z
+    m.def("good_utf32_string", [=]() {
+        return std::u32string({a32, mathbfA32, cake32, ib32, z32});
+    });                                                 // a𝐀🎂‽z
     m.def("good_wchar_string", [=]() { return wstr; }); // a‽𝐀z
-    m.def("bad_utf8_string", []()  { return std::string("abc\xd0" "def"); });
-    m.def("bad_utf16_string", [=]() { return std::u16string({ b16, char16_t(0xd800), z16 }); });
-    // Under Python 2.7, invalid unicode UTF-32 characters don't appear to trigger UnicodeDecodeError
+    m.def("bad_utf8_string", []() {
+        return std::string("abc\xd0"
+                           "def");
+    });
+    m.def("bad_utf16_string", [=]() { return std::u16string({b16, char16_t(0xd800), z16}); });
+    // Under Python 2.7, invalid unicode UTF-32 characters don't appear to trigger
+    // UnicodeDecodeError
     if (PY_MAJOR_VERSION >= 3)
-        m.def("bad_utf32_string", [=]() { return std::u32string({ a32, char32_t(0xd800), z32 }); });
+        m.def("bad_utf32_string", [=]() { return std::u32string({a32, char32_t(0xd800), z32}); });
     if (PY_MAJOR_VERSION >= 3 || sizeof(wchar_t) == 2)
-        m.def("bad_wchar_string", [=]() { return std::wstring({ wchar_t(0x61), wchar_t(0xd800) }); });
+        m.def("bad_wchar_string", [=]() {
+            return std::wstring({wchar_t(0x61), wchar_t(0xd800)});
+        });
     m.def("u8_Z", []() -> char { return 'Z'; });
     m.def("u8_eacute", []() -> char { return '\xe9'; });
     m.def("u16_ibang", [=]() -> char16_t { return ib16; });
@@ -110,8 +142,13 @@ TEST_SUBMODULE(builtin_casters, m) {
 
 #ifdef PYBIND11_HAS_U8STRING
     m.attr("has_u8string") = true;
-    m.def("good_utf8_u8string", []() { return std::u8string(u8"Say utf8\u203d \U0001f382 \U0001d400"); }); // Say utf8‽ 🎂 𝐀
-    m.def("bad_utf8_u8string", []()  { return std::u8string((const char8_t*)"abc\xd0" "def"); });
+    m.def("good_utf8_u8string", []() {
+        return std::u8string(u8"Say utf8\u203d \U0001f382 \U0001d400");
+    }); // Say utf8‽ 🎂 𝐀
+    m.def("bad_utf8_u8string", []() {
+        return std::u8string((const char8_t *)"abc\xd0"
+                                              "def");
+    });
 
     m.def("u8_char8_Z", []() -> char8_t { return u8'Z'; });
 
@@ -123,21 +160,44 @@ TEST_SUBMODULE(builtin_casters, m) {
     // test_string_view
 #ifdef PYBIND11_HAS_STRING_VIEW
     m.attr("has_string_view") = true;
-    m.def("string_view_print",   [](std::string_view s)    { py::print(s, s.size()); });
+    m.def("string_view_print", [](std::string_view s) { py::print(s, s.size()); });
     m.def("string_view16_print", [](std::u16string_view s) { py::print(s, s.size()); });
     m.def("string_view32_print", [](std::u32string_view s) { py::print(s, s.size()); });
-    m.def("string_view_chars",   [](std::string_view s)    { py::list l; for (auto c : s) l.append((std::uint8_t) c); return l; });
-    m.def("string_view16_chars", [](std::u16string_view s) { py::list l; for (auto c : s) l.append((int) c); return l; });
-    m.def("string_view32_chars", [](std::u32string_view s) { py::list l; for (auto c : s) l.append((int) c); return l; });
-    m.def("string_view_return",   []() { return std::string_view((const char*)u8"utf8 secret \U0001f382"); });
-    m.def("string_view16_return", []() { return std::u16string_view(u"utf16 secret \U0001f382"); });
-    m.def("string_view32_return", []() { return std::u32string_view(U"utf32 secret \U0001f382"); });
+    m.def("string_view_chars", [](std::string_view s) {
+        py::list l;
+        for (auto c : s)
+            l.append((std::uint8_t)c);
+        return l;
+    });
+    m.def("string_view16_chars", [](std::u16string_view s) {
+        py::list l;
+        for (auto c : s)
+            l.append((int)c);
+        return l;
+    });
+    m.def("string_view32_chars", [](std::u32string_view s) {
+        py::list l;
+        for (auto c : s)
+            l.append((int)c);
+        return l;
+    });
+    m.def("string_view_return",
+          []() { return std::string_view((const char *)u8"utf8 secret \U0001f382"); });
+    m.def("string_view16_return",
+          []() { return std::u16string_view(u"utf16 secret \U0001f382"); });
+    m.def("string_view32_return",
+          []() { return std::u32string_view(U"utf32 secret \U0001f382"); });
 
-#   ifdef PYBIND11_HAS_U8STRING
-    m.def("string_view8_print",  [](std::u8string_view s) { py::print(s, s.size()); });
-    m.def("string_view8_chars",  [](std::u8string_view s) { py::list l; for (auto c : s) l.append((std::uint8_t) c); return l; });
+#ifdef PYBIND11_HAS_U8STRING
+    m.def("string_view8_print", [](std::u8string_view s) { py::print(s, s.size()); });
+    m.def("string_view8_chars", [](std::u8string_view s) {
+        py::list l;
+        for (auto c : s)
+            l.append((std::uint8_t)c);
+        return l;
+    });
     m.def("string_view8_return", []() { return std::u8string_view(u8"utf8 secret \U0001f382"); });
-#   endif
+#endif
 #endif
 
     // test_integer_casting
@@ -148,7 +208,8 @@ TEST_SUBMODULE(builtin_casters, m) {
 
     // test_int_convert
     m.def("int_passthrough", [](int arg) { return arg; });
-    m.def("int_passthrough_noconvert", [](int arg) { return arg; }, py::arg{}.noconvert());
+    m.def(
+        "int_passthrough_noconvert", [](int arg) { return arg; }, py::arg{}.noconvert());
 
     // test_tuple
     m.def(
@@ -158,19 +219,27 @@ TEST_SUBMODULE(builtin_casters, m) {
             return std::make_pair(input.second, input.first);
         },
         "Return a pair in reversed order");
-    m.def("tuple_passthrough", [](std::tuple<bool, std::string, int> input) {
-        return std::make_tuple(std::get<2>(input), std::get<1>(input), std::get<0>(input));
-    }, "Return a triple in reversed order");
+    m.def(
+        "tuple_passthrough",
+        [](std::tuple<bool, std::string, int> input) {
+            return std::make_tuple(std::get<2>(input), std::get<1>(input), std::get<0>(input));
+        },
+        "Return a triple in reversed order");
     m.def("empty_tuple", []() { return std::tuple<>(); });
     static std::pair<RValueCaster, RValueCaster> lvpair;
     static std::tuple<RValueCaster, RValueCaster, RValueCaster> lvtuple;
-    static std::pair<RValueCaster, std::tuple<RValueCaster, std::pair<RValueCaster, RValueCaster>>> lvnested;
+    static std::pair<RValueCaster, std::tuple<RValueCaster, std::pair<RValueCaster, RValueCaster>>>
+        lvnested;
     m.def("rvalue_pair", []() { return std::make_pair(RValueCaster{}, RValueCaster{}); });
     m.def("lvalue_pair", []() -> const decltype(lvpair) & { return lvpair; });
-    m.def("rvalue_tuple", []() { return std::make_tuple(RValueCaster{}, RValueCaster{}, RValueCaster{}); });
+    m.def("rvalue_tuple",
+          []() { return std::make_tuple(RValueCaster{}, RValueCaster{}, RValueCaster{}); });
     m.def("lvalue_tuple", []() -> const decltype(lvtuple) & { return lvtuple; });
     m.def("rvalue_nested", []() {
-        return std::make_pair(RValueCaster{}, std::make_tuple(RValueCaster{}, std::make_pair(RValueCaster{}, RValueCaster{}))); });
+        return std::make_pair(
+            RValueCaster{},
+            std::make_tuple(RValueCaster{}, std::make_pair(RValueCaster{}, RValueCaster{})));
+    });
     m.def("lvalue_nested", []() -> const decltype(lvnested) & { return lvnested; });
 
     static std::pair<int, std::string> int_string_pair{2, "items"};
@@ -178,11 +247,11 @@ TEST_SUBMODULE(builtin_casters, m) {
 
     // test_builtins_cast_return_none
     m.def("return_none_string", []() -> std::string * { return nullptr; });
-    m.def("return_none_char",   []() -> const char *  { return nullptr; });
-    m.def("return_none_bool",   []() -> bool *        { return nullptr; });
-    m.def("return_none_int",    []() -> int *         { return nullptr; });
-    m.def("return_none_float",  []() -> float *       { return nullptr; });
-    m.def("return_none_pair",   []() -> std::pair<int,int> * { return nullptr; });
+    m.def("return_none_char", []() -> const char * { return nullptr; });
+    m.def("return_none_bool", []() -> bool * { return nullptr; });
+    m.def("return_none_int", []() -> int * { return nullptr; });
+    m.def("return_none_float", []() -> float * { return nullptr; });
+    m.def("return_none_pair", []() -> std::pair<int, int> * { return nullptr; });
 
     // test_none_deferred
     m.def("defer_none_cstring", [](char *) { return false; });
@@ -203,7 +272,8 @@ TEST_SUBMODULE(builtin_casters, m) {
 
     // test_bool_caster
     m.def("bool_passthrough", [](bool arg) { return arg; });
-    m.def("bool_passthrough_noconvert", [](bool arg) { return arg; }, py::arg{}.noconvert());
+    m.def(
+        "bool_passthrough_noconvert", [](bool arg) { return arg; }, py::arg{}.noconvert());
 
     // TODO: This should be disabled and fixed in future Intel compilers
 #if !defined(__INTEL_COMPILER)
@@ -211,13 +281,15 @@ TEST_SUBMODULE(builtin_casters, m) {
     // When compiled with the Intel compiler, this results in segmentation faults when importing
     // the module. Tested with icc (ICC) 2021.1 Beta 20200827, this should be tested again when
     // a newer version of icc is available.
-    m.def("bool_passthrough_noconvert2", [](bool arg) { return arg; }, py::arg().noconvert());
+    m.def(
+        "bool_passthrough_noconvert2", [](bool arg) { return arg; }, py::arg().noconvert());
 #endif
 
     // test_reference_wrapper
     m.def("refwrap_builtin", [](std::reference_wrapper<int> p) { return 10 * p.get(); });
     m.def("refwrap_usertype", [](std::reference_wrapper<UserType> p) { return p.get().value(); });
-    m.def("refwrap_usertype_const", [](std::reference_wrapper<const UserType> p) { return p.get().value(); });
+    m.def("refwrap_usertype_const",
+          [](std::reference_wrapper<const UserType> p) { return p.get().value(); });
 
     m.def("refwrap_lvalue", []() -> std::reference_wrapper<UserType> {
         static UserType x(1);
@@ -230,17 +302,20 @@ TEST_SUBMODULE(builtin_casters, m) {
 
     // Not currently supported (std::pair caster has return-by-value cast operator);
     // triggers static_assert failure.
-    //m.def("refwrap_pair", [](std::reference_wrapper<std::pair<int, int>>) { });
+    // m.def("refwrap_pair", [](std::reference_wrapper<std::pair<int, int>>) { });
 
-    m.def("refwrap_list", [](bool copy) {
-        static IncType x1(1), x2(2);
-        py::list l;
-        for (auto &f : {std::ref(x1), std::ref(x2)}) {
-            l.append(py::cast(f, copy ? py::return_value_policy::copy
-                                      : py::return_value_policy::reference));
-        }
-        return l;
-    }, "copy"_a);
+    m.def(
+        "refwrap_list",
+        [](bool copy) {
+            static IncType x1(1), x2(2);
+            py::list l;
+            for (auto &f : {std::ref(x1), std::ref(x2)}) {
+                l.append(py::cast(f, copy ? py::return_value_policy::copy
+                                          : py::return_value_policy::reference));
+            }
+            return l;
+        },
+        "copy"_a);
 
     m.def("refwrap_iiw", [](const IncType &w) { return w.value(); });
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
@@ -258,27 +333,29 @@ TEST_SUBMODULE(builtin_casters, m) {
 
     // test_complex
     m.def("complex_cast", [](float x) { return "{}"_s.format(x); });
-    m.def("complex_cast", [](std::complex<float> x) { return "({}, {})"_s.format(x.real(), x.imag()); });
+    m.def("complex_cast",
+          [](std::complex<float> x) { return "({}, {})"_s.format(x.real(), x.imag()); });
 
     // test int vs. long (Python 2)
-    m.def("int_cast", []() {return (int) 42;});
-    m.def("long_cast", []() {return (long) 42;});
-    m.def("longlong_cast", []() {return  ULLONG_MAX;});
+    m.def("int_cast", []() { return (int)42; });
+    m.def("long_cast", []() { return (long)42; });
+    m.def("longlong_cast", []() { return ULLONG_MAX; });
 
     /// test void* cast operator
     m.def("test_void_caster", []() -> bool {
-        void *v = (void *) 0xabcd;
+        void *v = (void *)0xabcd;
         py::object o = py::cast(v);
         return py::cast<void *>(o) == v;
     });
 
     // Tests const/non-const propagation in cast_op.
     m.def("takes", [](ConstRefCasted x) { return x.tag; });
-    m.def("takes_move", [](ConstRefCasted&& x) { return x.tag; });
-    m.def("takes_ptr", [](ConstRefCasted* x) { return x->tag; });
-    m.def("takes_ref", [](ConstRefCasted& x) { return x.tag; });
+    m.def("takes_move", [](ConstRefCasted &&x) { return x.tag; });
+    m.def("takes_ptr", [](ConstRefCasted *x) { return x->tag; });
+    m.def("takes_ref", [](ConstRefCasted &x) { return x.tag; });
     m.def("takes_ref_wrap", [](std::reference_wrapper<ConstRefCasted> x) { return x.get().tag; });
-    m.def("takes_const_ptr", [](const ConstRefCasted* x) { return x->tag; });
-    m.def("takes_const_ref", [](const ConstRefCasted& x) { return x.tag; });
-    m.def("takes_const_ref_wrap", [](std::reference_wrapper<const ConstRefCasted> x) { return x.get().tag; });
+    m.def("takes_const_ptr", [](const ConstRefCasted *x) { return x->tag; });
+    m.def("takes_const_ref", [](const ConstRefCasted &x) { return x.tag; });
+    m.def("takes_const_ref_wrap",
+          [](std::reference_wrapper<const ConstRefCasted> x) { return x.get().tag; });
 }

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -40,18 +40,17 @@ TEST_SUBMODULE(call_policies, m) {
         Child(Child &&) = default;
         ~Child() { py::print("Releasing child."); }
     };
-    py::class_<Child>(m, "Child")
-        .def(py::init<>());
+    py::class_<Child>(m, "Child").def(py::init<>());
 
     class Parent {
     public:
         Parent() { py::print("Allocating parent."); }
-        Parent(const Parent& parent) = default;
+        Parent(const Parent &parent) = default;
         ~Parent() { py::print("Releasing parent."); }
-        void addChild(Child *) { }
+        void addChild(Child *) {}
         Child *returnChild() { return new Child(); }
         Child *returnNullChild() { return nullptr; }
-        static Child *staticFunction(Parent*) { return new Child(); }
+        static Child *staticFunction(Parent *) { return new Child(); }
     };
     py::class_<Parent>(m, "Parent")
         .def(py::init<>())
@@ -62,11 +61,12 @@ TEST_SUBMODULE(call_policies, m) {
         .def("returnChildKeepAlive", &Parent::returnChild, py::keep_alive<1, 0>())
         .def("returnNullChildKeepAliveChild", &Parent::returnNullChild, py::keep_alive<1, 0>())
         .def("returnNullChildKeepAliveParent", &Parent::returnNullChild, py::keep_alive<0, 1>())
-        .def_static(
-            "staticFunction", &Parent::staticFunction, py::keep_alive<1, 0>());
+        .def_static("staticFunction", &Parent::staticFunction, py::keep_alive<1, 0>());
 
-    m.def("free_function", [](Parent*, Child*) {}, py::keep_alive<1, 2>());
-    m.def("invalid_arg_index", []{}, py::keep_alive<0, 1>());
+    m.def(
+        "free_function", [](Parent *, Child *) {}, py::keep_alive<1, 2>());
+    m.def(
+        "invalid_arg_index", [] {}, py::keep_alive<0, 1>());
 
 #if !defined(PYPY_VERSION)
     // test_alive_gc
@@ -74,21 +74,28 @@ TEST_SUBMODULE(call_policies, m) {
     public:
         using Parent::Parent;
     };
-    py::class_<ParentGC, Parent>(m, "ParentGC", py::dynamic_attr())
-        .def(py::init<>());
+    py::class_<ParentGC, Parent>(m, "ParentGC", py::dynamic_attr()).def(py::init<>());
 #endif
 
     // test_call_guard
     m.def("unguarded_call", &CustomGuard::report_status);
     m.def("guarded_call", &CustomGuard::report_status, py::call_guard<CustomGuard>());
 
-    m.def("multiple_guards_correct_order", []() {
-        return CustomGuard::report_status() + std::string(" & ") + DependentGuard::report_status();
-    }, py::call_guard<CustomGuard, DependentGuard>());
+    m.def(
+        "multiple_guards_correct_order",
+        []() {
+            return CustomGuard::report_status() + std::string(" & ") +
+                   DependentGuard::report_status();
+        },
+        py::call_guard<CustomGuard, DependentGuard>());
 
-    m.def("multiple_guards_wrong_order", []() {
-        return DependentGuard::report_status() + std::string(" & ") + CustomGuard::report_status();
-    }, py::call_guard<DependentGuard, CustomGuard>());
+    m.def(
+        "multiple_guards_wrong_order",
+        []() {
+            return DependentGuard::report_status() + std::string(" & ") +
+                   CustomGuard::report_status();
+        },
+        py::call_guard<DependentGuard, CustomGuard>());
 
 #if defined(WITH_THREAD) && !defined(PYPY_VERSION)
     // `py::call_guard<py::gil_scoped_release>()` should work in PyPy as well,

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -122,7 +122,7 @@ TEST_SUBMODULE(callbacks, m) {
         // [workaround(intel)] = default does not work here
         // Defaulting this destructor results in linking errors with the Intel compiler
         // (in Debug builds only, tested with icpc (ICC) 2021.1 Beta 20200827)
-        virtual ~AbstractBase() {};  // NOLINT(modernize-use-equals-default)
+        virtual ~AbstractBase() {} // NOLINT(modernize-use-equals-default)
         virtual unsigned int func() = 0;
     };
     m.def("func_accepting_func_accepting_base",

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -7,11 +7,10 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 #include <pybind11/functional.h>
 #include <thread>
-
 
 int dummy_function(int i) { return i + 1; }
 
@@ -20,11 +19,12 @@ TEST_SUBMODULE(callbacks, m) {
     m.def("test_callback1", [](const py::object &func) { return func(); });
     m.def("test_callback2", [](const py::object &func) { return func("Hello", 'x', true, 5); });
     m.def("test_callback3", [](const std::function<int(int)> &func) {
-        return "func(43) = " + std::to_string(func(43)); });
-    m.def("test_callback4", []() -> std::function<int(int)> { return [](int i) { return i+1; }; });
-    m.def("test_callback5", []() {
-        return py::cpp_function([](int i) { return i+1; }, py::arg("number"));
+        return "func(43) = " + std::to_string(func(43));
     });
+    m.def("test_callback4",
+          []() -> std::function<int(int)> { return [](int i) { return i + 1; }; });
+    m.def("test_callback5",
+          []() { return py::cpp_function([](int i) { return i + 1; }, py::arg("number")); });
 
     // test_keyword_args_and_generalized_unpacking
     m.def("test_tuple_unpacking", [](const py::function &f) {
@@ -34,9 +34,9 @@ TEST_SUBMODULE(callbacks, m) {
     });
 
     m.def("test_dict_unpacking", [](const py::function &f) {
-        auto d1 = py::dict("key"_a="value", "a"_a=1);
+        auto d1 = py::dict("key"_a = "value", "a"_a = 1);
         auto d2 = py::dict();
-        auto d3 = py::dict("b"_a=2);
+        auto d3 = py::dict("b"_a = 2);
         return f("positional", 1, **d1, **d2, **d3);
     });
 
@@ -44,32 +44,32 @@ TEST_SUBMODULE(callbacks, m) {
 
     m.def("test_unpacking_and_keywords1", [](const py::function &f) {
         auto args = py::make_tuple(2);
-        auto kwargs = py::dict("d"_a=4);
-        return f(1, *args, "c"_a=3, **kwargs);
+        auto kwargs = py::dict("d"_a = 4);
+        return f(1, *args, "c"_a = 3, **kwargs);
     });
 
     m.def("test_unpacking_and_keywords2", [](const py::function &f) {
-        auto kwargs1 = py::dict("a"_a=1);
-        auto kwargs2 = py::dict("c"_a=3, "d"_a=4);
-        return f("positional", *py::make_tuple(1), 2, *py::make_tuple(3, 4), 5,
-                 "key"_a="value", **kwargs1, "b"_a=2, **kwargs2, "e"_a=5);
+        auto kwargs1 = py::dict("a"_a = 1);
+        auto kwargs2 = py::dict("c"_a = 3, "d"_a = 4);
+        return f("positional", *py::make_tuple(1), 2, *py::make_tuple(3, 4), 5, "key"_a = "value",
+                 **kwargs1, "b"_a = 2, **kwargs2, "e"_a = 5);
     });
 
     m.def("test_unpacking_error1", [](const py::function &f) {
-        auto kwargs = py::dict("x"_a=3);
-        return f("x"_a=1, "y"_a=2, **kwargs); // duplicate ** after keyword
+        auto kwargs = py::dict("x"_a = 3);
+        return f("x"_a = 1, "y"_a = 2, **kwargs); // duplicate ** after keyword
     });
 
     m.def("test_unpacking_error2", [](const py::function &f) {
-        auto kwargs = py::dict("x"_a=3);
-        return f(**kwargs, "x"_a=1); // duplicate keyword after **
+        auto kwargs = py::dict("x"_a = 3);
+        return f(**kwargs, "x"_a = 1); // duplicate keyword after **
     });
 
     m.def("test_arg_conversion_error1",
           [](const py::function &f) { f(234, UnregisteredType(), "kw"_a = 567); });
 
     m.def("test_arg_conversion_error2", [](const py::function &f) {
-        f(234, "expected_name"_a=UnregisteredType(), "kw"_a=567);
+        f(234, "expected_name"_a = UnregisteredType(), "kw"_a = 567);
     });
 
     // test_lambda_closure_cleanup
@@ -87,7 +87,7 @@ TEST_SUBMODULE(callbacks, m) {
 
         return [p]() {
             /* p should be cleaned up when the returned function is garbage collected */
-            (void) p;
+            (void)p;
         };
     });
 
@@ -97,11 +97,14 @@ TEST_SUBMODULE(callbacks, m) {
     m.def("dummy_function_overloaded", [](int i, int j) { return i + j; });
     m.def("dummy_function_overloaded", &dummy_function);
     m.def("dummy_function2", [](int i, int j) { return i + j; });
-    m.def("roundtrip", [](std::function<int(int)> f, bool expect_none = false) {
-        if (expect_none && f)
-            throw std::runtime_error("Expected None to be converted to empty std::function");
-        return f;
-    }, py::arg("f"), py::arg("expect_none")=false);
+    m.def(
+        "roundtrip",
+        [](std::function<int(int)> f, bool expect_none = false) {
+            if (expect_none && f)
+                throw std::runtime_error("Expected None to be converted to empty std::function");
+            return f;
+        },
+        py::arg("f"), py::arg("expect_none") = false);
     m.def("test_dummy_function", [](const std::function<int(int)> &f) -> std::string {
         using fn_type = int (*)(int);
         auto result = f.target<fn_type>();
@@ -114,7 +117,6 @@ TEST_SUBMODULE(callbacks, m) {
             return "matches dummy_function: eval(1) = " + std::to_string(r);
         }
         return "argument does NOT match dummy_function. This should never happen!";
-
     });
 
     class AbstractBase {
@@ -146,7 +148,7 @@ TEST_SUBMODULE(callbacks, m) {
     // test_movable_object
     m.def("callback_with_movable", [](const std::function<void(MovableObject &)> &f) {
         auto x = MovableObject();
-        f(x); // lvalue reference shouldn't move out object
+        f(x);           // lvalue reference shouldn't move out object
         return x.valid; // must still return `true`
     });
 

--- a/tests/test_chrono.cpp
+++ b/tests/test_chrono.cpp
@@ -9,20 +9,17 @@
 */
 
 #include "pybind11_tests.h"
-#include <pybind11/chrono.h>
 #include <chrono>
+#include <pybind11/chrono.h>
 
 struct different_resolutions {
-    using time_point_h = std::chrono::time_point<
-        std::chrono::system_clock, std::chrono::hours>;
-    using time_point_m = std::chrono::time_point<
-        std::chrono::system_clock, std::chrono::minutes>;
-    using time_point_s = std::chrono::time_point<
-        std::chrono::system_clock, std::chrono::seconds>;
-    using time_point_ms = std::chrono::time_point<
-        std::chrono::system_clock, std::chrono::milliseconds>;
-    using time_point_us = std::chrono::time_point<
-        std::chrono::system_clock, std::chrono::microseconds>;
+    using time_point_h = std::chrono::time_point<std::chrono::system_clock, std::chrono::hours>;
+    using time_point_m = std::chrono::time_point<std::chrono::system_clock, std::chrono::minutes>;
+    using time_point_s = std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
+    using time_point_ms =
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>;
+    using time_point_us =
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds>;
     time_point_h timestamp_h;
     time_point_m timestamp_m;
     time_point_s timestamp_s;
@@ -65,12 +62,11 @@ TEST_SUBMODULE(chrono, m) {
     // Roundtrip a duration in microseconds from a float argument
     m.def("test_chrono7", [](std::chrono::microseconds t) { return t; });
     // Float durations (issue #719)
-    m.def("test_chrono_float_diff", [](std::chrono::duration<float> a, std::chrono::duration<float> b) {
-        return a - b; });
+    m.def("test_chrono_float_diff",
+          [](std::chrono::duration<float> a, std::chrono::duration<float> b) { return a - b; });
 
-    m.def("test_nano_timepoint", [](timestamp start, timespan delta) -> timestamp {
-        return start + delta;
-    });
+    m.def("test_nano_timepoint",
+          [](timestamp start, timespan delta) -> timestamp { return start + delta; });
 
     // Test different resolutions
     py::class_<different_resolutions>(m, "different_resolutions")
@@ -79,6 +75,5 @@ TEST_SUBMODULE(chrono, m) {
         .def_readwrite("timestamp_m", &different_resolutions::timestamp_m)
         .def_readwrite("timestamp_s", &different_resolutions::timestamp_s)
         .def_readwrite("timestamp_ms", &different_resolutions::timestamp_ms)
-        .def_readwrite("timestamp_us", &different_resolutions::timestamp_us)
-        ;
+        .def_readwrite("timestamp_us", &different_resolutions::timestamp_us);
 }

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -14,22 +14,21 @@
 #include <aligned_new>
 #endif
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
 #include "local_bindings.h"
+#include "pybind11_tests.h"
 #include <pybind11/stl.h>
 
 #include <utility>
 
 #if defined(_MSC_VER)
-#  pragma warning(disable: 4324) // warning C4324: structure was padded due to alignment specifier
+#pragma warning(disable : 4324) // warning C4324: structure was padded due to alignment specifier
 #endif
 
 // test_brace_initialization
 struct NoBraceInitialization {
     NoBraceInitialization(std::vector<int> v) : vec{std::move(v)} {}
-    template <typename T>
-    NoBraceInitialization(std::initializer_list<T> l) : vec(l) {}
+    template <typename T> NoBraceInitialization(std::initializer_list<T> l) : vec(l) {}
 
     std::vector<int> vec;
 };
@@ -58,6 +57,7 @@ TEST_SUBMODULE(class_, m) {
             : m_name(name), m_species(species) {}
         std::string name() const { return m_name; }
         std::string species() const { return m_species; }
+
     private:
         std::string m_name;
         std::string m_species;
@@ -84,27 +84,24 @@ TEST_SUBMODULE(class_, m) {
     };
 
     py::class_<Pet> pet_class(m, "Pet");
-    pet_class
-        .def(py::init<std::string, std::string>())
+    pet_class.def(py::init<std::string, std::string>())
         .def("name", &Pet::name)
         .def("species", &Pet::species);
 
     /* One way of declaring a subclass relationship: reference parent's class_ object */
-    py::class_<Dog>(m, "Dog", pet_class)
-        .def(py::init<std::string>());
+    py::class_<Dog>(m, "Dog", pet_class).def(py::init<std::string>());
 
     /* Another way of declaring a subclass relationship: reference parent's C++ type */
-    py::class_<Rabbit, Pet>(m, "Rabbit")
-        .def(py::init<std::string>());
+    py::class_<Rabbit, Pet>(m, "Rabbit").def(py::init<std::string>());
 
     /* And another: list parent in class template arguments */
-    py::class_<Hamster, Pet>(m, "Hamster")
-        .def(py::init<std::string>());
+    py::class_<Hamster, Pet>(m, "Hamster").def(py::init<std::string>());
 
     /* Constructors are not inherited by default */
     py::class_<Chimera, Pet>(m, "Chimera");
 
-    m.def("pet_name_species", [](const Pet &pet) { return pet.name() + " is a " + pet.species(); });
+    m.def("pet_name_species",
+          [](const Pet &pet) { return pet.name() + " is a " + pet.species(); });
     m.def("dog_bark", [](const Dog &dog) { return dog.bark(); });
 
     // test_automatic_upcasting
@@ -114,34 +111,31 @@ TEST_SUBMODULE(class_, m) {
         BaseClass(BaseClass &&) = default;
         virtual ~BaseClass() = default;
     };
-    struct DerivedClass1 : BaseClass { };
-    struct DerivedClass2 : BaseClass { };
+    struct DerivedClass1 : BaseClass {};
+    struct DerivedClass2 : BaseClass {};
 
     py::class_<BaseClass>(m, "BaseClass").def(py::init<>());
     py::class_<DerivedClass1>(m, "DerivedClass1").def(py::init<>());
     py::class_<DerivedClass2>(m, "DerivedClass2").def(py::init<>());
 
-    m.def("return_class_1", []() -> BaseClass* { return new DerivedClass1(); });
-    m.def("return_class_2", []() -> BaseClass* { return new DerivedClass2(); });
-    m.def("return_class_n", [](int n) -> BaseClass* {
-        if (n == 1) return new DerivedClass1();
-        if (n == 2) return new DerivedClass2();
+    m.def("return_class_1", []() -> BaseClass * { return new DerivedClass1(); });
+    m.def("return_class_2", []() -> BaseClass * { return new DerivedClass2(); });
+    m.def("return_class_n", [](int n) -> BaseClass * {
+        if (n == 1)
+            return new DerivedClass1();
+        if (n == 2)
+            return new DerivedClass2();
         return new BaseClass();
     });
-    m.def("return_none", []() -> BaseClass* { return nullptr; });
+    m.def("return_none", []() -> BaseClass * { return nullptr; });
 
     // test_isinstance
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m.def("check_instances", [](py::list l) {
-        return py::make_tuple(
-            py::isinstance<py::tuple>(l[0]),
-            py::isinstance<py::dict>(l[1]),
-            py::isinstance<Pet>(l[2]),
-            py::isinstance<Pet>(l[3]),
-            py::isinstance<Dog>(l[4]),
-            py::isinstance<Rabbit>(l[5]),
-            py::isinstance<UnregisteredType>(l[6])
-        );
+        return py::make_tuple(py::isinstance<py::tuple>(l[0]), py::isinstance<py::dict>(l[1]),
+                              py::isinstance<Pet>(l[2]), py::isinstance<Pet>(l[3]),
+                              py::isinstance<Dog>(l[4]), py::isinstance<Rabbit>(l[5]),
+                              py::isinstance<UnregisteredType>(l[6]));
     });
 
     struct Invalid {};
@@ -159,18 +153,16 @@ TEST_SUBMODULE(class_, m) {
 
     m.def("get_type_of", [](py::object ob) { return py::type::of(std::move(ob)); });
 
-    m.def("get_type_classic", [](py::handle h) {
-        return h.get_type();
-    });
+    m.def("get_type_classic", [](py::handle h) { return h.get_type(); });
 
     m.def("as_type", [](const py::object &ob) { return py::type(ob); });
 
     // test_mismatched_holder
-    struct MismatchBase1 { };
-    struct MismatchDerived1 : MismatchBase1 { };
+    struct MismatchBase1 {};
+    struct MismatchDerived1 : MismatchBase1 {};
 
-    struct MismatchBase2 { };
-    struct MismatchDerived2 : MismatchBase2 { };
+    struct MismatchBase2 {};
+    struct MismatchDerived2 : MismatchBase2 {};
 
     m.def("mismatched_holder_1", []() {
         auto mod = py::module_::import("__main__");
@@ -180,16 +172,14 @@ TEST_SUBMODULE(class_, m) {
     m.def("mismatched_holder_2", []() {
         auto mod = py::module_::import("__main__");
         py::class_<MismatchBase2>(mod, "MismatchBase2");
-        py::class_<MismatchDerived2, std::shared_ptr<MismatchDerived2>,
-                   MismatchBase2>(mod, "MismatchDerived2");
+        py::class_<MismatchDerived2, std::shared_ptr<MismatchDerived2>, MismatchBase2>(
+            mod, "MismatchDerived2");
     });
 
     // test_override_static
     // #511: problem with inheritance + overwritten def_static
     struct MyBase {
-        static std::unique_ptr<MyBase> make() {
-            return std::unique_ptr<MyBase>(new MyBase());
-        }
+        static std::unique_ptr<MyBase> make() { return std::unique_ptr<MyBase>(new MyBase()); }
     };
 
     struct MyDerived : MyBase {
@@ -198,8 +188,7 @@ TEST_SUBMODULE(class_, m) {
         }
     };
 
-    py::class_<MyBase>(m, "MyBase")
-        .def_static("make", &MyBase::make);
+    py::class_<MyBase>(m, "MyBase").def_static("make", &MyBase::make);
 
     py::class_<MyDerived, MyBase>(m, "MyDerived")
         .def_static("make", &MyDerived::make)
@@ -209,11 +198,10 @@ TEST_SUBMODULE(class_, m) {
     struct ConvertibleFromUserType {
         int i;
 
-        ConvertibleFromUserType(UserType u) : i(u.value()) { }
+        ConvertibleFromUserType(UserType u) : i(u.value()) {}
     };
 
-    py::class_<ConvertibleFromUserType>(m, "AcceptsUserType")
-        .def(py::init<UserType>());
+    py::class_<ConvertibleFromUserType>(m, "AcceptsUserType").def(py::init<UserType>());
     py::implicitly_convertible<UserType, ConvertibleFromUserType>();
 
     m.def("implicitly_convert_argument", [](const ConvertibleFromUserType &r) { return r.i; });
@@ -237,48 +225,90 @@ TEST_SUBMODULE(class_, m) {
         };
 
         auto def = new PyMethodDef{"f", f, METH_VARARGS, nullptr};
-        py::capsule def_capsule(def, [](void *ptr) { delete reinterpret_cast<PyMethodDef *>(ptr); });
-        return py::reinterpret_steal<py::object>(PyCFunction_NewEx(def, def_capsule.ptr(), m.ptr()));
+        py::capsule def_capsule(def,
+                                [](void *ptr) { delete reinterpret_cast<PyMethodDef *>(ptr); });
+        return py::reinterpret_steal<py::object>(
+            PyCFunction_NewEx(def, def_capsule.ptr(), m.ptr()));
     }());
 
     // test_operator_new_delete
     struct HasOpNewDel {
         std::uint64_t i;
-        static void *operator new(size_t s) { py::print("A new", s); return ::operator new(s); }
-        static void *operator new(size_t s, void *ptr) { py::print("A placement-new", s); return ptr; }
-        static void operator delete(void *p) { py::print("A delete"); return ::operator delete(p); }
+        static void *operator new(size_t s) {
+            py::print("A new", s);
+            return ::operator new(s);
+        }
+        static void *operator new(size_t s, void *ptr) {
+            py::print("A placement-new", s);
+            return ptr;
+        }
+        static void operator delete(void *p) {
+            py::print("A delete");
+            return ::operator delete(p);
+        }
     };
     struct HasOpNewDelSize {
         std::uint32_t i;
-        static void *operator new(size_t s) { py::print("B new", s); return ::operator new(s); }
-        static void *operator new(size_t s, void *ptr) { py::print("B placement-new", s); return ptr; }
-        static void operator delete(void *p, size_t s) { py::print("B delete", s); return ::operator delete(p); }
+        static void *operator new(size_t s) {
+            py::print("B new", s);
+            return ::operator new(s);
+        }
+        static void *operator new(size_t s, void *ptr) {
+            py::print("B placement-new", s);
+            return ptr;
+        }
+        static void operator delete(void *p, size_t s) {
+            py::print("B delete", s);
+            return ::operator delete(p);
+        }
     };
     struct AliasedHasOpNewDelSize {
         std::uint64_t i;
-        static void *operator new(size_t s) { py::print("C new", s); return ::operator new(s); }
-        static void *operator new(size_t s, void *ptr) { py::print("C placement-new", s); return ptr; }
-        static void operator delete(void *p, size_t s) { py::print("C delete", s); return ::operator delete(p); }
+        static void *operator new(size_t s) {
+            py::print("C new", s);
+            return ::operator new(s);
+        }
+        static void *operator new(size_t s, void *ptr) {
+            py::print("C placement-new", s);
+            return ptr;
+        }
+        static void operator delete(void *p, size_t s) {
+            py::print("C delete", s);
+            return ::operator delete(p);
+        }
         virtual ~AliasedHasOpNewDelSize() = default;
         AliasedHasOpNewDelSize() = default;
-        AliasedHasOpNewDelSize(const AliasedHasOpNewDelSize&) = delete;
+        AliasedHasOpNewDelSize(const AliasedHasOpNewDelSize &) = delete;
     };
     struct PyAliasedHasOpNewDelSize : AliasedHasOpNewDelSize {
         PyAliasedHasOpNewDelSize() = default;
-        PyAliasedHasOpNewDelSize(int) { }
+        PyAliasedHasOpNewDelSize(int) {}
         std::uint64_t j;
     };
     struct HasOpNewDelBoth {
         std::uint32_t i[8];
-        static void *operator new(size_t s) { py::print("D new", s); return ::operator new(s); }
-        static void *operator new(size_t s, void *ptr) { py::print("D placement-new", s); return ptr; }
-        static void operator delete(void *p) { py::print("D delete"); return ::operator delete(p); }
-        static void operator delete(void *p, size_t s) { py::print("D wrong delete", s); return ::operator delete(p); }
+        static void *operator new(size_t s) {
+            py::print("D new", s);
+            return ::operator new(s);
+        }
+        static void *operator new(size_t s, void *ptr) {
+            py::print("D placement-new", s);
+            return ptr;
+        }
+        static void operator delete(void *p) {
+            py::print("D delete");
+            return ::operator delete(p);
+        }
+        static void operator delete(void *p, size_t s) {
+            py::print("D wrong delete", s);
+            return ::operator delete(p);
+        }
     };
     py::class_<HasOpNewDel>(m, "HasOpNewDel").def(py::init<>());
     py::class_<HasOpNewDelSize>(m, "HasOpNewDelSize").def(py::init<>());
     py::class_<HasOpNewDelBoth>(m, "HasOpNewDelBoth").def(py::init<>());
-    py::class_<AliasedHasOpNewDelSize, PyAliasedHasOpNewDelSize> aliased(m, "AliasedHasOpNewDelSize");
+    py::class_<AliasedHasOpNewDelSize, PyAliasedHasOpNewDelSize> aliased(m,
+                                                                         "AliasedHasOpNewDelSize");
     aliased.def(py::init<>());
     aliased.attr("size_noalias") = py::int_(sizeof(AliasedHasOpNewDelSize));
     aliased.attr("size_alias") = py::int_(sizeof(PyAliasedHasOpNewDelSize));
@@ -332,7 +362,7 @@ TEST_SUBMODULE(class_, m) {
         // [workaround(intel)] = default does not work here
         // Removing or defaulting this destructor results in linking errors with the Intel compiler
         // (in Debug builds only, tested with icpc (ICC) 2021.1 Beta 20200827)
-        ~PublicistB() override {};  // NOLINT(modernize-use-equals-default)
+        ~PublicistB() override{}; // NOLINT(modernize-use-equals-default)
         using ProtectedB::foo;
     };
 
@@ -382,8 +412,8 @@ TEST_SUBMODULE(class_, m) {
     py::class_<Nested>(base, "Nested")
         .def(py::init<>())
         .def("fn", [](Nested &, int, NestBase &, Nested &) {})
-        .def("fa", [](Nested &, int, NestBase &, Nested &) {},
-                "a"_a, "b"_a, "c"_a);
+        .def(
+            "fa", [](Nested &, int, NestBase &, Nested &) {}, "a"_a, "b"_a, "c"_a);
     base.def("g", [](NestBase &, Nested &) {});
     base.def("h", []() { return NestBase(); });
 
@@ -393,7 +423,9 @@ TEST_SUBMODULE(class_, m) {
     // generate a useful error message
 
     struct NotRegistered {};
-    struct StringWrapper { std::string str; };
+    struct StringWrapper {
+        std::string str;
+    };
     m.def("test_error_after_conversions", [](int) {});
     m.def("test_error_after_conversions",
           // NOLINTNEXTLINE(performance-unnecessary-value-param)
@@ -401,14 +433,12 @@ TEST_SUBMODULE(class_, m) {
     py::class_<StringWrapper>(m, "StringWrapper").def(py::init<std::string>());
     py::implicitly_convertible<std::string, StringWrapper>();
 
-    #if defined(PYBIND11_CPP17)
-        struct alignas(1024) Aligned {
-            std::uintptr_t ptr() const { return (uintptr_t) this; }
-        };
-        py::class_<Aligned>(m, "Aligned")
-            .def(py::init<>())
-            .def("ptr", &Aligned::ptr);
-    #endif
+#if defined(PYBIND11_CPP17)
+    struct alignas(1024) Aligned {
+        std::uintptr_t ptr() const { return (uintptr_t)this; }
+    };
+    py::class_<Aligned>(m, "Aligned").def(py::init<>()).def("ptr", &Aligned::ptr);
+#endif
 
     // test_final
     struct IsFinal final {};
@@ -421,9 +451,7 @@ TEST_SUBMODULE(class_, m) {
     // test_exception_rvalue_abort
     struct PyPrintDestructor {
         PyPrintDestructor() = default;
-        ~PyPrintDestructor() {
-            py::print("Print from destructor");
-        }
+        ~PyPrintDestructor() { py::print("Print from destructor"); }
         void throw_something() { throw std::runtime_error("error"); }
     };
     py::class_<PyPrintDestructor>(m, "PyPrintDestructor")
@@ -437,8 +465,7 @@ TEST_SUBMODULE(class_, m) {
         .def(py::init([]() { return &samePointer; }));
 
     struct Empty {};
-    py::class_<Empty>(m, "Empty")
-        .def(py::init<>());
+    py::class_<Empty>(m, "Empty").def(py::init<>());
 
     // test_base_and_derived_nested_scope
     struct BaseWithNested {
@@ -480,10 +507,11 @@ TEST_SUBMODULE(class_, m) {
     });
 }
 
-template <int N> class BreaksBase { public:
+template <int N> class BreaksBase {
+public:
     virtual ~BreaksBase() = default;
     BreaksBase() = default;
-    BreaksBase(const BreaksBase&) = delete;
+    BreaksBase(const BreaksBase &) = delete;
 };
 template <int N> class BreaksTramp : public BreaksBase<N> {};
 // These should all compile just fine:
@@ -495,43 +523,71 @@ using DoesntBreak5 = py::class_<BreaksBase<5>>;
 using DoesntBreak6 = py::class_<BreaksBase<6>, std::shared_ptr<BreaksBase<6>>, BreaksTramp<6>>;
 using DoesntBreak7 = py::class_<BreaksBase<7>, BreaksTramp<7>, std::shared_ptr<BreaksBase<7>>>;
 using DoesntBreak8 = py::class_<BreaksBase<8>, std::shared_ptr<BreaksBase<8>>>;
-#define CHECK_BASE(N) static_assert(std::is_same<typename DoesntBreak##N::type, BreaksBase<N>>::value, \
-        "DoesntBreak" #N " has wrong type!")
-CHECK_BASE(1); CHECK_BASE(2); CHECK_BASE(3); CHECK_BASE(4); CHECK_BASE(5); CHECK_BASE(6); CHECK_BASE(7); CHECK_BASE(8);
-#define CHECK_ALIAS(N) static_assert(DoesntBreak##N::has_alias && std::is_same<typename DoesntBreak##N::type_alias, BreaksTramp<N>>::value, \
-        "DoesntBreak" #N " has wrong type_alias!")
-#define CHECK_NOALIAS(N) static_assert(!DoesntBreak##N::has_alias && std::is_void<typename DoesntBreak##N::type_alias>::value, \
-        "DoesntBreak" #N " has type alias, but shouldn't!")
-CHECK_ALIAS(1); CHECK_ALIAS(2); CHECK_NOALIAS(3); CHECK_ALIAS(4); CHECK_NOALIAS(5); CHECK_ALIAS(6); CHECK_ALIAS(7); CHECK_NOALIAS(8);
-#define CHECK_HOLDER(N, TYPE) static_assert(std::is_same<typename DoesntBreak##N::holder_type, std::TYPE##_ptr<BreaksBase<N>>>::value, \
-        "DoesntBreak" #N " has wrong holder_type!")
-CHECK_HOLDER(1, unique); CHECK_HOLDER(2, unique); CHECK_HOLDER(3, unique); CHECK_HOLDER(4, unique); CHECK_HOLDER(5, unique);
-CHECK_HOLDER(6, shared); CHECK_HOLDER(7, shared); CHECK_HOLDER(8, shared);
+#define CHECK_BASE(N)                                                                             \
+    static_assert(std::is_same<typename DoesntBreak##N::type, BreaksBase<N>>::value,              \
+                  "DoesntBreak" #N " has wrong type!")
+CHECK_BASE(1);
+CHECK_BASE(2);
+CHECK_BASE(3);
+CHECK_BASE(4);
+CHECK_BASE(5);
+CHECK_BASE(6);
+CHECK_BASE(7);
+CHECK_BASE(8);
+#define CHECK_ALIAS(N)                                                                            \
+    static_assert(DoesntBreak##N::has_alias &&                                                    \
+                      std::is_same<typename DoesntBreak##N::type_alias, BreaksTramp<N>>::value,   \
+                  "DoesntBreak" #N " has wrong type_alias!")
+#define CHECK_NOALIAS(N)                                                                          \
+    static_assert(!DoesntBreak##N::has_alias &&                                                   \
+                      std::is_void<typename DoesntBreak##N::type_alias>::value,                   \
+                  "DoesntBreak" #N " has type alias, but shouldn't!")
+CHECK_ALIAS(1);
+CHECK_ALIAS(2);
+CHECK_NOALIAS(3);
+CHECK_ALIAS(4);
+CHECK_NOALIAS(5);
+CHECK_ALIAS(6);
+CHECK_ALIAS(7);
+CHECK_NOALIAS(8);
+#define CHECK_HOLDER(N, TYPE)                                                                     \
+    static_assert(std::is_same<typename DoesntBreak##N::holder_type,                              \
+                               std::TYPE##_ptr<BreaksBase<N>>>::value,                            \
+                  "DoesntBreak" #N " has wrong holder_type!")
+CHECK_HOLDER(1, unique);
+CHECK_HOLDER(2, unique);
+CHECK_HOLDER(3, unique);
+CHECK_HOLDER(4, unique);
+CHECK_HOLDER(5, unique);
+CHECK_HOLDER(6, shared);
+CHECK_HOLDER(7, shared);
+CHECK_HOLDER(8, shared);
 
 // There's no nice way to test that these fail because they fail to compile; leave them here,
 // though, so that they can be manually tested by uncommenting them (and seeing that compilation
 // failures occurs).
 
 // We have to actually look into the type: the typedef alone isn't enough to instantiate the type:
-#define CHECK_BROKEN(N) static_assert(std::is_same<typename Breaks##N::type, BreaksBase<-N>>::value, \
-        "Breaks1 has wrong type!");
+#define CHECK_BROKEN(N)                                                                           \
+    static_assert(std::is_same<typename Breaks##N::type, BreaksBase<-N>>::value,                  \
+                  "Breaks1 has wrong type!");
 
 //// Two holder classes:
-//typedef py::class_<BreaksBase<-1>, std::unique_ptr<BreaksBase<-1>>, std::unique_ptr<BreaksBase<-1>>> Breaks1;
-//CHECK_BROKEN(1);
+// typedef py::class_<BreaksBase<-1>, std::unique_ptr<BreaksBase<-1>>,
+// std::unique_ptr<BreaksBase<-1>>> Breaks1; CHECK_BROKEN(1);
 //// Two aliases:
-//typedef py::class_<BreaksBase<-2>, BreaksTramp<-2>, BreaksTramp<-2>> Breaks2;
-//CHECK_BROKEN(2);
+// typedef py::class_<BreaksBase<-2>, BreaksTramp<-2>, BreaksTramp<-2>> Breaks2;
+// CHECK_BROKEN(2);
 //// Holder + 2 aliases
-//typedef py::class_<BreaksBase<-3>, std::unique_ptr<BreaksBase<-3>>, BreaksTramp<-3>, BreaksTramp<-3>> Breaks3;
-//CHECK_BROKEN(3);
+// typedef py::class_<BreaksBase<-3>, std::unique_ptr<BreaksBase<-3>>, BreaksTramp<-3>,
+// BreaksTramp<-3>> Breaks3; CHECK_BROKEN(3);
 //// Alias + 2 holders
-//typedef py::class_<BreaksBase<-4>, std::unique_ptr<BreaksBase<-4>>, BreaksTramp<-4>, std::shared_ptr<BreaksBase<-4>>> Breaks4;
-//CHECK_BROKEN(4);
+// typedef py::class_<BreaksBase<-4>, std::unique_ptr<BreaksBase<-4>>, BreaksTramp<-4>,
+// std::shared_ptr<BreaksBase<-4>>> Breaks4; CHECK_BROKEN(4);
 //// Invalid option (not a subclass or holder)
-//typedef py::class_<BreaksBase<-5>, BreaksTramp<-4>> Breaks5;
-//CHECK_BROKEN(5);
+// typedef py::class_<BreaksBase<-5>, BreaksTramp<-4>> Breaks5;
+// CHECK_BROKEN(5);
 //// Invalid option: multiple inheritance not supported:
-//template <> struct BreaksBase<-8> : BreaksBase<-6>, BreaksBase<-7> {};
-//typedef py::class_<BreaksBase<-8>, BreaksBase<-6>, BreaksBase<-7>> Breaks8;
-//CHECK_BROKEN(8);
+// template <> struct BreaksBase<-8> : BreaksBase<-6>, BreaksBase<-7> {};
+// typedef py::class_<BreaksBase<-8>, BreaksBase<-6>, BreaksBase<-7>> Breaks8;
+// CHECK_BROKEN(8);

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -12,20 +12,14 @@
 
 enum MyEnum { EFirstEntry = 1, ESecondEntry };
 
-std::string test_function1() {
-    return "test_function()";
-}
+std::string test_function1() { return "test_function()"; }
 
-std::string test_function2(MyEnum k) {
-    return "test_function(enum=" + std::to_string(k) + ")";
-}
+std::string test_function2(MyEnum k) { return "test_function(enum=" + std::to_string(k) + ")"; }
 
-std::string test_function3(int i) {
-    return "test_function(" + std::to_string(i) + ")";
-}
+std::string test_function3(int i) { return "test_function(" + std::to_string(i) + ")"; }
 
-py::str test_function4()           { return "test_function()"; }
-py::str test_function4(char *)     { return "test_function(char *)"; }
+py::str test_function4() { return "test_function()"; }
+py::str test_function4(char *) { return "test_function(char *)"; }
 py::str test_function4(int, float) { return "test_function(int, float)"; }
 py::str test_function4(float, int) { return "test_function(float, int)"; }
 
@@ -44,49 +38,49 @@ std::string print_bytes(const py::bytes &bytes) {
     return ret;
 }
 
-// Test that we properly handle C++17 exception specifiers (which are part of the function signature
-// in C++17).  These should all still work before C++17, but don't affect the function signature.
+// Test that we properly handle C++17 exception specifiers (which are part of the function
+// signature in C++17).  These should all still work before C++17, but don't affect the function
+// signature.
 namespace test_exc_sp {
 // [workaround(intel)] Unable to use noexcept instead of noexcept(true)
 // Make the f1 test basically the same as the f2 test in C++17 mode for the Intel compiler as
 // it fails to compile with a plain noexcept (tested with icc (ICC) 2021.1 Beta 20200827).
 #if defined(__INTEL_COMPILER) && defined(PYBIND11_CPP17)
-int f1(int x) noexcept(true) { return x+1; }
+int f1(int x) noexcept(true) { return x + 1; }
 #else
-int f1(int x) noexcept { return x+1; }
+int f1(int x) noexcept { return x + 1; }
 #endif
-int f2(int x) noexcept(true) { return x+2; }
-int f3(int x) noexcept(false) { return x+3; }
+int f2(int x) noexcept(true) { return x + 2; }
+int f3(int x) noexcept(false) { return x + 3; }
 #if defined(__GNUG__) && !defined(__INTEL_COMPILER)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wdeprecated"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
 #endif
 // NOLINTNEXTLINE(modernize-use-noexcept)
-int f4(int x) throw() { return x+4; } // Deprecated equivalent to noexcept(true)
+int f4(int x) throw() { return x + 4; } // Deprecated equivalent to noexcept(true)
 #if defined(__GNUG__) && !defined(__INTEL_COMPILER)
-#  pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 struct C {
-    int m1(int x) noexcept { return x-1; }
-    int m2(int x) const noexcept { return x-2; }
-    int m3(int x) noexcept(true) { return x-3; }
-    int m4(int x) const noexcept(true) { return x-4; }
-    int m5(int x) noexcept(false) { return x-5; }
-    int m6(int x) const noexcept(false) { return x-6; }
+    int m1(int x) noexcept { return x - 1; }
+    int m2(int x) const noexcept { return x - 2; }
+    int m3(int x) noexcept(true) { return x - 3; }
+    int m4(int x) const noexcept(true) { return x - 4; }
+    int m5(int x) noexcept(false) { return x - 5; }
+    int m6(int x) const noexcept(false) { return x - 6; }
 #if defined(__GNUG__) && !defined(__INTEL_COMPILER)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wdeprecated"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
 #endif
     // NOLINTNEXTLINE(modernize-use-noexcept)
     int m7(int x) throw() { return x - 7; }
     // NOLINTNEXTLINE(modernize-use-noexcept)
     int m8(int x) const throw() { return x - 8; }
 #if defined(__GNUG__) && !defined(__INTEL_COMPILER)
-#  pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 };
 } // namespace test_exc_sp
-
 
 TEST_SUBMODULE(constants_and_functions, m) {
     // test_constants
@@ -129,8 +123,7 @@ TEST_SUBMODULE(constants_and_functions, m) {
         .def("m5", &C::m5)
         .def("m6", &C::m6)
         .def("m7", &C::m7)
-        .def("m8", &C::m8)
-        ;
+        .def("m8", &C::m8);
     m.def("f1", f1);
     m.def("f2", f2);
     m.def("f3", f3);
@@ -143,16 +136,14 @@ TEST_SUBMODULE(constants_and_functions, m) {
         uint64_t zeros[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     };
     m.def("register_large_capture_with_invalid_arguments", [](py::module_ m) {
-        LargeCapture capture;  // VS 2015's MSVC is acting up if we create the array here
-        m.def("should_raise", [capture](int) { return capture.zeros[9] + 33; }, py::kw_only(), py::arg());
+        LargeCapture capture; // VS 2015's MSVC is acting up if we create the array here
+        m.def(
+            "should_raise", [capture](int) { return capture.zeros[9] + 33; }, py::kw_only(),
+            py::arg());
     });
     m.def("register_with_raising_repr", [](py::module_ m, const py::object &default_value) {
         m.def(
-            "should_raise",
-            [](int, int, const py::object &) { return 42; },
-            "some docstring",
-            py::arg_v("x", 42),
-            py::arg_v("y", 42, "<the answer>"),
-            py::arg_v("z", default_value));
+            "should_raise", [](int, int, const py::object &) { return 42; }, "some docstring",
+            py::arg_v("x", 42), py::arg_v("y", 42, "<the answer>"), py::arg_v("z", default_value));
     });
 }

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -8,27 +8,26 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 #include <pybind11/stl.h>
 
-template <typename derived>
-struct empty {
-    static const derived& get_one() { return instance_; }
+template <typename derived> struct empty {
+    static const derived &get_one() { return instance_; }
     static derived instance_;
 };
 
 struct lacking_copy_ctor : public empty<lacking_copy_ctor> {
     lacking_copy_ctor() = default;
-    lacking_copy_ctor(const lacking_copy_ctor& other) = delete;
+    lacking_copy_ctor(const lacking_copy_ctor &other) = delete;
 };
 
 template <> lacking_copy_ctor empty<lacking_copy_ctor>::instance_ = {};
 
 struct lacking_move_ctor : public empty<lacking_move_ctor> {
     lacking_move_ctor() = default;
-    lacking_move_ctor(const lacking_move_ctor& other) = delete;
-    lacking_move_ctor(lacking_move_ctor&& other) = delete;
+    lacking_move_ctor(const lacking_move_ctor &other) = delete;
+    lacking_move_ctor(lacking_move_ctor &&other) = delete;
 };
 
 template <> lacking_move_ctor empty<lacking_move_ctor>::instance_ = {};
@@ -66,8 +65,15 @@ public:
         std::swap(value, m.value);
         return *this;
     }
-    MoveOrCopyInt(const MoveOrCopyInt &c) { print_copy_created(this, c.value); value = c.value; }
-    MoveOrCopyInt &operator=(const MoveOrCopyInt &c) { print_copy_assigned(this, c.value); value = c.value; return *this; }
+    MoveOrCopyInt(const MoveOrCopyInt &c) {
+        print_copy_created(this, c.value);
+        value = c.value;
+    }
+    MoveOrCopyInt &operator=(const MoveOrCopyInt &c) {
+        print_copy_assigned(this, c.value);
+        value = c.value;
+        return *this;
+    }
     ~MoveOrCopyInt() { print_destroyed(this); }
 
     int value;
@@ -76,8 +82,15 @@ class CopyOnlyInt {
 public:
     CopyOnlyInt() { print_default_created(this); }
     CopyOnlyInt(int v) : value{v} { print_created(this, value); }
-    CopyOnlyInt(const CopyOnlyInt &c) { print_copy_created(this, c.value); value = c.value; }
-    CopyOnlyInt &operator=(const CopyOnlyInt &c) { print_copy_assigned(this, c.value); value = c.value; return *this; }
+    CopyOnlyInt(const CopyOnlyInt &c) {
+        print_copy_created(this, c.value);
+        value = c.value;
+    }
+    CopyOnlyInt &operator=(const CopyOnlyInt &c) {
+        print_copy_assigned(this, c.value);
+        value = c.value;
+        return *this;
+    }
     ~CopyOnlyInt() { print_destroyed(this); }
 
     int value;
@@ -86,29 +99,46 @@ PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
 template <> struct type_caster<MoveOnlyInt> {
     PYBIND11_TYPE_CASTER(MoveOnlyInt, _("MoveOnlyInt"));
-    bool load(handle src, bool) { value = MoveOnlyInt(src.cast<int>()); return true; }
-    static handle cast(const MoveOnlyInt &m, return_value_policy r, handle p) { return pybind11::cast(m.value, r, p); }
+    bool load(handle src, bool) {
+        value = MoveOnlyInt(src.cast<int>());
+        return true;
+    }
+    static handle cast(const MoveOnlyInt &m, return_value_policy r, handle p) {
+        return pybind11::cast(m.value, r, p);
+    }
 };
 
 template <> struct type_caster<MoveOrCopyInt> {
     PYBIND11_TYPE_CASTER(MoveOrCopyInt, _("MoveOrCopyInt"));
-    bool load(handle src, bool) { value = MoveOrCopyInt(src.cast<int>()); return true; }
-    static handle cast(const MoveOrCopyInt &m, return_value_policy r, handle p) { return pybind11::cast(m.value, r, p); }
+    bool load(handle src, bool) {
+        value = MoveOrCopyInt(src.cast<int>());
+        return true;
+    }
+    static handle cast(const MoveOrCopyInt &m, return_value_policy r, handle p) {
+        return pybind11::cast(m.value, r, p);
+    }
 };
 
 template <> struct type_caster<CopyOnlyInt> {
 protected:
     CopyOnlyInt value;
+
 public:
     static constexpr auto name = _("CopyOnlyInt");
-    bool load(handle src, bool) { value = CopyOnlyInt(src.cast<int>()); return true; }
-    static handle cast(const CopyOnlyInt &m, return_value_policy r, handle p) { return pybind11::cast(m.value, r, p); }
+    bool load(handle src, bool) {
+        value = CopyOnlyInt(src.cast<int>());
+        return true;
+    }
+    static handle cast(const CopyOnlyInt &m, return_value_policy r, handle p) {
+        return pybind11::cast(m.value, r, p);
+    }
     static handle cast(const CopyOnlyInt *src, return_value_policy policy, handle parent) {
-        if (!src) return none().release();
+        if (!src)
+            return none().release();
         return cast(*src, policy, parent);
     }
-    operator CopyOnlyInt*() { return &value; }
-    operator CopyOnlyInt&() { return value; }
+    operator CopyOnlyInt *() { return &value; }
+    operator CopyOnlyInt &() { return value; }
     template <typename T> using cast_op_type = pybind11::detail::cast_op_type<T>;
 };
 PYBIND11_NAMESPACE_END(detail)
@@ -117,23 +147,21 @@ PYBIND11_NAMESPACE_END(pybind11)
 TEST_SUBMODULE(copy_move_policies, m) {
     // test_lacking_copy_ctor
     py::class_<lacking_copy_ctor>(m, "lacking_copy_ctor")
-        .def_static("get_one", &lacking_copy_ctor::get_one,
-                    py::return_value_policy::copy);
+        .def_static("get_one", &lacking_copy_ctor::get_one, py::return_value_policy::copy);
     // test_lacking_move_ctor
     py::class_<lacking_move_ctor>(m, "lacking_move_ctor")
-        .def_static("get_one", &lacking_move_ctor::get_one,
-                    py::return_value_policy::move);
+        .def_static("get_one", &lacking_move_ctor::get_one, py::return_value_policy::move);
 
     // test_move_and_copy_casts
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m.def("move_and_copy_casts", [](py::object o) {
         int r = 0;
         r += py::cast<MoveOrCopyInt>(o).value; /* moves */
-        r += py::cast<MoveOnlyInt>(o).value; /* moves */
-        r += py::cast<CopyOnlyInt>(o).value; /* copies */
-        auto m1(py::cast<MoveOrCopyInt>(o)); /* moves */
-        auto m2(py::cast<MoveOnlyInt>(o)); /* moves */
-        auto m3(py::cast<CopyOnlyInt>(o)); /* copies */
+        r += py::cast<MoveOnlyInt>(o).value;   /* moves */
+        r += py::cast<CopyOnlyInt>(o).value;   /* copies */
+        auto m1(py::cast<MoveOrCopyInt>(o));   /* moves */
+        auto m2(py::cast<MoveOnlyInt>(o));     /* moves */
+        auto m3(py::cast<CopyOnlyInt>(o));     /* copies */
         r += m1.value + m2.value + m3.value;
 
         return r;
@@ -145,28 +173,35 @@ TEST_SUBMODULE(copy_move_policies, m) {
     m.def("move_or_copy", [](MoveOrCopyInt m) { return m.value; });
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m.def("copy_only", [](CopyOnlyInt m) { return m.value; });
-    m.def("move_pair", [](std::pair<MoveOnlyInt, MoveOrCopyInt> p) {
-        return p.first.value + p.second.value;
-    });
+    m.def("move_pair",
+          [](std::pair<MoveOnlyInt, MoveOrCopyInt> p) { return p.first.value + p.second.value; });
     m.def("move_tuple", [](std::tuple<MoveOnlyInt, MoveOrCopyInt, MoveOnlyInt> t) {
         return std::get<0>(t).value + std::get<1>(t).value + std::get<2>(t).value;
     });
     m.def("copy_tuple", [](std::tuple<CopyOnlyInt, CopyOnlyInt> t) {
         return std::get<0>(t).value + std::get<1>(t).value;
     });
-    m.def("move_copy_nested", [](std::pair<MoveOnlyInt, std::pair<std::tuple<MoveOrCopyInt, CopyOnlyInt, std::tuple<MoveOnlyInt>>, MoveOrCopyInt>> x) {
-        return x.first.value + std::get<0>(x.second.first).value + std::get<1>(x.second.first).value +
-            std::get<0>(std::get<2>(x.second.first)).value + x.second.second.value;
-    });
+    m.def("move_copy_nested",
+          [](std::pair<MoveOnlyInt,
+                       std::pair<std::tuple<MoveOrCopyInt, CopyOnlyInt, std::tuple<MoveOnlyInt>>,
+                                 MoveOrCopyInt>>
+                 x) {
+              return x.first.value + std::get<0>(x.second.first).value +
+                     std::get<1>(x.second.first).value +
+                     std::get<0>(std::get<2>(x.second.first)).value + x.second.second.value;
+          });
     m.def("move_and_copy_cstats", []() {
         ConstructorStats::gc();
         // Reset counts to 0 so that previous tests don't affect later ones:
         auto &mc = ConstructorStats::get<MoveOrCopyInt>();
-        mc.move_assignments = mc.move_constructions = mc.copy_assignments = mc.copy_constructions = 0;
+        mc.move_assignments = mc.move_constructions = mc.copy_assignments = mc.copy_constructions =
+            0;
         auto &mo = ConstructorStats::get<MoveOnlyInt>();
-        mo.move_assignments = mo.move_constructions = mo.copy_assignments = mo.copy_constructions = 0;
+        mo.move_assignments = mo.move_constructions = mo.copy_assignments = mo.copy_constructions =
+            0;
         auto &co = ConstructorStats::get<CopyOnlyInt>();
-        co.move_assignments = co.move_constructions = co.copy_assignments = co.copy_constructions = 0;
+        co.move_assignments = co.move_constructions = co.copy_assignments = co.copy_constructions =
+            0;
         py::dict d;
         d["MoveOrCopyInt"] = py::cast(mc, py::return_value_policy::reference);
         d["MoveOnlyInt"] = py::cast(mo, py::return_value_policy::reference);
@@ -176,18 +211,13 @@ TEST_SUBMODULE(copy_move_policies, m) {
 #ifdef PYBIND11_HAS_OPTIONAL
     // test_move_and_copy_load_optional
     m.attr("has_optional") = true;
-    m.def("move_optional", [](std::optional<MoveOnlyInt> o) {
-        return o->value;
-    });
-    m.def("move_or_copy_optional", [](std::optional<MoveOrCopyInt> o) {
-        return o->value;
-    });
-    m.def("copy_optional", [](std::optional<CopyOnlyInt> o) {
-        return o->value;
-    });
-    m.def("move_optional_tuple", [](std::optional<std::tuple<MoveOrCopyInt, MoveOnlyInt, CopyOnlyInt>> x) {
-        return std::get<0>(*x).value + std::get<1>(*x).value + std::get<2>(*x).value;
-    });
+    m.def("move_optional", [](std::optional<MoveOnlyInt> o) { return o->value; });
+    m.def("move_or_copy_optional", [](std::optional<MoveOrCopyInt> o) { return o->value; });
+    m.def("copy_optional", [](std::optional<CopyOnlyInt> o) { return o->value; });
+    m.def("move_optional_tuple",
+          [](std::optional<std::tuple<MoveOrCopyInt, MoveOnlyInt, CopyOnlyInt>> x) {
+              return std::get<0>(*x).value + std::get<1>(*x).value + std::get<2>(*x).value;
+          });
 #else
     m.attr("has_optional") = false;
 #endif
@@ -198,6 +228,7 @@ TEST_SUBMODULE(copy_move_policies, m) {
     // added later.
     struct PrivateOpNew {
         int value = 1;
+
     private:
         void *operator new(size_t bytes) {
             void *ptr = std::malloc(bytes);
@@ -208,10 +239,13 @@ TEST_SUBMODULE(copy_move_policies, m) {
     };
     py::class_<PrivateOpNew>(m, "PrivateOpNew").def_readonly("value", &PrivateOpNew::value);
     m.def("private_op_new_value", []() { return PrivateOpNew(); });
-    m.def("private_op_new_reference", []() -> const PrivateOpNew & {
-        static PrivateOpNew x{};
-        return x;
-    }, py::return_value_policy::reference);
+    m.def(
+        "private_op_new_reference",
+        []() -> const PrivateOpNew & {
+            static PrivateOpNew x{};
+            return x;
+        },
+        py::return_value_policy::reference);
 
     // test_move_fallback
     // #389: rvp::move should fall-through to copy on non-movable objects
@@ -221,16 +255,24 @@ TEST_SUBMODULE(copy_move_policies, m) {
         MoveIssue1(const MoveIssue1 &c) = default;
         MoveIssue1(MoveIssue1 &&) = delete;
     };
-    py::class_<MoveIssue1>(m, "MoveIssue1").def(py::init<int>()).def_readwrite("value", &MoveIssue1::v);
+    py::class_<MoveIssue1>(m, "MoveIssue1")
+        .def(py::init<int>())
+        .def_readwrite("value", &MoveIssue1::v);
 
     struct MoveIssue2 {
         int v;
         MoveIssue2(int v) : v{v} {}
         MoveIssue2(MoveIssue2 &&) = default;
     };
-    py::class_<MoveIssue2>(m, "MoveIssue2").def(py::init<int>()).def_readwrite("value", &MoveIssue2::v);
+    py::class_<MoveIssue2>(m, "MoveIssue2")
+        .def(py::init<int>())
+        .def_readwrite("value", &MoveIssue2::v);
 
-    // #2742: Don't expect ownership of raw pointer to `new`ed object to be transferred with `py::return_value_policy::move`
-    m.def("get_moveissue1", [](int i) { return std::unique_ptr<MoveIssue1>(new MoveIssue1(i)); }, py::return_value_policy::move);
-    m.def("get_moveissue2", [](int i) { return MoveIssue2(i); }, py::return_value_policy::move);
+    // #2742: Don't expect ownership of raw pointer to `new`ed object to be transferred with
+    // `py::return_value_policy::move`
+    m.def(
+        "get_moveissue1", [](int i) { return std::unique_ptr<MoveIssue1>(new MoveIssue1(i)); },
+        py::return_value_policy::move);
+    m.def(
+        "get_moveissue2", [](int i) { return MoveIssue2(i); }, py::return_value_policy::move);
 }

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -7,23 +7,30 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
-
+#include "pybind11_tests.h"
 
 // py::arg/py::arg_v testing: these arguments just record their argument when invoked
-class ArgInspector1 { public: std::string arg = "(default arg inspector 1)"; };
-class ArgInspector2 { public: std::string arg = "(default arg inspector 2)"; };
-class ArgAlwaysConverts { };
-namespace pybind11 { namespace detail {
+class ArgInspector1 {
+public:
+    std::string arg = "(default arg inspector 1)";
+};
+class ArgInspector2 {
+public:
+    std::string arg = "(default arg inspector 2)";
+};
+class ArgAlwaysConverts {};
+namespace pybind11 {
+namespace detail {
 template <> struct type_caster<ArgInspector1> {
 public:
     PYBIND11_TYPE_CASTER(ArgInspector1, _("ArgInspector1"));
 
     bool load(handle src, bool convert) {
-        value.arg = "loading ArgInspector1 argument " +
-            std::string(convert ? "WITH" : "WITHOUT") + " conversion allowed.  "
-            "Argument value = " + (std::string) str(src);
+        value.arg = "loading ArgInspector1 argument " + std::string(convert ? "WITH" : "WITHOUT") +
+                    " conversion allowed.  "
+                    "Argument value = " +
+                    (std::string)str(src);
         return true;
     }
 
@@ -36,9 +43,10 @@ public:
     PYBIND11_TYPE_CASTER(ArgInspector2, _("ArgInspector2"));
 
     bool load(handle src, bool convert) {
-        value.arg = "loading ArgInspector2 argument " +
-            std::string(convert ? "WITH" : "WITHOUT") + " conversion allowed.  "
-            "Argument value = " + (std::string) str(src);
+        value.arg = "loading ArgInspector2 argument " + std::string(convert ? "WITH" : "WITHOUT") +
+                    " conversion allowed.  "
+                    "Argument value = " +
+                    (std::string)str(src);
         return true;
     }
 
@@ -50,9 +58,7 @@ template <> struct type_caster<ArgAlwaysConverts> {
 public:
     PYBIND11_TYPE_CASTER(ArgAlwaysConverts, _("ArgAlwaysConverts"));
 
-    bool load(handle, bool convert) {
-        return convert;
-    }
+    bool load(handle, bool convert) { return convert; }
 
     static handle cast(const ArgAlwaysConverts &, return_value_policy, handle) {
         return py::none().release();
@@ -68,13 +74,17 @@ public:
     ~DestructionTester() { print_destroyed(this); }
     DestructionTester(const DestructionTester &) { print_copy_created(this); }
     DestructionTester(DestructionTester &&) noexcept { print_move_created(this); }
-    DestructionTester &operator=(const DestructionTester &) { print_copy_assigned(this); return *this; }
+    DestructionTester &operator=(const DestructionTester &) {
+        print_copy_assigned(this);
+        return *this;
+    }
     DestructionTester &operator=(DestructionTester &&) noexcept {
         print_move_assigned(this);
         return *this;
     }
 };
-namespace pybind11 { namespace detail {
+namespace pybind11 {
+namespace detail {
 template <> struct type_caster<DestructionTester> {
     PYBIND11_TYPE_CASTER(DestructionTester, _("DestructionTester"));
     bool load(handle, bool) { return true; }
@@ -97,10 +107,7 @@ TEST_SUBMODULE(custom_type_casters, m) {
     class ArgInspector {
     public:
         ArgInspector1 f(ArgInspector1 a, ArgAlwaysConverts) { return a; }
-        std::string g(const ArgInspector1 &a,
-                      const ArgInspector1 &b,
-                      int c,
-                      ArgInspector2 *d,
+        std::string g(const ArgInspector1 &a, const ArgInspector1 &b, int c, ArgInspector2 *d,
                       ArgAlwaysConverts) {
             return a.arg + "\n" + b.arg + "\n" + std::to_string(c) + "\n" + d->arg;
         }
@@ -110,32 +117,42 @@ TEST_SUBMODULE(custom_type_casters, m) {
     py::class_<ArgInspector>(m, "ArgInspector")
         .def(py::init<>())
         .def("f", &ArgInspector::f, py::arg(), py::arg() = ArgAlwaysConverts())
-        .def("g", &ArgInspector::g, "a"_a.noconvert(), "b"_a, "c"_a.noconvert()=13, "d"_a=ArgInspector2(), py::arg() = ArgAlwaysConverts())
-        .def_static("h", &ArgInspector::h, py::arg{}.noconvert(), py::arg() = ArgAlwaysConverts())
-        ;
+        .def("g", &ArgInspector::g, "a"_a.noconvert(), "b"_a, "c"_a.noconvert() = 13,
+             "d"_a = ArgInspector2(), py::arg() = ArgAlwaysConverts())
+        .def_static("h", &ArgInspector::h, py::arg{}.noconvert(), py::arg() = ArgAlwaysConverts());
     m.def(
         "arg_inspect_func",
         [](const ArgInspector2 &a, const ArgInspector1 &b, ArgAlwaysConverts) {
             return a.arg + "\n" + b.arg;
         },
-        py::arg{}.noconvert(false),
-        py::arg_v(nullptr, ArgInspector1()).noconvert(true),
+        py::arg{}.noconvert(false), py::arg_v(nullptr, ArgInspector1()).noconvert(true),
         py::arg() = ArgAlwaysConverts());
 
-    m.def("floats_preferred", [](double f) { return 0.5 * f; }, "f"_a);
-    m.def("floats_only", [](double f) { return 0.5 * f; }, "f"_a.noconvert());
-    m.def("ints_preferred", [](int i) { return i / 2; }, "i"_a);
-    m.def("ints_only", [](int i) { return i / 2; }, "i"_a.noconvert());
+    m.def(
+        "floats_preferred", [](double f) { return 0.5 * f; }, "f"_a);
+    m.def(
+        "floats_only", [](double f) { return 0.5 * f; }, "f"_a.noconvert());
+    m.def(
+        "ints_preferred", [](int i) { return i / 2; }, "i"_a);
+    m.def(
+        "ints_only", [](int i) { return i / 2; }, "i"_a.noconvert());
 
     // test_custom_caster_destruction
     // Test that `take_ownership` works on types with a custom type caster when given a pointer
 
     // default policy: don't take ownership:
-    m.def("custom_caster_no_destroy", []() { static auto *dt = new DestructionTester(); return dt; });
+    m.def("custom_caster_no_destroy", []() {
+        static auto *dt = new DestructionTester();
+        return dt;
+    });
 
-    m.def("custom_caster_destroy", []() { return new DestructionTester(); },
-            py::return_value_policy::take_ownership); // Takes ownership: destroy when finished
-    m.def("custom_caster_destroy_const", []() -> const DestructionTester * { return new DestructionTester(); },
-            py::return_value_policy::take_ownership); // Likewise (const doesn't inhibit destruction)
-    m.def("destruction_tester_cstats", &ConstructorStats::get<DestructionTester>, py::return_value_policy::reference);
+    m.def(
+        "custom_caster_destroy", []() { return new DestructionTester(); },
+        py::return_value_policy::take_ownership); // Takes ownership: destroy when finished
+    m.def(
+        "custom_caster_destroy_const",
+        []() -> const DestructionTester * { return new DestructionTester(); },
+        py::return_value_policy::take_ownership); // Likewise (const doesn't inhibit destruction)
+    m.def("destruction_tester_cstats", &ConstructorStats::get<DestructionTester>,
+          py::return_value_policy::reference);
 }

--- a/tests/test_docstring_options.cpp
+++ b/tests/test_docstring_options.cpp
@@ -15,35 +15,49 @@ TEST_SUBMODULE(docstring_options, m) {
         py::options options;
         options.disable_function_signatures();
 
-        m.def("test_function1", [](int, int) {}, py::arg("a"), py::arg("b"));
-        m.def("test_function2", [](int, int) {}, py::arg("a"), py::arg("b"), "A custom docstring");
+        m.def(
+            "test_function1", [](int, int) {}, py::arg("a"), py::arg("b"));
+        m.def(
+            "test_function2", [](int, int) {}, py::arg("a"), py::arg("b"), "A custom docstring");
 
-        m.def("test_overloaded1", [](int) {}, py::arg("i"), "Overload docstring");
-        m.def("test_overloaded1", [](double) {}, py::arg("d"));
+        m.def(
+            "test_overloaded1", [](int) {}, py::arg("i"), "Overload docstring");
+        m.def(
+            "test_overloaded1", [](double) {}, py::arg("d"));
 
-        m.def("test_overloaded2", [](int) {}, py::arg("i"), "overload docstring 1");
-        m.def("test_overloaded2", [](double) {}, py::arg("d"), "overload docstring 2");
+        m.def(
+            "test_overloaded2", [](int) {}, py::arg("i"), "overload docstring 1");
+        m.def(
+            "test_overloaded2", [](double) {}, py::arg("d"), "overload docstring 2");
 
-        m.def("test_overloaded3", [](int) {}, py::arg("i"));
-        m.def("test_overloaded3", [](double) {}, py::arg("d"), "Overload docstr");
+        m.def(
+            "test_overloaded3", [](int) {}, py::arg("i"));
+        m.def(
+            "test_overloaded3", [](double) {}, py::arg("d"), "Overload docstr");
 
         options.enable_function_signatures();
 
-        m.def("test_function3", [](int, int) {}, py::arg("a"), py::arg("b"));
-        m.def("test_function4", [](int, int) {}, py::arg("a"), py::arg("b"), "A custom docstring");
+        m.def(
+            "test_function3", [](int, int) {}, py::arg("a"), py::arg("b"));
+        m.def(
+            "test_function4", [](int, int) {}, py::arg("a"), py::arg("b"), "A custom docstring");
 
         options.disable_function_signatures().disable_user_defined_docstrings();
 
-        m.def("test_function5", [](int, int) {}, py::arg("a"), py::arg("b"), "A custom docstring");
+        m.def(
+            "test_function5", [](int, int) {}, py::arg("a"), py::arg("b"), "A custom docstring");
 
         {
             py::options nested_options;
             nested_options.enable_user_defined_docstrings();
-            m.def("test_function6", [](int, int) {}, py::arg("a"), py::arg("b"), "A custom docstring");
+            m.def(
+                "test_function6", [](int, int) {}, py::arg("a"), py::arg("b"),
+                "A custom docstring");
         }
     }
 
-    m.def("test_function7", [](int, int) {}, py::arg("a"), py::arg("b"), "A custom docstring");
+    m.def(
+        "test_function7", [](int, int) {}, py::arg("a"), py::arg("b"), "A custom docstring");
 
     {
         py::options options;
@@ -63,7 +77,7 @@ TEST_SUBMODULE(docstring_options, m) {
             int getValue() const { return value; }
         };
         py::class_<DocstringTestFoo>(m, "DocstringTestFoo", "This is a class docstring")
-            .def_property("value_prop", &DocstringTestFoo::getValue, &DocstringTestFoo::setValue, "This is a property docstring")
-        ;
+            .def_property("value_prop", &DocstringTestFoo::getValue, &DocstringTestFoo::setValue,
+                          "This is a property docstring");
     }
 }

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -98,12 +98,14 @@ TEST_SUBMODULE(eigen, m) {
 
     // test_eigen_ref_to_python
     // Different ways of passing via Eigen::Ref; the first and second are the Eigen-recommended
-    // NOLINTNEXTLINE (performance-unnecessary-value-param)
-    m.def("cholesky1", [](Eigen::Ref<MatrixXdR> x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
+    m.def("cholesky1",
+          // NOLINTNEXTLINE (performance-unnecessary-value-param)
+          [](Eigen::Ref<MatrixXdR> x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
     m.def("cholesky2", [](const Eigen::Ref<const MatrixXdR> &x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
     m.def("cholesky3", [](const Eigen::Ref<MatrixXdR> &x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
-    // NOLINTNEXTLINE (performance-unnecessary-value-param)
-    m.def("cholesky4", [](Eigen::Ref<const MatrixXdR> x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
+    m.def("cholesky4",
+          // NOLINTNEXTLINE (performance-unnecessary-value-param)
+          [](Eigen::Ref<const MatrixXdR> x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
 
     // test_eigen_ref_mutators
     // Mutators: these add some value to the given element using Eigen, but Eigen should be mapping into
@@ -260,7 +262,10 @@ TEST_SUBMODULE(eigen, m) {
     m.def("dense_copy_r", [](const DenseMatrixR &m) -> DenseMatrixR { return m; });
     m.def("dense_copy_c", [](const DenseMatrixC &m) -> DenseMatrixC { return m; });
     // test_sparse, test_sparse_signature
-    m.def("sparse_r", [mat]() -> SparseMatrixR { return Eigen::SparseView<Eigen::MatrixXf>(mat); }); //NOLINT(clang-analyzer-core.uninitialized.UndefReturn)
+    m.def("sparse_r", [mat]() -> SparseMatrixR {
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+        return Eigen::SparseView<Eigen::MatrixXf>(mat);
+    });
     m.def("sparse_c", [mat]() -> SparseMatrixC { return Eigen::SparseView<Eigen::MatrixXf>(mat); });
     m.def("sparse_copy_r", [](const SparseMatrixR &m) -> SparseMatrixR { return m; });
     m.def("sparse_copy_c", [](const SparseMatrixC &m) -> SparseMatrixC { return m; });
@@ -284,9 +289,11 @@ TEST_SUBMODULE(eigen, m) {
     // that would allow copying (if types or strides don't match) for comparison:
     m.def("get_elem", &get_elem);
     // Now this alternative that calls the tells pybind to fail rather than copy:
-    // NOLINTNEXTLINE (performance-unnecessary-value-param)
-    m.def("get_elem_nocopy", [](Eigen::Ref<const Eigen::MatrixXd> m) -> double { return get_elem(m); },
-            py::arg{}.noconvert());
+    m.def(
+        "get_elem_nocopy",
+        // NOLINTNEXTLINE (performance-unnecessary-value-param)
+        [](Eigen::Ref<const Eigen::MatrixXd> m) -> double { return get_elem(m); },
+        py::arg{}.noconvert());
     // Also test a row-major-only no-copy const ref:
     m.def("get_elem_rm_nocopy", [](Eigen::Ref<const Eigen::Matrix<long, -1, -1, Eigen::RowMajor>> &m) -> long { return m(2, 1); },
             py::arg{}.noconvert());
@@ -301,7 +308,7 @@ TEST_SUBMODULE(eigen, m) {
     // test_issue1105
     // Issue #1105: when converting from a numpy two-dimensional (Nx1) or (1xN) value into a dense
     // eigen Vector or RowVector, the argument would fail to load because the numpy copy would
-    // fail: numpy won't broadcast a Nx1 into a 1-dimensional vector. NOLINTNEXTLINE
+    // fail: numpy won't broadcast a Nx1 into a 1-dimensional vector.
     // NOLINTNEXTLINE (performance-unnecessary-value-param)
     m.def("iss1105_col", [](Eigen::VectorXd) { return true; });
     // NOLINTNEXTLINE (performance-unnecessary-value-param)
@@ -309,12 +316,18 @@ TEST_SUBMODULE(eigen, m) {
 
     // test_named_arguments
     // Make sure named arguments are working properly:
-    // NOLINTNEXTLINE (performance-unnecessary-value-param)
-    m.def("matrix_multiply", [](const py::EigenDRef<const Eigen::MatrixXd> A, const py::EigenDRef<const Eigen::MatrixXd> B)
-            -> Eigen::MatrixXd {
-        if (A.cols() != B.rows()) throw std::domain_error("Nonconformable matrices!");
-        return A * B;
-    }, py::arg("A"), py::arg("B"));
+    m.def(
+        "matrix_multiply",
+        // NOLINTNEXTLINE (performance-unnecessary-value-param)
+        [](const py::EigenDRef<const Eigen::MatrixXd> A,
+           // NOLINTNEXTLINE (performance-unnecessary-value-param)
+           const py::EigenDRef<const Eigen::MatrixXd> B) -> Eigen::MatrixXd {
+            if (A.cols() != B.rows())
+                throw std::domain_error("Nonconformable matrices!");
+            return A * B;
+        },
+        py::arg("A"),
+        py::arg("B"));
 
     // test_custom_operator_new
     py::class_<CustomOperatorNew>(m, "CustomOperatorNew")

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -7,26 +7,25 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 #include <pybind11/eigen.h>
 #include <pybind11/stl.h>
 
 #if defined(_MSC_VER)
-#  pragma warning(disable: 4996) // C4996: std::unary_negation is deprecated
+#pragma warning(disable : 4996) // C4996: std::unary_negation is deprecated
 #endif
 
 #include <Eigen/Cholesky>
 
 using MatrixXdR = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
-
-
 // Sets/resets a testing reference matrix to have values of 10*r + c, where r and c are the
 // (1-based) row/column number.
 template <typename M> void reset_ref(M &x) {
-    for (int i = 0; i < x.rows(); i++) for (int j = 0; j < x.cols(); j++)
-        x(i, j) = 11 + 10*i + j;
+    for (int i = 0; i < x.rows(); i++)
+        for (int j = 0; j < x.cols(); j++)
+            x(i, j) = 11 + 10 * i + j;
 }
 
 // Returns a static, column-major matrix
@@ -62,7 +61,7 @@ template <typename MatrixArgType> Eigen::MatrixXd adjust_matrix(MatrixArgType m)
     Eigen::MatrixXd ret(m);
     for (int c = 0; c < m.cols(); c++)
         for (int r = 0; r < m.rows(); r++)
-            ret(r, c) += 10*r + 100*c;  // NOLINT(clang-analyzer-core.uninitialized.Assign)
+            ret(r, c) += 10 * r + 100 * c; // NOLINT(clang-analyzer-core.uninitialized.Assign)
     return ret;
 }
 
@@ -89,8 +88,10 @@ TEST_SUBMODULE(eigen, m) {
 
     // various tests
     m.def("double_col", [](const Eigen::VectorXf &x) -> Eigen::VectorXf { return 2.0f * x; });
-    m.def("double_row", [](const Eigen::RowVectorXf &x) -> Eigen::RowVectorXf { return 2.0f * x; });
-    m.def("double_complex", [](const Eigen::VectorXcf &x) -> Eigen::VectorXcf { return 2.0f * x; });
+    m.def("double_row",
+          [](const Eigen::RowVectorXf &x) -> Eigen::RowVectorXf { return 2.0f * x; });
+    m.def("double_complex",
+          [](const Eigen::VectorXcf &x) -> Eigen::VectorXcf { return 2.0f * x; });
     m.def("double_threec", [](py::EigenDRef<Eigen::Vector3f> x) { x *= 2; });
     m.def("double_threer", [](py::EigenDRef<Eigen::RowVector3f> x) { x *= 2; });
     m.def("double_mat_cm", [](const Eigen::MatrixXf &x) -> Eigen::MatrixXf { return 2.0f * x; });
@@ -101,19 +102,22 @@ TEST_SUBMODULE(eigen, m) {
     m.def("cholesky1",
           // NOLINTNEXTLINE (performance-unnecessary-value-param)
           [](Eigen::Ref<MatrixXdR> x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
-    m.def("cholesky2", [](const Eigen::Ref<const MatrixXdR> &x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
-    m.def("cholesky3", [](const Eigen::Ref<MatrixXdR> &x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
+    m.def("cholesky2", [](const Eigen::Ref<const MatrixXdR> &x) -> Eigen::MatrixXd {
+        return x.llt().matrixL();
+    });
+    m.def("cholesky3",
+          [](const Eigen::Ref<MatrixXdR> &x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
     m.def("cholesky4",
           // NOLINTNEXTLINE (performance-unnecessary-value-param)
           [](Eigen::Ref<const MatrixXdR> x) -> Eigen::MatrixXd { return x.llt().matrixL(); });
 
     // test_eigen_ref_mutators
-    // Mutators: these add some value to the given element using Eigen, but Eigen should be mapping into
-    // the numpy array data and so the result should show up there.  There are three versions: one that
-    // works on a contiguous-row matrix (numpy's default), one for a contiguous-column matrix, and one
-    // for any matrix.
-    auto add_rm = [](Eigen::Ref<MatrixXdR> x, int r, int c, double v) { x(r,c) += v; };
-    auto add_cm = [](Eigen::Ref<Eigen::MatrixXd> x, int r, int c, double v) { x(r,c) += v; };
+    // Mutators: these add some value to the given element using Eigen, but Eigen should be mapping
+    // into the numpy array data and so the result should show up there.  There are three versions:
+    // one that works on a contiguous-row matrix (numpy's default), one for a contiguous-column
+    // matrix, and one for any matrix.
+    auto add_rm = [](Eigen::Ref<MatrixXdR> x, int r, int c, double v) { x(r, c) += v; };
+    auto add_cm = [](Eigen::Ref<Eigen::MatrixXd> x, int r, int c, double v) { x(r, c) += v; };
 
     // Mutators (Eigen maps into numpy variables):
     m.def("add_rm", add_rm); // Only takes row-contiguous
@@ -124,7 +128,8 @@ TEST_SUBMODULE(eigen, m) {
     m.def("add2", add_cm);
     m.def("add2", add_rm);
     // This one accepts a matrix of any stride:
-    m.def("add_any", [](py::EigenDRef<Eigen::MatrixXd> x, int r, int c, double v) { x(r,c) += v; });
+    m.def("add_any",
+          [](py::EigenDRef<Eigen::MatrixXd> x, int r, int c, double v) { x(r, c) += v; });
 
     // Return mutable references (numpy maps into eigen variables)
     m.def("get_cm_ref", []() { return Eigen::Ref<Eigen::MatrixXd>(get_cm()); });
@@ -136,38 +141,53 @@ TEST_SUBMODULE(eigen, m) {
     m.def("reset_refs", reset_refs); // Restores get_{cm,rm}_ref to original values
 
     // Increments and returns ref to (same) matrix
-    m.def("incr_matrix", [](Eigen::Ref<Eigen::MatrixXd> m, double v) {
-        m += Eigen::MatrixXd::Constant(m.rows(), m.cols(), v);
-        return m;
-    }, py::return_value_policy::reference);
+    m.def(
+        "incr_matrix",
+        [](Eigen::Ref<Eigen::MatrixXd> m, double v) {
+            m += Eigen::MatrixXd::Constant(m.rows(), m.cols(), v);
+            return m;
+        },
+        py::return_value_policy::reference);
 
     // Same, but accepts a matrix of any strides
-    m.def("incr_matrix_any", [](py::EigenDRef<Eigen::MatrixXd> m, double v) {
-        m += Eigen::MatrixXd::Constant(m.rows(), m.cols(), v);
-        return m;
-    }, py::return_value_policy::reference);
+    m.def(
+        "incr_matrix_any",
+        [](py::EigenDRef<Eigen::MatrixXd> m, double v) {
+            m += Eigen::MatrixXd::Constant(m.rows(), m.cols(), v);
+            return m;
+        },
+        py::return_value_policy::reference);
 
     // Returns an eigen slice of even rows
-    m.def("even_rows", [](py::EigenDRef<Eigen::MatrixXd> m) {
-        return py::EigenDMap<Eigen::MatrixXd>(
+    m.def(
+        "even_rows",
+        [](py::EigenDRef<Eigen::MatrixXd> m) {
+            return py::EigenDMap<Eigen::MatrixXd>(
                 m.data(), (m.rows() + 1) / 2, m.cols(),
                 py::EigenDStride(m.outerStride(), 2 * m.innerStride()));
-    }, py::return_value_policy::reference);
+        },
+        py::return_value_policy::reference);
 
     // Returns an eigen slice of even columns
-    m.def("even_cols", [](py::EigenDRef<Eigen::MatrixXd> m) {
-        return py::EigenDMap<Eigen::MatrixXd>(
+    m.def(
+        "even_cols",
+        [](py::EigenDRef<Eigen::MatrixXd> m) {
+            return py::EigenDMap<Eigen::MatrixXd>(
                 m.data(), m.rows(), (m.cols() + 1) / 2,
                 py::EigenDStride(2 * m.outerStride(), m.innerStride()));
-    }, py::return_value_policy::reference);
+        },
+        py::return_value_policy::reference);
 
     // Returns diagonals: a vector-like object with an inner stride != 1
     m.def("diagonal", [](const Eigen::Ref<const Eigen::MatrixXd> &x) { return x.diagonal(); });
-    m.def("diagonal_1", [](const Eigen::Ref<const Eigen::MatrixXd> &x) { return x.diagonal<1>(); });
-    m.def("diagonal_n", [](const Eigen::Ref<const Eigen::MatrixXd> &x, int index) { return x.diagonal(index); });
+    m.def("diagonal_1",
+          [](const Eigen::Ref<const Eigen::MatrixXd> &x) { return x.diagonal<1>(); });
+    m.def("diagonal_n",
+          [](const Eigen::Ref<const Eigen::MatrixXd> &x, int index) { return x.diagonal(index); });
 
     // Return a block of a matrix (gives non-standard strides)
-    m.def("block", [](const Eigen::Ref<const Eigen::MatrixXd> &x, int start_row, int start_col, int block_rows, int block_cols) {
+    m.def("block", [](const Eigen::Ref<const Eigen::MatrixXd> &x, int start_row, int start_col,
+                      int block_rows, int block_cols) {
         return x.block(start_row, start_col, block_rows, block_cols);
     });
 
@@ -175,6 +195,7 @@ TEST_SUBMODULE(eigen, m) {
     // return value referencing/copying tests:
     class ReturnTester {
         Eigen::MatrixXd mat = create();
+
     public:
         ReturnTester() { print_created(this); }
         ~ReturnTester() { print_destroyed(this); }
@@ -186,12 +207,22 @@ TEST_SUBMODULE(eigen, m) {
         const Eigen::MatrixXd *viewPtr() { return &mat; }
         Eigen::Ref<Eigen::MatrixXd> ref() { return mat; }
         Eigen::Ref<const Eigen::MatrixXd> refConst() { return mat; }
-        Eigen::Block<Eigen::MatrixXd> block(int r, int c, int nrow, int ncol) { return mat.block(r, c, nrow, ncol); }
-        Eigen::Block<const Eigen::MatrixXd> blockConst(int r, int c, int nrow, int ncol) const { return mat.block(r, c, nrow, ncol); }
-        py::EigenDMap<Eigen::Matrix2d> corners() { return py::EigenDMap<Eigen::Matrix2d>(mat.data(),
-                    py::EigenDStride(mat.outerStride() * (mat.outerSize()-1), mat.innerStride() * (mat.innerSize()-1))); }
-        py::EigenDMap<const Eigen::Matrix2d> cornersConst() const { return py::EigenDMap<const Eigen::Matrix2d>(mat.data(),
-                    py::EigenDStride(mat.outerStride() * (mat.outerSize()-1), mat.innerStride() * (mat.innerSize()-1))); }
+        Eigen::Block<Eigen::MatrixXd> block(int r, int c, int nrow, int ncol) {
+            return mat.block(r, c, nrow, ncol);
+        }
+        Eigen::Block<const Eigen::MatrixXd> blockConst(int r, int c, int nrow, int ncol) const {
+            return mat.block(r, c, nrow, ncol);
+        }
+        py::EigenDMap<Eigen::Matrix2d> corners() {
+            return py::EigenDMap<Eigen::Matrix2d>(
+                mat.data(), py::EigenDStride(mat.outerStride() * (mat.outerSize() - 1),
+                                             mat.innerStride() * (mat.innerSize() - 1)));
+        }
+        py::EigenDMap<const Eigen::Matrix2d> cornersConst() const {
+            return py::EigenDMap<const Eigen::Matrix2d>(
+                mat.data(), py::EigenDStride(mat.outerStride() * (mat.outerSize() - 1),
+                                             mat.innerStride() * (mat.innerSize() - 1)));
+        }
     };
     using rvp = py::return_value_policy;
     py::class_<ReturnTester>(m, "ReturnTester")
@@ -202,9 +233,9 @@ TEST_SUBMODULE(eigen, m) {
         .def("get_ptr", &ReturnTester::getPtr, rvp::reference_internal)
         .def("view", &ReturnTester::view, rvp::reference_internal)
         .def("view_ptr", &ReturnTester::view, rvp::reference_internal)
-        .def("copy_get", &ReturnTester::get)   // Default rvp: copy
-        .def("copy_view", &ReturnTester::view) //         "
-        .def("ref", &ReturnTester::ref) // Default for Ref is to reference
+        .def("copy_get", &ReturnTester::get)       // Default rvp: copy
+        .def("copy_view", &ReturnTester::view)     //         "
+        .def("ref", &ReturnTester::ref)            // Default for Ref is to reference
         .def("ref_const", &ReturnTester::refConst) // Likewise, but const
         .def("ref_safe", &ReturnTester::ref, rvp::reference_internal)
         .def("ref_const_safe", &ReturnTester::refConst, rvp::reference_internal)
@@ -215,33 +246,28 @@ TEST_SUBMODULE(eigen, m) {
         .def("block_const", &ReturnTester::blockConst, rvp::reference_internal)
         .def("copy_block", &ReturnTester::block, rvp::copy)
         .def("corners", &ReturnTester::corners, rvp::reference_internal)
-        .def("corners_const", &ReturnTester::cornersConst, rvp::reference_internal)
-        ;
+        .def("corners_const", &ReturnTester::cornersConst, rvp::reference_internal);
 
     // test_special_matrix_objects
     // Returns a DiagonalMatrix with diagonal (1,2,3,...)
     m.def("incr_diag", [](int k) {
         Eigen::DiagonalMatrix<int, Eigen::Dynamic> m(k);
-        for (int i = 0; i < k; i++) m.diagonal()[i] = i+1;
+        for (int i = 0; i < k; i++)
+            m.diagonal()[i] = i + 1;
         return m;
     });
 
     // Returns a SelfAdjointView referencing the lower triangle of m
-    m.def("symmetric_lower", [](const Eigen::MatrixXi &m) {
-            return m.selfadjointView<Eigen::Lower>();
-    });
+    m.def("symmetric_lower",
+          [](const Eigen::MatrixXi &m) { return m.selfadjointView<Eigen::Lower>(); });
     // Returns a SelfAdjointView referencing the lower triangle of m
-    m.def("symmetric_upper", [](const Eigen::MatrixXi &m) {
-            return m.selfadjointView<Eigen::Upper>();
-    });
+    m.def("symmetric_upper",
+          [](const Eigen::MatrixXi &m) { return m.selfadjointView<Eigen::Upper>(); });
 
     // Test matrix for various functions below.
     Eigen::MatrixXf mat(5, 6);
-    mat << 0,  3,  0,  0,  0, 11,
-           22, 0,  0,  0, 17, 11,
-           7,  5,  0,  1,  0, 11,
-           0,  0,  0,  0,  0, 11,
-           0,  0, 14,  0,  8, 11;
+    mat << 0, 3, 0, 0, 0, 11, 22, 0, 0, 0, 17, 11, 7, 5, 0, 1, 0, 11, 0, 0, 0, 0, 0, 11, 0, 0, 14,
+        0, 8, 11;
 
     // test_fixed, and various other tests
     m.def("fixed_r", [mat]() -> FixedMatrixR { return FixedMatrixR(mat); });
@@ -266,7 +292,8 @@ TEST_SUBMODULE(eigen, m) {
         // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
         return Eigen::SparseView<Eigen::MatrixXf>(mat);
     });
-    m.def("sparse_c", [mat]() -> SparseMatrixC { return Eigen::SparseView<Eigen::MatrixXf>(mat); });
+    m.def("sparse_c",
+          [mat]() -> SparseMatrixC { return Eigen::SparseView<Eigen::MatrixXf>(mat); });
     m.def("sparse_copy_r", [](const SparseMatrixR &m) -> SparseMatrixR { return m; });
     m.def("sparse_copy_c", [](const SparseMatrixC &m) -> SparseMatrixC { return m; });
     // test_partially_fixed
@@ -280,7 +307,8 @@ TEST_SUBMODULE(eigen, m) {
     m.def("cpp_copy", [](py::handle m) { return m.cast<Eigen::MatrixXd>()(1, 0); });
     m.def("cpp_ref_c", [](py::handle m) { return m.cast<Eigen::Ref<Eigen::MatrixXd>>()(1, 0); });
     m.def("cpp_ref_r", [](py::handle m) { return m.cast<Eigen::Ref<MatrixXdR>>()(1, 0); });
-    m.def("cpp_ref_any", [](py::handle m) { return m.cast<py::EigenDRef<Eigen::MatrixXd>>()(1, 0); });
+    m.def("cpp_ref_any",
+          [](py::handle m) { return m.cast<py::EigenDRef<Eigen::MatrixXd>>()(1, 0); });
 
     // [workaround(intel)] ICC 20/21 breaks with py::arg().stuff, using py::arg{}.stuff works.
 
@@ -295,15 +323,22 @@ TEST_SUBMODULE(eigen, m) {
         [](Eigen::Ref<const Eigen::MatrixXd> m) -> double { return get_elem(m); },
         py::arg{}.noconvert());
     // Also test a row-major-only no-copy const ref:
-    m.def("get_elem_rm_nocopy", [](Eigen::Ref<const Eigen::Matrix<long, -1, -1, Eigen::RowMajor>> &m) -> long { return m(2, 1); },
-            py::arg{}.noconvert());
+    m.def(
+        "get_elem_rm_nocopy",
+        [](Eigen::Ref<const Eigen::Matrix<long, -1, -1, Eigen::RowMajor>> &m) -> long {
+            return m(2, 1);
+        },
+        py::arg{}.noconvert());
 
     // test_issue738
     // Issue #738: 1xN or Nx1 2D matrices were neither accepted nor properly copied with an
     // incompatible stride value on the length-1 dimension--but that should be allowed (without
     // requiring a copy!) because the stride value can be safely ignored on a size-1 dimension.
-    m.def("iss738_f1", &adjust_matrix<const Eigen::Ref<const Eigen::MatrixXd> &>, py::arg{}.noconvert());
-    m.def("iss738_f2", &adjust_matrix<const Eigen::Ref<const Eigen::Matrix<double, -1, -1, Eigen::RowMajor>> &>, py::arg{}.noconvert());
+    m.def("iss738_f1", &adjust_matrix<const Eigen::Ref<const Eigen::MatrixXd> &>,
+          py::arg{}.noconvert());
+    m.def("iss738_f2",
+          &adjust_matrix<const Eigen::Ref<const Eigen::Matrix<double, -1, -1, Eigen::RowMajor>> &>,
+          py::arg{}.noconvert());
 
     // test_issue1105
     // Issue #1105: when converting from a numpy two-dimensional (Nx1) or (1xN) value into a dense
@@ -326,8 +361,7 @@ TEST_SUBMODULE(eigen, m) {
                 throw std::domain_error("Nonconformable matrices!");
             return A * B;
         },
-        py::arg("A"),
-        py::arg("B"));
+        py::arg("A"), py::arg("B"));
 
     // test_custom_operator_new
     py::class_<CustomOperatorNew>(m, "CustomOperatorNew")

--- a/tests/test_embed/catch.cpp
+++ b/tests/test_embed/catch.cpp
@@ -4,9 +4,9 @@
 #include <pybind11/embed.h>
 
 #ifdef _MSC_VER
-// Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to catch
-// 2.0.1; this should be fixed in the next catch release after 2.0.1).
-#  pragma warning(disable: 4996)
+// Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to
+// catch 2.0.1; this should be fixed in the next catch release after 2.0.1).
+#pragma warning(disable : 4996)
 #endif
 
 #define CATCH_CONFIG_RUNNER

--- a/tests/test_embed/external_module.cpp
+++ b/tests/test_embed/external_module.cpp
@@ -13,11 +13,8 @@ PYBIND11_MODULE(external_module, m) {
         int v;
     };
 
-    py::class_<A>(m, "A")
-        .def(py::init<int>())
-        .def_readwrite("value", &A::v);
+    py::class_<A>(m, "A").def(py::init<int>()).def_readwrite("value", &A::v);
 
-    m.def("internals_at", []() {
-        return reinterpret_cast<uintptr_t>(&py::detail::get_internals());
-    });
+    m.def("internals_at",
+          []() { return reinterpret_cast<uintptr_t>(&py::detail::get_internals()); });
 }

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -1,9 +1,9 @@
 #include <pybind11/embed.h>
 
 #ifdef _MSC_VER
-// Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to catch
-// 2.0.1; this should be fixed in the next catch release after 2.0.1).
-#  pragma warning(disable: 4996)
+// Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to
+// catch 2.0.1; this should be fixed in the next catch release after 2.0.1).
+#pragma warning(disable : 4996)
 #endif
 
 #include <catch.hpp>
@@ -42,9 +42,7 @@ PYBIND11_EMBEDDED_MODULE(widget_module, m) {
     m.def("add", [](int i, int j) { return i + j; });
 }
 
-PYBIND11_EMBEDDED_MODULE(throw_exception, ) {
-    throw std::runtime_error("C++ Error");
-}
+PYBIND11_EMBEDDED_MODULE(throw_exception, ) { throw std::runtime_error("C++ Error"); }
 
 PYBIND11_EMBEDDED_MODULE(throw_error_already_set, ) {
     auto d = py::dict();
@@ -55,11 +53,12 @@ TEST_CASE("Pass classes and data between modules defined in C++ and Python") {
     auto module_ = py::module_::import("test_interpreter");
     REQUIRE(py::hasattr(module_, "DerivedWidget"));
 
-    auto locals = py::dict("hello"_a="Hello, World!", "x"_a=5, **module_.attr("__dict__"));
+    auto locals = py::dict("hello"_a = "Hello, World!", "x"_a = 5, **module_.attr("__dict__"));
     py::exec(R"(
         widget = DerivedWidget("{} - {}".format(hello, x))
         message = widget.the_message
-    )", py::globals(), locals);
+    )",
+             py::globals(), locals);
     REQUIRE(locals["message"].cast<std::string>() == "Hello, World! - 5");
 
     auto py_widget = module_.attr("DerivedWidget")("The question");
@@ -72,8 +71,7 @@ TEST_CASE("Pass classes and data between modules defined in C++ and Python") {
 
 TEST_CASE("Import error handling") {
     REQUIRE_NOTHROW(py::module_::import("widget_module"));
-    REQUIRE_THROWS_WITH(py::module_::import("throw_exception"),
-                        "ImportError: C++ Error");
+    REQUIRE_THROWS_WITH(py::module_::import("throw_exception"), "ImportError: C++ Error");
     REQUIRE_THROWS_WITH(py::module_::import("throw_error_already_set"),
                         Catch::Contains("ImportError: KeyError"));
 }
@@ -111,7 +109,8 @@ TEST_CASE("Restart the interpreter") {
     REQUIRE(py::module_::import("widget_module").attr("add")(1, 2).cast<int>() == 3);
     REQUIRE(has_pybind11_internals_builtin());
     REQUIRE(has_pybind11_internals_static());
-    REQUIRE(py::module_::import("external_module").attr("A")(123).attr("value").cast<int>() == 123);
+    REQUIRE(py::module_::import("external_module").attr("A")(123).attr("value").cast<int>() ==
+            123);
 
     // local and foreign module internals should point to the same internals:
     REQUIRE(reinterpret_cast<uintptr_t>(*py::detail::get_internals_pp()) ==
@@ -139,7 +138,10 @@ TEST_CASE("Restart the interpreter") {
     py::initialize_interpreter();
     bool ran = false;
     py::module_::import("__main__").attr("internals_destroy_test") =
-        py::capsule(&ran, [](void *ran) { py::detail::get_internals(); *static_cast<bool *>(ran) = true; });
+        py::capsule(&ran, [](void *ran) {
+            py::detail::get_internals();
+            *static_cast<bool *>(ran) = true;
+        });
     REQUIRE_FALSE(has_pybind11_internals_builtin());
     REQUIRE_FALSE(has_pybind11_internals_static());
     REQUIRE_FALSE(ran);
@@ -213,7 +215,7 @@ TEST_CASE("Threads") {
     REQUIRE_FALSE(has_pybind11_internals_static());
 
     constexpr auto num_threads = 10;
-    auto locals = py::dict("count"_a=0);
+    auto locals = py::dict("count"_a = 0);
 
     {
         py::gil_scoped_release gil_release{};
@@ -239,7 +241,10 @@ TEST_CASE("Threads") {
 struct scope_exit {
     std::function<void()> f_;
     explicit scope_exit(std::function<void()> f) noexcept : f_(std::move(f)) {}
-    ~scope_exit() { if (f_) f_(); }
+    ~scope_exit() {
+        if (f_)
+            f_();
+    }
 };
 
 TEST_CASE("Reload module from file") {
@@ -250,9 +255,8 @@ TEST_CASE("Reload module from file") {
     bool dont_write_bytecode = sys.attr("dont_write_bytecode").cast<bool>();
     sys.attr("dont_write_bytecode") = true;
     // Reset the value at scope exit
-    scope_exit reset_dont_write_bytecode([&]() {
-        sys.attr("dont_write_bytecode") = dont_write_bytecode;
-    });
+    scope_exit reset_dont_write_bytecode(
+        [&]() { sys.attr("dont_write_bytecode") = dont_write_bytecode; });
 
     std::string module_name = "test_module_reload";
     std::string module_file = module_name + ".py";
@@ -263,9 +267,7 @@ TEST_CASE("Reload module from file") {
     test_module << "    return 1\n";
     test_module.close();
     // Delete the file at scope exit
-    scope_exit delete_module_file([&]() {
-        std::remove(module_file.c_str());
-    });
+    scope_exit delete_module_file([&]() { std::remove(module_file.c_str()); });
 
     // Import the module from file
     auto module_ = py::module_::import(module_name.c_str());

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -11,11 +11,7 @@
 
 TEST_SUBMODULE(enums, m) {
     // test_unscoped_enum
-    enum UnscopedEnum {
-        EOne = 1,
-        ETwo,
-        EThree
-    };
+    enum UnscopedEnum { EOne = 1, ETwo, EThree };
     py::enum_<UnscopedEnum>(m, "UnscopedEnum", py::arithmetic(), "An unscoped enumeration")
         .value("EOne", EOne, "Docstring for EOne")
         .value("ETwo", ETwo, "Docstring for ETwo")
@@ -23,10 +19,7 @@ TEST_SUBMODULE(enums, m) {
         .export_values();
 
     // test_scoped_enum
-    enum class ScopedEnum {
-        Two = 2,
-        Three
-    };
+    enum class ScopedEnum { Two = 2, Three };
     py::enum_<ScopedEnum>(m, "ScopedEnum", py::arithmetic())
         .value("Two", ScopedEnum::Two)
         .value("Three", ScopedEnum::Three);
@@ -36,11 +29,7 @@ TEST_SUBMODULE(enums, m) {
     });
 
     // test_binary_operators
-    enum Flags {
-        Read = 4,
-        Write = 2,
-        Execute = 1
-    };
+    enum Flags { Read = 4, Write = 2, Execute = 1 };
     py::enum_<Flags>(m, "Flags", py::arithmetic())
         .value("Read", Flags::Read)
         .value("Write", Flags::Write)
@@ -50,14 +39,9 @@ TEST_SUBMODULE(enums, m) {
     // test_implicit_conversion
     class ClassWithUnscopedEnum {
     public:
-        enum EMode {
-            EFirstMode = 1,
-            ESecondMode
-        };
+        enum EMode { EFirstMode = 1, ESecondMode };
 
-        static EMode test_function(EMode mode) {
-            return mode;
-        }
+        static EMode test_function(EMode mode) { return mode; }
     };
     py::class_<ClassWithUnscopedEnum> exenum_class(m, "ClassWithUnscopedEnum");
     exenum_class.def_static("test_function", &ClassWithUnscopedEnum::test_function);
@@ -67,19 +51,17 @@ TEST_SUBMODULE(enums, m) {
         .export_values();
 
     // test_enum_to_int
-    m.def("test_enum_to_int", [](int) { });
-    m.def("test_enum_to_uint", [](uint32_t) { });
-    m.def("test_enum_to_long_long", [](long long) { });
+    m.def("test_enum_to_int", [](int) {});
+    m.def("test_enum_to_uint", [](uint32_t) {});
+    m.def("test_enum_to_long_long", [](long long) {});
 
     // test_duplicate_enum_name
-    enum SimpleEnum
-    {
-        ONE, TWO, THREE
-    };
+    enum SimpleEnum { ONE, TWO, THREE };
 
     m.def("register_bad_enum", [m]() {
         py::enum_<SimpleEnum>(m, "SimpleEnum")
-            .value("ONE", SimpleEnum::ONE)          //NOTE: all value function calls are called with the same first parameter value
+            .value("ONE", SimpleEnum::ONE) // NOTE: all value function calls are called with the
+                                           // same first parameter value
             .value("ONE", SimpleEnum::TWO)
             .value("ONE", SimpleEnum::THREE)
             .export_values();

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -7,7 +7,6 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-
 #include <pybind11/eval.h>
 
 #include "pybind11_tests.h"
@@ -20,16 +19,12 @@ TEST_SUBMODULE(eval_, m) {
 
     m.def("test_eval_statements", [global]() {
         auto local = py::dict();
-        local["call_test"] = py::cpp_function([&]() -> int {
-            return 42;
-        });
+        local["call_test"] = py::cpp_function([&]() -> int { return 42; });
 
         // Regular string literal
-        py::exec(
-            "message = 'Hello World!'\n"
-            "x = call_test()",
-            global, local
-        );
+        py::exec("message = 'Hello World!'\n"
+                 "x = call_test()",
+                 global, local);
 
         // Multi-line raw string literal
         py::exec(R"(
@@ -37,8 +32,8 @@ TEST_SUBMODULE(eval_, m) {
                 print(message)
             else:
                 raise RuntimeError
-            )", global, local
-        );
+            )",
+                 global, local);
         auto x = local["x"].cast<int>();
 
         return x == 42;
@@ -53,9 +48,7 @@ TEST_SUBMODULE(eval_, m) {
 
     m.def("test_eval_single_statement", []() {
         auto local = py::dict();
-        local["call_test"] = py::cpp_function([&]() -> int {
-            return 42;
-        });
+        local["call_test"] = py::cpp_function([&]() -> int { return 42; });
 
         auto result = py::eval<py::eval_single_statement>("x = call_test()", py::dict(), local);
         auto x = local["x"].cast<int>();

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -15,8 +15,9 @@
 // A type that should be raised as an exception in Python
 class MyException : public std::exception {
 public:
-    explicit MyException(const char * m) : message{m} {}
-    const char * what() const noexcept override {return message.c_str();}
+    explicit MyException(const char *m) : message{m} {}
+    const char *what() const noexcept override { return message.c_str(); }
+
 private:
     std::string message = "";
 };
@@ -24,8 +25,9 @@ private:
 // A type that should be translated to a standard Python exception
 class MyException2 : public std::exception {
 public:
-    explicit MyException2(const char * m) : message{m} {}
-    const char * what() const noexcept override {return message.c_str();}
+    explicit MyException2(const char *m) : message{m} {}
+    const char *what() const noexcept override { return message.c_str(); }
+
 private:
     std::string message = "";
 };
@@ -33,13 +35,13 @@ private:
 // A type that is not derived from std::exception (and is thus unknown)
 class MyException3 {
 public:
-    explicit MyException3(const char * m) : message{m} {}
-    virtual const char * what() const noexcept {return message.c_str();}
+    explicit MyException3(const char *m) : message{m} {}
+    virtual const char *what() const noexcept { return message.c_str(); }
     // Rule of 5 BEGIN: to preempt compiler warnings.
-    MyException3(const MyException3&) = default;
-    MyException3(MyException3&&) = default;
-    MyException3& operator=(const MyException3&) = default;
-    MyException3& operator=(MyException3&&) = default;
+    MyException3(const MyException3 &) = default;
+    MyException3(MyException3 &&) = default;
+    MyException3 &operator=(const MyException3 &) = default;
+    MyException3 &operator=(MyException3 &&) = default;
     virtual ~MyException3() = default;
     // Rule of 5 END.
 private:
@@ -50,12 +52,12 @@ private:
 // and delegated to its exception translator
 class MyException4 : public std::exception {
 public:
-    explicit MyException4(const char * m) : message{m} {}
-    const char * what() const noexcept override {return message.c_str();}
+    explicit MyException4(const char *m) : message{m} {}
+    const char *what() const noexcept override { return message.c_str(); }
+
 private:
     std::string message = "";
 };
-
 
 // Like the above, but declared via the helper function
 class MyException5 : public std::logic_error {
@@ -75,8 +77,6 @@ struct PythonCallInDestructor {
     py::dict d;
 };
 
-
-
 struct PythonAlreadySetInDestructor {
     PythonAlreadySetInDestructor(const py::str &s) : s(s) {}
     ~PythonAlreadySetInDestructor() {
@@ -84,8 +84,7 @@ struct PythonAlreadySetInDestructor {
         try {
             // Assign to a py::object to force read access of nonexistent dict entry
             py::object o = foo["bar"];
-        }
-        catch (py::error_already_set& ex) {
+        } catch (py::error_already_set &ex) {
             ex.discard_as_unraisable(s);
         }
     }
@@ -93,17 +92,16 @@ struct PythonAlreadySetInDestructor {
     py::str s;
 };
 
-
 TEST_SUBMODULE(exceptions, m) {
-    m.def("throw_std_exception", []() {
-        throw std::runtime_error("This exception was intentionally thrown.");
-    });
+    m.def("throw_std_exception",
+          []() { throw std::runtime_error("This exception was intentionally thrown."); });
 
     // make a new custom exception and use it as a translation target
     static py::exception<MyException> ex(m, "MyException");
     py::register_exception_translator([](std::exception_ptr p) {
         try {
-            if (p) std::rethrow_exception(p);
+            if (p)
+                std::rethrow_exception(p);
         } catch (const MyException &e) {
             // Set MyException as the active python error
             ex(e.what());
@@ -115,7 +113,8 @@ TEST_SUBMODULE(exceptions, m) {
     // never by visible from Python
     py::register_exception_translator([](std::exception_ptr p) {
         try {
-            if (p) std::rethrow_exception(p);
+            if (p)
+                std::rethrow_exception(p);
         } catch (const MyException2 &e) {
             // Translate this exception to a standard RuntimeError
             PyErr_SetString(PyExc_RuntimeError, e.what());
@@ -127,7 +126,8 @@ TEST_SUBMODULE(exceptions, m) {
     // translator for MyException by throwing a new exception
     py::register_exception_translator([](std::exception_ptr p) {
         try {
-            if (p) std::rethrow_exception(p);
+            if (p)
+                std::rethrow_exception(p);
         } catch (const MyException4 &e) {
             throw MyException(e.what());
         }
@@ -139,21 +139,25 @@ TEST_SUBMODULE(exceptions, m) {
     py::register_exception<MyException5_1>(m, "MyException5_1", ex5.ptr());
 
     m.def("throws1", []() { throw MyException("this error should go to a custom type"); });
-    m.def("throws2", []() { throw MyException2("this error should go to a standard Python exception"); });
+    m.def("throws2",
+          []() { throw MyException2("this error should go to a standard Python exception"); });
     m.def("throws3", []() { throw MyException3("this error cannot be translated"); });
     m.def("throws4", []() { throw MyException4("this error is rethrown"); });
-    m.def("throws5", []() { throw MyException5("this is a helper-defined translated exception"); });
+    m.def("throws5",
+          []() { throw MyException5("this is a helper-defined translated exception"); });
     m.def("throws5_1", []() { throw MyException5_1("MyException5 subclass"); });
-    m.def("throws_logic_error", []() { throw std::logic_error("this error should fall through to the standard handler"); });
-    m.def("throws_overflow_error", []() {throw std::overflow_error(""); });
+    m.def("throws_logic_error", []() {
+        throw std::logic_error("this error should fall through to the standard handler");
+    });
+    m.def("throws_overflow_error", []() { throw std::overflow_error(""); });
     m.def("exception_matches", []() {
         py::dict foo;
         try {
             // Assign to a py::object to force read access of nonexistent dict entry
             py::object o = foo["bar"];
-        }
-        catch (py::error_already_set& ex) {
-            if (!ex.matches(PyExc_KeyError)) throw;
+        } catch (py::error_already_set &ex) {
+            if (!ex.matches(PyExc_KeyError))
+                throw;
             return true;
         }
         return false;
@@ -163,9 +167,9 @@ TEST_SUBMODULE(exceptions, m) {
         try {
             // Assign to a py::object to force read access of nonexistent dict entry
             py::object o = foo["bar"];
-        }
-        catch (py::error_already_set &ex) {
-            if (!ex.matches(PyExc_Exception)) throw;
+        } catch (py::error_already_set &ex) {
+            if (!ex.matches(PyExc_Exception))
+                throw;
             return true;
         }
         return false;
@@ -174,9 +178,9 @@ TEST_SUBMODULE(exceptions, m) {
         try {
             // On Python >= 3.6, this raises a ModuleNotFoundError, a subclass of ImportError
             py::module_::import("nonexistent");
-        }
-        catch (py::error_already_set &ex) {
-            if (!ex.matches(PyExc_ImportError)) throw;
+        } catch (py::error_already_set &ex) {
+            if (!ex.matches(PyExc_ImportError))
+                throw;
             return true;
         }
         return false;
@@ -187,10 +191,9 @@ TEST_SUBMODULE(exceptions, m) {
             PyErr_SetString(PyExc_ValueError, "foo");
         try {
             throw py::error_already_set();
-        } catch (const std::runtime_error& e) {
+        } catch (const std::runtime_error &e) {
             if ((err && e.what() != std::string("ValueError: foo")) ||
-                (!err && e.what() != std::string("Unknown internal error occurred")))
-            {
+                (!err && e.what() != std::string("Unknown internal error occurred"))) {
                 PyErr_Clear();
                 throw std::runtime_error("error message mismatch");
             }
@@ -208,7 +211,7 @@ TEST_SUBMODULE(exceptions, m) {
             PythonCallInDestructor set_dict_in_destructor(d);
             PyErr_SetString(PyExc_ValueError, "foo");
             throw py::error_already_set();
-        } catch (const py::error_already_set&) {
+        } catch (const py::error_already_set &) {
             return true;
         }
         return false;
@@ -233,7 +236,7 @@ TEST_SUBMODULE(exceptions, m) {
           });
 
     // Test repr that cannot be displayed
-    m.def("simple_bool_passthrough", [](bool x) {return x;});
+    m.def("simple_bool_passthrough", [](bool x) { return x; });
 
     m.def("throw_should_be_translated_to_key_error", []() { throw shared_exception(); });
 }

--- a/tests/test_factory_constructors.cpp
+++ b/tests/test_factory_constructors.cpp
@@ -21,6 +21,7 @@ class TestFactory1 {
     TestFactory1() : value("(empty)") { print_default_created(this); }
     TestFactory1(int v) : value(std::to_string(v)) { print_created(this, value); }
     TestFactory1(std::string v) : value(std::move(v)) { print_created(this, value); }
+
 public:
     std::string value;
     TestFactory1(TestFactory1 &&) = delete;
@@ -35,6 +36,7 @@ class TestFactory2 {
     TestFactory2() : value("(empty2)") { print_default_created(this); }
     TestFactory2(int v) : value(std::to_string(v)) { print_created(this, value); }
     TestFactory2(std::string v) : value(std::move(v)) { print_created(this, value); }
+
 public:
     TestFactory2(TestFactory2 &&m) noexcept {
         value = std::move(m.value);
@@ -54,6 +56,7 @@ protected:
     friend class TestFactoryHelper;
     TestFactory3() : value("(empty3)") { print_default_created(this); }
     TestFactory3(int v) : value(std::to_string(v)) { print_created(this, value); }
+
 public:
     TestFactory3(std::string v) : value(std::move(v)) { print_created(this, value); }
     TestFactory3(TestFactory3 &&m) noexcept {
@@ -86,6 +89,7 @@ class TestFactory6 {
 protected:
     int value;
     bool alias = false;
+
 public:
     TestFactory6(int i) : value{i} { print_created(this, i); }
     TestFactory6(TestFactory6 &&f) noexcept {
@@ -93,7 +97,11 @@ public:
         value = f.value;
         alias = f.alias;
     }
-    TestFactory6(const TestFactory6 &f) { print_copy_created(this); value = f.value; alias = f.alias; }
+    TestFactory6(const TestFactory6 &f) {
+        print_copy_created(this);
+        value = f.value;
+        alias = f.alias;
+    }
     virtual ~TestFactory6() { print_destroyed(this); }
     virtual int get() { return value; }
     bool has_alias() const { return alias; }
@@ -102,11 +110,20 @@ class PyTF6 : public TestFactory6 {
 public:
     // Special constructor that allows the factory to construct a PyTF6 from a TestFactory6 only
     // when an alias is needed:
-    PyTF6(TestFactory6 &&base) : TestFactory6(std::move(base)) { alias = true; print_created(this, "move", value); }
-    PyTF6(int i) : TestFactory6(i) { alias = true; print_created(this, i); }
+    PyTF6(TestFactory6 &&base) : TestFactory6(std::move(base)) {
+        alias = true;
+        print_created(this, "move", value);
+    }
+    PyTF6(int i) : TestFactory6(i) {
+        alias = true;
+        print_created(this, i);
+    }
     PyTF6(PyTF6 &&f) noexcept : TestFactory6(std::move(f)) { print_move_created(this); }
     PyTF6(const PyTF6 &f) : TestFactory6(f) { print_copy_created(this); }
-    PyTF6(std::string s) : TestFactory6((int) s.size()) { alias = true; print_created(this, s); }
+    PyTF6(std::string s) : TestFactory6((int)s.size()) {
+        alias = true;
+        print_created(this, s);
+    }
     ~PyTF6() override { print_destroyed(this); }
     int get() override { PYBIND11_OVERRIDE(int, TestFactory6, get, /*no args*/); }
 };
@@ -115,6 +132,7 @@ class TestFactory7 {
 protected:
     int value;
     bool alias = false;
+
 public:
     TestFactory7(int i) : value{i} { print_created(this, i); }
     TestFactory7(TestFactory7 &&f) noexcept {
@@ -122,20 +140,26 @@ public:
         value = f.value;
         alias = f.alias;
     }
-    TestFactory7(const TestFactory7 &f) { print_copy_created(this); value = f.value; alias = f.alias; }
+    TestFactory7(const TestFactory7 &f) {
+        print_copy_created(this);
+        value = f.value;
+        alias = f.alias;
+    }
     virtual ~TestFactory7() { print_destroyed(this); }
     virtual int get() { return value; }
     bool has_alias() const { return alias; }
 };
 class PyTF7 : public TestFactory7 {
 public:
-    PyTF7(int i) : TestFactory7(i) { alias = true; print_created(this, i); }
+    PyTF7(int i) : TestFactory7(i) {
+        alias = true;
+        print_created(this, i);
+    }
     PyTF7(PyTF7 &&f) noexcept : TestFactory7(std::move(f)) { print_move_created(this); }
     PyTF7(const PyTF7 &f) : TestFactory7(f) { print_copy_created(this); }
     ~PyTF7() override { print_destroyed(this); }
     int get() override { PYBIND11_OVERRIDE(int, TestFactory7, get, /*no args*/); }
 };
-
 
 class TestFactoryHelper {
 public:
@@ -143,7 +167,9 @@ public:
     // Return via pointer:
     static TestFactory1 *construct1() { return new TestFactory1(); }
     // Holder:
-    static std::unique_ptr<TestFactory1> construct1(int a) { return std::unique_ptr<TestFactory1>(new TestFactory1(a)); }
+    static std::unique_ptr<TestFactory1> construct1(int a) {
+        return std::unique_ptr<TestFactory1>(new TestFactory1(a));
+    }
     // pointer again
     static TestFactory1 *construct1_string(std::string a) {
         return new TestFactory1(std::move(a));
@@ -153,7 +179,9 @@ public:
     // pointer:
     static TestFactory2 *construct2() { return new TestFactory2(); }
     // holder:
-    static std::unique_ptr<TestFactory2> construct2(int a) { return std::unique_ptr<TestFactory2>(new TestFactory2(a)); }
+    static std::unique_ptr<TestFactory2> construct2(int a) {
+        return std::unique_ptr<TestFactory2>(new TestFactory2(a));
+    }
     // by value moving:
     static TestFactory2 construct2(std::string a) { return TestFactory2(std::move(a)); }
 
@@ -161,16 +189,18 @@ public:
     // pointer:
     static TestFactory3 *construct3() { return new TestFactory3(); }
     // holder:
-    static std::shared_ptr<TestFactory3> construct3(int a) { return std::shared_ptr<TestFactory3>(new TestFactory3(a)); }
+    static std::shared_ptr<TestFactory3> construct3(int a) {
+        return std::shared_ptr<TestFactory3>(new TestFactory3(a));
+    }
 };
 
 TEST_SUBMODULE(factory_constructors, m) {
 
     // Define various trivial types to allow simpler overload resolution:
     py::module_ m_tag = m.def_submodule("tag");
-#define MAKE_TAG_TYPE(Name) \
-    struct Name##_tag {}; \
-    py::class_<Name##_tag>(m_tag, #Name "_tag").def(py::init<>()); \
+#define MAKE_TAG_TYPE(Name)                                                                       \
+    struct Name##_tag {};                                                                         \
+    py::class_<Name##_tag>(m_tag, #Name "_tag").def(py::init<>());                                \
     m_tag.attr(#Name) = py::cast(Name##_tag{})
     MAKE_TAG_TYPE(pointer);
     MAKE_TAG_TYPE(unique_ptr);
@@ -193,9 +223,9 @@ TEST_SUBMODULE(factory_constructors, m) {
         .def(py::init([](unique_ptr_tag, int v) { return TestFactoryHelper::construct1(v); }))
         .def(py::init(&TestFactoryHelper::construct1_string)) // raw function pointer
         .def(py::init([](pointer_tag) { return TestFactoryHelper::construct1(); }))
-        .def(py::init([](py::handle, int v, py::handle) { return TestFactoryHelper::construct1(v); }))
-        .def_readwrite("value", &TestFactory1::value)
-        ;
+        .def(py::init(
+            [](py::handle, int v, py::handle) { return TestFactoryHelper::construct1(v); }))
+        .def_readwrite("value", &TestFactory1::value);
     py::class_<TestFactory2>(m, "TestFactory2")
         .def(py::init([](pointer_tag, int v) { return TestFactoryHelper::construct2(v); }))
         .def(py::init([](unique_ptr_tag, std::string v) {
@@ -206,7 +236,10 @@ TEST_SUBMODULE(factory_constructors, m) {
 
     // Stateful & reused:
     int c = 1;
-    auto c4a = [c](pointer_tag, TF4_tag, int a) { (void) c; return new TestFactory4(a);};
+    auto c4a = [c](pointer_tag, TF4_tag, int a) {
+        (void)c;
+        return new TestFactory4(a);
+    };
 
     // test_init_factory_basic, test_init_factory_casting
     py::class_<TestFactory3, std::shared_ptr<TestFactory3>> pyTestFactory3(m, "TestFactory3");
@@ -223,16 +256,17 @@ TEST_SUBMODULE(factory_constructors, m) {
         .def(py::init(c4a)) // derived ptr
         .def(py::init([](pointer_tag, TF5_tag, int a) { return new TestFactory5(a); }))
         // derived shared ptr:
-        .def(py::init([](shared_ptr_tag, TF4_tag, int a) { return std::make_shared<TestFactory4>(a); }))
-        .def(py::init([](shared_ptr_tag, TF5_tag, int a) { return std::make_shared<TestFactory5>(a); }))
+        .def(py::init(
+            [](shared_ptr_tag, TF4_tag, int a) { return std::make_shared<TestFactory4>(a); }))
+        .def(py::init(
+            [](shared_ptr_tag, TF5_tag, int a) { return std::make_shared<TestFactory5>(a); }))
 
         // Returns nullptr:
-        .def(py::init([](null_ptr_tag) { return (TestFactory3 *) nullptr; }))
+        .def(py::init([](null_ptr_tag) { return (TestFactory3 *)nullptr; }))
         .def(py::init([](null_unique_ptr_tag) { return std::unique_ptr<TestFactory3>(); }))
         .def(py::init([](null_shared_ptr_tag) { return std::shared_ptr<TestFactory3>(); }))
 
-        .def_readwrite("value", &TestFactory3::value)
-        ;
+        .def_readwrite("value", &TestFactory3::value);
 
     // test_init_factory_casting
     py::class_<TestFactory4, TestFactory3, std::shared_ptr<TestFactory4>>(m, "TestFactory4")
@@ -251,15 +285,15 @@ TEST_SUBMODULE(factory_constructors, m) {
         .def(py::init([](alias_tag, pointer_tag, int i) { return new PyTF6(i); }))
         .def(py::init([](base_tag, pointer_tag, int i) { return new TestFactory6(i); }))
         .def(py::init(
-            [](base_tag, alias_tag, pointer_tag, int i) { return (TestFactory6 *) new PyTF6(i); }))
+            [](base_tag, alias_tag, pointer_tag, int i) { return (TestFactory6 *)new PyTF6(i); }))
 
         .def("get", &TestFactory6::get)
         .def("has_alias", &TestFactory6::has_alias)
 
-        .def_static(
-            "get_cstats", &ConstructorStats::get<TestFactory6>, py::return_value_policy::reference)
-        .def_static(
-            "get_alias_cstats", &ConstructorStats::get<PyTF6>, py::return_value_policy::reference);
+        .def_static("get_cstats", &ConstructorStats::get<TestFactory6>,
+                    py::return_value_policy::reference)
+        .def_static("get_alias_cstats", &ConstructorStats::get<PyTF6>,
+                    py::return_value_policy::reference);
 
     // test_init_factory_dual
     // Separate alias constructor testing
@@ -269,10 +303,10 @@ TEST_SUBMODULE(factory_constructors, m) {
                       [](pointer_tag, int i) { return new PyTF7(i); }))
         .def(py::init([](mixed_tag, int i) { return new TestFactory7(i); },
                       [](mixed_tag, int i) { return PyTF7(i); }))
-        .def(py::init([](mixed_tag, const std::string &s) { return TestFactory7((int) s.size()); },
-                      [](mixed_tag, const std::string &s) { return new PyTF7((int) s.size()); }))
+        .def(py::init([](mixed_tag, const std::string &s) { return TestFactory7((int)s.size()); },
+                      [](mixed_tag, const std::string &s) { return new PyTF7((int)s.size()); }))
         .def(py::init([](base_tag, pointer_tag, int i) { return new TestFactory7(i); },
-                      [](base_tag, pointer_tag, int i) { return (TestFactory7 *) new PyTF7(i); }))
+                      [](base_tag, pointer_tag, int i) { return (TestFactory7 *)new PyTF7(i); }))
         .def(py::init([](alias_tag, pointer_tag, int i) { return new PyTF7(i); },
                       [](alias_tag, pointer_tag, int i) { return new PyTF7(10 * i); }))
         .def(py::init(
@@ -281,8 +315,7 @@ TEST_SUBMODULE(factory_constructors, m) {
                 auto *p = new PyTF7(i);
                 return std::shared_ptr<TestFactory7>(p);
             }))
-        .def(py::init([](shared_ptr_tag,
-                         invalid_base_tag,
+        .def(py::init([](shared_ptr_tag, invalid_base_tag,
                          int i) { return std::make_shared<TestFactory7>(i); },
                       [](shared_ptr_tag, invalid_base_tag, int i) {
                           return std::make_shared<TestFactory7>(i);
@@ -291,16 +324,16 @@ TEST_SUBMODULE(factory_constructors, m) {
         .def("get", &TestFactory7::get)
         .def("has_alias", &TestFactory7::has_alias)
 
-        .def_static(
-            "get_cstats", &ConstructorStats::get<TestFactory7>, py::return_value_policy::reference)
-        .def_static(
-            "get_alias_cstats", &ConstructorStats::get<PyTF7>, py::return_value_policy::reference);
+        .def_static("get_cstats", &ConstructorStats::get<TestFactory7>,
+                    py::return_value_policy::reference)
+        .def_static("get_alias_cstats", &ConstructorStats::get<PyTF7>,
+                    py::return_value_policy::reference);
 
     // test_placement_new_alternative
     // Class with a custom new operator but *without* a placement new operator (issue #948)
     class NoPlacementNew {
     public:
-        NoPlacementNew(int i) : i(i) { }
+        NoPlacementNew(int i) : i(i) {}
         static void *operator new(std::size_t s) {
             auto *p = ::operator new(s);
             py::print("operator new called, returning", reinterpret_cast<uintptr_t>(p));
@@ -316,9 +349,7 @@ TEST_SUBMODULE(factory_constructors, m) {
     py::class_<NoPlacementNew>(m, "NoPlacementNew")
         .def(py::init<int>())
         .def(py::init([]() { return new NoPlacementNew(100); }))
-        .def_readwrite("i", &NoPlacementNew::i)
-        ;
-
+        .def_readwrite("i", &NoPlacementNew::i);
 
     // test_reallocations
     // Class that has verbose operator_new/operator_delete calls
@@ -328,23 +359,36 @@ TEST_SUBMODULE(factory_constructors, m) {
         NoisyAlloc(double d) { py::print(py::str("NoisyAlloc(double {})").format(d)); }
         ~NoisyAlloc() { py::print("~NoisyAlloc()"); }
 
-        static void *operator new(size_t s) { py::print("noisy new"); return ::operator new(s); }
-        static void *operator new(size_t, void *p) { py::print("noisy placement new"); return p; }
-        static void operator delete(void *p, size_t) { py::print("noisy delete"); ::operator delete(p); }
+        static void *operator new(size_t s) {
+            py::print("noisy new");
+            return ::operator new(s);
+        }
+        static void *operator new(size_t, void *p) {
+            py::print("noisy placement new");
+            return p;
+        }
+        static void operator delete(void *p, size_t) {
+            py::print("noisy delete");
+            ::operator delete(p);
+        }
         static void operator delete(void *, void *) { py::print("noisy placement delete"); }
 #if defined(_MSC_VER) && _MSC_VER < 1910
         // MSVC 2015 bug: the above "noisy delete" isn't invoked (fixed in MSVC 2017)
-        static void operator delete(void *p) { py::print("noisy delete"); ::operator delete(p); }
+        static void operator delete(void *p) {
+            py::print("noisy delete");
+            ::operator delete(p);
+        }
 #endif
     };
 
-
     py::class_<NoisyAlloc> pyNoisyAlloc(m, "NoisyAlloc");
-        // Since these overloads have the same number of arguments, the dispatcher will try each of
-        // them until the arguments convert.  Thus we can get a pre-allocation here when passing a
-        // single non-integer:
+    // Since these overloads have the same number of arguments, the dispatcher will try each of
+    // them until the arguments convert.  Thus we can get a pre-allocation here when passing a
+    // single non-integer:
     ignoreOldStyleInitWarnings([&pyNoisyAlloc]() {
-        pyNoisyAlloc.def("__init__", [](NoisyAlloc *a, int i) { new (a) NoisyAlloc(i); }); // Regular constructor, runs first, requires preallocation
+        pyNoisyAlloc.def("__init__", [](NoisyAlloc *a, int i) {
+            new (a) NoisyAlloc(i);
+        }); // Regular constructor, runs first, requires preallocation
     });
 
     pyNoisyAlloc.def(py::init([](double d) { return new NoisyAlloc(d); }));
@@ -355,7 +399,8 @@ TEST_SUBMODULE(factory_constructors, m) {
     pyNoisyAlloc.def(py::init([](double d, int) { return NoisyAlloc(d); }));
     // Old-style placement new init; requires preallocation
     ignoreOldStyleInitWarnings([&pyNoisyAlloc]() {
-        pyNoisyAlloc.def("__init__", [](NoisyAlloc &a, double d, double) { new (&a) NoisyAlloc(d); });
+        pyNoisyAlloc.def("__init__",
+                         [](NoisyAlloc &a, double d, double) { new (&a) NoisyAlloc(d); });
     });
     // Requires deallocation of previous overload preallocated value:
     pyNoisyAlloc.def(py::init([](int i, double) { return new NoisyAlloc(i); }));
@@ -365,7 +410,8 @@ TEST_SUBMODULE(factory_constructors, m) {
             "__init__", [](NoisyAlloc &a, int i, const std::string &) { new (&a) NoisyAlloc(i); });
     });
 
-    // static_assert testing (the following def's should all fail with appropriate compilation errors):
+    // static_assert testing (the following def's should all fail with appropriate compilation
+    // errors):
 #if 0
     struct BadF1Base {};
     struct BadF1 : BadF1Base {};

--- a/tests/test_gil_scoped.cpp
+++ b/tests/test_gil_scoped.cpp
@@ -10,40 +10,37 @@
 #include "pybind11_tests.h"
 #include <pybind11/functional.h>
 
-
-class VirtClass  {
+class VirtClass {
 public:
     virtual ~VirtClass() = default;
     VirtClass() = default;
-    VirtClass(const VirtClass&) = delete;
+    VirtClass(const VirtClass &) = delete;
     virtual void virtual_func() {}
     virtual void pure_virtual_func() = 0;
 };
 
 class PyVirtClass : public VirtClass {
-    void virtual_func() override {
-        PYBIND11_OVERRIDE(void, VirtClass, virtual_func,);
-    }
+    void virtual_func() override { PYBIND11_OVERRIDE(void, VirtClass, virtual_func, ); }
     void pure_virtual_func() override {
-        PYBIND11_OVERRIDE_PURE(void, VirtClass, pure_virtual_func,);
+        PYBIND11_OVERRIDE_PURE(void, VirtClass, pure_virtual_func, );
     }
 };
 
 TEST_SUBMODULE(gil_scoped, m) {
-  py::class_<VirtClass, PyVirtClass>(m, "VirtClass")
-      .def(py::init<>())
-      .def("virtual_func", &VirtClass::virtual_func)
-      .def("pure_virtual_func", &VirtClass::pure_virtual_func);
+    py::class_<VirtClass, PyVirtClass>(m, "VirtClass")
+        .def(py::init<>())
+        .def("virtual_func", &VirtClass::virtual_func)
+        .def("pure_virtual_func", &VirtClass::pure_virtual_func);
 
-  m.def("test_callback_py_obj", [](py::object &func) { func(); });
-  m.def("test_callback_std_func", [](const std::function<void()> &func) { func(); });
-  m.def("test_callback_virtual_func", [](VirtClass &virt) { virt.virtual_func(); });
-  m.def("test_callback_pure_virtual_func", [](VirtClass &virt) { virt.pure_virtual_func(); });
-  m.def("test_cross_module_gil", []() {
-      auto cm = py::module_::import("cross_module_gil_utils");
-      auto gil_acquire
-          = reinterpret_cast<void (*)()>(PyLong_AsVoidPtr(cm.attr("gil_acquire_funcaddr").ptr()));
-      py::gil_scoped_release gil_release;
-      gil_acquire();
-  });
+    m.def("test_callback_py_obj", [](py::object &func) { func(); });
+    m.def("test_callback_std_func", [](const std::function<void()> &func) { func(); });
+    m.def("test_callback_virtual_func", [](VirtClass &virt) { virt.virtual_func(); });
+    m.def("test_callback_pure_virtual_func", [](VirtClass &virt) { virt.pure_virtual_func(); });
+    m.def("test_cross_module_gil", []() {
+        auto cm = py::module_::import("cross_module_gil_utils");
+        auto gil_acquire =
+            reinterpret_cast<void (*)()>(PyLong_AsVoidPtr(cm.attr("gil_acquire_funcaddr").ptr()));
+        py::gil_scoped_release gil_release;
+        gil_acquire();
+    });
 }

--- a/tests/test_iostream.cpp
+++ b/tests/test_iostream.cpp
@@ -7,14 +7,14 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#if defined(_MSC_VER) && _MSC_VER < 1910  // VS 2015's MSVC
-#  pragma warning(disable: 4702) // unreachable code in system header (xatomic.h(382))
+#if defined(_MSC_VER) && _MSC_VER < 1910 // VS 2015's MSVC
+#pragma warning(disable : 4702)          // unreachable code in system header (xatomic.h(382))
 #endif
 
-#include <pybind11/iostream.h>
 #include "pybind11_tests.h"
 #include <atomic>
 #include <iostream>
+#include <pybind11/iostream.h>
 #include <thread>
 
 void noisy_function(const std::string &msg, bool flush) {
@@ -38,13 +38,12 @@ struct TestThread {
             while (!stop_) {
                 std::cout << "x" << std::flush;
                 std::this_thread::sleep_for(std::chrono::microseconds(50));
-            } };
+            }
+        };
         t_ = new std::thread(std::move(thread_f));
     }
 
-    ~TestThread() {
-        delete t_;
-    }
+    ~TestThread() { delete t_; }
 
     void stop() { stop_ = true; }
 
@@ -62,7 +61,6 @@ struct TestThread {
     std::atomic<bool> stop_;
 };
 
-
 TEST_SUBMODULE(iostream, m) {
 
     add_ostream_redirect(m);
@@ -79,9 +77,8 @@ TEST_SUBMODULE(iostream, m) {
         std::cout << msg << std::flush;
     });
 
-    m.def("guard_output", &noisy_function,
-            py::call_guard<py::scoped_ostream_redirect>(),
-            py::arg("msg"), py::arg("flush")=true);
+    m.def("guard_output", &noisy_function, py::call_guard<py::scoped_ostream_redirect>(),
+          py::arg("msg"), py::arg("flush") = true);
 
     m.def("captured_err", [](const std::string &msg) {
         py::scoped_ostream_redirect redir(std::cerr, py::module_::import("sys").attr("stderr"));
@@ -91,8 +88,8 @@ TEST_SUBMODULE(iostream, m) {
     m.def("noisy_function", &noisy_function, py::arg("msg"), py::arg("flush") = true);
 
     m.def("dual_guard", &noisy_funct_dual,
-            py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>(),
-            py::arg("msg"), py::arg("emsg"));
+          py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>(),
+          py::arg("msg"), py::arg("emsg"));
 
     m.def("raw_output", [](const std::string &msg) { std::cout << msg << std::flush; });
 

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -7,38 +7,42 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 #include <pybind11/stl.h>
 
 #include <utility>
 
 TEST_SUBMODULE(kwargs_and_defaults, m) {
-    auto kw_func = [](int x, int y) { return "x=" + std::to_string(x) + ", y=" + std::to_string(y); };
+    auto kw_func = [](int x, int y) {
+        return "x=" + std::to_string(x) + ", y=" + std::to_string(y);
+    };
 
     // test_named_arguments
     m.def("kw_func0", kw_func);
     m.def("kw_func1", kw_func, py::arg("x"), py::arg("y"));
     m.def("kw_func2", kw_func, py::arg("x") = 100, py::arg("y") = 200);
-    m.def("kw_func3", [](const char *) { }, py::arg("data") = std::string("Hello world!"));
+    m.def(
+        "kw_func3", [](const char *) {}, py::arg("data") = std::string("Hello world!"));
 
     /* A fancier default argument */
     std::vector<int> list{{13, 17}};
-    m.def("kw_func4", [](const std::vector<int> &entries) {
-        std::string ret = "{";
-        for (int i : entries)
-            ret += std::to_string(i) + " ";
-        ret.back() = '}';
-        return ret;
-    }, py::arg("myList") = list);
+    m.def(
+        "kw_func4",
+        [](const std::vector<int> &entries) {
+            std::string ret = "{";
+            for (int i : entries)
+                ret += std::to_string(i) + " ";
+            ret.back() = '}';
+            return ret;
+        },
+        py::arg("myList") = list);
 
-    m.def("kw_func_udl", kw_func, "x"_a, "y"_a=300);
-    m.def("kw_func_udl_z", kw_func, "x"_a, "y"_a=0);
+    m.def("kw_func_udl", kw_func, "x"_a, "y"_a = 300);
+    m.def("kw_func_udl_z", kw_func, "x"_a, "y"_a = 0);
 
     // test_args_and_kwargs
-    m.def("args_function", [](py::args args) -> py::tuple {
-        return std::move(args);
-    });
+    m.def("args_function", [](py::args args) -> py::tuple { return std::move(args); });
     m.def("args_kwargs_function", [](const py::args &args, const py::kwargs &kwargs) {
         return py::make_tuple(args, kwargs);
     });
@@ -53,27 +57,36 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     };
     m.def("mixed_plus_args_kwargs", mixed_plus_both);
 
-    m.def("mixed_plus_args_kwargs_defaults", mixed_plus_both,
-            py::arg("i") = 1, py::arg("j") = 3.14159);
+    m.def("mixed_plus_args_kwargs_defaults", mixed_plus_both, py::arg("i") = 1,
+          py::arg("j") = 3.14159);
 
-    // test_args_refcount
-    // PyPy needs a garbage collection to get the reference count values to match CPython's behaviour
-    #ifdef PYPY_VERSION
-    #define GC_IF_NEEDED ConstructorStats::gc()
-    #else
-    #define GC_IF_NEEDED
-    #endif
-    m.def("arg_refcount_h", [](py::handle h) { GC_IF_NEEDED; return h.ref_count(); });
-    m.def("arg_refcount_h", [](py::handle h, py::handle, py::handle) { GC_IF_NEEDED; return h.ref_count(); });
+// test_args_refcount
+// PyPy needs a garbage collection to get the reference count values to match CPython's behaviour
+#ifdef PYPY_VERSION
+#define GC_IF_NEEDED ConstructorStats::gc()
+#else
+#define GC_IF_NEEDED
+#endif
+    m.def("arg_refcount_h", [](py::handle h) {
+        GC_IF_NEEDED;
+        return h.ref_count();
+    });
+    m.def("arg_refcount_h", [](py::handle h, py::handle, py::handle) {
+        GC_IF_NEEDED;
+        return h.ref_count();
+    });
     // TODO replace the following nolints as appropriate
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("arg_refcount_o", [](py::object o) { GC_IF_NEEDED; return o.ref_count(); });
+    m.def("arg_refcount_o", [](py::object o) {
+        GC_IF_NEEDED;
+        return o.ref_count();
+    });
     m.def("args_refcount", [](py::args a) {
         GC_IF_NEEDED;
         py::tuple t(a.size());
         for (size_t i = 0; i < a.size(); i++)
             // Use raw Python API here to avoid an extra, intermediate incref on the tuple item:
-            t[i] = (int) Py_REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i)));
+            t[i] = (int)Py_REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i)));
         return t;
     });
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
@@ -83,62 +96,71 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
         t[0] = o.ref_count();
         for (size_t i = 0; i < a.size(); i++)
             // Use raw Python API here to avoid an extra, intermediate incref on the tuple item:
-            t[i + 1] = (int) Py_REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i)));
+            t[i + 1] = (int)Py_REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i)));
         return t;
     });
 
     // pybind11 won't allow these to be bound: args and kwargs, if present, must be at the end.
     // Uncomment these to test that the static_assert is indeed working:
-//    m.def("bad_args1", [](py::args, int) {});
-//    m.def("bad_args2", [](py::kwargs, int) {});
-//    m.def("bad_args3", [](py::kwargs, py::args) {});
-//    m.def("bad_args4", [](py::args, int, py::kwargs) {});
-//    m.def("bad_args5", [](py::args, py::kwargs, int) {});
-//    m.def("bad_args6", [](py::args, py::args) {});
-//    m.def("bad_args7", [](py::kwargs, py::kwargs) {});
+    //    m.def("bad_args1", [](py::args, int) {});
+    //    m.def("bad_args2", [](py::kwargs, int) {});
+    //    m.def("bad_args3", [](py::kwargs, py::args) {});
+    //    m.def("bad_args4", [](py::args, int, py::kwargs) {});
+    //    m.def("bad_args5", [](py::args, py::kwargs, int) {});
+    //    m.def("bad_args6", [](py::args, py::args) {});
+    //    m.def("bad_args7", [](py::kwargs, py::kwargs) {});
 
     // test_keyword_only_args
-    m.def("kw_only_all", [](int i, int j) { return py::make_tuple(i, j); },
-            py::kw_only(), py::arg("i"), py::arg("j"));
-    m.def("kw_only_some", [](int i, int j, int k) { return py::make_tuple(i, j, k); },
-            py::arg(), py::kw_only(), py::arg("j"), py::arg("k"));
-    m.def("kw_only_with_defaults", [](int i, int j, int k, int z) { return py::make_tuple(i, j, k, z); },
-            py::arg() = 3, "j"_a = 4, py::kw_only(), "k"_a = 5, "z"_a);
-    m.def("kw_only_mixed", [](int i, int j) { return py::make_tuple(i, j); },
-            "i"_a, py::kw_only(), "j"_a);
+    m.def(
+        "kw_only_all", [](int i, int j) { return py::make_tuple(i, j); }, py::kw_only(),
+        py::arg("i"), py::arg("j"));
+    m.def(
+        "kw_only_some", [](int i, int j, int k) { return py::make_tuple(i, j, k); }, py::arg(),
+        py::kw_only(), py::arg("j"), py::arg("k"));
+    m.def(
+        "kw_only_with_defaults",
+        [](int i, int j, int k, int z) { return py::make_tuple(i, j, k, z); }, py::arg() = 3,
+        "j"_a = 4, py::kw_only(), "k"_a = 5, "z"_a);
+    m.def(
+        "kw_only_mixed", [](int i, int j) { return py::make_tuple(i, j); }, "i"_a, py::kw_only(),
+        "j"_a);
     m.def(
         "kw_only_plus_more",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
         [](int i, int j, int k, py::kwargs kwargs) { return py::make_tuple(i, j, k, kwargs); },
-        py::arg() /* positional */,
-        py::arg("j") = -1 /* both */,
-        py::kw_only(),
+        py::arg() /* positional */, py::arg("j") = -1 /* both */, py::kw_only(),
         py::arg("k") /* kw-only */);
 
     m.def("register_invalid_kw_only", [](py::module_ m) {
-        m.def("bad_kw_only", [](int i, int j) { return py::make_tuple(i, j); },
-                py::kw_only(), py::arg() /* invalid unnamed argument */, "j"_a);
+        m.def(
+            "bad_kw_only", [](int i, int j) { return py::make_tuple(i, j); }, py::kw_only(),
+            py::arg() /* invalid unnamed argument */, "j"_a);
     });
 
     // test_positional_only_args
-    m.def("pos_only_all", [](int i, int j) { return py::make_tuple(i, j); },
-            py::arg("i"), py::arg("j"), py::pos_only());
-    m.def("pos_only_mix", [](int i, int j) { return py::make_tuple(i, j); },
-            py::arg("i"), py::pos_only(), py::arg("j"));
-    m.def("pos_kw_only_mix", [](int i, int j, int k) { return py::make_tuple(i, j, k); },
-            py::arg("i"), py::pos_only(), py::arg("j"), py::kw_only(), py::arg("k"));
-    m.def("pos_only_def_mix", [](int i, int j, int k) { return py::make_tuple(i, j, k); },
-            py::arg("i"), py::arg("j") = 2, py::pos_only(), py::arg("k") = 3);
-
+    m.def(
+        "pos_only_all", [](int i, int j) { return py::make_tuple(i, j); }, py::arg("i"),
+        py::arg("j"), py::pos_only());
+    m.def(
+        "pos_only_mix", [](int i, int j) { return py::make_tuple(i, j); }, py::arg("i"),
+        py::pos_only(), py::arg("j"));
+    m.def(
+        "pos_kw_only_mix", [](int i, int j, int k) { return py::make_tuple(i, j, k); },
+        py::arg("i"), py::pos_only(), py::arg("j"), py::kw_only(), py::arg("k"));
+    m.def(
+        "pos_only_def_mix", [](int i, int j, int k) { return py::make_tuple(i, j, k); },
+        py::arg("i"), py::arg("j") = 2, py::pos_only(), py::arg("k") = 3);
 
     // These should fail to compile:
     // argument annotations are required when using kw_only
-//    m.def("bad_kw_only1", [](int) {}, py::kw_only());
+    //    m.def("bad_kw_only1", [](int) {}, py::kw_only());
     // can't specify both `py::kw_only` and a `py::args` argument
-//    m.def("bad_kw_only2", [](int i, py::args) {}, py::kw_only(), "i"_a);
+    //    m.def("bad_kw_only2", [](int i, py::args) {}, py::kw_only(), "i"_a);
 
     // test_function_signatures (along with most of the above)
-    struct KWClass { void foo(int, float) {} };
+    struct KWClass {
+        void foo(int, float) {}
+    };
     py::class_<KWClass>(m, "KWClass")
         .def("foo0", &KWClass::foo)
         .def("foo1", &KWClass::foo, "x"_a, "y"_a);
@@ -146,7 +168,6 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     // Make sure a class (not an instance) can be used as a default argument.
     // The return value doesn't matter, only that the module is importable.
     m.def(
-        "class_default_argument",
-        [](py::object a) { return py::repr(std::move(a)); },
+        "class_default_argument", [](py::object a) { return py::repr(std::move(a)); },
         "a"_a = py::module_::import("decimal").attr("Decimal"));
 }

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -106,10 +106,14 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
             py::arg() = 3, "j"_a = 4, py::kw_only(), "k"_a = 5, "z"_a);
     m.def("kw_only_mixed", [](int i, int j) { return py::make_tuple(i, j); },
             "i"_a, py::kw_only(), "j"_a);
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("kw_only_plus_more", [](int i, int j, int k, py::kwargs kwargs) {
-            return py::make_tuple(i, j, k, kwargs); },
-            py::arg() /* positional */, py::arg("j") = -1 /* both */, py::kw_only(), py::arg("k") /* kw-only */);
+    m.def(
+        "kw_only_plus_more",
+        // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        [](int i, int j, int k, py::kwargs kwargs) { return py::make_tuple(i, j, k, kwargs); },
+        py::arg() /* positional */,
+        py::arg("j") = -1 /* both */,
+        py::kw_only(),
+        py::arg("k") /* kw-only */);
 
     m.def("register_invalid_kw_only", [](py::module_ m) {
         m.def("bad_kw_only", [](int i, int j) { return py::make_tuple(i, j); },

--- a/tests/test_local_bindings.cpp
+++ b/tests/test_local_bindings.cpp
@@ -8,11 +8,11 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "local_bindings.h"
+#include "pybind11_tests.h"
+#include <numeric>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
-#include <numeric>
 
 TEST_SUBMODULE(local_bindings, m) {
     // test_load_external
@@ -21,9 +21,9 @@ TEST_SUBMODULE(local_bindings, m) {
 
     // test_local_bindings
     // Register a class with py::module_local:
-    bind_local<LocalType, -1>(m, "LocalType", py::module_local())
-        .def("get3", [](LocalType &t) { return t.i + 3; })
-        ;
+    bind_local<LocalType, -1>(m, "LocalType", py::module_local()).def("get3", [](LocalType &t) {
+        return t.i + 3;
+    });
 
     m.def("local_value", [](LocalType &l) { return l.i; });
 
@@ -32,20 +32,20 @@ TEST_SUBMODULE(local_bindings, m) {
     // one, in pybind11_cross_module_tests.cpp, is designed to fail):
     bind_local<NonLocalType, 0>(m, "NonLocalType")
         .def(py::init<int>())
-        .def("get", [](LocalType &i) { return i.i; })
-        ;
+        .def("get", [](LocalType &i) { return i.i; });
 
     // test_duplicate_local
-    // py::module_local declarations should be visible across compilation units that get linked together;
-    // this tries to register a duplicate local.  It depends on a definition in test_class.cpp and
-    // should raise a runtime error from the duplicate definition attempt.  If test_class isn't
-    // available it *also* throws a runtime error (with "test_class not enabled" as value).
+    // py::module_local declarations should be visible across compilation units that get linked
+    // together; this tries to register a duplicate local.  It depends on a definition in
+    // test_class.cpp and should raise a runtime error from the duplicate definition attempt.  If
+    // test_class isn't available it *also* throws a runtime error (with "test_class not enabled"
+    // as value).
     m.def("register_local_external", [m]() {
         auto main = py::module_::import("pybind11_tests");
         if (py::hasattr(main, "class_")) {
             bind_local<LocalExternal, 7>(m, "LocalExternal", py::module_local());
-        }
-        else throw std::runtime_error("test_class not enabled");
+        } else
+            throw std::runtime_error("test_class not enabled");
     });
 
     // test_stl_bind_local
@@ -75,12 +75,12 @@ TEST_SUBMODULE(local_bindings, m) {
     m.def("get_mixed_lg", [](int i) { return MixedLocalGlobal(i); });
 
     // test_internal_locals_differ
-    m.def("local_cpp_types_addr", []() { return (uintptr_t) &py::detail::registered_local_types_cpp(); });
+    m.def("local_cpp_types_addr",
+          []() { return (uintptr_t)&py::detail::registered_local_types_cpp(); });
 
     // test_stl_caster_vs_stl_bind
-    m.def("load_vector_via_caster", [](std::vector<int> v) {
-        return std::accumulate(v.begin(), v.end(), 0);
-    });
+    m.def("load_vector_via_caster",
+          [](std::vector<int> v) { return std::accumulate(v.begin(), v.end(), 0); });
 
     // test_cross_module_calls
     m.def("return_self", [](LocalVec *v) { return v; });
@@ -92,11 +92,9 @@ TEST_SUBMODULE(local_bindings, m) {
         // NOLINTNEXTLINE
         Cat(std::string name) : Pet(name) {}
     };
-    py::class_<pets::Pet>(m, "Pet", py::module_local())
-        .def("get_name", &pets::Pet::name);
+    py::class_<pets::Pet>(m, "Pet", py::module_local()).def("get_name", &pets::Pet::name);
     // Binding for local extending class:
-    py::class_<Cat, pets::Pet>(m, "Cat")
-        .def(py::init<std::string>());
+    py::class_<Cat, pets::Pet>(m, "Cat").def(py::init<std::string>());
     m.def("pet_name", [](pets::Pet &p) { return p.name(); });
 
     py::class_<MixGL>(m, "MixGL").def(py::init<int>());

--- a/tests/test_local_bindings.cpp
+++ b/tests/test_local_bindings.cpp
@@ -86,9 +86,12 @@ TEST_SUBMODULE(local_bindings, m) {
     m.def("return_self", [](LocalVec *v) { return v; });
     m.def("return_copy", [](const LocalVec &v) { return LocalVec(v); });
 
-    // Reformatting this class broke pygrep checks
-    // NOLINTNEXTLINE
-    class Cat : public pets::Pet { public: Cat(std::string name) : Pet(name) {}; };
+    class Cat : public pets::Pet {
+    public:
+        // Reformatting this class broke pygrep checks
+        // NOLINTNEXTLINE
+        Cat(std::string name) : Pet(name) {}
+    };
     py::class_<pets::Pet>(m, "Pet", py::module_local())
         .def("get_name", &pets::Pet::name);
     // Binding for local extending class:

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -8,12 +8,11 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 
 #if !defined(PYBIND11_OVERLOAD_CAST)
-template <typename... Args>
-using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
+template <typename... Args> using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
 #endif
 
 class ExampleMandA {
@@ -21,13 +20,16 @@ public:
     ExampleMandA() { print_default_created(this); }
     ExampleMandA(int value) : value(value) { print_created(this, value); }
     ExampleMandA(const ExampleMandA &e) : value(e.value) { print_copy_created(this); }
-    ExampleMandA(std::string&&) {}
+    ExampleMandA(std::string &&) {}
     ExampleMandA(ExampleMandA &&e) noexcept : value(e.value) { print_move_created(this); }
     ~ExampleMandA() { print_destroyed(this); }
 
     std::string toString() const { return "ExampleMandA[value=" + std::to_string(value) + "]"; }
 
-    void operator=(const ExampleMandA &e) { print_copy_assigned(this); value = e.value; }
+    void operator=(const ExampleMandA &e) {
+        print_copy_assigned(this);
+        value = e.value;
+    }
     void operator=(ExampleMandA &&e) noexcept {
         print_move_assigned(this);
         value = e.value;
@@ -40,36 +42,36 @@ public:
     void add4(ExampleMandA *other) { value += other->value; }       // passing by pointer
     void add5(const ExampleMandA *other) { value += other->value; } // passing by const pointer
 
-    void add6(int other) { value += other; }                        // passing by value
-    void add7(int &other) { value += other; }                       // passing by reference
-    void add8(const int &other) { value += other; }                 // passing by const reference
-    void add9(int *other) { value += *other; }                      // passing by pointer
-    void add10(const int *other) { value += *other; }               // passing by const pointer
+    void add6(int other) { value += other; }          // passing by value
+    void add7(int &other) { value += other; }         // passing by reference
+    void add8(const int &other) { value += other; }   // passing by const reference
+    void add9(int *other) { value += *other; }        // passing by pointer
+    void add10(const int *other) { value += *other; } // passing by const pointer
 
-    void consume_str(std::string&&) {}
+    void consume_str(std::string &&) {}
 
-    ExampleMandA self1() { return *this; }                          // return by value
-    ExampleMandA &self2() { return *this; }                         // return by reference
-    const ExampleMandA &self3() const { return *this; }             // return by const reference
-    ExampleMandA *self4() { return this; }                          // return by pointer
-    const ExampleMandA *self5() const { return this; }              // return by const pointer
+    ExampleMandA self1() { return *this; }              // return by value
+    ExampleMandA &self2() { return *this; }             // return by reference
+    const ExampleMandA &self3() const { return *this; } // return by const reference
+    ExampleMandA *self4() { return this; }              // return by pointer
+    const ExampleMandA *self5() const { return this; }  // return by const pointer
 
-    int internal1() const { return value; }                         // return by value
-    int &internal2() { return value; }                              // return by reference
-    const int &internal3() const { return value; }                  // return by const reference
-    int *internal4() { return &value; }                             // return by pointer
-    const int *internal5() { return &value; }                       // return by const pointer
+    int internal1() const { return value; }        // return by value
+    int &internal2() { return value; }             // return by reference
+    const int &internal3() const { return value; } // return by const reference
+    int *internal4() { return &value; }            // return by pointer
+    const int *internal5() { return &value; }      // return by const pointer
 
-    py::str overloaded()             { return "()"; }
-    py::str overloaded(int)          { return "(int)"; }
-    py::str overloaded(int, float)   { return "(int, float)"; }
-    py::str overloaded(float, int)   { return "(float, int)"; }
-    py::str overloaded(int, int)     { return "(int, int)"; }
+    py::str overloaded() { return "()"; }
+    py::str overloaded(int) { return "(int)"; }
+    py::str overloaded(int, float) { return "(int, float)"; }
+    py::str overloaded(float, int) { return "(float, int)"; }
+    py::str overloaded(int, int) { return "(int, int)"; }
     py::str overloaded(float, float) { return "(float, float)"; }
-    py::str overloaded(int)          const { return "(int) const"; }
-    py::str overloaded(int, float)   const { return "(int, float) const"; }
-    py::str overloaded(float, int)   const { return "(float, int) const"; }
-    py::str overloaded(int, int)     const { return "(int, int) const"; }
+    py::str overloaded(int) const { return "(int) const"; }
+    py::str overloaded(int, float) const { return "(int, float) const"; }
+    py::str overloaded(float, int) const { return "(float, int) const"; }
+    py::str overloaded(int, int) const { return "(int, int) const"; }
     py::str overloaded(float, float) const { return "(float, float) const"; }
 
     static py::str overloaded(float) { return "static float"; }
@@ -111,7 +113,10 @@ UserType TestPropRVP::sv1(1);
 UserType TestPropRVP::sv2(1);
 
 // Test None-allowed py::arg argument policy
-class NoneTester { public: int answer = 42; };
+class NoneTester {
+public:
+    int answer = 42;
+};
 int none1(const NoneTester &obj) { return obj.answer; }
 int none2(NoneTester *obj) { return obj ? obj->answer : -1; }
 int none3(std::shared_ptr<NoneTester> &obj) { return obj ? obj->answer : -1; }
@@ -133,11 +138,15 @@ struct StrIssue {
     StrIssue(int i) : val{i} {}
 };
 
-// Issues #854, #910: incompatible function args when member function/pointer is in unregistered base class
+// Issues #854, #910: incompatible function args when member function/pointer is in unregistered
+// base class
 class UnregisteredBase {
 public:
     void do_nothing() const {}
-    void increase_value() { rw_value++; ro_value += 0.25; }
+    void increase_value() {
+        rw_value++;
+        ro_value += 0.25;
+    }
     void set_int(int v) { rw_value = v; }
     int get_int() const { return rw_value; }
     double get_double() const { return ro_value; }
@@ -163,8 +172,8 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     py::class_<ExampleMandA> emna(m, "ExampleMandA");
     emna.def(py::init<>())
         .def(py::init<int>())
-        .def(py::init<std::string&&>())
-        .def(py::init<const ExampleMandA&>())
+        .def(py::init<std::string &&>())
+        .def(py::init<const ExampleMandA &>())
         .def("add1", &ExampleMandA::add1)
         .def("add2", &ExampleMandA::add2)
         .def("add3", &ExampleMandA::add3)
@@ -189,16 +198,20 @@ TEST_SUBMODULE(methods_and_attributes, m) {
 #if defined(PYBIND11_OVERLOAD_CAST)
         .def("overloaded", py::overload_cast<>(&ExampleMandA::overloaded))
         .def("overloaded", py::overload_cast<int>(&ExampleMandA::overloaded))
-        .def("overloaded", py::overload_cast<int,   float>(&ExampleMandA::overloaded))
-        .def("overloaded", py::overload_cast<float,   int>(&ExampleMandA::overloaded))
-        .def("overloaded", py::overload_cast<int,     int>(&ExampleMandA::overloaded))
+        .def("overloaded", py::overload_cast<int, float>(&ExampleMandA::overloaded))
+        .def("overloaded", py::overload_cast<float, int>(&ExampleMandA::overloaded))
+        .def("overloaded", py::overload_cast<int, int>(&ExampleMandA::overloaded))
         .def("overloaded", py::overload_cast<float, float>(&ExampleMandA::overloaded))
         .def("overloaded_float", py::overload_cast<float, float>(&ExampleMandA::overloaded))
-        .def("overloaded_const", py::overload_cast<int         >(&ExampleMandA::overloaded, py::const_))
-        .def("overloaded_const", py::overload_cast<int,   float>(&ExampleMandA::overloaded, py::const_))
-        .def("overloaded_const", py::overload_cast<float,   int>(&ExampleMandA::overloaded, py::const_))
-        .def("overloaded_const", py::overload_cast<int,     int>(&ExampleMandA::overloaded, py::const_))
-        .def("overloaded_const", py::overload_cast<float, float>(&ExampleMandA::overloaded, py::const_))
+        .def("overloaded_const", py::overload_cast<int>(&ExampleMandA::overloaded, py::const_))
+        .def("overloaded_const",
+             py::overload_cast<int, float>(&ExampleMandA::overloaded, py::const_))
+        .def("overloaded_const",
+             py::overload_cast<float, int>(&ExampleMandA::overloaded, py::const_))
+        .def("overloaded_const",
+             py::overload_cast<int, int>(&ExampleMandA::overloaded, py::const_))
+        .def("overloaded_const",
+             py::overload_cast<float, float>(&ExampleMandA::overloaded, py::const_))
 #else
         // Use both the traditional static_cast method and the C++11 compatible overload_cast_
         .def("overloaded", overload_cast_<>()(&ExampleMandA::overloaded))
@@ -216,16 +229,28 @@ TEST_SUBMODULE(methods_and_attributes, m) {
 #endif
         // test_no_mixed_overloads
         // Raise error if trying to mix static/non-static overloads on the same name:
-        .def_static("add_mixed_overloads1", []() {
-            auto emna = py::reinterpret_borrow<py::class_<ExampleMandA>>(py::module_::import("pybind11_tests.methods_and_attributes").attr("ExampleMandA"));
-            emna.def       ("overload_mixed1", static_cast<py::str (ExampleMandA::*)(int, int)>(&ExampleMandA::overloaded))
-                .def_static("overload_mixed1", static_cast<py::str (              *)(float   )>(&ExampleMandA::overloaded));
-        })
-        .def_static("add_mixed_overloads2", []() {
-            auto emna = py::reinterpret_borrow<py::class_<ExampleMandA>>(py::module_::import("pybind11_tests.methods_and_attributes").attr("ExampleMandA"));
-            emna.def_static("overload_mixed2", static_cast<py::str (              *)(float   )>(&ExampleMandA::overloaded))
-                .def       ("overload_mixed2", static_cast<py::str (ExampleMandA::*)(int, int)>(&ExampleMandA::overloaded));
-        })
+        .def_static(
+            "add_mixed_overloads1",
+            []() {
+                auto emna = py::reinterpret_borrow<py::class_<ExampleMandA>>(
+                    py::module_::import("pybind11_tests.methods_and_attributes")
+                        .attr("ExampleMandA"));
+                emna.def("overload_mixed1", static_cast<py::str (ExampleMandA::*)(int, int)>(
+                                                &ExampleMandA::overloaded))
+                    .def_static("overload_mixed1",
+                                static_cast<py::str (*)(float)>(&ExampleMandA::overloaded));
+            })
+        .def_static("add_mixed_overloads2",
+                    []() {
+                        auto emna = py::reinterpret_borrow<py::class_<ExampleMandA>>(
+                            py::module_::import("pybind11_tests.methods_and_attributes")
+                                .attr("ExampleMandA"));
+                        emna.def_static("overload_mixed2",
+                                        static_cast<py::str (*)(float)>(&ExampleMandA::overloaded))
+                            .def("overload_mixed2",
+                                 static_cast<py::str (ExampleMandA::*)(int, int)>(
+                                     &ExampleMandA::overloaded));
+                    })
         .def("__str__", &ExampleMandA::toString)
         .def_readwrite("value", &ExampleMandA::value);
 
@@ -245,23 +270,19 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         .def_property("def_property_impossible", nullptr, nullptr)
         .def_readonly_static("def_readonly_static", &TestProperties::static_value)
         .def_readwrite_static("def_readwrite_static", &TestProperties::static_value)
-        .def_property_static("def_writeonly_static",
-                             nullptr,
+        .def_property_static("def_writeonly_static", nullptr,
                              [](const py::object &, int v) { TestProperties::static_value = v; })
         .def_property_readonly_static(
             "def_property_readonly_static",
             [](const py::object &) { return TestProperties::static_get(); })
         .def_property_static(
-            "def_property_writeonly_static",
-            nullptr,
+            "def_property_writeonly_static", nullptr,
             [](const py::object &, int v) { return TestProperties::static_set(v); })
         .def_property_static(
-            "def_property_static",
-            [](const py::object &) { return TestProperties::static_get(); },
+            "def_property_static", [](const py::object &) { return TestProperties::static_get(); },
             [](const py::object &, int v) { TestProperties::static_set(v); })
         .def_property_static(
-            "static_cls",
-            [](py::object cls) { return cls; },
+            "static_cls", [](py::object cls) { return cls; },
             [](const py::object &cls, const py::function &f) { f(cls); });
 
     py::class_<TestPropertiesOverride, TestProperties>(m, "TestPropertiesOverride")
@@ -283,23 +304,23 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         .def_property_readonly("ro_func", py::cpp_function(&TestPropRVP::get2, rvp_copy))
         .def_property("rw_ref", &TestPropRVP::get1, &TestPropRVP::set1)
         .def_property("rw_copy", &TestPropRVP::get2, &TestPropRVP::set2, rvp_copy)
-        .def_property(
-            "rw_func", py::cpp_function(&TestPropRVP::get2, rvp_copy), &TestPropRVP::set2)
+        .def_property("rw_func", py::cpp_function(&TestPropRVP::get2, rvp_copy),
+                      &TestPropRVP::set2)
         .def_property_readonly_static("static_ro_ref", static_get1)
         .def_property_readonly_static("static_ro_copy", static_get2, rvp_copy)
         .def_property_readonly_static("static_ro_func", py::cpp_function(static_get2, rvp_copy))
         .def_property_static("static_rw_ref", static_get1, static_set1)
         .def_property_static("static_rw_copy", static_get2, static_set2, rvp_copy)
-        .def_property_static(
-            "static_rw_func", py::cpp_function(static_get2, rvp_copy), static_set2)
+        .def_property_static("static_rw_func", py::cpp_function(static_get2, rvp_copy),
+                             static_set2)
         // test_property_rvalue_policy
         .def_property_readonly("rvalue", &TestPropRVP::get_rvalue)
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
         .def_property_readonly_static("static_rvalue", [](py::object) { return UserType(1); });
 
     // test_metaclass_override
-    struct MetaclassOverride { };
-    py::class_<MetaclassOverride>(m, "MetaclassOverride", py::metaclass((PyObject *) &PyType_Type))
+    struct MetaclassOverride {};
+    py::class_<MetaclassOverride>(m, "MetaclassOverride", py::metaclass((PyObject *)&PyType_Type))
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
         .def_property_readonly_static("readonly", [](py::object) { return 1; });
 
@@ -309,22 +330,21 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m.def("overload_order", [](std::string) { return 2; });
     m.def("overload_order", [](int) { return 3; });
-    m.def("overload_order", [](int) { return 4; }, py::prepend{});
+    m.def(
+        "overload_order", [](int) { return 4; }, py::prepend{});
 
 #if !defined(PYPY_VERSION)
     // test_dynamic_attributes
     class DynamicClass {
     public:
         DynamicClass() { print_default_created(this); }
-        DynamicClass(const DynamicClass&) = delete;
+        DynamicClass(const DynamicClass &) = delete;
         ~DynamicClass() { print_destroyed(this); }
     };
-    py::class_<DynamicClass>(m, "DynamicClass", py::dynamic_attr())
-        .def(py::init());
+    py::class_<DynamicClass>(m, "DynamicClass", py::dynamic_attr()).def(py::init());
 
-    class CppDerivedDynamicClass : public DynamicClass { };
-    py::class_<CppDerivedDynamicClass, DynamicClass>(m, "CppDerivedDynamicClass")
-        .def(py::init());
+    class CppDerivedDynamicClass : public DynamicClass {};
+    py::class_<CppDerivedDynamicClass, DynamicClass>(m, "CppDerivedDynamicClass").def(py::init());
 #endif
 
     // test_bad_arg_default
@@ -334,20 +354,23 @@ TEST_SUBMODULE(methods_and_attributes, m) {
 #else
     m.attr("debug_enabled") = false;
 #endif
-    m.def("bad_arg_def_named", []{
+    m.def("bad_arg_def_named", [] {
         auto m = py::module_::import("pybind11_tests");
-        m.def("should_fail", [](int, UnregisteredType) {}, py::arg(), py::arg("a") = UnregisteredType());
+        m.def(
+            "should_fail", [](int, UnregisteredType) {}, py::arg(),
+            py::arg("a") = UnregisteredType());
     });
-    m.def("bad_arg_def_unnamed", []{
+    m.def("bad_arg_def_unnamed", [] {
         auto m = py::module_::import("pybind11_tests");
-        m.def("should_fail", [](int, UnregisteredType) {}, py::arg(), py::arg() = UnregisteredType());
+        m.def(
+            "should_fail", [](int, UnregisteredType) {}, py::arg(),
+            py::arg() = UnregisteredType());
     });
 
     // [workaround(intel)] ICC 20/21 breaks with py::arg().stuff, using py::arg{}.stuff works.
 
     // test_accepts_none
-    py::class_<NoneTester, std::shared_ptr<NoneTester>>(m, "NoneTester")
-        .def(py::init<>());
+    py::class_<NoneTester, std::shared_ptr<NoneTester>>(m, "NoneTester").def(py::init<>());
     m.def("no_none1", &none1, py::arg{}.none(false));
     m.def("no_none2", &none2, py::arg{}.none(false));
     m.def("no_none3", &none3, py::arg{}.none(false));
@@ -365,21 +388,19 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     // test_casts_none
     // Issue #2778: implicit casting from None to object (not pointer)
     py::class_<NoneCastTester>(m, "NoneCastTester")
-          .def(py::init<>())
-          .def(py::init<int>())
-          .def(py::init([](py::none const&) { return NoneCastTester{}; }));
+        .def(py::init<>())
+        .def(py::init<int>())
+        .def(py::init([](py::none const &) { return NoneCastTester{}; }));
     py::implicitly_convertible<py::none, NoneCastTester>();
-    m.def("ok_obj_or_none", [](NoneCastTester const& foo) { return foo.answer; });
-
+    m.def("ok_obj_or_none", [](NoneCastTester const &foo) { return foo.answer; });
 
     // test_str_issue
     // Issue #283: __str__ called on uninitialized instance when constructor arguments invalid
     py::class_<StrIssue>(m, "StrIssue")
         .def(py::init<int>())
         .def(py::init<>())
-        .def("__str__", [](const StrIssue &si) {
-            return "StrIssue[" + std::to_string(si.val) + "]"; }
-        );
+        .def("__str__",
+             [](const StrIssue &si) { return "StrIssue[" + std::to_string(si.val) + "]"; });
 
     // test_unregistered_base_implementations
     //
@@ -402,7 +423,8 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         // This one is in the registered class:
         .def("sum", &RegisteredDerived::sum);
 
-    using Adapted = decltype(py::method_adaptor<RegisteredDerived>(&RegisteredDerived::do_nothing));
+    using Adapted =
+        decltype(py::method_adaptor<RegisteredDerived>(&RegisteredDerived::do_nothing));
     static_assert(std::is_same<Adapted, void (RegisteredDerived::*)() const>::value, "");
 
     // test_methods_and_attributes

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -123,7 +123,7 @@ class NoneCastTester {
 public:
     int answer = -1;
     NoneCastTester() = default;
-    NoneCastTester(int v) : answer(v) {};
+    NoneCastTester(int v) : answer(v) {}
 };
 
 struct StrIssue {
@@ -393,14 +393,14 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         .def("increase_value", &RegisteredDerived::increase_value)
         .def_readwrite("rw_value", &RegisteredDerived::rw_value)
         .def_readonly("ro_value", &RegisteredDerived::ro_value)
-        // These should trigger a static_assert if uncommented
-        //.def_readwrite("fails", &UserType::value) // should trigger a static_assert if uncommented
-        //.def_readonly("fails", &UserType::value) // should trigger a static_assert if uncommented
+        // Uncommenting the next line should trigger a static_assert:
+        // .def_readwrite("fails", &UserType::value)
+        // Uncommenting the next line should trigger a static_assert:
+        // .def_readonly("fails", &UserType::value)
         .def_property("rw_value_prop", &RegisteredDerived::get_int, &RegisteredDerived::set_int)
         .def_property_readonly("ro_value_prop", &RegisteredDerived::get_double)
         // This one is in the registered class:
-        .def("sum", &RegisteredDerived::sum)
-        ;
+        .def("sum", &RegisteredDerived::sum);
 
     using Adapted = decltype(py::method_adaptor<RegisteredDerived>(&RegisteredDerived::do_nothing));
     static_assert(std::is_same<Adapted, void (RegisteredDerived::*)() const>::value, "");

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -8,8 +8,8 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 
 TEST_SUBMODULE(modules, m) {
     // test_nested_modules
@@ -22,23 +22,30 @@ TEST_SUBMODULE(modules, m) {
     public:
         A(int v) : v(v) { print_created(this, v); }
         ~A() { print_destroyed(this); }
-        A(const A&) { print_copy_created(this); }
-        A& operator=(const A &copy) { print_copy_assigned(this); v = copy.v; return *this; }
+        A(const A &) { print_copy_created(this); }
+        A &operator=(const A &copy) {
+            print_copy_assigned(this);
+            v = copy.v;
+            return *this;
+        }
         std::string toString() const { return "A[" + std::to_string(v) + "]"; }
 
     private:
         int v;
     };
-    py::class_<A>(m_sub, "A")
-        .def(py::init<int>())
-        .def("__repr__", &A::toString);
+    py::class_<A>(m_sub, "A").def(py::init<int>()).def("__repr__", &A::toString);
 
     class B {
     public:
         B() { print_default_created(this); }
         ~B() { print_destroyed(this); }
-        B(const B&) { print_copy_created(this); }
-        B& operator=(const B &copy) { print_copy_assigned(this); a1 = copy.a1; a2 = copy.a2; return *this; }
+        B(const B &) { print_copy_created(this); }
+        B &operator=(const B &copy) {
+            print_copy_assigned(this);
+            a1 = copy.a1;
+            a2 = copy.a2;
+            return *this;
+        }
         A &get_a1() { return a1; }
         A &get_a2() { return a2; }
 
@@ -47,9 +54,12 @@ TEST_SUBMODULE(modules, m) {
     };
     py::class_<B>(m_sub, "B")
         .def(py::init<>())
-        .def("get_a1", &B::get_a1, "Return the internal A 1", py::return_value_policy::reference_internal)
-        .def("get_a2", &B::get_a2, "Return the internal A 2", py::return_value_policy::reference_internal)
-        .def_readwrite("a1", &B::a1)  // def_readonly uses an internal reference return policy by default
+        .def("get_a1", &B::get_a1, "Return the internal A 1",
+             py::return_value_policy::reference_internal)
+        .def("get_a2", &B::get_a2, "Return the internal A 2",
+             py::return_value_policy::reference_internal)
+        .def_readwrite("a1",
+                       &B::a1) // def_readonly uses an internal reference return policy by default
         .def_readwrite("a2", &B::a2);
 
     // This is intentionally "py::module" to verify it still can be used in place of "py::module_"
@@ -58,13 +68,14 @@ TEST_SUBMODULE(modules, m) {
     // test_duplicate_registration
     // Registering two things with the same name
     m.def("duplicate_registration", []() {
-        class Dupe1 { };
-        class Dupe2 { };
-        class Dupe3 { };
-        class DupeException { };
+        class Dupe1 {};
+        class Dupe2 {};
+        class Dupe3 {};
+        class DupeException {};
 
         // Go ahead and leak, until we have a non-leaking py::module_ constructor
-        auto dm = py::module_::create_extension_module("dummy", nullptr, new py::module_::module_def);
+        auto dm =
+            py::module_::create_extension_module("dummy", nullptr, new py::module_::module_def);
         auto failures = py::list();
 
         py::class_<Dupe1>(dm, "Dupe1");
@@ -75,27 +86,33 @@ TEST_SUBMODULE(modules, m) {
         try {
             py::class_<Dupe1>(dm, "Dupe1");
             failures.append("Dupe1 class");
-        } catch (std::runtime_error &) {}
+        } catch (std::runtime_error &) {
+        }
         try {
             dm.def("Dupe1", []() { return Dupe1(); });
             failures.append("Dupe1 function");
-        } catch (std::runtime_error &) {}
+        } catch (std::runtime_error &) {
+        }
         try {
             py::class_<Dupe3>(dm, "dupe1_factory");
             failures.append("dupe1_factory");
-        } catch (std::runtime_error &) {}
+        } catch (std::runtime_error &) {
+        }
         try {
             py::exception<Dupe3>(dm, "Dupe2");
             failures.append("Dupe2");
-        } catch (std::runtime_error &) {}
+        } catch (std::runtime_error &) {
+        }
         try {
             dm.def("DupeException", []() { return 30; });
             failures.append("DupeException1");
-        } catch (std::runtime_error &) {}
+        } catch (std::runtime_error &) {
+        }
         try {
             py::class_<DupeException>(dm, "DupeException");
             failures.append("DupeException2");
-        } catch (std::runtime_error &) {}
+        } catch (std::runtime_error &) {
+        }
 
         return failures;
     });

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -8,15 +8,15 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 
 namespace {
 
 // Many bases for testing that multiple inheritance from many classes (i.e. requiring extra
 // space for holder constructed flags) works.
 template <int N> struct BaseN {
-    BaseN(int i) : i(i) { }
+    BaseN(int i) : i(i) {}
     int i;
 };
 
@@ -47,23 +47,33 @@ int VanillaStaticMix2::static_value = 12;
 
 // test_multiple_inheritance_virtbase
 struct Base1a {
-    Base1a(int i) : i(i) { }
+    Base1a(int i) : i(i) {}
     int foo() const { return i; }
     int i;
 };
 struct Base2a {
-    Base2a(int i) : i(i) { }
+    Base2a(int i) : i(i) {}
     int bar() const { return i; }
     int i;
 };
 struct Base12a : Base1a, Base2a {
-    Base12a(int i, int j) : Base1a(i), Base2a(j) { }
+    Base12a(int i, int j) : Base1a(i), Base2a(j) {}
 };
 
 // test_mi_unaligned_base
 // test_mi_base_return
-struct I801B1 { int a = 1; I801B1() = default; I801B1(const I801B1 &) = default; virtual ~I801B1() = default; };
-struct I801B2 { int b = 2; I801B2() = default; I801B2(const I801B2 &) = default; virtual ~I801B2() = default; };
+struct I801B1 {
+    int a = 1;
+    I801B1() = default;
+    I801B1(const I801B1 &) = default;
+    virtual ~I801B1() = default;
+};
+struct I801B2 {
+    int b = 2;
+    I801B2() = default;
+    I801B2(const I801B2 &) = default;
+    virtual ~I801B2() = default;
+};
 struct I801C : I801B1, I801B2 {};
 struct I801D : I801C {}; // Indirect MI
 
@@ -77,53 +87,62 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     // test_multiple_inheritance_mix1
     // test_multiple_inheritance_mix2
     struct Base1 {
-        Base1(int i) : i(i) { }
+        Base1(int i) : i(i) {}
         int foo() const { return i; }
         int i;
     };
     py::class_<Base1> b1(m, "Base1");
-    b1.def(py::init<int>())
-      .def("foo", &Base1::foo);
+    b1.def(py::init<int>()).def("foo", &Base1::foo);
 
     struct Base2 {
-        Base2(int i) : i(i) { }
+        Base2(int i) : i(i) {}
         int bar() const { return i; }
         int i;
     };
     py::class_<Base2> b2(m, "Base2");
-    b2.def(py::init<int>())
-      .def("bar", &Base2::bar);
-
+    b2.def(py::init<int>()).def("bar", &Base2::bar);
 
     // test_multiple_inheritance_cpp
     struct Base12 : Base1, Base2 {
-        Base12(int i, int j) : Base1(i), Base2(j) { }
+        Base12(int i, int j) : Base1(i), Base2(j) {}
     };
     struct MIType : Base12 {
-        MIType(int i, int j) : Base12(i, j) { }
+        MIType(int i, int j) : Base12(i, j) {}
     };
     py::class_<Base12, Base1, Base2>(m, "Base12");
-    py::class_<MIType, Base12>(m, "MIType")
-        .def(py::init<int, int>());
+    py::class_<MIType, Base12>(m, "MIType").def(py::init<int, int>());
 
-
-    // test_multiple_inheritance_python_many_bases
-    #define PYBIND11_BASEN(N) py::class_<BaseN<N>>(m, "BaseN" #N).def(py::init<int>()).def("f" #N, [](BaseN<N> &b) { return b.i + N; })
-    PYBIND11_BASEN( 1); PYBIND11_BASEN( 2); PYBIND11_BASEN( 3); PYBIND11_BASEN( 4);
-    PYBIND11_BASEN( 5); PYBIND11_BASEN( 6); PYBIND11_BASEN( 7); PYBIND11_BASEN( 8);
-    PYBIND11_BASEN( 9); PYBIND11_BASEN(10); PYBIND11_BASEN(11); PYBIND11_BASEN(12);
-    PYBIND11_BASEN(13); PYBIND11_BASEN(14); PYBIND11_BASEN(15); PYBIND11_BASEN(16);
+// test_multiple_inheritance_python_many_bases
+#define PYBIND11_BASEN(N)                                                                         \
+    py::class_<BaseN<N>>(m, "BaseN" #N).def(py::init<int>()).def("f" #N, [](BaseN<N> &b) {        \
+        return b.i + N;                                                                           \
+    })
+    PYBIND11_BASEN(1);
+    PYBIND11_BASEN(2);
+    PYBIND11_BASEN(3);
+    PYBIND11_BASEN(4);
+    PYBIND11_BASEN(5);
+    PYBIND11_BASEN(6);
+    PYBIND11_BASEN(7);
+    PYBIND11_BASEN(8);
+    PYBIND11_BASEN(9);
+    PYBIND11_BASEN(10);
+    PYBIND11_BASEN(11);
+    PYBIND11_BASEN(12);
+    PYBIND11_BASEN(13);
+    PYBIND11_BASEN(14);
+    PYBIND11_BASEN(15);
+    PYBIND11_BASEN(16);
     PYBIND11_BASEN(17);
 
     // Uncommenting this should result in a compile time failure (MI can only be specified via
-    // template parameters because pybind has to know the types involved; see discussion in #742 for
-    // details).
-//    struct Base12v2 : Base1, Base2 {
-//        Base12v2(int i, int j) : Base1(i), Base2(j) { }
-//    };
-//    py::class_<Base12v2>(m, "Base12v2", b1, b2)
-//        .def(py::init<int, int>());
-
+    // template parameters because pybind has to know the types involved; see discussion in #742
+    // for details).
+    //    struct Base12v2 : Base1, Base2 {
+    //        Base12v2(int i, int j) : Base1(i), Base2(j) { }
+    //    };
+    //    py::class_<Base12v2>(m, "Base12v2", b1, b2)
+    //        .def(py::init<int, int>());
 
     // test_multiple_inheritance_virtbase
     // Test the case where not all base classes are specified, and where pybind11 requires the
@@ -136,8 +155,8 @@ TEST_SUBMODULE(multiple_inheritance, m) {
         .def(py::init<int>())
         .def("bar", &Base2a::bar);
 
-    py::class_<Base12a, /* Base1 missing */ Base2a,
-               std::shared_ptr<Base12a>>(m, "Base12a", py::multiple_inheritance())
+    py::class_<Base12a, /* Base1 missing */ Base2a, std::shared_ptr<Base12a>>(
+        m, "Base12a", py::multiple_inheritance())
         .def(py::init<int, int>());
 
     m.def("bar_base2a", [](Base2a *b) { return b->bar(); });
@@ -148,11 +167,18 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     // test_mi_base_return
     // Issue #801: invalid casting to derived type with MI bases
     // Unregistered classes:
-    struct I801B3 { int c = 3; virtual ~I801B3() = default; };
+    struct I801B3 {
+        int c = 3;
+        virtual ~I801B3() = default;
+    };
     struct I801E : I801B3, I801D {};
 
-    py::class_<I801B1, std::shared_ptr<I801B1>>(m, "I801B1").def(py::init<>()).def_readonly("a", &I801B1::a);
-    py::class_<I801B2, std::shared_ptr<I801B2>>(m, "I801B2").def(py::init<>()).def_readonly("b", &I801B2::b);
+    py::class_<I801B1, std::shared_ptr<I801B1>>(m, "I801B1")
+        .def(py::init<>())
+        .def_readonly("a", &I801B1::a);
+    py::class_<I801B2, std::shared_ptr<I801B2>>(m, "I801B2")
+        .def(py::init<>())
+        .def_readonly("b", &I801B2::b);
     py::class_<I801C, I801B1, I801B2, std::shared_ptr<I801C>>(m, "I801C").def(py::init<>());
     py::class_<I801D, I801C, std::shared_ptr<I801D>>(m, "I801D").def(py::init<>());
 
@@ -177,11 +203,8 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     m.def("i801e_c", []() -> I801C * { return new I801E(); });
     m.def("i801e_b2", []() -> I801B2 * { return new I801E(); });
 
-
     // test_mi_static_properties
-    py::class_<Vanilla>(m, "Vanilla")
-        .def(py::init<>())
-        .def("vanilla", &Vanilla::vanilla);
+    py::class_<Vanilla>(m, "Vanilla").def(py::init<>()).def("vanilla", &Vanilla::vanilla);
 
     py::class_<WithStatic1>(m, "WithStatic1")
         .def(py::init<>())
@@ -193,22 +216,19 @@ TEST_SUBMODULE(multiple_inheritance, m) {
         .def_static("static_func2", &WithStatic2::static_func2)
         .def_readwrite_static("static_value2", &WithStatic2::static_value2);
 
-    py::class_<VanillaStaticMix1, Vanilla, WithStatic1, WithStatic2>(
-        m, "VanillaStaticMix1")
+    py::class_<VanillaStaticMix1, Vanilla, WithStatic1, WithStatic2>(m, "VanillaStaticMix1")
         .def(py::init<>())
         .def_static("static_func", &VanillaStaticMix1::static_func)
         .def_readwrite_static("static_value", &VanillaStaticMix1::static_value);
 
-    py::class_<VanillaStaticMix2, WithStatic1, Vanilla, WithStatic2>(
-        m, "VanillaStaticMix2")
+    py::class_<VanillaStaticMix2, WithStatic1, Vanilla, WithStatic2>(m, "VanillaStaticMix2")
         .def(py::init<>())
         .def_static("static_func", &VanillaStaticMix2::static_func)
         .def_readwrite_static("static_value", &VanillaStaticMix2::static_value);
 
-
-    struct WithDict { };
-    struct VanillaDictMix1 : Vanilla, WithDict { };
-    struct VanillaDictMix2 : WithDict, Vanilla { };
+    struct WithDict {};
+    struct VanillaDictMix1 : Vanilla, WithDict {};
+    struct VanillaDictMix2 : WithDict, Vanilla {};
     py::class_<WithDict>(m, "WithDict", py::dynamic_attr()).def(py::init<>());
     py::class_<VanillaDictMix1, Vanilla, WithDict>(m, "VanillaDictMix1").def(py::init<>());
     py::class_<VanillaDictMix2, WithDict, Vanilla>(m, "VanillaDictMix2").def(py::init<>());
@@ -216,16 +236,23 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     // test_diamond_inheritance
     // Issue #959: segfault when constructing diamond inheritance instance
     // All of these have int members so that there will be various unequal pointers involved.
-    struct B { int b; B() = default; B(const B&) = default; virtual ~B() = default; };
-    struct C0 : public virtual B { int c0; };
-    struct C1 : public virtual B { int c1; };
-    struct D : public C0, public C1 { int d; };
-    py::class_<B>(m, "B")
-        .def("b", [](B *self) { return self; });
-    py::class_<C0, B>(m, "C0")
-        .def("c0", [](C0 *self) { return self; });
-    py::class_<C1, B>(m, "C1")
-        .def("c1", [](C1 *self) { return self; });
-    py::class_<D, C0, C1>(m, "D")
-        .def(py::init<>());
+    struct B {
+        int b;
+        B() = default;
+        B(const B &) = default;
+        virtual ~B() = default;
+    };
+    struct C0 : public virtual B {
+        int c0;
+    };
+    struct C1 : public virtual B {
+        int c1;
+    };
+    struct D : public C0, public C1 {
+        int d;
+    };
+    py::class_<B>(m, "B").def("b", [](B *self) { return self; });
+    py::class_<C0, B>(m, "C0").def("c0", [](C0 *self) { return self; });
+    py::class_<C1, B>(m, "C1").def("c1", [](C1 *self) { return self; });
+    py::class_<D, C0, C1>(m, "D").def(py::init<>());
 }

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -275,10 +275,16 @@ TEST_SUBMODULE(numpy_array, sm) {
     // [workaround(intel)] ICC 20/21 breaks with py::arg().stuff, using py::arg{}.stuff works.
 
     // Only accept the exact types:
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    sm.def("overloaded3", [](py::array_t<int>) { return "int"; }, py::arg{}.noconvert());
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    sm.def("overloaded3", [](py::array_t<double>) { return "double"; }, py::arg{}.noconvert());
+    sm.def(
+        "overloaded3",
+        // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        [](py::array_t<int>) { return "int"; },
+        py::arg{}.noconvert());
+    sm.def(
+        "overloaded3",
+        // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        [](py::array_t<double>) { return "double"; },
+        py::arg{}.noconvert());
 
     // Make sure we don't do unsafe coercion (e.g. float to int) when not using forcecast, but
     // rather that float gets converted via the safe (conversion to double) overload:

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -21,8 +21,7 @@ struct DtypeCheck {
     py::dtype pybind11{};
 };
 
-template <typename T>
-DtypeCheck get_dtype_check(const char* name) {
+template <typename T> DtypeCheck get_dtype_check(const char *name) {
     py::module_ np = py::module_::import("numpy");
     DtypeCheck check{};
     check.numpy = np.attr("dtype")(np.attr(name));
@@ -31,17 +30,11 @@ DtypeCheck get_dtype_check(const char* name) {
 }
 
 std::vector<DtypeCheck> get_concrete_dtype_checks() {
-    return {
-        // Normalization
-        get_dtype_check<std::int8_t>("int8"),
-        get_dtype_check<std::uint8_t>("uint8"),
-        get_dtype_check<std::int16_t>("int16"),
-        get_dtype_check<std::uint16_t>("uint16"),
-        get_dtype_check<std::int32_t>("int32"),
-        get_dtype_check<std::uint32_t>("uint32"),
-        get_dtype_check<std::int64_t>("int64"),
-        get_dtype_check<std::uint64_t>("uint64")
-    };
+    return {// Normalization
+            get_dtype_check<std::int8_t>("int8"),   get_dtype_check<std::uint8_t>("uint8"),
+            get_dtype_check<std::int16_t>("int16"), get_dtype_check<std::uint16_t>("uint16"),
+            get_dtype_check<std::int32_t>("int32"), get_dtype_check<std::uint32_t>("uint32"),
+            get_dtype_check<std::int64_t>("int64"), get_dtype_check<std::uint64_t>("uint64")};
 }
 
 struct DtypeSizeCheck {
@@ -52,8 +45,7 @@ struct DtypeSizeCheck {
     py::dtype dtype{};
 };
 
-template <typename T>
-DtypeSizeCheck get_dtype_size_check() {
+template <typename T> DtypeSizeCheck get_dtype_size_check() {
     DtypeSizeCheck check{};
     check.name = py::type_id<T>();
     check.size_cpp = sizeof(T);
@@ -64,14 +56,10 @@ DtypeSizeCheck get_dtype_size_check() {
 
 std::vector<DtypeSizeCheck> get_platform_dtype_size_checks() {
     return {
-        get_dtype_size_check<short>(),
-        get_dtype_size_check<unsigned short>(),
-        get_dtype_size_check<int>(),
-        get_dtype_size_check<unsigned int>(),
-        get_dtype_size_check<long>(),
-        get_dtype_size_check<unsigned long>(),
-        get_dtype_size_check<long long>(),
-        get_dtype_size_check<unsigned long long>(),
+        get_dtype_size_check<short>(),     get_dtype_size_check<unsigned short>(),
+        get_dtype_size_check<int>(),       get_dtype_size_check<unsigned int>(),
+        get_dtype_size_check<long>(),      get_dtype_size_check<unsigned long>(),
+        get_dtype_size_check<long long>(), get_dtype_size_check<unsigned long long>(),
     };
 }
 
@@ -80,43 +68,55 @@ using arr = py::array;
 using arr_t = py::array_t<uint16_t, 0>;
 static_assert(std::is_same<arr_t::value_type, uint16_t>::value, "");
 
-template<typename... Ix> arr data(const arr& a, Ix... index) {
-    return arr(a.nbytes() - a.offset_at(index...), (const uint8_t *) a.data(index...));
+template <typename... Ix> arr data(const arr &a, Ix... index) {
+    return arr(a.nbytes() - a.offset_at(index...), (const uint8_t *)a.data(index...));
 }
 
-template<typename... Ix> arr data_t(const arr_t& a, Ix... index) {
+template <typename... Ix> arr data_t(const arr_t &a, Ix... index) {
     return arr(a.size() - a.index_at(index...), a.data(index...));
 }
 
-template<typename... Ix> arr& mutate_data(arr& a, Ix... index) {
-    auto ptr = (uint8_t *) a.mutable_data(index...);
+template <typename... Ix> arr &mutate_data(arr &a, Ix... index) {
+    auto ptr = (uint8_t *)a.mutable_data(index...);
     for (py::ssize_t i = 0; i < a.nbytes() - a.offset_at(index...); i++)
-        ptr[i] = (uint8_t) (ptr[i] * 2);
+        ptr[i] = (uint8_t)(ptr[i] * 2);
     return a;
 }
 
-template<typename... Ix> arr_t& mutate_data_t(arr_t& a, Ix... index) {
+template <typename... Ix> arr_t &mutate_data_t(arr_t &a, Ix... index) {
     auto ptr = a.mutable_data(index...);
     for (py::ssize_t i = 0; i < a.size() - a.index_at(index...); i++)
         ptr[i]++;
     return a;
 }
 
-template<typename... Ix> py::ssize_t index_at(const arr& a, Ix... idx) { return a.index_at(idx...); }
-template<typename... Ix> py::ssize_t index_at_t(const arr_t& a, Ix... idx) { return a.index_at(idx...); }
-template<typename... Ix> py::ssize_t offset_at(const arr& a, Ix... idx) { return a.offset_at(idx...); }
-template<typename... Ix> py::ssize_t offset_at_t(const arr_t& a, Ix... idx) { return a.offset_at(idx...); }
-template<typename... Ix> py::ssize_t at_t(const arr_t& a, Ix... idx) { return a.at(idx...); }
-template<typename... Ix> arr_t& mutate_at_t(arr_t& a, Ix... idx) { a.mutable_at(idx...)++; return a; }
+template <typename... Ix> py::ssize_t index_at(const arr &a, Ix... idx) {
+    return a.index_at(idx...);
+}
+template <typename... Ix> py::ssize_t index_at_t(const arr_t &a, Ix... idx) {
+    return a.index_at(idx...);
+}
+template <typename... Ix> py::ssize_t offset_at(const arr &a, Ix... idx) {
+    return a.offset_at(idx...);
+}
+template <typename... Ix> py::ssize_t offset_at_t(const arr_t &a, Ix... idx) {
+    return a.offset_at(idx...);
+}
+template <typename... Ix> py::ssize_t at_t(const arr_t &a, Ix... idx) { return a.at(idx...); }
+template <typename... Ix> arr_t &mutate_at_t(arr_t &a, Ix... idx) {
+    a.mutable_at(idx...)++;
+    return a;
+}
 
-#define def_index_fn(name, type) \
-    sm.def(#name, [](type a) { return name(a); }); \
-    sm.def(#name, [](type a, int i) { return name(a, i); }); \
-    sm.def(#name, [](type a, int i, int j) { return name(a, i, j); }); \
+#define def_index_fn(name, type)                                                                  \
+    sm.def(#name, [](type a) { return name(a); });                                                \
+    sm.def(#name, [](type a, int i) { return name(a, i); });                                      \
+    sm.def(#name, [](type a, int i, int j) { return name(a, i, j); });                            \
     sm.def(#name, [](type a, int i, int j, int k) { return name(a, i, j, k); });
 
 template <typename T, typename T2> py::handle auxiliaries(T &&r, T2 &&r2) {
-    if (r.ndim() != 2) throw std::domain_error("error: ndim != 2");
+    if (r.ndim() != 2)
+        throw std::domain_error("error: ndim != 2");
     py::list l;
     l.append(*r.data(0, 0));
     l.append(*r2.mutable_data(0, 0));
@@ -134,16 +134,18 @@ template <typename T, typename T2> py::handle auxiliaries(T &&r, T2 &&r2) {
 static int data_i = 42;
 
 TEST_SUBMODULE(numpy_array, sm) {
-    try { py::module_::import("numpy"); }
-    catch (...) { return; }
+    try {
+        py::module_::import("numpy");
+    } catch (...) {
+        return;
+    }
 
     // test_dtypes
     py::class_<DtypeCheck>(sm, "DtypeCheck")
         .def_readonly("numpy", &DtypeCheck::numpy)
         .def_readonly("pybind11", &DtypeCheck::pybind11)
-        .def("__repr__", [](const DtypeCheck& self) {
-            return py::str("<DtypeCheck numpy={} pybind11={}>").format(
-                self.numpy, self.pybind11);
+        .def("__repr__", [](const DtypeCheck &self) {
+            return py::str("<DtypeCheck numpy={} pybind11={}>").format(self.numpy, self.pybind11);
         });
     sm.def("get_concrete_dtype_checks", &get_concrete_dtype_checks);
 
@@ -151,41 +153,41 @@ TEST_SUBMODULE(numpy_array, sm) {
         .def_readonly("name", &DtypeSizeCheck::name)
         .def_readonly("size_cpp", &DtypeSizeCheck::size_cpp)
         .def_readonly("size_numpy", &DtypeSizeCheck::size_numpy)
-        .def("__repr__", [](const DtypeSizeCheck& self) {
-            return py::str("<DtypeSizeCheck name='{}' size_cpp={} size_numpy={} dtype={}>").format(
-                self.name, self.size_cpp, self.size_numpy, self.dtype);
+        .def("__repr__", [](const DtypeSizeCheck &self) {
+            return py::str("<DtypeSizeCheck name='{}' size_cpp={} size_numpy={} dtype={}>")
+                .format(self.name, self.size_cpp, self.size_numpy, self.dtype);
         });
     sm.def("get_platform_dtype_size_checks", &get_platform_dtype_size_checks);
 
     // test_array_attributes
-    sm.def("ndim", [](const arr& a) { return a.ndim(); });
-    sm.def("shape", [](const arr& a) { return arr(a.ndim(), a.shape()); });
-    sm.def("shape", [](const arr& a, py::ssize_t dim) { return a.shape(dim); });
-    sm.def("strides", [](const arr& a) { return arr(a.ndim(), a.strides()); });
-    sm.def("strides", [](const arr& a, py::ssize_t dim) { return a.strides(dim); });
-    sm.def("writeable", [](const arr& a) { return a.writeable(); });
-    sm.def("size", [](const arr& a) { return a.size(); });
-    sm.def("itemsize", [](const arr& a) { return a.itemsize(); });
-    sm.def("nbytes", [](const arr& a) { return a.nbytes(); });
-    sm.def("owndata", [](const arr& a) { return a.owndata(); });
+    sm.def("ndim", [](const arr &a) { return a.ndim(); });
+    sm.def("shape", [](const arr &a) { return arr(a.ndim(), a.shape()); });
+    sm.def("shape", [](const arr &a, py::ssize_t dim) { return a.shape(dim); });
+    sm.def("strides", [](const arr &a) { return arr(a.ndim(), a.strides()); });
+    sm.def("strides", [](const arr &a, py::ssize_t dim) { return a.strides(dim); });
+    sm.def("writeable", [](const arr &a) { return a.writeable(); });
+    sm.def("size", [](const arr &a) { return a.size(); });
+    sm.def("itemsize", [](const arr &a) { return a.itemsize(); });
+    sm.def("nbytes", [](const arr &a) { return a.nbytes(); });
+    sm.def("owndata", [](const arr &a) { return a.owndata(); });
 
     // test_index_offset
-    def_index_fn(index_at, const arr&);
-    def_index_fn(index_at_t, const arr_t&);
-    def_index_fn(offset_at, const arr&);
-    def_index_fn(offset_at_t, const arr_t&);
+    def_index_fn(index_at, const arr &);
+    def_index_fn(index_at_t, const arr_t &);
+    def_index_fn(offset_at, const arr &);
+    def_index_fn(offset_at_t, const arr_t &);
     // test_data
-    def_index_fn(data, const arr&);
-    def_index_fn(data_t, const arr_t&);
+    def_index_fn(data, const arr &);
+    def_index_fn(data_t, const arr_t &);
     // test_mutate_data, test_mutate_readonly
-    def_index_fn(mutate_data, arr&);
-    def_index_fn(mutate_data_t, arr_t&);
-    def_index_fn(at_t, const arr_t&);
-    def_index_fn(mutate_at_t, arr_t&);
+    def_index_fn(mutate_data, arr &);
+    def_index_fn(mutate_data_t, arr_t &);
+    def_index_fn(at_t, const arr_t &);
+    def_index_fn(mutate_at_t, arr_t &);
 
     // test_make_c_f_array
-    sm.def("make_f_array", [] { return py::array_t<float>({ 2, 2 }, { 4, 8 }); });
-    sm.def("make_c_array", [] { return py::array_t<float>({ 2, 2 }, { 8, 4 }); });
+    sm.def("make_f_array", [] { return py::array_t<float>({2, 2}, {4, 8}); });
+    sm.def("make_c_array", [] { return py::array_t<float>({2, 2}, {8, 4}); });
 
     // test_empty_shaped_array
     sm.def("make_empty_shaped_array", [] { return py::array(py::dtype("f"), {}, {}); });
@@ -194,18 +196,13 @@ TEST_SUBMODULE(numpy_array, sm) {
 
     // test_wrap
     sm.def("wrap", [](const py::array &a) {
-        return py::array(
-            a.dtype(),
-            {a.shape(), a.shape() + a.ndim()},
-            {a.strides(), a.strides() + a.ndim()},
-            a.data(),
-            a
-        );
+        return py::array(a.dtype(), {a.shape(), a.shape() + a.ndim()},
+                         {a.strides(), a.strides() + a.ndim()}, a.data(), a);
     });
 
     // test_numpy_view
     struct ArrayClass {
-        int data[2] = { 1, 2 };
+        int data[2] = {1, 2};
         ArrayClass() { py::print("ArrayClass()"); }
         ~ArrayClass() { py::print("~ArrayClass()"); }
     };
@@ -213,18 +210,17 @@ TEST_SUBMODULE(numpy_array, sm) {
         .def(py::init<>())
         .def("numpy_view", [](py::object &obj) {
             py::print("ArrayClass::numpy_view()");
-            auto &a = obj.cast<ArrayClass&>();
+            auto &a = obj.cast<ArrayClass &>();
             return py::array_t<int>({2}, {4}, a.data, obj);
-        }
-    );
+        });
 
     // test_cast_numpy_int64_to_uint64
-    sm.def("function_taking_uint64", [](uint64_t) { });
+    sm.def("function_taking_uint64", [](uint64_t) {});
 
     // test_isinstance
     sm.def("isinstance_untyped", [](py::object yes, py::object no) {
-        return py::isinstance<py::array>(std::move(yes))
-               && !py::isinstance<py::array>(std::move(no));
+        return py::isinstance<py::array>(std::move(yes)) &&
+               !py::isinstance<py::array>(std::move(no));
     });
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     sm.def("isinstance_typed", [](py::object o) {
@@ -233,18 +229,13 @@ TEST_SUBMODULE(numpy_array, sm) {
 
     // test_constructors
     sm.def("default_constructors", []() {
-        return py::dict(
-            "array"_a=py::array(),
-            "array_t<int32>"_a=py::array_t<std::int32_t>(),
-            "array_t<double>"_a=py::array_t<double>()
-        );
+        return py::dict("array"_a = py::array(), "array_t<int32>"_a = py::array_t<std::int32_t>(),
+                        "array_t<double>"_a = py::array_t<double>());
     });
     sm.def("converting_constructors", [](const py::object &o) {
-        return py::dict(
-            "array"_a=py::array(o),
-            "array_t<int32>"_a=py::array_t<std::int32_t>(o),
-            "array_t<double>"_a=py::array_t<double>(o)
-        );
+        return py::dict("array"_a = py::array(o),
+                        "array_t<int32>"_a = py::array_t<std::int32_t>(o),
+                        "array_t<double>"_a = py::array_t<double>(o));
     });
 
     // test_overload_resolution
@@ -278,13 +269,11 @@ TEST_SUBMODULE(numpy_array, sm) {
     sm.def(
         "overloaded3",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<int>) { return "int"; },
-        py::arg{}.noconvert());
+        [](py::array_t<int>) { return "int"; }, py::arg{}.noconvert());
     sm.def(
         "overloaded3",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double>) { return "double"; },
-        py::arg{}.noconvert());
+        [](py::array_t<double>) { return "double"; }, py::arg{}.noconvert());
 
     // Make sure we don't do unsafe coercion (e.g. float to int) when not using forcecast, but
     // rather that float gets converted via the safe (conversion to double) overload:
@@ -310,29 +299,32 @@ TEST_SUBMODULE(numpy_array, sm) {
     sm.def("issue685", [](py::object) { return "other"; });
 
     // test_array_unchecked_fixed_dims
-    sm.def("proxy_add2", [](py::array_t<double> a, double v) {
-        auto r = a.mutable_unchecked<2>();
-        for (py::ssize_t i = 0; i < r.shape(0); i++)
-            for (py::ssize_t j = 0; j < r.shape(1); j++)
-                r(i, j) += v;
-    }, py::arg{}.noconvert(), py::arg());
+    sm.def(
+        "proxy_add2",
+        [](py::array_t<double> a, double v) {
+            auto r = a.mutable_unchecked<2>();
+            for (py::ssize_t i = 0; i < r.shape(0); i++)
+                for (py::ssize_t j = 0; j < r.shape(1); j++)
+                    r(i, j) += v;
+        },
+        py::arg{}.noconvert(), py::arg());
 
     sm.def("proxy_init3", [](double start) {
-        py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
+        py::array_t<double, py::array::c_style> a({3, 3, 3});
         auto r = a.mutable_unchecked<3>();
         for (py::ssize_t i = 0; i < r.shape(0); i++)
-        for (py::ssize_t j = 0; j < r.shape(1); j++)
-        for (py::ssize_t k = 0; k < r.shape(2); k++)
-            r(i, j, k) = start++;
+            for (py::ssize_t j = 0; j < r.shape(1); j++)
+                for (py::ssize_t k = 0; k < r.shape(2); k++)
+                    r(i, j, k) = start++;
         return a;
     });
     sm.def("proxy_init3F", [](double start) {
-        py::array_t<double, py::array::f_style> a({ 3, 3, 3 });
+        py::array_t<double, py::array::f_style> a({3, 3, 3});
         auto r = a.mutable_unchecked<3>();
         for (py::ssize_t k = 0; k < r.shape(2); k++)
-        for (py::ssize_t j = 0; j < r.shape(1); j++)
-        for (py::ssize_t i = 0; i < r.shape(0); i++)
-            r(i, j, k) = start++;
+            for (py::ssize_t j = 0; j < r.shape(1); j++)
+                for (py::ssize_t i = 0; i < r.shape(0); i++)
+                    r(i, j, k) = start++;
         return a;
     });
     sm.def("proxy_squared_L2_norm", [](const py::array_t<double> &a) {
@@ -363,51 +355,60 @@ TEST_SUBMODULE(numpy_array, sm) {
 
     // test_array_unchecked_dyn_dims
     // Same as the above, but without a compile-time dimensions specification:
-    sm.def("proxy_add2_dyn", [](py::array_t<double> a, double v) {
+    sm.def(
+        "proxy_add2_dyn",
+        [](py::array_t<double> a, double v) {
+            auto r = a.mutable_unchecked();
+            if (r.ndim() != 2)
+                throw std::domain_error("error: ndim != 2");
+            for (py::ssize_t i = 0; i < r.shape(0); i++)
+                for (py::ssize_t j = 0; j < r.shape(1); j++)
+                    r(i, j) += v;
+        },
+        py::arg{}.noconvert(), py::arg());
+    sm.def("proxy_init3_dyn", [](double start) {
+        py::array_t<double, py::array::c_style> a({3, 3, 3});
         auto r = a.mutable_unchecked();
-        if (r.ndim() != 2) throw std::domain_error("error: ndim != 2");
+        if (r.ndim() != 3)
+            throw std::domain_error("error: ndim != 3");
         for (py::ssize_t i = 0; i < r.shape(0); i++)
             for (py::ssize_t j = 0; j < r.shape(1); j++)
-                r(i, j) += v;
-    }, py::arg{}.noconvert(), py::arg());
-    sm.def("proxy_init3_dyn", [](double start) {
-        py::array_t<double, py::array::c_style> a({ 3, 3, 3 });
-        auto r = a.mutable_unchecked();
-        if (r.ndim() != 3) throw std::domain_error("error: ndim != 3");
-        for (py::ssize_t i = 0; i < r.shape(0); i++)
-        for (py::ssize_t j = 0; j < r.shape(1); j++)
-        for (py::ssize_t k = 0; k < r.shape(2); k++)
-            r(i, j, k) = start++;
+                for (py::ssize_t k = 0; k < r.shape(2); k++)
+                    r(i, j, k) = start++;
         return a;
     });
     sm.def("proxy_auxiliaries2_dyn", [](py::array_t<double> a) {
         return auxiliaries(a.unchecked(), a.mutable_unchecked());
     });
 
-    sm.def("array_auxiliaries2", [](py::array_t<double> a) {
-        return auxiliaries(a, a);
-    });
+    sm.def("array_auxiliaries2", [](py::array_t<double> a) { return auxiliaries(a, a); });
 
     // test_array_failures
-    // Issue #785: Uninformative "Unknown internal error" exception when constructing array from empty object:
+    // Issue #785: Uninformative "Unknown internal error" exception when constructing array from
+    // empty object:
     sm.def("array_fail_test", []() { return py::array(py::object()); });
     sm.def("array_t_fail_test", []() { return py::array_t<double>(py::object()); });
     // Make sure the error from numpy is being passed through:
-    sm.def("array_fail_test_negative_size", []() { int c = 0; return py::array(-1, &c); });
+    sm.def("array_fail_test_negative_size", []() {
+        int c = 0;
+        return py::array(-1, &c);
+    });
 
     // test_initializer_list
     // Issue (unnumbered; reported in #788): regression: initializer lists can be ambiguous
-    sm.def("array_initializer_list1", []() { return py::array_t<float>(1); }); // { 1 } also works, but clang warns about it
-    sm.def("array_initializer_list2", []() { return py::array_t<float>({ 1, 2 }); });
-    sm.def("array_initializer_list3", []() { return py::array_t<float>({ 1, 2, 3 }); });
-    sm.def("array_initializer_list4", []() { return py::array_t<float>({ 1, 2, 3, 4 }); });
+    sm.def("array_initializer_list1",
+           []() { return py::array_t<float>(1); }); // { 1 } also works, but clang warns about it
+    sm.def("array_initializer_list2", []() { return py::array_t<float>({1, 2}); });
+    sm.def("array_initializer_list3", []() { return py::array_t<float>({1, 2, 3}); });
+    sm.def("array_initializer_list4", []() { return py::array_t<float>({1, 2, 3, 4}); });
 
     // test_array_resize
     // reshape array to 2D without changing size
     sm.def("array_reshape2", [](py::array_t<double> a) {
         const auto dim_sz = (py::ssize_t)std::sqrt(a.size());
         if (dim_sz * dim_sz != a.size())
-            throw std::domain_error("array_reshape2: input array total size is not a squared integer");
+            throw std::domain_error(
+                "array_reshape2: input array total size is not a squared integer");
         a.resize({dim_sz, dim_sz});
     });
 
@@ -432,63 +433,51 @@ TEST_SUBMODULE(numpy_array, sm) {
     sm.def(
         "accept_double",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, 0>) {},
-        py::arg("a"));
+        [](py::array_t<double, 0>) {}, py::arg("a"));
     sm.def(
         "accept_double_forcecast",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, py::array::forcecast>) {},
-        py::arg("a"));
+        [](py::array_t<double, py::array::forcecast>) {}, py::arg("a"));
     sm.def(
         "accept_double_c_style",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, py::array::c_style>) {},
-        py::arg("a"));
+        [](py::array_t<double, py::array::c_style>) {}, py::arg("a"));
     sm.def(
         "accept_double_c_style_forcecast",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, py::array::forcecast | py::array::c_style>) {},
-        py::arg("a"));
+        [](py::array_t<double, py::array::forcecast | py::array::c_style>) {}, py::arg("a"));
     sm.def(
         "accept_double_f_style",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, py::array::f_style>) {},
-        py::arg("a"));
+        [](py::array_t<double, py::array::f_style>) {}, py::arg("a"));
     sm.def(
         "accept_double_f_style_forcecast",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, py::array::forcecast | py::array::f_style>) {},
-        py::arg("a"));
+        [](py::array_t<double, py::array::forcecast | py::array::f_style>) {}, py::arg("a"));
     sm.def(
         "accept_double_noconvert",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, 0>) {},
-        "a"_a.noconvert());
+        [](py::array_t<double, 0>) {}, "a"_a.noconvert());
     sm.def(
         "accept_double_forcecast_noconvert",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, py::array::forcecast>) {},
-        "a"_a.noconvert());
+        [](py::array_t<double, py::array::forcecast>) {}, "a"_a.noconvert());
     sm.def(
         "accept_double_c_style_noconvert",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, py::array::c_style>) {},
-        "a"_a.noconvert());
+        [](py::array_t<double, py::array::c_style>) {}, "a"_a.noconvert());
     sm.def(
         "accept_double_c_style_forcecast_noconvert",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, py::array::forcecast | py::array::c_style>) {},
-        "a"_a.noconvert());
+        [](py::array_t<double, py::array::forcecast | py::array::c_style>) {}, "a"_a.noconvert());
     sm.def(
         "accept_double_f_style_noconvert",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, py::array::f_style>) {},
-        "a"_a.noconvert());
+        [](py::array_t<double, py::array::f_style>) {}, "a"_a.noconvert());
     sm.def(
         "accept_double_f_style_forcecast_noconvert",
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](py::array_t<double, py::array::forcecast | py::array::f_style>) {},
-        "a"_a.noconvert());
+        [](py::array_t<double, py::array::forcecast | py::array::f_style>) {}, "a"_a.noconvert());
 
     // Check that types returns correct npy format descriptor
     // NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -25,7 +25,7 @@ struct SimpleStruct {
     long double ldbl_;
 };
 
-std::ostream& operator<<(std::ostream& os, const SimpleStruct& v) {
+std::ostream &operator<<(std::ostream &os, const SimpleStruct &v) {
     return os << "s:" << v.bool_ << "," << v.uint_ << "," << v.float_ << "," << v.ldbl_;
 }
 
@@ -43,7 +43,7 @@ PYBIND11_PACKED(struct PackedStruct {
     long double ldbl_;
 });
 
-std::ostream& operator<<(std::ostream& os, const PackedStruct& v) {
+std::ostream &operator<<(std::ostream &os, const PackedStruct &v) {
     return os << "p:" << v.bool_ << "," << v.uint_ << "," << v.float_ << "," << v.ldbl_;
 }
 
@@ -52,7 +52,7 @@ PYBIND11_PACKED(struct NestedStruct {
     PackedStruct b;
 });
 
-std::ostream& operator<<(std::ostream& os, const NestedStruct& v) {
+std::ostream &operator<<(std::ostream &os, const NestedStruct &v) {
     return os << "n:a=" << v.a << ";b=" << v.b;
 }
 
@@ -70,7 +70,7 @@ struct PartialNestedStruct {
     uint64_t dummy2;
 };
 
-struct UnboundStruct { };
+struct UnboundStruct {};
 
 struct StringStruct {
     char a[3];
@@ -82,7 +82,7 @@ struct ComplexStruct {
     std::complex<double> cdbl;
 };
 
-std::ostream& operator<<(std::ostream& os, const ComplexStruct& v) {
+std::ostream &operator<<(std::ostream &os, const ComplexStruct &v) {
     return os << "c:" << v.cflt << "," << v.cdbl;
 }
 
@@ -106,15 +106,17 @@ PYBIND11_PACKED(struct EnumStruct {
     E2 e2;
 });
 
-std::ostream& operator<<(std::ostream& os, const StringStruct& v) {
+std::ostream &operator<<(std::ostream &os, const StringStruct &v) {
     os << "a='";
-    for (size_t i = 0; i < 3 && v.a[i]; i++) os << v.a[i];
+    for (size_t i = 0; i < 3 && v.a[i]; i++)
+        os << v.a[i];
     os << "',b='";
-    for (size_t i = 0; i < 3 && v.b[i]; i++) os << v.b[i];
+    for (size_t i = 0; i < 3 && v.b[i]; i++)
+        os << v.b[i];
     return os << "'";
 }
 
-std::ostream& operator<<(std::ostream& os, const ArrayStruct& v) {
+std::ostream &operator<<(std::ostream &os, const ArrayStruct &v) {
     os << "a={";
     for (int i = 0; i < 3; i++) {
         if (i > 0)
@@ -135,38 +137,36 @@ std::ostream& operator<<(std::ostream& os, const ArrayStruct& v) {
     return os << '}';
 }
 
-std::ostream& operator<<(std::ostream& os, const EnumStruct& v) {
+std::ostream &operator<<(std::ostream &os, const EnumStruct &v) {
     return os << "e1=" << (v.e1 == E1::A ? "A" : "B") << ",e2=" << (v.e2 == E2::X ? "X" : "Y");
 }
 
-template <typename T>
-py::array mkarray_via_buffer(size_t n) {
-    return py::array(py::buffer_info(nullptr, sizeof(T),
-                                     py::format_descriptor<T>::format(),
-                                     1, { n }, { sizeof(T) }));
+template <typename T> py::array mkarray_via_buffer(size_t n) {
+    return py::array(py::buffer_info(nullptr, sizeof(T), py::format_descriptor<T>::format(), 1,
+                                     {n}, {sizeof(T)}));
 }
 
-#define SET_TEST_VALS(s, i) do { \
-    s.bool_ = (i) % 2 != 0; \
-    s.uint_ = (uint32_t) (i); \
-    s.float_ = (float) (i) * 1.5f; \
-    s.ldbl_ = (long double) (i) * -2.5L; } while (0)
+#define SET_TEST_VALS(s, i)                                                                       \
+    do {                                                                                          \
+        s.bool_ = (i) % 2 != 0;                                                                   \
+        s.uint_ = (uint32_t)(i);                                                                  \
+        s.float_ = (float)(i)*1.5f;                                                               \
+        s.ldbl_ = (long double)(i) * -2.5L;                                                       \
+    } while (0)
 
-template <typename S>
-py::array_t<S, 0> create_recarray(size_t n) {
+template <typename S> py::array_t<S, 0> create_recarray(size_t n) {
     auto arr = mkarray_via_buffer<S>(n);
     auto req = arr.request();
-    auto ptr = static_cast<S*>(req.ptr);
+    auto ptr = static_cast<S *>(req.ptr);
     for (size_t i = 0; i < n; i++) {
         SET_TEST_VALS(ptr[i], i);
     }
     return arr;
 }
 
-template <typename S>
-py::list print_recarray(py::array_t<S, 0> arr) {
+template <typename S> py::list print_recarray(py::array_t<S, 0> arr) {
     const auto req = arr.request();
-    const auto ptr = static_cast<S*>(req.ptr);
+    const auto ptr = static_cast<S *>(req.ptr);
     auto l = py::list();
     for (py::ssize_t i = 0; i < req.size; i++) {
         std::stringstream ss;
@@ -179,12 +179,12 @@ py::list print_recarray(py::array_t<S, 0> arr) {
 py::array_t<int32_t, 0> test_array_ctors(int i) {
     using arr_t = py::array_t<int32_t, 0>;
 
-    std::vector<int32_t> data { 1, 2, 3, 4, 5, 6 };
-    std::vector<py::ssize_t> shape { 3, 2 };
-    std::vector<py::ssize_t> strides { 8, 4 };
+    std::vector<int32_t> data{1, 2, 3, 4, 5, 6};
+    std::vector<py::ssize_t> shape{3, 2};
+    std::vector<py::ssize_t> strides{8, 4};
 
     auto ptr = data.data();
-    auto vptr = (void *) ptr;
+    auto vptr = (void *)ptr;
     auto dtype = py::dtype("int32");
 
     py::buffer_info buf_ndim1(vptr, 4, "i", 6);
@@ -194,41 +194,68 @@ py::array_t<int32_t, 0> test_array_ctors(int i) {
 
     auto fill = [](py::array arr) {
         auto req = arr.request();
-        for (int i = 0; i < 6; i++) ((int32_t *) req.ptr)[i] = i + 1;
+        for (int i = 0; i < 6; i++)
+            ((int32_t *)req.ptr)[i] = i + 1;
         return arr;
     };
 
     switch (i) {
     // shape: (3, 2)
-    case 10: return arr_t(shape, strides, ptr);
-    case 11: return py::array(shape, strides, ptr);
-    case 12: return py::array(dtype, shape, strides, vptr);
-    case 13: return arr_t(shape, ptr);
-    case 14: return py::array(shape, ptr);
-    case 15: return py::array(dtype, shape, vptr);
-    case 16: return arr_t(buf_ndim2);
-    case 17: return py::array(buf_ndim2);
+    case 10:
+        return arr_t(shape, strides, ptr);
+    case 11:
+        return py::array(shape, strides, ptr);
+    case 12:
+        return py::array(dtype, shape, strides, vptr);
+    case 13:
+        return arr_t(shape, ptr);
+    case 14:
+        return py::array(shape, ptr);
+    case 15:
+        return py::array(dtype, shape, vptr);
+    case 16:
+        return arr_t(buf_ndim2);
+    case 17:
+        return py::array(buf_ndim2);
     // shape: (3, 2) - post-fill
-    case 20: return fill(arr_t(shape, strides));
-    case 21: return py::array(shape, strides, ptr); // can't have nullptr due to templated ctor
-    case 22: return fill(py::array(dtype, shape, strides));
-    case 23: return fill(arr_t(shape));
-    case 24: return py::array(shape, ptr); // can't have nullptr due to templated ctor
-    case 25: return fill(py::array(dtype, shape));
-    case 26: return fill(arr_t(buf_ndim2_null));
-    case 27: return fill(py::array(buf_ndim2_null));
+    case 20:
+        return fill(arr_t(shape, strides));
+    case 21:
+        return py::array(shape, strides, ptr); // can't have nullptr due to templated ctor
+    case 22:
+        return fill(py::array(dtype, shape, strides));
+    case 23:
+        return fill(arr_t(shape));
+    case 24:
+        return py::array(shape, ptr); // can't have nullptr due to templated ctor
+    case 25:
+        return fill(py::array(dtype, shape));
+    case 26:
+        return fill(arr_t(buf_ndim2_null));
+    case 27:
+        return fill(py::array(buf_ndim2_null));
     // shape: (6, )
-    case 30: return arr_t(6, ptr);
-    case 31: return py::array(6, ptr);
-    case 32: return py::array(dtype, 6, vptr);
-    case 33: return arr_t(buf_ndim1);
-    case 34: return py::array(buf_ndim1);
+    case 30:
+        return arr_t(6, ptr);
+    case 31:
+        return py::array(6, ptr);
+    case 32:
+        return py::array(dtype, 6, vptr);
+    case 33:
+        return arr_t(buf_ndim1);
+    case 34:
+        return py::array(buf_ndim1);
     // shape: (6, )
-    case 40: return fill(arr_t(6));
-    case 41: return py::array(6, ptr);  // can't have nullptr due to templated ctor
-    case 42: return fill(py::array(dtype, 6));
-    case 43: return fill(arr_t(buf_ndim1_null));
-    case 44: return fill(py::array(buf_ndim1_null));
+    case 40:
+        return fill(arr_t(6));
+    case 41:
+        return py::array(6, ptr); // can't have nullptr due to templated ctor
+    case 42:
+        return fill(py::array(dtype, 6));
+    case 43:
+        return fill(arr_t(buf_ndim1_null));
+    case 44:
+        return fill(py::array(buf_ndim1_null));
     }
     return arr_t();
 }
@@ -240,14 +267,20 @@ py::list test_dtype_ctors() {
     list.append(py::dtype::from_args(py::str("bool")));
     py::list names, offsets, formats;
     py::dict dict;
-    names.append(py::str("a")); names.append(py::str("b")); dict["names"] = names;
-    offsets.append(py::int_(1)); offsets.append(py::int_(10)); dict["offsets"] = offsets;
-    formats.append(py::dtype("int32")); formats.append(py::dtype("float64")); dict["formats"] = formats;
+    names.append(py::str("a"));
+    names.append(py::str("b"));
+    dict["names"] = names;
+    offsets.append(py::int_(1));
+    offsets.append(py::int_(10));
+    dict["offsets"] = offsets;
+    formats.append(py::dtype("int32"));
+    formats.append(py::dtype("float64"));
+    dict["formats"] = formats;
     dict["itemsize"] = py::int_(20);
     list.append(py::dtype::from_args(dict));
     list.append(py::dtype(names, formats, offsets, 20));
-    list.append(py::dtype(py::buffer_info((void *) 0, sizeof(unsigned int), "I", 1)));
-    list.append(py::dtype(py::buffer_info((void *) 0, 0, "T{i:a:f:b:}", 1)));
+    list.append(py::dtype(py::buffer_info((void *)0, sizeof(unsigned int), "I", 1)));
+    list.append(py::dtype(py::buffer_info((void *)0, 0, "T{i:a:f:b:}", 1)));
     return list;
 }
 
@@ -255,8 +288,11 @@ struct A {};
 struct B {};
 
 TEST_SUBMODULE(numpy_dtypes, m) {
-    try { py::module_::import("numpy"); }
-    catch (...) { return; }
+    try {
+        py::module_::import("numpy");
+    } catch (...) {
+        return;
+    }
 
     // typeinfo may be registered before the dtype descriptor for scalar casts to work...
     py::class_<SimpleStruct>(m, "SimpleStruct")
@@ -274,11 +310,8 @@ TEST_SUBMODULE(numpy_dtypes, m) {
             if (py::len(tup) != 4) {
                 throw py::cast_error("Invalid size");
             }
-            return SimpleStruct{
-                tup[0].cast<bool>(),
-                tup[1].cast<uint32_t>(),
-                tup[2].cast<float>(),
-                tup[3].cast<long double>()};
+            return SimpleStruct{tup[0].cast<bool>(), tup[1].cast<uint32_t>(), tup[2].cast<float>(),
+                                tup[3].cast<long double>()};
         });
 
     PYBIND11_NUMPY_DTYPE(SimpleStruct, bool_, uint_, float_, ldbl_);
@@ -299,17 +332,14 @@ TEST_SUBMODULE(numpy_dtypes, m) {
 
     // If uncommented, this should produce a static_assert failure telling the user that the struct
     // is not a POD type
-//    struct NotPOD { std::string v; NotPOD() : v("hi") {}; };
-//    PYBIND11_NUMPY_DTYPE(NotPOD, v);
+    //    struct NotPOD { std::string v; NotPOD() : v("hi") {}; };
+    //    PYBIND11_NUMPY_DTYPE(NotPOD, v);
 
     // Check that dtypes can be registered programmatically, both from
     // initializer lists of field descriptors and from other containers.
-    py::detail::npy_format_descriptor<A>::register_dtype(
-        {}
-    );
+    py::detail::npy_format_descriptor<A>::register_dtype({});
     py::detail::npy_format_descriptor<B>::register_dtype(
-        std::vector<py::detail::field_descriptor>{}
-    );
+        std::vector<py::detail::field_descriptor>{});
 
     // test_recarray, test_scalar_conversion
     m.def("create_rec_simple", &create_recarray<SimpleStruct>);
@@ -317,7 +347,7 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     m.def("create_rec_nested", [](size_t n) { // test_signature
         py::array_t<NestedStruct, 0> arr = mkarray_via_buffer<NestedStruct>(n);
         auto req = arr.request();
-        auto ptr = static_cast<NestedStruct*>(req.ptr);
+        auto ptr = static_cast<NestedStruct *>(req.ptr);
         for (size_t i = 0; i < n; i++) {
             SET_TEST_VALS(ptr[i].a, i);
             SET_TEST_VALS(ptr[i].b, i + 1);
@@ -328,7 +358,7 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     m.def("create_rec_partial_nested", [](size_t n) {
         py::array_t<PartialNestedStruct, 0> arr = mkarray_via_buffer<PartialNestedStruct>(n);
         auto req = arr.request();
-        auto ptr = static_cast<PartialNestedStruct*>(req.ptr);
+        auto ptr = static_cast<PartialNestedStruct *>(req.ptr);
         for (size_t i = 0; i < n; i++) {
             SET_TEST_VALS(ptr[i].a, i);
         }
@@ -342,17 +372,15 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     m.def("get_format_unbound", []() { return py::format_descriptor<UnboundStruct>::format(); });
     m.def("print_format_descriptors", []() {
         py::list l;
-        for (const auto &fmt : {
-            py::format_descriptor<SimpleStruct>::format(),
-            py::format_descriptor<PackedStruct>::format(),
-            py::format_descriptor<NestedStruct>::format(),
-            py::format_descriptor<PartialStruct>::format(),
-            py::format_descriptor<PartialNestedStruct>::format(),
-            py::format_descriptor<StringStruct>::format(),
-            py::format_descriptor<ArrayStruct>::format(),
-            py::format_descriptor<EnumStruct>::format(),
-            py::format_descriptor<ComplexStruct>::format()
-        }) {
+        for (const auto &fmt : {py::format_descriptor<SimpleStruct>::format(),
+                                py::format_descriptor<PackedStruct>::format(),
+                                py::format_descriptor<NestedStruct>::format(),
+                                py::format_descriptor<PartialStruct>::format(),
+                                py::format_descriptor<PartialNestedStruct>::format(),
+                                py::format_descriptor<StringStruct>::format(),
+                                py::format_descriptor<ArrayStruct>::format(),
+                                py::format_descriptor<EnumStruct>::format(),
+                                py::format_descriptor<ComplexStruct>::format()}) {
             l.append(py::cast(fmt));
         }
         return l;
@@ -360,40 +388,31 @@ TEST_SUBMODULE(numpy_dtypes, m) {
 
     // test_dtype
     std::vector<const char *> dtype_names{
-        "byte", "short", "intc", "int_", "longlong",
-        "ubyte", "ushort", "uintc", "uint", "ulonglong",
-        "half", "single", "double", "longdouble",
-        "csingle", "cdouble", "clongdouble",
-        "bool_", "datetime64", "timedelta64", "object_"
-    };
+        "byte",    "short",   "intc",        "int_",  "longlong",   "ubyte",       "ushort",
+        "uintc",   "uint",    "ulonglong",   "half",  "single",     "double",      "longdouble",
+        "csingle", "cdouble", "clongdouble", "bool_", "datetime64", "timedelta64", "object_"};
 
     m.def("print_dtypes", []() {
         py::list l;
-        for (const py::handle &d : {
-            py::dtype::of<SimpleStruct>(),
-            py::dtype::of<PackedStruct>(),
-            py::dtype::of<NestedStruct>(),
-            py::dtype::of<PartialStruct>(),
-            py::dtype::of<PartialNestedStruct>(),
-            py::dtype::of<StringStruct>(),
-            py::dtype::of<ArrayStruct>(),
-            py::dtype::of<EnumStruct>(),
-            py::dtype::of<StructWithUglyNames>(),
-            py::dtype::of<ComplexStruct>()
-        })
+        for (const py::handle &d :
+             {py::dtype::of<SimpleStruct>(), py::dtype::of<PackedStruct>(),
+              py::dtype::of<NestedStruct>(), py::dtype::of<PartialStruct>(),
+              py::dtype::of<PartialNestedStruct>(), py::dtype::of<StringStruct>(),
+              py::dtype::of<ArrayStruct>(), py::dtype::of<EnumStruct>(),
+              py::dtype::of<StructWithUglyNames>(), py::dtype::of<ComplexStruct>()})
             l.append(py::str(d));
         return l;
     });
     m.def("test_dtype_ctors", &test_dtype_ctors);
     m.def("test_dtype_kind", [dtype_names]() {
         py::list list;
-        for (auto& dt_name : dtype_names)
+        for (auto &dt_name : dtype_names)
             list.append(py::dtype(dt_name).kind());
         return list;
     });
     m.def("test_dtype_char_", [dtype_names]() {
         py::list list;
-        for (auto& dt_name : dtype_names)
+        for (auto &dt_name : dtype_names)
             list.append(py::dtype(dt_name).char_());
         return list;
     });
@@ -401,9 +420,12 @@ TEST_SUBMODULE(numpy_dtypes, m) {
         py::list list;
         auto dt1 = py::dtype::of<int32_t>();
         auto dt2 = py::dtype::of<SimpleStruct>();
-        list.append(dt1); list.append(dt2);
-        list.append(py::bool_(dt1.has_fields())); list.append(py::bool_(dt2.has_fields()));
-        list.append(py::int_(dt1.itemsize())); list.append(py::int_(dt2.itemsize()));
+        list.append(dt1);
+        list.append(dt2);
+        list.append(py::bool_(dt1.has_fields()));
+        list.append(py::bool_(dt2.has_fields()));
+        list.append(py::int_(dt1.itemsize()));
+        list.append(py::int_(dt2.itemsize()));
         return list;
     });
     struct TrailingPaddingStruct {
@@ -418,17 +440,23 @@ TEST_SUBMODULE(numpy_dtypes, m) {
         py::array_t<StringStruct, 0> arr = mkarray_via_buffer<StringStruct>(non_empty ? 4 : 0);
         if (non_empty) {
             auto req = arr.request();
-            auto ptr = static_cast<StringStruct*>(req.ptr);
+            auto ptr = static_cast<StringStruct *>(req.ptr);
             for (py::ssize_t i = 0; i < req.size * req.itemsize; i++)
-                static_cast<char*>(req.ptr)[i] = 0;
-            ptr[1].a[0] = 'a'; ptr[1].b[0] = 'a';
-            ptr[2].a[0] = 'a'; ptr[2].b[0] = 'a';
-            ptr[3].a[0] = 'a'; ptr[3].b[0] = 'a';
+                static_cast<char *>(req.ptr)[i] = 0;
+            ptr[1].a[0] = 'a';
+            ptr[1].b[0] = 'a';
+            ptr[2].a[0] = 'a';
+            ptr[2].b[0] = 'a';
+            ptr[3].a[0] = 'a';
+            ptr[3].b[0] = 'a';
 
-            ptr[2].a[1] = 'b'; ptr[2].b[1] = 'b';
-            ptr[3].a[1] = 'b'; ptr[3].b[1] = 'b';
+            ptr[2].a[1] = 'b';
+            ptr[2].b[1] = 'b';
+            ptr[3].a[1] = 'b';
+            ptr[3].b[1] = 'b';
 
-            ptr[3].a[2] = 'c'; ptr[3].b[2] = 'c';
+            ptr[3].a[2] = 'c';
+            ptr[3].b[2] = 'c';
         }
         return arr;
     });
@@ -437,7 +465,7 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     // test_array_array
     m.def("create_array_array", [](size_t n) {
         py::array_t<ArrayStruct, 0> arr = mkarray_via_buffer<ArrayStruct>(n);
-        auto ptr = (ArrayStruct *) arr.mutable_data();
+        auto ptr = (ArrayStruct *)arr.mutable_data();
         for (size_t i = 0; i < n; i++) {
             for (size_t j = 0; j < 3; j++)
                 for (size_t k = 0; k < 4; k++)
@@ -457,9 +485,9 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     // test_enum_array
     m.def("create_enum_array", [](size_t n) {
         py::array_t<EnumStruct, 0> arr = mkarray_via_buffer<EnumStruct>(n);
-        auto ptr = (EnumStruct *) arr.mutable_data();
+        auto ptr = (EnumStruct *)arr.mutable_data();
         for (size_t i = 0; i < n; i++) {
-            ptr[i].e1 = static_cast<E1>(-1 + ((int) i % 2) * 2);
+            ptr[i].e1 = static_cast<E1>(-1 + ((int)i % 2) * 2);
             ptr[i].e2 = static_cast<E2>(1 + (i % 2));
         }
         return arr;
@@ -469,7 +497,7 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     // test_complex_array
     m.def("create_complex_array", [](size_t n) {
         py::array_t<ComplexStruct, 0> arr = mkarray_via_buffer<ComplexStruct>(n);
-        auto ptr = (ComplexStruct *) arr.mutable_data();
+        auto ptr = (ComplexStruct *)arr.mutable_data();
         for (size_t i = 0; i < n; i++) {
             ptr[i].cflt.real(float(i));
             ptr[i].cflt.imag(float(i) + 0.25f);
@@ -492,14 +520,19 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     PYBIND11_NUMPY_DTYPE(CompareStruct, x, y, z);
     m.def("compare_buffer_info", []() {
         py::list list;
-        list.append(py::bool_(py::detail::compare_buffer_info<float>::compare(py::buffer_info(nullptr, sizeof(float), "f", 1))));
-        list.append(py::bool_(py::detail::compare_buffer_info<unsigned>::compare(py::buffer_info(nullptr, sizeof(int), "I", 1))));
-        list.append(py::bool_(py::detail::compare_buffer_info<long>::compare(py::buffer_info(nullptr, sizeof(long), "l", 1))));
-        list.append(py::bool_(py::detail::compare_buffer_info<long>::compare(py::buffer_info(nullptr, sizeof(long), sizeof(long) == sizeof(int) ? "i" : "q", 1))));
-        list.append(py::bool_(py::detail::compare_buffer_info<CompareStruct>::compare(py::buffer_info(nullptr, sizeof(CompareStruct), "T{?:x:3xI:y:f:z:}", 1))));
+        list.append(py::bool_(py::detail::compare_buffer_info<float>::compare(
+            py::buffer_info(nullptr, sizeof(float), "f", 1))));
+        list.append(py::bool_(py::detail::compare_buffer_info<unsigned>::compare(
+            py::buffer_info(nullptr, sizeof(int), "I", 1))));
+        list.append(py::bool_(py::detail::compare_buffer_info<long>::compare(
+            py::buffer_info(nullptr, sizeof(long), "l", 1))));
+        list.append(py::bool_(py::detail::compare_buffer_info<long>::compare(
+            py::buffer_info(nullptr, sizeof(long), sizeof(long) == sizeof(int) ? "i" : "q", 1))));
+        list.append(py::bool_(py::detail::compare_buffer_info<CompareStruct>::compare(
+            py::buffer_info(nullptr, sizeof(CompareStruct), "T{?:x:3xI:y:f:z:}", 1))));
         return list;
     });
-    m.def("buffer_to_dtype", [](py::buffer& buf) { return py::dtype(buf.request()); });
+    m.def("buffer_to_dtype", [](py::buffer &buf) { return py::dtype(buf.request()); });
 
     // test_scalar_conversion
     auto f_simple = [](SimpleStruct s) { return s.uint_ * 10; };
@@ -513,7 +546,8 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     m.def("f_simple_pass_thru_vectorized", py::vectorize(f_simple_pass_thru));
 
     // test_register_dtype
-    m.def("register_dtype", []() { PYBIND11_NUMPY_DTYPE(SimpleStruct, bool_, uint_, float_, ldbl_); });
+    m.def("register_dtype",
+          []() { PYBIND11_NUMPY_DTYPE(SimpleStruct, bool_, uint_, float_, ldbl_); });
 
     // test_str_leak
     m.def("dtype_wrapper", [](py::object d) { return py::dtype::from_args(std::move(d)); });

--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -38,15 +38,19 @@ TEST_SUBMODULE(numpy_vectorize, m) {
     ));
 
     // test_type_selection
-    // NumPy function which only accepts specific data types
-    // A lot of these no lints could be replaced with const refs, and probably should at some point.
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("selective_func", [](py::array_t<int, py::array::c_style>) { return "Int branch taken."; });
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("selective_func", [](py::array_t<float, py::array::c_style>) { return "Float branch taken."; });
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("selective_func", [](py::array_t<std::complex<float>, py::array::c_style>) { return "Complex float branch taken."; });
-
+    // A lot of these no lints could be replaced with const refs,
+    // and probably should at some point.
+    m.def("selective_func",
+          // NOLINTNEXTLINE(performance-unnecessary-value-param)
+          [](py::array_t<int, py::array::c_style>) { return "Int branch taken."; });
+    m.def("selective_func",
+          // NOLINTNEXTLINE(performance-unnecessary-value-param)
+          [](py::array_t<float, py::array::c_style>) { return "Float branch taken."; });
+    m.def("selective_func",
+          // NOLINTNEXTLINE(performance-unnecessary-value-param)
+          [](py::array_t<std::complex<float>, py::array::c_style>) {
+              return "Complex float branch taken.";
+          });
 
     // test_passthrough_arguments
     // Passthrough test: references and non-pod types should be automatically passed through (in the

--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -15,27 +15,30 @@
 
 double my_func(int x, float y, double z) {
     py::print("my_func(x:int={}, y:float={:.0f}, z:float={:.0f})"_s.format(x, y, z));
-    return (float) x*y*z;
+    return (float)x * y * z;
 }
 
 TEST_SUBMODULE(numpy_vectorize, m) {
-    try { py::module_::import("numpy"); }
-    catch (...) { return; }
+    try {
+        py::module_::import("numpy");
+    } catch (...) {
+        return;
+    }
 
     // test_vectorize, test_docs, test_array_collapse
     // Vectorize all arguments of a function (though non-vector arguments are also allowed)
     m.def("vectorized_func", py::vectorize(my_func));
 
-    // Vectorize a lambda function with a capture object (e.g. to exclude some arguments from the vectorization)
+    // Vectorize a lambda function with a capture object (e.g. to exclude some arguments from the
+    // vectorization)
     m.def("vectorized_func2", [](py::array_t<int> x, py::array_t<float> y, float z) {
         return py::vectorize([z](int x, float y) { return my_func(x, y, z); })(std::move(x),
                                                                                std::move(y));
     });
 
     // Vectorize a complex-valued function
-    m.def("vectorized_func3", py::vectorize(
-        [](std::complex<double> c) { return c * std::complex<double>(2.f); }
-    ));
+    m.def("vectorized_func3",
+          py::vectorize([](std::complex<double> c) { return c * std::complex<double>(2.f); }));
 
     // test_type_selection
     // A lot of these no lints could be replaced with const refs,
@@ -53,8 +56,8 @@ TEST_SUBMODULE(numpy_vectorize, m) {
           });
 
     // test_passthrough_arguments
-    // Passthrough test: references and non-pod types should be automatically passed through (in the
-    // function definition below, only `b`, `d`, and `g` are vectorized):
+    // Passthrough test: references and non-pod types should be automatically passed through (in
+    // the function definition below, only `b`, `d`, and `g` are vectorized):
     struct NonPODClass {
         NonPODClass(int v) : value{v} {}
         int value;
@@ -63,25 +66,20 @@ TEST_SUBMODULE(numpy_vectorize, m) {
         .def(py::init<int>())
         .def_readwrite("value", &NonPODClass::value);
     m.def("vec_passthrough",
-          py::vectorize([](double *a,
-                           double b,
+          py::vectorize([](double *a, double b,
                            // Changing this broke things
                            // NOLINTNEXTLINE(performance-unnecessary-value-param)
-                           py::array_t<double> c,
-                           const int &d,
-                           int &e,
-                           NonPODClass f,
+                           py::array_t<double> c, const int &d, int &e, NonPODClass f,
                            const double g) { return *a + b + c.at(0) + d + e + f.value + g; }));
 
     // test_method_vectorization
     struct VectorizeTestClass {
         VectorizeTestClass(int v) : value{v} {};
-        float method(int x, float y) const { return y + (float) (x + value); }
+        float method(int x, float y) const { return y + (float)(x + value); }
         int value = 0;
     };
     py::class_<VectorizeTestClass> vtc(m, "VectorizeTestClass");
-    vtc .def(py::init<int>())
-        .def_readwrite("value", &VectorizeTestClass::value);
+    vtc.def(py::init<int>()).def_readwrite("value", &VectorizeTestClass::value);
 
     // Automatic vectorizing of methods
     vtc.def("method", py::vectorize(&VectorizeTestClass::method));
@@ -92,20 +90,18 @@ TEST_SUBMODULE(numpy_vectorize, m) {
         .value("f_trivial", py::detail::broadcast_trivial::f_trivial)
         .value("c_trivial", py::detail::broadcast_trivial::c_trivial)
         .value("non_trivial", py::detail::broadcast_trivial::non_trivial);
-    m.def("vectorized_is_trivial",
-          [](
-              // NOLINTNEXTLINE(performance-unnecessary-value-param)
-              py::array_t<int, py::array::forcecast> arg1,
-              // NOLINTNEXTLINE(performance-unnecessary-value-param)
-              py::array_t<float, py::array::forcecast> arg2,
-              // NOLINTNEXTLINE(performance-unnecessary-value-param)
-              py::array_t<double, py::array::forcecast> arg3) {
-              py::ssize_t ndim;
-              std::vector<py::ssize_t> shape;
-              std::array<py::buffer_info, 3> buffers{
-                  {arg1.request(), arg2.request(), arg3.request()}};
-              return py::detail::broadcast(buffers, ndim, shape);
-          });
+    m.def("vectorized_is_trivial", [](
+                                       // NOLINTNEXTLINE(performance-unnecessary-value-param)
+                                       py::array_t<int, py::array::forcecast> arg1,
+                                       // NOLINTNEXTLINE(performance-unnecessary-value-param)
+                                       py::array_t<float, py::array::forcecast> arg2,
+                                       // NOLINTNEXTLINE(performance-unnecessary-value-param)
+                                       py::array_t<double, py::array::forcecast> arg3) {
+        py::ssize_t ndim;
+        std::vector<py::ssize_t> shape;
+        std::array<py::buffer_info, 3> buffers{{arg1.request(), arg2.request(), arg3.request()}};
+        return py::detail::broadcast(buffers, ndim, shape);
+    });
 
-    m.def("add_to", py::vectorize([](NonPODClass& x, int a) { x.value += a; }));
+    m.def("add_to", py::vectorize([](NonPODClass &x, int a) { x.value += a; }));
 }

--- a/tests/test_opaque_types.cpp
+++ b/tests/test_opaque_types.cpp
@@ -26,12 +26,12 @@ TEST_SUBMODULE(opaque_types, m) {
         .def(py::init<>())
         .def("pop_back", &StringList::pop_back)
         /* There are multiple versions of push_back(), etc. Select the right ones. */
-        .def("push_back", (void (StringList::*)(const std::string &)) &StringList::push_back)
-        .def("back", (std::string &(StringList::*)()) &StringList::back)
+        .def("push_back", (void (StringList::*)(const std::string &)) & StringList::push_back)
+        .def("back", (std::string & (StringList::*)()) & StringList::back)
         .def("__len__", [](const StringList &v) { return v.size(); })
-        .def("__iter__", [](StringList &v) {
-           return py::make_iterator(v.begin(), v.end());
-        }, py::keep_alive<0, 1>());
+        .def(
+            "__iter__", [](StringList &v) { return py::make_iterator(v.begin(), v.end()); },
+            py::keep_alive<0, 1>());
 
     class ClassWithSTLVecProperty {
     public:
@@ -54,9 +54,9 @@ TEST_SUBMODULE(opaque_types, m) {
     });
 
     // test_pointers
-    m.def("return_void_ptr", []() { return (void *) 0x1234; });
+    m.def("return_void_ptr", []() { return (void *)0x1234; });
     m.def("get_void_ptr_value", [](void *ptr) { return reinterpret_cast<std::intptr_t>(ptr); });
-    m.def("return_null_str", []() { return (char *) nullptr; });
+    m.def("return_null_str", []() { return (char *)nullptr; });
     m.def("get_null_str_value", [](char *ptr) { return reinterpret_cast<std::intptr_t>(ptr); });
 
     m.def("return_unique_ptr", []() -> std::unique_ptr<StringList> {

--- a/tests/test_operator_overloading.cpp
+++ b/tests/test_operator_overloading.cpp
@@ -7,10 +7,10 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
-#include <pybind11/operators.h>
+#include "pybind11_tests.h"
 #include <functional>
+#include <pybind11/operators.h>
 
 class Vector2 {
 public:
@@ -20,17 +20,24 @@ public:
         print_move_created(this);
         v.x = v.y = 0;
     }
-    Vector2 &operator=(const Vector2 &v) { x = v.x; y = v.y; print_copy_assigned(this); return *this; }
+    Vector2 &operator=(const Vector2 &v) {
+        x = v.x;
+        y = v.y;
+        print_copy_assigned(this);
+        return *this;
+    }
     Vector2 &operator=(Vector2 &&v) noexcept {
-        x   = v.x;
-        y   = v.y;
+        x = v.x;
+        y = v.y;
         v.x = v.y = 0;
         print_move_assigned(this);
         return *this;
     }
     ~Vector2() { print_destroyed(this); }
 
-    std::string toString() const { return "[" + std::to_string(x) + ", " + std::to_string(y) + "]"; }
+    std::string toString() const {
+        return "[" + std::to_string(x) + ", " + std::to_string(y) + "]";
+    }
 
     Vector2 operator-() const { return Vector2(-x, -y); }
     Vector2 operator+(const Vector2 &v) const { return Vector2(x + v.x, y + v.y); }
@@ -41,30 +48,51 @@ public:
     Vector2 operator/(float value) const { return Vector2(x / value, y / value); }
     Vector2 operator*(const Vector2 &v) const { return Vector2(x * v.x, y * v.y); }
     Vector2 operator/(const Vector2 &v) const { return Vector2(x / v.x, y / v.y); }
-    Vector2& operator+=(const Vector2 &v) { x += v.x; y += v.y; return *this; }
-    Vector2& operator-=(const Vector2 &v) { x -= v.x; y -= v.y; return *this; }
-    Vector2& operator*=(float v) { x *= v; y *= v; return *this; }
-    Vector2& operator/=(float v) { x /= v; y /= v; return *this; }
-    Vector2& operator*=(const Vector2 &v) { x *= v.x; y *= v.y; return *this; }
-    Vector2& operator/=(const Vector2 &v) { x /= v.x; y /= v.y; return *this; }
+    Vector2 &operator+=(const Vector2 &v) {
+        x += v.x;
+        y += v.y;
+        return *this;
+    }
+    Vector2 &operator-=(const Vector2 &v) {
+        x -= v.x;
+        y -= v.y;
+        return *this;
+    }
+    Vector2 &operator*=(float v) {
+        x *= v;
+        y *= v;
+        return *this;
+    }
+    Vector2 &operator/=(float v) {
+        x /= v;
+        y /= v;
+        return *this;
+    }
+    Vector2 &operator*=(const Vector2 &v) {
+        x *= v.x;
+        y *= v.y;
+        return *this;
+    }
+    Vector2 &operator/=(const Vector2 &v) {
+        x /= v.x;
+        y /= v.y;
+        return *this;
+    }
 
     friend Vector2 operator+(float f, const Vector2 &v) { return Vector2(f + v.x, f + v.y); }
     friend Vector2 operator-(float f, const Vector2 &v) { return Vector2(f - v.x, f - v.y); }
     friend Vector2 operator*(float f, const Vector2 &v) { return Vector2(f * v.x, f * v.y); }
     friend Vector2 operator/(float f, const Vector2 &v) { return Vector2(f / v.x, f / v.y); }
 
-    bool operator==(const Vector2 &v) const {
-        return x == v.x && y == v.y;
-    }
-    bool operator!=(const Vector2 &v) const {
-        return x != v.x || y != v.y;
-    }
+    bool operator==(const Vector2 &v) const { return x == v.x && y == v.y; }
+    bool operator!=(const Vector2 &v) const { return x != v.x || y != v.y; }
+
 private:
     float x, y;
 };
 
-class C1 { };
-class C2 { };
+class C1 {};
+class C2 {};
 
 int operator+(const C1 &, const C1 &) { return 11; }
 int operator+(const C2 &, const C2 &) { return 22; }
@@ -77,35 +105,32 @@ int operator+(const C1 &, const C2 &) { return 12; }
 // namespace instead, per this recommendation:
 // https://en.cppreference.com/w/cpp/language/extending_std#Adding_template_specializations
 namespace std {
-    template<>
-    struct hash<Vector2> {
-        // Not a good hash function, but easy to test
-        size_t operator()(const Vector2 &) { return 4; }
-    };
+template <> struct hash<Vector2> {
+    // Not a good hash function, but easy to test
+    size_t operator()(const Vector2 &) { return 4; }
+};
 } // namespace std
 
 // Not a good abs function, but easy to test.
-std::string abs(const Vector2&) {
-    return "abs(Vector2)";
-}
+std::string abs(const Vector2 &) { return "abs(Vector2)"; }
 
 // MSVC & Intel warns about unknown pragmas, and warnings are errors.
 #if !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-  #pragma GCC diagnostic push
-  // clang 7.0.0 and Apple LLVM 10.0.1 introduce `-Wself-assign-overloaded` to
-  // `-Wall`, which is used here for overloading (e.g. `py::self += py::self `).
-  // Here, we suppress the warning using `#pragma diagnostic`.
-  // Taken from: https://github.com/RobotLocomotion/drake/commit/aaf84b46
-  // TODO(eric): This could be resolved using a function / functor (e.g. `py::self()`).
-  #if defined(__APPLE__) && defined(__clang__)
-    #if (__clang_major__ >= 10)
-      #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
-    #endif
-  #elif defined(__clang__)
-    #if (__clang_major__ >= 7)
-      #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
-    #endif
-  #endif
+#pragma GCC diagnostic push
+// clang 7.0.0 and Apple LLVM 10.0.1 introduce `-Wself-assign-overloaded` to
+// `-Wall`, which is used here for overloading (e.g. `py::self += py::self `).
+// Here, we suppress the warning using `#pragma diagnostic`.
+// Taken from: https://github.com/RobotLocomotion/drake/commit/aaf84b46
+// TODO(eric): This could be resolved using a function / functor (e.g. `py::self()`).
+#if defined(__APPLE__) && defined(__clang__)
+#if (__clang_major__ >= 10)
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
+#elif defined(__clang__)
+#if (__clang_major__ >= 7)
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
+#endif
 #endif
 
 TEST_SUBMODULE(operators, m) {
@@ -139,46 +164,51 @@ TEST_SUBMODULE(operators, m) {
         .def(py::hash(py::self))
         // N.B. See warning about usage of `py::detail::abs(py::self)` in
         // `operators.h`.
-        .def("__abs__", [](const Vector2& v) { return abs(v); })
-        ;
+        .def("__abs__", [](const Vector2 &v) { return abs(v); });
 
     m.attr("Vector") = m.attr("Vector2");
 
     // test_operators_notimplemented
     // #393: need to return NotSupported to ensure correct arithmetic operator behavior
-    py::class_<C1>(m, "C1")
-        .def(py::init<>())
-        .def(py::self + py::self);
+    py::class_<C1>(m, "C1").def(py::init<>()).def(py::self + py::self);
 
     py::class_<C2>(m, "C2")
         .def(py::init<>())
         .def(py::self + py::self)
-        .def("__add__", [](const C2& c2, const C1& c1) { return c2 + c1; })
-        .def("__radd__", [](const C2& c2, const C1& c1) { return c1 + c2; });
+        .def("__add__", [](const C2 &c2, const C1 &c1) { return c2 + c1; })
+        .def("__radd__", [](const C2 &c2, const C1 &c1) { return c1 + c2; });
 
     // test_nested
     // #328: first member in a class can't be used in operators
-    struct NestABase { int value = -2; };
+    struct NestABase {
+        int value = -2;
+    };
     py::class_<NestABase>(m, "NestABase")
         .def(py::init<>())
         .def_readwrite("value", &NestABase::value);
 
     struct NestA : NestABase {
         int value = 3;
-        NestA& operator+=(int i) { value += i; return *this; }
+        NestA &operator+=(int i) {
+            value += i;
+            return *this;
+        }
     };
     py::class_<NestA>(m, "NestA")
         .def(py::init<>())
         .def(py::self += int())
-        .def("as_base", [](NestA &a) -> NestABase& {
-            return (NestABase&) a;
-        }, py::return_value_policy::reference_internal);
+        .def(
+            "as_base", [](NestA &a) -> NestABase & { return (NestABase &)a; },
+            py::return_value_policy::reference_internal);
     m.def("get_NestA", [](const NestA &a) { return a.value; });
 
     struct NestB {
         NestA a;
         int value = 4;
-        NestB& operator-=(int i) { value -= i; return *this; }
+        NestB &operator-=(int i) {
+            value -= i;
+            return *this;
+        }
     };
     py::class_<NestB>(m, "NestB")
         .def(py::init<>())
@@ -189,7 +219,10 @@ TEST_SUBMODULE(operators, m) {
     struct NestC {
         NestB b;
         int value = 5;
-        NestC& operator*=(int i) { value *= i; return *this; }
+        NestC &operator*=(int i) {
+            value *= i;
+            return *this;
+        }
     };
     py::class_<NestC>(m, "NestC")
         .def(py::init<>())
@@ -197,16 +230,15 @@ TEST_SUBMODULE(operators, m) {
         .def_readwrite("b", &NestC::b);
     m.def("get_NestC", [](const NestC &c) { return c.value; });
 
-
     // test_overriding_eq_reset_hash
     // #2191 Overriding __eq__ should set __hash__ to None
     struct Comparable {
         int value;
-        bool operator==(const Comparable& rhs) const {return value == rhs.value;}
+        bool operator==(const Comparable &rhs) const { return value == rhs.value; }
     };
 
     struct Hashable : Comparable {
-        explicit Hashable(int value): Comparable{value}{};
+        explicit Hashable(int value) : Comparable{value} {};
         size_t hash() const { return static_cast<size_t>(value); }
     };
 
@@ -214,9 +246,7 @@ TEST_SUBMODULE(operators, m) {
         using Hashable::Hashable;
     };
 
-    py::class_<Comparable>(m, "Comparable")
-        .def(py::init<int>())
-        .def(py::self == py::self);
+    py::class_<Comparable>(m, "Comparable").def(py::init<int>()).def(py::self == py::self);
 
     py::class_<Hashable>(m, "Hashable")
         .def(py::init<int>())
@@ -231,5 +261,5 @@ TEST_SUBMODULE(operators, m) {
 }
 
 #if !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-  #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif

--- a/tests/test_pickling.cpp
+++ b/tests/test_pickling.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /*
     tests/test_pickling.cpp -- pickle support
 
@@ -10,8 +9,6 @@
 */
 
 #include "pybind11_tests.h"
-
-// clang-format on
 
 #include <memory>
 #include <stdexcept>
@@ -60,8 +57,6 @@ void wrap(py::module m) {
 }
 
 } // namespace exercise_trampoline
-
-// clang-format off
 
 TEST_SUBMODULE(pickling, m) {
     // test_roundtrip

--- a/tests/test_pickling.cpp
+++ b/tests/test_pickling.cpp
@@ -17,11 +17,11 @@
 namespace exercise_trampoline {
 
 struct SimpleBase {
-    int num               = 0;
+    int num = 0;
     virtual ~SimpleBase() = default;
 
     // For compatibility with old clang versions:
-    SimpleBase()                   = default;
+    SimpleBase() = default;
     SimpleBase(const SimpleBase &) = default;
 };
 
@@ -45,7 +45,7 @@ void wrap(py::module m) {
                     throw std::runtime_error("Invalid state!");
                 auto cpp_state = std::unique_ptr<SimpleBase>(new SimpleBaseTrampoline);
                 cpp_state->num = t[0].cast<int>();
-                auto py_state  = t[1].cast<py::dict>();
+                auto py_state = t[1].cast<py::dict>();
                 return std::make_pair(std::move(cpp_state), py_state);
             }));
 
@@ -62,13 +62,14 @@ TEST_SUBMODULE(pickling, m) {
     // test_roundtrip
     class Pickleable {
     public:
-        Pickleable(const std::string &value) : m_value(value) { }
+        Pickleable(const std::string &value) : m_value(value) {}
         const std::string &value() const { return m_value; }
 
         void setExtra1(int extra1) { m_extra1 = extra1; }
         void setExtra2(int extra2) { m_extra2 = extra2; }
         int extra1() const { return m_extra1; }
         int extra2() const { return m_extra2; }
+
     private:
         std::string m_value;
         int m_extra1 = 0;
@@ -81,8 +82,7 @@ TEST_SUBMODULE(pickling, m) {
     };
 
     py::class_<Pickleable> pyPickleable(m, "Pickleable");
-    pyPickleable
-        .def(py::init<std::string>())
+    pyPickleable.def(py::init<std::string>())
         .def("value", &Pickleable::value)
         .def("extra1", &Pickleable::extra1)
         .def("extra2", &Pickleable::extra2)
@@ -127,7 +127,7 @@ TEST_SUBMODULE(pickling, m) {
     // test_roundtrip_with_dict
     class PickleableWithDict {
     public:
-        PickleableWithDict(const std::string &value) : value(value) { }
+        PickleableWithDict(const std::string &value) : value(value) {}
 
         std::string value;
         int extra;
@@ -138,7 +138,8 @@ TEST_SUBMODULE(pickling, m) {
         using PickleableWithDict::PickleableWithDict;
     };
 
-    py::class_<PickleableWithDict> pyPickleableWithDict(m, "PickleableWithDict", py::dynamic_attr());
+    py::class_<PickleableWithDict> pyPickleableWithDict(m, "PickleableWithDict",
+                                                        py::dynamic_attr());
     pyPickleableWithDict.def(py::init<std::string>())
         .def_readwrite("value", &PickleableWithDict::value)
         .def_readwrite("extra", &PickleableWithDict::extra)
@@ -166,7 +167,8 @@ TEST_SUBMODULE(pickling, m) {
         .def(py::init<std::string>())
         .def(py::pickle(
             [](const py::object &self) {
-                return py::make_tuple(self.attr("value"), self.attr("extra"), self.attr("__dict__"));
+                return py::make_tuple(self.attr("value"), self.attr("extra"),
+                                      self.attr("__dict__"));
             },
             [](const py::tuple &t) {
                 if (t.size() != 3)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -258,8 +258,9 @@ TEST_SUBMODULE(pytypes, m) {
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m.def("convert_to_pybind11_str", [](py::object o) { return py::str(o); });
 
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("nonconverting_constructor", [](std::string type, py::object value, bool move) -> py::object {
+    m.def("nonconverting_constructor",
+        // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        [](std::string type, py::object value, bool move) -> py::object {
         if (type == "bytes") {
             return move ? py::bytes(std::move(value)) : py::bytes(value);
         }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -259,22 +259,22 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("convert_to_pybind11_str", [](py::object o) { return py::str(o); });
 
     m.def("nonconverting_constructor",
-        // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        [](std::string type, py::object value, bool move) -> py::object {
-        if (type == "bytes") {
-            return move ? py::bytes(std::move(value)) : py::bytes(value);
-        }
-        if (type == "none") {
-            return move ? py::none(std::move(value)) : py::none(value);
-        }
-        if (type == "ellipsis") {
-            return move ? py::ellipsis(std::move(value)) : py::ellipsis(value);
-        }
-        if (type == "type") {
-            return move ? py::type(std::move(value)) : py::type(value);
-        }
-        throw std::runtime_error("Invalid type");
-    });
+          // NOLINTNEXTLINE(performance-unnecessary-value-param)
+          [](std::string type, py::object value, bool move) -> py::object {
+              if (type == "bytes") {
+                  return move ? py::bytes(std::move(value)) : py::bytes(value);
+              }
+              if (type == "none") {
+                  return move ? py::none(std::move(value)) : py::none(value);
+              }
+              if (type == "ellipsis") {
+                  return move ? py::ellipsis(std::move(value)) : py::ellipsis(value);
+              }
+              if (type == "type") {
+                  return move ? py::type(std::move(value)) : py::type(value);
+              }
+              throw std::runtime_error("Invalid type");
+          });
 
     m.def("get_implicit_casting", []() {
         py::dict d;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -11,14 +11,13 @@
 
 #include "pybind11_tests.h"
 
-
 TEST_SUBMODULE(pytypes, m) {
     // test_int
-    m.def("get_int", []{return py::int_(0);});
+    m.def("get_int", [] { return py::int_(0); });
     // test_iterator
-    m.def("get_iterator", []{return py::iterator();});
+    m.def("get_iterator", [] { return py::iterator(); });
     // test_iterable
-    m.def("get_iterable", []{return py::iterable();});
+    m.def("get_iterable", [] { return py::iterable(); });
     // test_list
     m.def("get_list", []() {
         py::list list;
@@ -35,7 +34,7 @@ TEST_SUBMODULE(pytypes, m) {
             py::print("list item {}: {}"_s.format(index++, item));
     });
     // test_none
-    m.def("get_none", []{return py::none();});
+    m.def("get_none", [] { return py::none(); });
     m.def("print_none", [](const py::none &none) { py::print("none: {}"_s.format(none)); });
 
     // test_set
@@ -55,14 +54,14 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("set_contains", [](const py::set &set, const char *key) { return set.contains(key); });
 
     // test_dict
-    m.def("get_dict", []() { return py::dict("key"_a="value"); });
+    m.def("get_dict", []() { return py::dict("key"_a = "value"); });
     m.def("print_dict", [](const py::dict &dict) {
         for (auto item : dict)
             py::print("key: {}, value={}"_s.format(item.first, item.second));
     });
     m.def("dict_keyword_constructor", []() {
-        auto d1 = py::dict("x"_a=1, "y"_a=2);
-        auto d2 = py::dict("z"_a=3, **d1);
+        auto d1 = py::dict("x"_a = 1, "y"_a = 2);
+        auto d2 = py::dict("z"_a = 3, **d1);
         return d2;
     });
     m.def("dict_contains",
@@ -73,13 +72,13 @@ TEST_SUBMODULE(pytypes, m) {
     // test_str
     m.def("str_from_string", []() { return py::str(std::string("baz")); });
     m.def("str_from_bytes", []() { return py::str(py::bytes("boo", 3)); });
-    m.def("str_from_object", [](const py::object& obj) { return py::str(obj); });
-    m.def("repr_from_object", [](const py::object& obj) { return py::repr(obj); });
+    m.def("str_from_object", [](const py::object &obj) { return py::str(obj); });
+    m.def("repr_from_object", [](const py::object &obj) { return py::repr(obj); });
     m.def("str_from_handle", [](py::handle h) { return py::str(h); });
 
     m.def("str_format", []() {
         auto s1 = "{} + {} = {}"_s.format(1, 2, 3);
-        auto s2 = "{a} + {b} = {c}"_s.format("a"_a=1, "b"_a=2, "c"_a=3);
+        auto s2 = "{a} + {b} = {c}"_s.format("a"_a = 1, "b"_a = 2, "c"_a = 3);
         return py::make_tuple(s1, s2);
     });
 
@@ -94,40 +93,38 @@ TEST_SUBMODULE(pytypes, m) {
     // test_capsule
     m.def("return_capsule_with_destructor", []() {
         py::print("creating capsule");
-        return py::capsule([]() {
-            py::print("destructing capsule");
-        });
+        return py::capsule([]() { py::print("destructing capsule"); });
     });
 
     m.def("return_capsule_with_destructor_2", []() {
         py::print("creating capsule");
-        return py::capsule((void *) 1234, [](void *ptr) {
-            py::print("destructing capsule: {}"_s.format((size_t) ptr));
+        return py::capsule((void *)1234, [](void *ptr) {
+            py::print("destructing capsule: {}"_s.format((size_t)ptr));
         });
     });
 
     m.def("return_capsule_with_name_and_destructor", []() {
-        auto capsule = py::capsule((void *) 12345, "pointer type description", [](PyObject *ptr) {
+        auto capsule = py::capsule((void *)12345, "pointer type description", [](PyObject *ptr) {
             if (ptr) {
                 auto name = PyCapsule_GetName(ptr);
                 py::print("destructing capsule ({}, '{}')"_s.format(
-                    (size_t) PyCapsule_GetPointer(ptr, name), name
-                ));
+                    (size_t)PyCapsule_GetPointer(ptr, name), name));
             }
         });
 
-        capsule.set_pointer((void *) 1234);
+        capsule.set_pointer((void *)1234);
 
         // Using get_pointer<T>()
-        void* contents1 = static_cast<void*>(capsule);
-        void* contents2 = capsule.get_pointer();
-        void* contents3 = capsule.get_pointer<void>();
+        void *contents1 = static_cast<void *>(capsule);
+        void *contents2 = capsule.get_pointer();
+        void *contents3 = capsule.get_pointer<void>();
 
         auto result1 = reinterpret_cast<size_t>(contents1);
         auto result2 = reinterpret_cast<size_t>(contents2);
         auto result3 = reinterpret_cast<size_t>(contents3);
 
-        py::print("created capsule ({}, '{}')"_s.format(result1 & result2 & result3, capsule.name()));
+        py::print(
+            "created capsule ({}, '{}')"_s.format(result1 & result2 & result3, capsule.name()));
         return capsule;
     });
 
@@ -207,52 +204,33 @@ TEST_SUBMODULE(pytypes, m) {
 
     // test_constructors
     m.def("default_constructors", []() {
-        return py::dict(
-            "bytes"_a=py::bytes(),
-            "bytearray"_a=py::bytearray(),
-            "str"_a=py::str(),
-            "bool"_a=py::bool_(),
-            "int"_a=py::int_(),
-            "float"_a=py::float_(),
-            "tuple"_a=py::tuple(),
-            "list"_a=py::list(),
-            "dict"_a=py::dict(),
-            "set"_a=py::set()
-        );
+        return py::dict("bytes"_a = py::bytes(), "bytearray"_a = py::bytearray(),
+                        "str"_a = py::str(), "bool"_a = py::bool_(), "int"_a = py::int_(),
+                        "float"_a = py::float_(), "tuple"_a = py::tuple(), "list"_a = py::list(),
+                        "dict"_a = py::dict(), "set"_a = py::set());
     });
 
     m.def("converting_constructors", [](const py::dict &d) {
-        return py::dict(
-            "bytes"_a=py::bytes(d["bytes"]),
-            "bytearray"_a=py::bytearray(d["bytearray"]),
-            "str"_a=py::str(d["str"]),
-            "bool"_a=py::bool_(d["bool"]),
-            "int"_a=py::int_(d["int"]),
-            "float"_a=py::float_(d["float"]),
-            "tuple"_a=py::tuple(d["tuple"]),
-            "list"_a=py::list(d["list"]),
-            "dict"_a=py::dict(d["dict"]),
-            "set"_a=py::set(d["set"]),
-            "memoryview"_a=py::memoryview(d["memoryview"])
-        );
+        return py::dict("bytes"_a = py::bytes(d["bytes"]),
+                        "bytearray"_a = py::bytearray(d["bytearray"]), "str"_a = py::str(d["str"]),
+                        "bool"_a = py::bool_(d["bool"]), "int"_a = py::int_(d["int"]),
+                        "float"_a = py::float_(d["float"]), "tuple"_a = py::tuple(d["tuple"]),
+                        "list"_a = py::list(d["list"]), "dict"_a = py::dict(d["dict"]),
+                        "set"_a = py::set(d["set"]),
+                        "memoryview"_a = py::memoryview(d["memoryview"]));
     });
 
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m.def("cast_functions", [](py::dict d) {
         // When converting between Python types, obj.cast<T>() should be the same as T(obj)
         return py::dict(
-            "bytes"_a=d["bytes"].cast<py::bytes>(),
-            "bytearray"_a=d["bytearray"].cast<py::bytearray>(),
-            "str"_a=d["str"].cast<py::str>(),
-            "bool"_a=d["bool"].cast<py::bool_>(),
-            "int"_a=d["int"].cast<py::int_>(),
-            "float"_a=d["float"].cast<py::float_>(),
-            "tuple"_a=d["tuple"].cast<py::tuple>(),
-            "list"_a=d["list"].cast<py::list>(),
-            "dict"_a=d["dict"].cast<py::dict>(),
-            "set"_a=d["set"].cast<py::set>(),
-            "memoryview"_a=d["memoryview"].cast<py::memoryview>()
-        );
+            "bytes"_a = d["bytes"].cast<py::bytes>(),
+            "bytearray"_a = d["bytearray"].cast<py::bytearray>(),
+            "str"_a = d["str"].cast<py::str>(), "bool"_a = d["bool"].cast<py::bool_>(),
+            "int"_a = d["int"].cast<py::int_>(), "float"_a = d["float"].cast<py::float_>(),
+            "tuple"_a = d["tuple"].cast<py::tuple>(), "list"_a = d["list"].cast<py::list>(),
+            "dict"_a = d["dict"].cast<py::dict>(), "set"_a = d["set"].cast<py::set>(),
+            "memoryview"_a = d["memoryview"].cast<py::memoryview>());
     });
 
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
@@ -307,10 +285,7 @@ TEST_SUBMODULE(pytypes, m) {
         l.append(py::cast(12));
         l.append(py::int_(15));
 
-        return py::dict(
-            "d"_a=d,
-            "l"_a=l
-        );
+        return py::dict("d"_a = d, "l"_a = l);
     });
 
     // test_print
@@ -318,16 +293,17 @@ TEST_SUBMODULE(pytypes, m) {
         py::print("Hello, World!");
         py::print(1, 2.0, "three", true, std::string("-- multiple args"));
         auto args = py::make_tuple("and", "a", "custom", "separator");
-        py::print("*args", *args, "sep"_a="-");
-        py::print("no new line here", "end"_a=" -- ");
+        py::print("*args", *args, "sep"_a = "-");
+        py::print("no new line here", "end"_a = " -- ");
         py::print("next print");
 
         auto py_stderr = py::module_::import("sys").attr("stderr");
-        py::print("this goes to stderr", "file"_a=py_stderr);
+        py::print("this goes to stderr", "file"_a = py_stderr);
 
-        py::print("flush", "flush"_a=true);
+        py::print("flush", "flush"_a = true);
 
-        py::print("{a} + {b} = {c}"_s.format("a"_a="py::print", "b"_a="str.format", "c"_a="this"));
+        py::print(
+            "{a} + {b} = {c}"_s.format("a"_a = "py::print", "b"_a = "str.format", "c"_a = "this"));
     });
 
     m.def("print_failure", []() { py::print(42, UnregisteredType()); });
@@ -356,9 +332,7 @@ TEST_SUBMODULE(pytypes, m) {
     });
 
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("test_list_slicing", [](py::list a) {
-        return a[py::slice(0, -1, 2)];
-    });
+    m.def("test_list_slicing", [](py::list a) { return a[py::slice(0, -1, 2)]; });
 
     // See #2361
     m.def("issue2361_str_implicit_copy_none", []() {
@@ -371,51 +345,43 @@ TEST_SUBMODULE(pytypes, m) {
     });
 
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("test_memoryview_object", [](py::buffer b) {
-        return py::memoryview(b);
-    });
+    m.def("test_memoryview_object", [](py::buffer b) { return py::memoryview(b); });
 
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("test_memoryview_buffer_info", [](py::buffer b) {
-        return py::memoryview(b.request());
-    });
+    m.def("test_memoryview_buffer_info", [](py::buffer b) { return py::memoryview(b.request()); });
 
     m.def("test_memoryview_from_buffer", [](bool is_unsigned) {
-        static const int16_t si16[] = { 3, 1, 4, 1, 5 };
-        static const uint16_t ui16[] = { 2, 7, 1, 8 };
+        static const int16_t si16[] = {3, 1, 4, 1, 5};
+        static const uint16_t ui16[] = {2, 7, 1, 8};
         if (is_unsigned)
-            return py::memoryview::from_buffer(
-                ui16, { 4 }, { sizeof(uint16_t) });
+            return py::memoryview::from_buffer(ui16, {4}, {sizeof(uint16_t)});
         return py::memoryview::from_buffer(si16, {5}, {sizeof(int16_t)});
     });
 
     m.def("test_memoryview_from_buffer_nativeformat", []() {
-        static const char* format = "@i";
-        static const int32_t arr[] = { 4, 7, 5 };
-        return py::memoryview::from_buffer(
-            arr, sizeof(int32_t), format, { 3 }, { sizeof(int32_t) });
+        static const char *format = "@i";
+        static const int32_t arr[] = {4, 7, 5};
+        return py::memoryview::from_buffer(arr, sizeof(int32_t), format, {3}, {sizeof(int32_t)});
     });
 
     m.def("test_memoryview_from_buffer_empty_shape", []() {
-        static const char* buf = "";
-        return py::memoryview::from_buffer(buf, 1, "B", { }, { });
+        static const char *buf = "";
+        return py::memoryview::from_buffer(buf, 1, "B", {}, {});
     });
 
     m.def("test_memoryview_from_buffer_invalid_strides", []() {
-        static const char* buf = "\x02\x03\x04";
-        return py::memoryview::from_buffer(buf, 1, "B", { 3 }, { });
+        static const char *buf = "\x02\x03\x04";
+        return py::memoryview::from_buffer(buf, 1, "B", {3}, {});
     });
 
     m.def("test_memoryview_from_buffer_nullptr", []() {
-        return py::memoryview::from_buffer(
-            static_cast<void*>(nullptr), 1, "B", { }, { });
+        return py::memoryview::from_buffer(static_cast<void *>(nullptr), 1, "B", {}, {});
     });
 
 #if PY_MAJOR_VERSION >= 3
     m.def("test_memoryview_from_memory", []() {
-        const char* buf = "\xff\xe1\xab\x37";
-        return py::memoryview::from_memory(
-            buf, static_cast<py::ssize_t>(strlen(buf)));
+        const char *buf = "\xff\xe1\xab\x37";
+        return py::memoryview::from_memory(buf, static_cast<py::ssize_t>(strlen(buf)));
     });
 #endif
 
@@ -437,8 +403,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("pass_to_std_string", [](std::string s) { return s.size(); });
 
     // test_weakref
-    m.def("weakref_from_handle",
-          [](py::handle h) { return py::weakref(h); });
+    m.def("weakref_from_handle", [](py::handle h) { return py::weakref(h); });
     m.def("weakref_from_handle_and_function",
           [](py::handle h, py::function f) { return py::weakref(h, std::move(f)); });
     m.def("weakref_from_object", [](const py::object &o) { return py::weakref(o); });

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -8,39 +8,43 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
 #include <algorithm>
 #include <utility>
 
-template<typename T>
-class NonZeroIterator {
-    const T* ptr_;
+template <typename T> class NonZeroIterator {
+    const T *ptr_;
+
 public:
-    NonZeroIterator(const T* ptr) : ptr_(ptr) {}
-    const T& operator*() const { return *ptr_; }
-    NonZeroIterator& operator++() { ++ptr_; return *this; }
+    NonZeroIterator(const T *ptr) : ptr_(ptr) {}
+    const T &operator*() const { return *ptr_; }
+    NonZeroIterator &operator++() {
+        ++ptr_;
+        return *this;
+    }
 };
 
 class NonZeroSentinel {};
 
-template<typename A, typename B>
-bool operator==(const NonZeroIterator<std::pair<A, B>>& it, const NonZeroSentinel&) {
+template <typename A, typename B>
+bool operator==(const NonZeroIterator<std::pair<A, B>> &it, const NonZeroSentinel &) {
     return !(*it).first || !(*it).second;
 }
 
-template <typename PythonType>
-py::list test_random_access_iterator(PythonType x) {
+template <typename PythonType> py::list test_random_access_iterator(PythonType x) {
     if (x.size() < 5)
         throw py::value_error("Please provide at least 5 elements for testing.");
 
     auto checks = py::list();
     auto assert_equal = [&checks](py::handle a, py::handle b) {
         auto result = PyObject_RichCompareBool(a.ptr(), b.ptr(), Py_EQ);
-        if (result == -1) { throw py::error_already_set(); }
+        if (result == -1) {
+            throw py::error_already_set();
+        }
         checks.append(result != 0);
     };
 
@@ -75,11 +79,11 @@ py::list test_random_access_iterator(PythonType x) {
 
 TEST_SUBMODULE(sequences_and_iterators, m) {
     // test_sliceable
-    class Sliceable{
+    class Sliceable {
     public:
-      Sliceable(int n): size(n) {}
-      int start,stop,step;
-      int size;
+        Sliceable(int n) : size(n) {}
+        int start, stop, step;
+        int size;
     };
     py::class_<Sliceable>(m, "Sliceable")
         .def(py::init<int>())
@@ -88,8 +92,8 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
             if (!slice.compute(s.size, &start, &stop, &step, &slicelength))
                 throw py::error_already_set();
             int istart = static_cast<int>(start);
-            int istop  = static_cast<int>(stop);
-            int istep  = static_cast<int>(step);
+            int istop = static_cast<int>(stop);
+            int istep = static_cast<int>(step);
             return std::make_tuple(istart, istop, istep);
         });
 
@@ -109,7 +113,7 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
         Sequence(const Sequence &s) : m_size(s.m_size) {
             print_copy_created(this);
             m_data = new float[m_size];
-            memcpy(m_data, s.m_data, sizeof(float)*m_size);
+            memcpy(m_data, s.m_data, sizeof(float) * m_size);
         }
         Sequence(Sequence &&s) noexcept : m_size(s.m_size), m_data(s.m_data) {
             print_move_created(this);
@@ -117,14 +121,17 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
             s.m_data = nullptr;
         }
 
-        ~Sequence() { print_destroyed(this); delete[] m_data; }
+        ~Sequence() {
+            print_destroyed(this);
+            delete[] m_data;
+        }
 
         Sequence &operator=(const Sequence &s) {
             if (&s != this) {
                 delete[] m_data;
                 m_size = s.m_size;
                 m_data = new float[m_size];
-                memcpy(m_data, s.m_data, sizeof(float)*m_size);
+                memcpy(m_data, s.m_data, sizeof(float) * m_size);
             }
             print_copy_assigned(this);
             return *this;
@@ -143,7 +150,8 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
         }
 
         bool operator==(const Sequence &s) const {
-            if (m_size != s.size()) return false;
+            if (m_size != s.size())
+                return false;
             for (size_t i = 0; i < m_size; ++i)
                 if (m_data[i] != s[i])
                     return false;
@@ -171,7 +179,7 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
         size_t size() const { return m_size; }
 
         const float *begin() const { return m_data; }
-        const float *end() const { return m_data+m_size; }
+        const float *end() const { return m_data + m_size; }
 
     private:
         size_t m_size;
@@ -196,8 +204,7 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
         .def("__len__", &Sequence::size)
         /// Optional sequence protocol operations
         .def(
-            "__iter__",
-            [](const Sequence &s) { return py::make_iterator(s.begin(), s.end()); },
+            "__iter__", [](const Sequence &s) { return py::make_iterator(s.begin(), s.end()); },
             py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */)
         .def("__contains__", [](const Sequence &s, float v) { return s.contains(v); })
         .def("__reversed__", [](const Sequence &s) -> Sequence { return s.reversed(); })
@@ -234,19 +241,20 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
         ;
 
     // test_map_iterator
-    // Interface of a map-like object that isn't (directly) an unordered_map, but provides some basic
-    // map-like functionality.
+    // Interface of a map-like object that isn't (directly) an unordered_map, but provides some
+    // basic map-like functionality.
     class StringMap {
     public:
         StringMap() = default;
-        StringMap(std::unordered_map<std::string, std::string> init)
-            : map(std::move(init)) {}
+        StringMap(std::unordered_map<std::string, std::string> init) : map(std::move(init)) {}
 
         void set(const std::string &key, std::string val) { map[key] = std::move(val); }
         std::string get(const std::string &key) const { return map.at(key); }
         size_t size() const { return map.size(); }
+
     private:
         std::unordered_map<std::string, std::string> map;
+
     public:
         decltype(map.cbegin()) begin() const { return map.cbegin(); }
         decltype(map.cend()) end() const { return map.cend(); }
@@ -277,20 +285,27 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
     class IntPairs {
     public:
         IntPairs(std::vector<std::pair<int, int>> data) : data_(std::move(data)) {}
-        const std::pair<int, int>* begin() const { return data_.data(); }
+        const std::pair<int, int> *begin() const { return data_.data(); }
+
     private:
         std::vector<std::pair<int, int>> data_;
     };
     py::class_<IntPairs>(m, "IntPairs")
         .def(py::init<std::vector<std::pair<int, int>>>())
-        .def("nonzero", [](const IntPairs& s) {
-                return py::make_iterator(NonZeroIterator<std::pair<int, int>>(s.begin()), NonZeroSentinel());
-        }, py::keep_alive<0, 1>())
-        .def("nonzero_keys", [](const IntPairs& s) {
-            return py::make_key_iterator(NonZeroIterator<std::pair<int, int>>(s.begin()), NonZeroSentinel());
-        }, py::keep_alive<0, 1>())
-        ;
-
+        .def(
+            "nonzero",
+            [](const IntPairs &s) {
+                return py::make_iterator(NonZeroIterator<std::pair<int, int>>(s.begin()),
+                                         NonZeroSentinel());
+            },
+            py::keep_alive<0, 1>())
+        .def(
+            "nonzero_keys",
+            [](const IntPairs &s) {
+                return py::make_key_iterator(NonZeroIterator<std::pair<int, int>>(s.begin()),
+                                             NonZeroSentinel());
+            },
+            py::keep_alive<0, 1>());
 
 #if 0
     // Obsolete: special data structure for exposing custom iterator types to python
@@ -368,7 +383,9 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
 
     // test_iterator_rvp
     // #388: Can't make iterators via make_iterator() with different r/v policies
-    static std::vector<int> list = { 1, 2, 3 };
-    m.def("make_iterator_1", []() { return py::make_iterator<py::return_value_policy::copy>(list); });
-    m.def("make_iterator_2", []() { return py::make_iterator<py::return_value_policy::automatic>(list); });
+    static std::vector<int> list = {1, 2, 3};
+    m.def("make_iterator_1",
+          []() { return py::make_iterator<py::return_value_policy::copy>(list); });
+    m.def("make_iterator_2",
+          []() { return py::make_iterator<py::return_value_policy::automatic>(list); });
 }

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -8,61 +8,62 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#if defined(_MSC_VER) && _MSC_VER < 1910  // VS 2015's MSVC
-#  pragma warning(disable: 4702) // unreachable code in system header (xatomic.h(382))
+#if defined(_MSC_VER) && _MSC_VER < 1910 // VS 2015's MSVC
+#pragma warning(disable : 4702)          // unreachable code in system header (xatomic.h(382))
 #endif
 
-#include "pybind11_tests.h"
 #include "object.h"
+#include "pybind11_tests.h"
 
 namespace {
 
 // This is just a wrapper around unique_ptr, but with extra fields to deliberately bloat up the
-// holder size to trigger the non-simple-layout internal instance layout for single inheritance with
-// large holder type:
+// holder size to trigger the non-simple-layout internal instance layout for single inheritance
+// with large holder type:
 template <typename T> class huge_unique_ptr {
     std::unique_ptr<T> ptr;
     uint64_t padding[10];
+
 public:
     huge_unique_ptr(T *p) : ptr(p) {}
     T *get() { return ptr.get(); }
 };
 
 // Simple custom holder that works like unique_ptr
-template <typename T>
-class custom_unique_ptr {
+template <typename T> class custom_unique_ptr {
     std::unique_ptr<T> impl;
+
 public:
-    custom_unique_ptr(T* p) : impl(p) { }
-    T* get() const { return impl.get(); }
-    T* release_ptr() { return impl.release(); }
+    custom_unique_ptr(T *p) : impl(p) {}
+    T *get() const { return impl.get(); }
+    T *release_ptr() { return impl.release(); }
 };
 
 // Simple custom holder that works like shared_ptr and has operator& overload
 // To obtain address of an instance of this holder pybind should use std::addressof
 // Attempt to get address via operator& may leads to segmentation fault
-template <typename T>
-class shared_ptr_with_addressof_operator {
+template <typename T> class shared_ptr_with_addressof_operator {
     std::shared_ptr<T> impl;
+
 public:
-    shared_ptr_with_addressof_operator( ) = default;
-    shared_ptr_with_addressof_operator(T* p) : impl(p) { }
-    T* get() const { return impl.get(); }
-    T** operator&() { throw std::logic_error("Call of overloaded operator& is not expected"); }
+    shared_ptr_with_addressof_operator() = default;
+    shared_ptr_with_addressof_operator(T *p) : impl(p) {}
+    T *get() const { return impl.get(); }
+    T **operator&() { throw std::logic_error("Call of overloaded operator& is not expected"); }
 };
 
 // Simple custom holder that works like unique_ptr and has operator& overload
 // To obtain address of an instance of this holder pybind should use std::addressof
 // Attempt to get address via operator& may leads to segmentation fault
-template <typename T>
-class unique_ptr_with_addressof_operator {
+template <typename T> class unique_ptr_with_addressof_operator {
     std::unique_ptr<T> impl;
+
 public:
     unique_ptr_with_addressof_operator() = default;
-    unique_ptr_with_addressof_operator(T* p) : impl(p) { }
-    T* get() const { return impl.get(); }
-    T* release_ptr() { return impl.release(); }
-    T** operator&() { throw std::logic_error("Call of overloaded operator& is not expected"); }
+    unique_ptr_with_addressof_operator(T *p) : impl(p) {}
+    T *get() const { return impl.get(); }
+    T *release_ptr() { return impl.release(); }
+    T **operator&() { throw std::logic_error("Call of overloaded operator& is not expected"); }
 };
 
 // Custom object with builtin reference counting (see 'object.h' for the implementation)
@@ -70,8 +71,10 @@ class MyObject1 : public Object {
 public:
     MyObject1(int value) : value(value) { print_created(this, toString()); }
     std::string toString() const override { return "MyObject1[" + std::to_string(value) + "]"; }
+
 protected:
     ~MyObject1() override { print_destroyed(this); }
+
 private:
     int value;
 };
@@ -83,6 +86,7 @@ public:
     MyObject2(int value) : value(value) { print_created(this, toString()); }
     std::string toString() const { return "MyObject2[" + std::to_string(value) + "]"; }
     virtual ~MyObject2() { print_destroyed(this); }
+
 private:
     int value;
 };
@@ -94,6 +98,7 @@ public:
     MyObject3(int value) : value(value) { print_created(this, toString()); }
     std::string toString() const { return "MyObject3[" + std::to_string(value) + "]"; }
     virtual ~MyObject3() { print_destroyed(this); }
+
 private:
     int value;
 };
@@ -116,6 +121,7 @@ public:
         for (auto o : tmp)
             delete o;
     }
+
 private:
     ~MyObject4() {
         myobject4_instances.erase(this);
@@ -143,6 +149,7 @@ public:
         for (auto o : tmp)
             delete o;
     }
+
 protected:
     virtual ~MyObject4a() {
         myobject4a_instances.erase(this);
@@ -230,18 +237,18 @@ struct TypeForMoveOnlyHolderWithAddressOf {
 };
 
 // test_smart_ptr_from_default
-struct HeldByDefaultHolder { };
+struct HeldByDefaultHolder {};
 
 // test_shared_ptr_gc
 // #187: issue involving std::shared_ptr<> return value policy & garbage collection
 struct ElementBase {
     virtual ~ElementBase() = default; /* Force creation of virtual table */
     ElementBase() = default;
-    ElementBase(const ElementBase&) = delete;
+    ElementBase(const ElementBase &) = delete;
 };
 
 struct ElementA : ElementBase {
-    ElementA(int v) : v(v) { }
+    ElementA(int v) : v(v) {}
     int value() const { return v; }
     int v;
 };
@@ -257,11 +264,11 @@ struct ElementList {
 // It is always possible to construct a ref<T> from an Object* pointer without
 // possible inconsistencies, hence the 'true' argument at the end.
 // Make pybind11 aware of the non-standard getter member function
-namespace pybind11 { namespace detail {
-    template <typename T>
-    struct holder_helper<ref<T>> {
-        static const T *get(const ref<T> &p) { return p.get_ptr(); }
-    };
+namespace pybind11 {
+namespace detail {
+template <typename T> struct holder_helper<ref<T>> {
+    static const T *get(const ref<T> &p) { return p.get_ptr(); }
+};
 } // namespace detail
 } // namespace pybind11
 
@@ -285,8 +292,7 @@ TEST_SUBMODULE(smart_ptr, m) {
     py::class_<Object, ref<Object>> obj(m, "Object");
     obj.def("getRefCount", &Object::getRefCount);
 
-    py::class_<MyObject1, ref<MyObject1>>(m, "MyObject1", obj)
-        .def(py::init<int>());
+    py::class_<MyObject1, ref<MyObject1>>(m, "MyObject1", obj).def(py::init<int>());
     py::implicitly_convertible<py::int_, MyObject1>();
 
     m.def("make_object_1", []() -> Object * { return new MyObject1(1); });
@@ -305,25 +311,27 @@ TEST_SUBMODULE(smart_ptr, m) {
     // Expose constructor stats for the ref type
     m.def("cstats_ref", &ConstructorStats::get<ref_tag>);
 
-    py::class_<MyObject2, std::shared_ptr<MyObject2>>(m, "MyObject2")
-        .def(py::init<int>());
+    py::class_<MyObject2, std::shared_ptr<MyObject2>>(m, "MyObject2").def(py::init<int>());
     m.def("make_myobject2_1", []() { return new MyObject2(6); });
     m.def("make_myobject2_2", []() { return std::make_shared<MyObject2>(7); });
     m.def("print_myobject2_1", [](const MyObject2 *obj) { py::print(obj->toString()); });
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m.def("print_myobject2_2", [](std::shared_ptr<MyObject2> obj) { py::print(obj->toString()); });
-    m.def("print_myobject2_3", [](const std::shared_ptr<MyObject2> &obj) { py::print(obj->toString()); });
-    m.def("print_myobject2_4", [](const std::shared_ptr<MyObject2> *obj) { py::print((*obj)->toString()); });
+    m.def("print_myobject2_3",
+          [](const std::shared_ptr<MyObject2> &obj) { py::print(obj->toString()); });
+    m.def("print_myobject2_4",
+          [](const std::shared_ptr<MyObject2> *obj) { py::print((*obj)->toString()); });
 
-    py::class_<MyObject3, std::shared_ptr<MyObject3>>(m, "MyObject3")
-        .def(py::init<int>());
+    py::class_<MyObject3, std::shared_ptr<MyObject3>>(m, "MyObject3").def(py::init<int>());
     m.def("make_myobject3_1", []() { return new MyObject3(8); });
     m.def("make_myobject3_2", []() { return std::make_shared<MyObject3>(9); });
     m.def("print_myobject3_1", [](const MyObject3 *obj) { py::print(obj->toString()); });
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     m.def("print_myobject3_2", [](std::shared_ptr<MyObject3> obj) { py::print(obj->toString()); });
-    m.def("print_myobject3_3", [](const std::shared_ptr<MyObject3> &obj) { py::print(obj->toString()); });
-    m.def("print_myobject3_4", [](const std::shared_ptr<MyObject3> *obj) { py::print((*obj)->toString()); });
+    m.def("print_myobject3_3",
+          [](const std::shared_ptr<MyObject3> &obj) { py::print(obj->toString()); });
+    m.def("print_myobject3_4",
+          [](const std::shared_ptr<MyObject3> *obj) { py::print((*obj)->toString()); });
 
     // test_smart_ptr_refcounting
     m.def("test_object1_refcounting", []() {
@@ -366,8 +374,7 @@ TEST_SUBMODULE(smart_ptr, m) {
             "copy", [](const SharedPtrRef &s) { return s.value; }, py::return_value_policy::copy)
         .def_readonly("holder_ref", &SharedPtrRef::shared)
         .def_property_readonly(
-            "holder_copy",
-            [](const SharedPtrRef &s) { return s.shared; },
+            "holder_copy", [](const SharedPtrRef &s) { return s.shared; },
             py::return_value_policy::copy)
         .def("set_ref", [](SharedPtrRef &, const A &) { return true; })
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
@@ -382,13 +389,11 @@ TEST_SUBMODULE(smart_ptr, m) {
         .def_property_readonly("ref",
                                [](const SharedFromThisRef &s) -> const B & { return *s.shared; })
         .def_property_readonly(
-            "copy",
-            [](const SharedFromThisRef &s) { return s.value; },
+            "copy", [](const SharedFromThisRef &s) { return s.value; },
             py::return_value_policy::copy)
         .def_readonly("holder_ref", &SharedFromThisRef::shared)
         .def_property_readonly(
-            "holder_copy",
-            [](const SharedFromThisRef &s) { return s.shared; },
+            "holder_copy", [](const SharedFromThisRef &s) { return s.shared; },
             py::return_value_policy::copy)
         .def("set_ref", [](SharedFromThisRef &, const B &) { return true; })
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
@@ -419,11 +424,18 @@ TEST_SUBMODULE(smart_ptr, m) {
              [](const HolderWithAddressOf *obj) { py::print((*obj).get()->toString()); });
 
     // test_move_only_holder_with_addressof_operator
-    using MoveOnlyHolderWithAddressOf = unique_ptr_with_addressof_operator<TypeForMoveOnlyHolderWithAddressOf>;
-    py::class_<TypeForMoveOnlyHolderWithAddressOf, MoveOnlyHolderWithAddressOf>(m, "TypeForMoveOnlyHolderWithAddressOf")
-        .def_static("make", []() { return MoveOnlyHolderWithAddressOf(new TypeForMoveOnlyHolderWithAddressOf(0)); })
+    using MoveOnlyHolderWithAddressOf =
+        unique_ptr_with_addressof_operator<TypeForMoveOnlyHolderWithAddressOf>;
+    py::class_<TypeForMoveOnlyHolderWithAddressOf, MoveOnlyHolderWithAddressOf>(
+        m, "TypeForMoveOnlyHolderWithAddressOf")
+        .def_static("make",
+                    []() {
+                        return MoveOnlyHolderWithAddressOf(
+                            new TypeForMoveOnlyHolderWithAddressOf(0));
+                    })
         .def_readwrite("value", &TypeForMoveOnlyHolderWithAddressOf::value)
-        .def("print_object", [](const TypeForMoveOnlyHolderWithAddressOf *obj) { py::print(obj->toString()); });
+        .def("print_object",
+             [](const TypeForMoveOnlyHolderWithAddressOf *obj) { py::print(obj->toString()); });
 
     // test_smart_ptr_from_default
     py::class_<HeldByDefaultHolder, std::unique_ptr<HeldByDefaultHolder>>(m, "HeldByDefaultHolder")

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -24,7 +24,7 @@ template <typename T> class huge_unique_ptr {
     std::unique_ptr<T> ptr;
     uint64_t padding[10];
 public:
-    huge_unique_ptr(T *p) : ptr(p) {};
+    huge_unique_ptr(T *p) : ptr(p) {}
     T *get() { return ptr.get(); }
 };
 

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -7,8 +7,8 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 #include <pybind11/stl.h>
 
 #ifndef PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL
@@ -16,55 +16,51 @@
 #endif
 #include <pybind11/stl/filesystem.h>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 // Test with `std::variant` in C++17 mode, or with `boost::variant` in C++11/14
 #if defined(PYBIND11_HAS_VARIANT)
 using std::variant;
 #elif defined(PYBIND11_TEST_BOOST) && (!defined(_MSC_VER) || _MSC_VER >= 1910)
-#  include <boost/variant.hpp>
-#  define PYBIND11_HAS_VARIANT 1
+#include <boost/variant.hpp>
+#define PYBIND11_HAS_VARIANT 1
 using boost::variant;
 
-namespace pybind11 { namespace detail {
+namespace pybind11 {
+namespace detail {
 template <typename... Ts>
 struct type_caster<boost::variant<Ts...>> : variant_caster<boost::variant<Ts...>> {};
 
-template <>
-struct visit_helper<boost::variant> {
+template <> struct visit_helper<boost::variant> {
     template <typename... Args>
     static auto call(Args &&...args) -> decltype(boost::apply_visitor(args...)) {
         return boost::apply_visitor(args...);
     }
 };
-}} // namespace pybind11::detail
+} // namespace detail
+} // namespace pybind11
 #endif
 
 PYBIND11_MAKE_OPAQUE(std::vector<std::string, std::allocator<std::string>>);
 
 /// Issue #528: templated constructor
 struct TplCtorClass {
-    template <typename T> TplCtorClass(const T &) { }
+    template <typename T> TplCtorClass(const T &) {}
     bool operator==(const TplCtorClass &) const { return true; }
 };
 
 namespace std {
-    template <>
-    struct hash<TplCtorClass> { size_t operator()(const TplCtorClass &) const { return 0; } };
+template <> struct hash<TplCtorClass> {
+    size_t operator()(const TplCtorClass &) const { return 0; }
+};
 } // namespace std
 
-
-template <template <typename> class OptionalImpl, typename T>
-struct OptionalHolder
-{
+template <template <typename> class OptionalImpl, typename T> struct OptionalHolder {
     OptionalHolder() = default;
-    bool member_initialized() const {
-        return member && member->initialized;
-    }
+    bool member_initialized() const { return member && member->initialized; }
     OptionalImpl<T> member = T{};
 };
-
 
 TEST_SUBMODULE(stl, m) {
     // test_vector
@@ -72,9 +68,8 @@ TEST_SUBMODULE(stl, m) {
     m.def("load_vector", [](const std::vector<int> &v) { return v.at(0) == 1 && v.at(1) == 2; });
     // `std::vector<bool>` is special because it returns proxy objects instead of references
     m.def("cast_bool_vector", []() { return std::vector<bool>{true, false}; });
-    m.def("load_bool_vector", [](const std::vector<bool> &v) {
-        return v.at(0) == true && v.at(1) == false;
-    });
+    m.def("load_bool_vector",
+          [](const std::vector<bool> &v) { return v.at(0) == true && v.at(1) == false; });
     // Unnumbered regression (caused by #936): pointers to stl containers aren't castable
     static std::vector<RValueCaster> lvv{2};
     m.def("cast_ptr_vector", []() { return &lvv; });
@@ -84,12 +79,12 @@ TEST_SUBMODULE(stl, m) {
     m.def("load_deque", [](const std::deque<int> &v) { return v.at(0) == 1 && v.at(1) == 2; });
 
     // test_array
-    m.def("cast_array", []() { return std::array<int, 2> {{1 , 2}}; });
+    m.def("cast_array", []() { return std::array<int, 2>{{1, 2}}; });
     m.def("load_array", [](const std::array<int, 2> &a) { return a[0] == 1 && a[1] == 2; });
 
     // test_valarray
     m.def("cast_valarray", []() { return std::valarray<int>{1, 4, 9}; });
-    m.def("load_valarray", [](const std::valarray<int>& v) {
+    m.def("load_valarray", [](const std::valarray<int> &v) {
         return v.size() == 3 && v[0] == 1 && v[1] == 4 && v[2] == 9;
     });
 
@@ -111,10 +106,12 @@ TEST_SUBMODULE(stl, m) {
     // NB: map and set keys are `const`, so while we technically do move them (as `const Type &&`),
     // casters don't typically do anything with that, which means they fall to the `const Type &`
     // caster.
-    m.def("cast_rv_map", []() { return std::unordered_map<std::string, RValueCaster>{{"a", RValueCaster{}}}; });
+    m.def("cast_rv_map", []() {
+        return std::unordered_map<std::string, RValueCaster>{{"a", RValueCaster{}}};
+    });
     m.def("cast_rv_nested", []() {
         std::vector<std::array<std::list<std::unordered_map<std::string, RValueCaster>>, 2>> v;
-        v.emplace_back(); // add an array
+        v.emplace_back();           // add an array
         v.back()[0].emplace_back(); // add a map to the array
         v.back()[0].back().emplace("b", RValueCaster{});
         v.back()[0].back().emplace("c", RValueCaster{});
@@ -123,13 +120,15 @@ TEST_SUBMODULE(stl, m) {
         return v;
     });
     static std::array<RValueCaster, 2> lva;
-    static std::unordered_map<std::string, RValueCaster> lvm{{"a", RValueCaster{}}, {"b", RValueCaster{}}};
-    static std::unordered_map<std::string, std::vector<std::list<std::array<RValueCaster, 2>>>> lvn;
-    lvn["a"].emplace_back(); // add a list
+    static std::unordered_map<std::string, RValueCaster> lvm{{"a", RValueCaster{}},
+                                                             {"b", RValueCaster{}}};
+    static std::unordered_map<std::string, std::vector<std::list<std::array<RValueCaster, 2>>>>
+        lvn;
+    lvn["a"].emplace_back();        // add a list
     lvn["a"].back().emplace_back(); // add an array
-    lvn["a"].emplace_back(); // another list
+    lvn["a"].emplace_back();        // another list
     lvn["a"].back().emplace_back(); // add an array
-    lvn["b"].emplace_back(); // add a list
+    lvn["b"].emplace_back();        // add a list
     lvn["b"].back().emplace_back(); // add an array
     lvn["b"].back().emplace_back(); // add another array
     m.def("cast_lv_vector", []() -> const decltype(lvv) & { return lvv; });
@@ -146,7 +145,9 @@ TEST_SUBMODULE(stl, m) {
 
     // test_move_out_container
     struct MoveOutContainer {
-        struct Value { int value; };
+        struct Value {
+            int value;
+        };
         std::list<Value> move_list() const { return {{0}, {1}, {2}}; }
     };
     py::class_<MoveOutContainer::Value>(m, "MoveOutContainerValue")
@@ -159,7 +160,7 @@ TEST_SUBMODULE(stl, m) {
     struct NoAssign {
         int value;
 
-        explicit NoAssign(int value = 0) : value(value) { }
+        explicit NoAssign(int value = 0) : value(value) {}
         NoAssign(const NoAssign &) = default;
         NoAssign(NoAssign &&) = default;
 
@@ -170,13 +171,10 @@ TEST_SUBMODULE(stl, m) {
         .def(py::init<>())
         .def(py::init<int>());
 
-
-    struct MoveOutDetector
-    {
+    struct MoveOutDetector {
         MoveOutDetector() = default;
-        MoveOutDetector(const MoveOutDetector&) = default;
-        MoveOutDetector(MoveOutDetector&& other) noexcept
-         : initialized(other.initialized) {
+        MoveOutDetector(const MoveOutDetector &) = default;
+        MoveOutDetector(MoveOutDetector &&other) noexcept : initialized(other.initialized) {
             // steal underlying resource
             other.initialized = false;
         }
@@ -186,25 +184,20 @@ TEST_SUBMODULE(stl, m) {
         .def(py::init<>())
         .def_readonly("initialized", &MoveOutDetector::initialized);
 
-
 #ifdef PYBIND11_HAS_OPTIONAL
     // test_optional
     m.attr("has_optional") = true;
 
     using opt_int = std::optional<int>;
     using opt_no_assign = std::optional<NoAssign>;
-    m.def("double_or_zero", [](const opt_int& x) -> int {
-        return x.value_or(0) * 2;
-    });
-    m.def("half_or_none", [](int x) -> opt_int {
-        return x ? opt_int(x / 2) : opt_int();
-    });
-    m.def("test_nullopt", [](opt_int x) {
-        return x.value_or(42);
-    }, py::arg_v("x", std::nullopt, "None"));
-    m.def("test_no_assign", [](const opt_no_assign &x) {
-        return x ? x->value : 42;
-    }, py::arg_v("x", std::nullopt, "None"));
+    m.def("double_or_zero", [](const opt_int &x) -> int { return x.value_or(0) * 2; });
+    m.def("half_or_none", [](int x) -> opt_int { return x ? opt_int(x / 2) : opt_int(); });
+    m.def(
+        "test_nullopt", [](opt_int x) { return x.value_or(42); },
+        py::arg_v("x", std::nullopt, "None"));
+    m.def(
+        "test_no_assign", [](const opt_no_assign &x) { return x ? x->value : 42; },
+        py::arg_v("x", std::nullopt, "None"));
 
     m.def("nodefer_none_optional", [](std::optional<int>) { return true; });
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
@@ -223,18 +216,15 @@ TEST_SUBMODULE(stl, m) {
 
     using exp_opt_int = std::experimental::optional<int>;
     using exp_opt_no_assign = std::experimental::optional<NoAssign>;
-    m.def("double_or_zero_exp", [](const exp_opt_int& x) -> int {
-        return x.value_or(0) * 2;
-    });
-    m.def("half_or_none_exp", [](int x) -> exp_opt_int {
-        return x ? exp_opt_int(x / 2) : exp_opt_int();
-    });
-    m.def("test_nullopt_exp", [](exp_opt_int x) {
-        return x.value_or(42);
-    }, py::arg_v("x", std::experimental::nullopt, "None"));
-    m.def("test_no_assign_exp", [](const exp_opt_no_assign &x) {
-        return x ? x->value : 42;
-    }, py::arg_v("x", std::experimental::nullopt, "None"));
+    m.def("double_or_zero_exp", [](const exp_opt_int &x) -> int { return x.value_or(0) * 2; });
+    m.def("half_or_none_exp",
+          [](int x) -> exp_opt_int { return x ? exp_opt_int(x / 2) : exp_opt_int(); });
+    m.def(
+        "test_nullopt_exp", [](exp_opt_int x) { return x.value_or(42); },
+        py::arg_v("x", std::experimental::nullopt, "None"));
+    m.def(
+        "test_no_assign_exp", [](const exp_opt_no_assign &x) { return x ? x->value : 42; },
+        py::arg_v("x", std::experimental::nullopt, "None"));
 
     using opt_exp_holder = OptionalHolder<std::experimental::optional, MoveOutDetector>;
     py::class_<opt_exp_holder>(m, "OptionalExpHolder", "Class with optional member")
@@ -246,7 +236,7 @@ TEST_SUBMODULE(stl, m) {
 #ifdef PYBIND11_HAS_FILESYSTEM
     // test_fs_path
     m.attr("has_filesystem") = true;
-    m.def("parent_path", [](const std::filesystem::path& p) { return p.parent_path(); });
+    m.def("parent_path", [](const std::filesystem::path &p) { return p.parent_path(); });
 #endif
 
 #ifdef PYBIND11_HAS_VARIANT
@@ -290,13 +280,13 @@ TEST_SUBMODULE(stl, m) {
     // #171: Can't return STL structures containing reference wrapper
     m.def("return_vec_of_reference_wrapper", [](std::reference_wrapper<UserType> p4) {
         static UserType p1{1}, p2{2}, p3{3};
-        return std::vector<std::reference_wrapper<UserType>> {
-            std::ref(p1), std::ref(p2), std::ref(p3), p4
-        };
+        return std::vector<std::reference_wrapper<UserType>>{std::ref(p1), std::ref(p2),
+                                                             std::ref(p3), p4};
     });
 
     // test_stl_pass_by_pointer
-    m.def("stl_pass_by_pointer", [](std::vector<int>* v) { return *v; }, "v"_a=nullptr);
+    m.def(
+        "stl_pass_by_pointer", [](std::vector<int> *v) { return *v; }, "v"_a = nullptr);
 
     // #1258: pybind11/stl.h converts string to vector<string>
     m.def("func_with_string_or_vector_string_arg_overload",
@@ -318,19 +308,24 @@ TEST_SUBMODULE(stl, m) {
     py::class_<Placeholder>(m, "Placeholder");
 
     /// test_stl_vector_ownership
-    m.def("test_stl_ownership",
-          []() {
-              std::vector<Placeholder *> result;
-              result.push_back(new Placeholder());
-              return result;
-          },
-          py::return_value_policy::take_ownership);
+    m.def(
+        "test_stl_ownership",
+        []() {
+            std::vector<Placeholder *> result;
+            result.push_back(new Placeholder());
+            return result;
+        },
+        py::return_value_policy::take_ownership);
 
     m.def("array_cast_sequence", [](std::array<int, 3> x) { return x; });
 
     /// test_issue_1561
-    struct Issue1561Inner { std::string data; };
-    struct Issue1561Outer { std::vector<Issue1561Inner> list; };
+    struct Issue1561Inner {
+        std::string data;
+    };
+    struct Issue1561Outer {
+        std::vector<Issue1561Inner> list;
+    };
 
     py::class_<Issue1561Inner>(m, "Issue1561Inner")
         .def(py::init<std::string>())

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -299,12 +299,15 @@ TEST_SUBMODULE(stl, m) {
     m.def("stl_pass_by_pointer", [](std::vector<int>* v) { return *v; }, "v"_a=nullptr);
 
     // #1258: pybind11/stl.h converts string to vector<string>
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("func_with_string_or_vector_string_arg_overload", [](std::vector<std::string>) { return 1; });
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("func_with_string_or_vector_string_arg_overload", [](std::list<std::string>) { return 2; });
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("func_with_string_or_vector_string_arg_overload", [](std::string) { return 3; });
+    m.def("func_with_string_or_vector_string_arg_overload",
+          // NOLINTNEXTLINE(performance-unnecessary-value-param)
+          [](std::vector<std::string>) { return 1; });
+    m.def("func_with_string_or_vector_string_arg_overload",
+          // NOLINTNEXTLINE(performance-unnecessary-value-param)
+          [](std::list<std::string>) { return 2; });
+    m.def("func_with_string_or_vector_string_arg_overload",
+          // NOLINTNEXTLINE(performance-unnecessary-value-param)
+          [](std::string) { return 3; });
 
     class Placeholder {
     public:

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -9,21 +9,21 @@
 
 #include "pybind11_tests.h"
 
-#include <pybind11/stl_bind.h>
-#include <pybind11/numpy.h>
-#include <map>
 #include <deque>
+#include <map>
+#include <pybind11/numpy.h>
+#include <pybind11/stl_bind.h>
 #include <unordered_map>
 
 class El {
 public:
     El() = delete;
-    El(int v) : a(v) { }
+    El(int v) : a(v) {}
 
     int a;
 };
 
-std::ostream & operator<<(std::ostream &s, El const&v) {
+std::ostream &operator<<(std::ostream &s, El const &v) {
     s << "El{" << v.a << '}';
     return s;
 }
@@ -50,7 +50,7 @@ template <class Container> Container *one_to_n(int n) {
 template <class Map> Map *times_ten(int n) {
     auto m = new Map();
     for (int i = 1; i <= n; i++)
-        m->emplace(int(i), E_nc(10*i));
+        m->emplace(int(i), E_nc(10 * i));
     return m;
 }
 
@@ -58,7 +58,7 @@ template <class NestMap> NestMap *times_hundred(int n) {
     auto m = new NestMap();
     for (int i = 1; i <= n; i++)
         for (int j = 1; j <= n; j++)
-            (*m)[i].emplace(int(j*10), E_nc(100*j));
+            (*m)[i].emplace(int(j * 10), E_nc(100 * j));
     return m;
 }
 
@@ -67,8 +67,7 @@ TEST_SUBMODULE(stl_binders, m) {
     py::bind_vector<std::vector<unsigned int>>(m, "VectorInt", py::buffer_protocol());
 
     // test_vector_custom
-    py::class_<El>(m, "El")
-        .def(py::init<int>());
+    py::class_<El>(m, "El").def(py::init<int>());
     py::bind_vector<std::vector<El>>(m, "VectorEl");
     py::bind_vector<std::vector<std::vector<El>>>(m, "VectorVectorEl");
 
@@ -78,11 +77,10 @@ TEST_SUBMODULE(stl_binders, m) {
 
     // test_map_string_double_const
     py::bind_map<std::map<std::string, double const>>(m, "MapStringDoubleConst");
-    py::bind_map<std::unordered_map<std::string, double const>>(m, "UnorderedMapStringDoubleConst");
+    py::bind_map<std::unordered_map<std::string, double const>>(m,
+                                                                "UnorderedMapStringDoubleConst");
 
-    py::class_<E_nc>(m, "ENC")
-        .def(py::init<int>())
-        .def_readwrite("value", &E_nc::value);
+    py::class_<E_nc>(m, "ENC").def(py::init<int>()).def_readwrite("value", &E_nc::value);
 
     // test_noncopyable_containers
     py::bind_vector<std::vector<E_nc>>(m, "VectorENC");
@@ -95,14 +93,13 @@ TEST_SUBMODULE(stl_binders, m) {
     m.def("get_umnc", &times_ten<std::unordered_map<int, E_nc>>);
     // Issue #1885: binding nested std::map<X, Container<E>> with E non-copyable
     py::bind_map<std::map<int, std::vector<E_nc>>>(m, "MapVecENC");
-    m.def("get_nvnc", [](int n)
-        {
-            auto m = new std::map<int, std::vector<E_nc>>();
-            for (int i = 1; i <= n; i++)
-                for (int j = 1; j <= n; j++)
-                    (*m)[i].emplace_back(j);
-            return m;
-        });
+    m.def("get_nvnc", [](int n) {
+        auto m = new std::map<int, std::vector<E_nc>>();
+        for (int i = 1; i <= n; i++)
+            for (int j = 1; j <= n; j++)
+                (*m)[i].emplace_back(j);
+        return m;
+    });
     py::bind_map<std::map<int, std::map<int, E_nc>>>(m, "MapMapENC");
     m.def("get_nmnc", &times_hundred<std::map<int, std::map<int, E_nc>>>);
     py::bind_map<std::unordered_map<int, std::unordered_map<int, E_nc>>>(m, "UmapUmapENC");
@@ -111,17 +108,31 @@ TEST_SUBMODULE(stl_binders, m) {
     // test_vector_buffer
     py::bind_vector<std::vector<unsigned char>>(m, "VectorUChar", py::buffer_protocol());
     // no dtype declared for this version:
-    struct VUndeclStruct { bool w; uint32_t x; double y; bool z; };
-    m.def("create_undeclstruct", [m] () mutable {
-        py::bind_vector<std::vector<VUndeclStruct>>(m, "VectorUndeclStruct", py::buffer_protocol());
+    struct VUndeclStruct {
+        bool w;
+        uint32_t x;
+        double y;
+        bool z;
+    };
+    m.def("create_undeclstruct", [m]() mutable {
+        py::bind_vector<std::vector<VUndeclStruct>>(m, "VectorUndeclStruct",
+                                                    py::buffer_protocol());
     });
 
     // The rest depends on numpy:
-    try { py::module_::import("numpy"); }
-    catch (...) { return; }
+    try {
+        py::module_::import("numpy");
+    } catch (...) {
+        return;
+    }
 
     // test_vector_buffer_numpy
-    struct VStruct { bool w; uint32_t x; double y; bool z; };
+    struct VStruct {
+        bool w;
+        uint32_t x;
+        double y;
+        bool z;
+    };
     PYBIND11_NUMPY_DTYPE(VStruct, w, x, y, z);
     py::class_<VStruct>(m, "VStruct").def_readwrite("x", &VStruct::x);
     py::bind_vector<std::vector<VStruct>>(m, "VectorStruct", py::buffer_protocol());

--- a/tests/test_tagbased_polymorphic.cpp
+++ b/tests/test_tagbased_polymorphic.cpp
@@ -10,8 +10,7 @@
 #include "pybind11_tests.h"
 #include <pybind11/stl.h>
 
-struct Animal
-{
+struct Animal {
     // Make this type also a "standard" polymorphic type, to confirm that
     // specializing polymorphic_type_hook using enable_if_t still works
     // (https://github.com/pybind/pybind11/pull/2016/).
@@ -20,55 +19,52 @@ struct Animal
     // Enum for tag-based polymorphism.
     enum class Kind {
         Unknown = 0,
-        Dog = 100, Labrador, Chihuahua, LastDog = 199,
-        Cat = 200, Panther, LastCat = 299
+        Dog = 100,
+        Labrador,
+        Chihuahua,
+        LastDog = 199,
+        Cat = 200,
+        Panther,
+        LastCat = 299
     };
-    static const std::type_info* type_of_kind(Kind kind);
+    static const std::type_info *type_of_kind(Kind kind);
     static std::string name_of_kind(Kind kind);
 
     const Kind kind;
     const std::string name;
 
-  protected:
-    Animal(const std::string& _name, Kind _kind)
-        : kind(_kind), name(_name)
-    {}
+protected:
+    Animal(const std::string &_name, Kind _kind) : kind(_kind), name(_name) {}
 };
 
-struct Dog : Animal
-{
-    Dog(const std::string& _name, Kind _kind = Kind::Dog) : Animal(_name, _kind) {}
+struct Dog : Animal {
+    Dog(const std::string &_name, Kind _kind = Kind::Dog) : Animal(_name, _kind) {}
     std::string bark() const { return name_of_kind(kind) + " " + name + " goes " + sound; }
     std::string sound = "WOOF!";
 };
 
-struct Labrador : Dog
-{
-    Labrador(const std::string& _name, int _excitement = 9001)
+struct Labrador : Dog {
+    Labrador(const std::string &_name, int _excitement = 9001)
         : Dog(_name, Kind::Labrador), excitement(_excitement) {}
     int excitement;
 };
 
-struct Chihuahua : Dog
-{
-    Chihuahua(const std::string& _name) : Dog(_name, Kind::Chihuahua) { sound = "iyiyiyiyiyi"; }
+struct Chihuahua : Dog {
+    Chihuahua(const std::string &_name) : Dog(_name, Kind::Chihuahua) { sound = "iyiyiyiyiyi"; }
     std::string bark() const { return Dog::bark() + " and runs in circles"; }
 };
 
-struct Cat : Animal
-{
-    Cat(const std::string& _name, Kind _kind = Kind::Cat) : Animal(_name, _kind) {}
+struct Cat : Animal {
+    Cat(const std::string &_name, Kind _kind = Kind::Cat) : Animal(_name, _kind) {}
     std::string purr() const { return "mrowr"; }
 };
 
-struct Panther : Cat
-{
-    Panther(const std::string& _name) : Cat(_name, Kind::Panther) {}
+struct Panther : Cat {
+    Panther(const std::string &_name) : Cat(_name, Kind::Panther) {}
     std::string purr() const { return "mrrrRRRRRR"; }
 };
 
-std::vector<std::unique_ptr<Animal>> create_zoo()
-{
+std::vector<std::unique_ptr<Animal>> create_zoo() {
     std::vector<std::unique_ptr<Animal>> ret;
     ret.emplace_back(new Labrador("Fido", 15000));
 
@@ -83,45 +79,53 @@ std::vector<std::unique_ptr<Animal>> create_zoo()
     return ret;
 }
 
-const std::type_info* Animal::type_of_kind(Kind kind)
-{
+const std::type_info *Animal::type_of_kind(Kind kind) {
     switch (kind) {
-        case Kind::Unknown: break;
+    case Kind::Unknown:
+        break;
 
-        case Kind::Dog: break;
-        case Kind::Labrador: return &typeid(Labrador);
-        case Kind::Chihuahua: return &typeid(Chihuahua);
-        case Kind::LastDog: break;
+    case Kind::Dog:
+        break;
+    case Kind::Labrador:
+        return &typeid(Labrador);
+    case Kind::Chihuahua:
+        return &typeid(Chihuahua);
+    case Kind::LastDog:
+        break;
 
-        case Kind::Cat: break;
-        case Kind::Panther: return &typeid(Panther);
-        case Kind::LastCat: break;
+    case Kind::Cat:
+        break;
+    case Kind::Panther:
+        return &typeid(Panther);
+    case Kind::LastCat:
+        break;
     }
 
-    if (kind >= Kind::Dog && kind <= Kind::LastDog) return &typeid(Dog);
-    if (kind >= Kind::Cat && kind <= Kind::LastCat) return &typeid(Cat);
+    if (kind >= Kind::Dog && kind <= Kind::LastDog)
+        return &typeid(Dog);
+    if (kind >= Kind::Cat && kind <= Kind::LastCat)
+        return &typeid(Cat);
     return nullptr;
 }
 
-std::string Animal::name_of_kind(Kind kind)
-{
+std::string Animal::name_of_kind(Kind kind) {
     std::string raw_name = type_of_kind(kind)->name();
     py::detail::clean_type_id(raw_name);
     return raw_name;
 }
 
 namespace pybind11 {
-    template <typename itype>
-    struct polymorphic_type_hook<itype, detail::enable_if_t<std::is_base_of<Animal, itype>::value>>
-    {
-        static const void *get(const itype *src, const std::type_info*& type)
-        { type = src ? Animal::type_of_kind(src->kind) : nullptr; return src; }
-    };
+template <typename itype>
+struct polymorphic_type_hook<itype, detail::enable_if_t<std::is_base_of<Animal, itype>::value>> {
+    static const void *get(const itype *src, const std::type_info *&type) {
+        type = src ? Animal::type_of_kind(src->kind) : nullptr;
+        return src;
+    }
+};
 } // namespace pybind11
 
 TEST_SUBMODULE(tagbased_polymorphic, m) {
-    py::class_<Animal>(m, "Animal")
-        .def_readonly("name", &Animal::name);
+    py::class_<Animal>(m, "Animal").def_readonly("name", &Animal::name);
     py::class_<Dog, Animal>(m, "Dog")
         .def(py::init<std::string>())
         .def_readwrite("sound", &Dog::sound)
@@ -132,9 +136,7 @@ TEST_SUBMODULE(tagbased_polymorphic, m) {
     py::class_<Chihuahua, Dog>(m, "Chihuahua")
         .def(py::init<std::string>())
         .def("bark", &Chihuahua::bark);
-    py::class_<Cat, Animal>(m, "Cat")
-        .def(py::init<std::string>())
-        .def("purr", &Cat::purr);
+    py::class_<Cat, Animal>(m, "Cat").def(py::init<std::string>()).def("purr", &Cat::purr);
     py::class_<Panther, Cat>(m, "Panther")
         .def(py::init<std::string>())
         .def("purr", &Panther::purr);

--- a/tests/test_virtual_functions.cpp
+++ b/tests/test_virtual_functions.cpp
@@ -7,13 +7,13 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
+#include "pybind11_tests.h"
 #include <pybind11/functional.h>
 #include <thread>
 
 /* This is an example class that we'll want to be able to extend from Python */
-class ExampleVirt  {
+class ExampleVirt {
 public:
     ExampleVirt(int state) : state(state) { print_created(this, state); }
     ExampleVirt(const ExampleVirt &e) : state(e.state) { print_copy_created(this); }
@@ -25,7 +25,8 @@ public:
 
     virtual int run(int value) {
         py::print("Original implementation of "
-                  "ExampleVirt::run(state={}, value={}, str1={}, str2={})"_s.format(state, value, get_string1(), *get_string2()));
+                  "ExampleVirt::run(state={}, value={}, str1={}, str2={})"_s.format(
+                      state, value, get_string1(), *get_string2()));
         return state + value;
     }
 
@@ -33,8 +34,8 @@ public:
     virtual void pure_virtual() = 0;
 
     // Returning a reference/pointer to a type converted from python (numbers, strings, etc.) is a
-    // bit trickier, because the actual int& or std::string& or whatever only exists temporarily, so
-    // we have to handle it specially in the trampoline class (see below).
+    // bit trickier, because the actual int& or std::string& or whatever only exists temporarily,
+    // so we have to handle it specially in the trampoline class (see below).
     virtual const std::string &get_string1() { return str1; }
     virtual const std::string *get_string2() { return &str2; }
 
@@ -50,59 +51,53 @@ public:
 
     int run(int value) override {
         /* Generate wrapping code that enables native function overloading */
-        PYBIND11_OVERRIDE(
-            int,         /* Return type */
-            ExampleVirt, /* Parent class */
-            run,         /* Name of function */
-            value        /* Argument(s) */
+        PYBIND11_OVERRIDE(int,         /* Return type */
+                          ExampleVirt, /* Parent class */
+                          run,         /* Name of function */
+                          value        /* Argument(s) */
         );
     }
 
     bool run_bool() override {
-        PYBIND11_OVERRIDE_PURE(
-            bool,         /* Return type */
-            ExampleVirt,  /* Parent class */
-            run_bool,     /* Name of function */
-                          /* This function has no arguments. The trailing comma
-                             in the previous line is needed for some compilers */
+        PYBIND11_OVERRIDE_PURE(bool,        /* Return type */
+                               ExampleVirt, /* Parent class */
+                               run_bool,    /* Name of function */
+                                            /* This function has no arguments. The trailing comma
+                                               in the previous line is needed for some compilers */
         );
     }
 
     void pure_virtual() override {
-        PYBIND11_OVERRIDE_PURE(
-            void,         /* Return type */
-            ExampleVirt,  /* Parent class */
-            pure_virtual, /* Name of function */
-                          /* This function has no arguments. The trailing comma
-                             in the previous line is needed for some compilers */
+        PYBIND11_OVERRIDE_PURE(void,         /* Return type */
+                               ExampleVirt,  /* Parent class */
+                               pure_virtual, /* Name of function */
+                                             /* This function has no arguments. The trailing comma
+                                                in the previous line is needed for some compilers */
         );
     }
 
     // We can return reference types for compatibility with C++ virtual interfaces that do so, but
     // note they have some significant limitations (see the documentation).
     const std::string &get_string1() override {
-        PYBIND11_OVERRIDE(
-            const std::string &, /* Return type */
-            ExampleVirt,         /* Parent class */
-            get_string1,         /* Name of function */
-                                 /* (no arguments) */
+        PYBIND11_OVERRIDE(const std::string &, /* Return type */
+                          ExampleVirt,         /* Parent class */
+                          get_string1,         /* Name of function */
+                                               /* (no arguments) */
         );
     }
 
     const std::string *get_string2() override {
-        PYBIND11_OVERRIDE(
-            const std::string *, /* Return type */
-            ExampleVirt,         /* Parent class */
-            get_string2,         /* Name of function */
-                                 /* (no arguments) */
+        PYBIND11_OVERRIDE(const std::string *, /* Return type */
+                          ExampleVirt,         /* Parent class */
+                          get_string2,         /* Name of function */
+                                               /* (no arguments) */
         );
     }
-
 };
 
 class NonCopyable {
 public:
-    NonCopyable(int a, int b) : value{new int(a*b)} { print_created(this, a, b); }
+    NonCopyable(int a, int b) : value{new int(a * b)} { print_created(this, a, b); }
     NonCopyable(NonCopyable &&o) noexcept {
         value = std::move(o.value);
         print_move_created(this);
@@ -126,14 +121,18 @@ private:
 // when it is not referenced elsewhere, but copied if it is still referenced.
 class Movable {
 public:
-    Movable(int a, int b) : value{a+b} { print_created(this, a, b); }
-    Movable(const Movable &m) { value = m.value; print_copy_created(this); }
+    Movable(int a, int b) : value{a + b} { print_created(this, a, b); }
+    Movable(const Movable &m) {
+        value = m.value;
+        print_copy_created(this);
+    }
     Movable(Movable &&m) noexcept {
         value = m.value;
         print_move_created(this);
     }
     std::string get_value() const { return std::to_string(value); }
     ~Movable() { print_destroyed(this); }
+
 private:
     int value;
 };
@@ -142,7 +141,7 @@ class NCVirt {
 public:
     virtual ~NCVirt() = default;
     NCVirt() = default;
-    NCVirt(const NCVirt&) = delete;
+    NCVirt(const NCVirt &) = delete;
     virtual NonCopyable get_noncopyable(int a, int b) { return NonCopyable(a, b); }
     virtual Movable get_movable(int a, int b) = 0;
 
@@ -165,7 +164,7 @@ struct Base {
     virtual std::string dispatch() const { return {}; };
     virtual ~Base() = default;
     Base() = default;
-    Base(const Base&) = delete;
+    Base(const Base &) = delete;
 };
 
 struct DispatchIssue : Base {
@@ -178,14 +177,12 @@ static void test_gil() {
     {
         py::gil_scoped_acquire lock;
         py::print("1st lock acquired");
-
     }
 
     {
         py::gil_scoped_acquire lock;
         py::print("2nd lock acquired");
     }
-
 }
 
 static void test_gil_from_thread() {
@@ -195,9 +192,8 @@ static void test_gil_from_thread() {
     t.join();
 }
 
-
-// Forward declaration (so that we can put the main tests here; the inherited virtual approaches are
-// rather long).
+// Forward declaration (so that we can put the main tests here; the inherited virtual approaches
+// are rather long).
 void initialize_inherited_virtuals(py::module_ &m);
 
 TEST_SUBMODULE(virtual_functions, m) {
@@ -209,11 +205,9 @@ TEST_SUBMODULE(virtual_functions, m) {
         .def("run_bool", &ExampleVirt::run_bool)
         .def("pure_virtual", &ExampleVirt::pure_virtual);
 
-    py::class_<NonCopyable>(m, "NonCopyable")
-        .def(py::init<int, int>());
+    py::class_<NonCopyable>(m, "NonCopyable").def(py::init<int, int>());
 
-    py::class_<Movable>(m, "Movable")
-        .def(py::init<int, int>());
+    py::class_<Movable>(m, "Movable").def(py::init<int, int>());
 
     // test_move_support
 #if !defined(__INTEL_COMPILER) && !defined(__CUDACC__) && !defined(__PGIC__)
@@ -226,7 +220,7 @@ TEST_SUBMODULE(virtual_functions, m) {
 #endif
 
     m.def("runExampleVirt", [](ExampleVirt *ex, int value) { return ex->run(value); });
-    m.def("runExampleVirtBool", [](ExampleVirt* ex) { return ex->run_bool(); });
+    m.def("runExampleVirtBool", [](ExampleVirt *ex) { return ex->run_bool(); });
     m.def("runExampleVirtVirtual", [](ExampleVirt *ex) { ex->pure_virtual(); });
 
     m.def("cstats_debug", &ConstructorStats::get<ExampleVirt>);
@@ -237,27 +231,25 @@ TEST_SUBMODULE(virtual_functions, m) {
     // that were not extended on the Python side
     struct A {
         A() = default;
-        A(const A&) = delete;
+        A(const A &) = delete;
         virtual ~A() = default;
         virtual void f() { py::print("A.f()"); }
     };
 
     struct PyA : A {
         PyA() { py::print("PyA.PyA()"); }
-        PyA(const PyA&) = delete;
+        PyA(const PyA &) = delete;
         ~PyA() override { py::print("PyA.~PyA()"); }
 
         void f() override {
             py::print("PyA.f()");
-            // This convolution just gives a `void`, but tests that PYBIND11_TYPE() works to protect
-            // a type containing a ,
+            // This convolution just gives a `void`, but tests that PYBIND11_TYPE() works to
+            // protect a type containing a ,
             PYBIND11_OVERRIDE(PYBIND11_TYPE(typename std::enable_if<true, void>::type), A, f);
         }
     };
 
-    py::class_<A, PyA>(m, "A")
-        .def(py::init<>())
-        .def("f", &A::f);
+    py::class_<A, PyA>(m, "A").def(py::init<>()).def("f", &A::f);
 
     m.def("call_f", [](A *a) { a->f(); });
 
@@ -265,14 +257,14 @@ TEST_SUBMODULE(virtual_functions, m) {
     // ... unless we explicitly request it, as in this example:
     struct A2 {
         A2() = default;
-        A2(const A2&) = delete;
+        A2(const A2 &) = delete;
         virtual ~A2() = default;
         virtual void f() { py::print("A2.f()"); }
     };
 
     struct PyA2 : A2 {
         PyA2() { py::print("PyA2.PyA2()"); }
-        PyA2(const PyA2&) = delete;
+        PyA2(const PyA2 &) = delete;
         ~PyA2() override { py::print("PyA2.~PyA2()"); }
         void f() override {
             py::print("PyA2.f()");
@@ -293,18 +285,20 @@ TEST_SUBMODULE(virtual_functions, m) {
         .def(py::init<>())
         .def("dispatch", &Base::dispatch);
 
-    m.def("dispatch_issue_go", [](const Base * b) { return b->dispatch(); });
+    m.def("dispatch_issue_go", [](const Base *b) { return b->dispatch(); });
 
     // test_override_ref
     // #392/397: overriding reference-returning functions
     class OverrideTest {
     public:
-        struct A { std::string value = "hi"; };
+        struct A {
+            std::string value = "hi";
+        };
         std::string v;
         A a;
         explicit OverrideTest(const std::string &v) : v{v} {}
         OverrideTest() = default;
-        OverrideTest(const OverrideTest&) = delete;
+        OverrideTest(const OverrideTest &) = delete;
         virtual std::string str_value() { return v; }
         virtual std::string &str_ref() { return v; }
         virtual A A_value() { return a; }
@@ -315,14 +309,18 @@ TEST_SUBMODULE(virtual_functions, m) {
     class PyOverrideTest : public OverrideTest {
     public:
         using OverrideTest::OverrideTest;
-        std::string str_value() override { PYBIND11_OVERRIDE(std::string, OverrideTest, str_value); }
+        std::string str_value() override {
+            PYBIND11_OVERRIDE(std::string, OverrideTest, str_value);
+        }
         // Not allowed (uncommenting should hit a static_assert failure): we can't get a reference
         // to a python numeric value, since we only copy values in the numeric type caster:
-//      std::string &str_ref() override { PYBIND11_OVERRIDE(std::string &, OverrideTest, str_ref); }
+        //      std::string &str_ref() override { PYBIND11_OVERRIDE(std::string &, OverrideTest,
+        //      str_ref); }
         // But we can work around it like this:
     private:
         std::string _tmp;
         std::string str_ref_helper() { PYBIND11_OVERRIDE(std::string, OverrideTest, str_ref); }
+
     public:
         std::string &str_ref() override { return _tmp = str_ref_helper(); }
 
@@ -335,11 +333,10 @@ TEST_SUBMODULE(virtual_functions, m) {
     py::class_<OverrideTest, PyOverrideTest>(m, "OverrideTest")
         .def(py::init<const std::string &>())
         .def("str_value", &OverrideTest::str_value)
-//      .def("str_ref", &OverrideTest::str_ref)
+        //      .def("str_ref", &OverrideTest::str_ref)
         .def("A_value", &OverrideTest::A_value)
         .def("A_ref", &OverrideTest::A_ref);
 }
-
 
 // Inheriting virtual methods.  We do two versions here: the repeat-everything version and the
 // templated trampoline versions mentioned in docs/advanced.rst.
@@ -349,93 +346,108 @@ TEST_SUBMODULE(virtual_functions, m) {
 // properly (pybind11, sensibly, doesn't allow us to bind the same C++ class to
 // multiple python classes).
 class A_Repeat {
-#define A_METHODS \
-public: \
-    virtual int unlucky_number() = 0; \
-    virtual std::string say_something(unsigned times) { \
-        std::string s = ""; \
-        for (unsigned i = 0; i < times; ++i) \
-            s += "hi"; \
-        return s; \
-    } \
-    std::string say_everything() { \
-        return say_something(1) + " " + std::to_string(unlucky_number()); \
+#define A_METHODS                                                                                 \
+public:                                                                                           \
+    virtual int unlucky_number() = 0;                                                             \
+    virtual std::string say_something(unsigned times) {                                           \
+        std::string s = "";                                                                       \
+        for (unsigned i = 0; i < times; ++i)                                                      \
+            s += "hi";                                                                            \
+        return s;                                                                                 \
+    }                                                                                             \
+    std::string say_everything() {                                                                \
+        return say_something(1) + " " + std::to_string(unlucky_number());                         \
     }
-A_METHODS
+    A_METHODS
     A_Repeat() = default;
-    A_Repeat(const A_Repeat&) = delete;
+    A_Repeat(const A_Repeat &) = delete;
     virtual ~A_Repeat() = default;
 };
 class B_Repeat : public A_Repeat {
-#define B_METHODS \
-public: \
-    int unlucky_number() override { return 13; } \
-    std::string say_something(unsigned times) override { \
-        return "B says hi " + std::to_string(times) + " times"; \
-    } \
+#define B_METHODS                                                                                 \
+public:                                                                                           \
+    int unlucky_number() override { return 13; }                                                  \
+    std::string say_something(unsigned times) override {                                          \
+        return "B says hi " + std::to_string(times) + " times";                                   \
+    }                                                                                             \
     virtual double lucky_number() { return 7.0; }
-B_METHODS
+    B_METHODS
 };
 class C_Repeat : public B_Repeat {
-#define C_METHODS \
-public: \
-    int unlucky_number() override { return 4444; } \
+#define C_METHODS                                                                                 \
+public:                                                                                           \
+    int unlucky_number() override { return 4444; }                                                \
     double lucky_number() override { return 888; }
-C_METHODS
+    C_METHODS
 };
 class D_Repeat : public C_Repeat {
 #define D_METHODS // Nothing overridden.
-D_METHODS
+    D_METHODS
 };
 
 // Base classes for templated inheritance trampolines.  Identical to the repeat-everything version:
 class A_Tpl {
     A_METHODS;
     A_Tpl() = default;
-    A_Tpl(const A_Tpl&) = delete;
+    A_Tpl(const A_Tpl &) = delete;
     virtual ~A_Tpl() = default;
 };
-class B_Tpl : public A_Tpl { B_METHODS };
-class C_Tpl : public B_Tpl { C_METHODS };
-class D_Tpl : public C_Tpl { D_METHODS };
-
+class B_Tpl : public A_Tpl {
+    B_METHODS
+};
+class C_Tpl : public B_Tpl {
+    C_METHODS
+};
+class D_Tpl : public C_Tpl {
+    D_METHODS
+};
 
 // Inheritance approach 1: each trampoline gets every virtual method (11 in total)
 class PyA_Repeat : public A_Repeat {
 public:
     using A_Repeat::A_Repeat;
     int unlucky_number() override { PYBIND11_OVERRIDE_PURE(int, A_Repeat, unlucky_number, ); }
-    std::string say_something(unsigned times) override { PYBIND11_OVERRIDE(std::string, A_Repeat, say_something, times); }
+    std::string say_something(unsigned times) override {
+        PYBIND11_OVERRIDE(std::string, A_Repeat, say_something, times);
+    }
 };
 class PyB_Repeat : public B_Repeat {
 public:
     using B_Repeat::B_Repeat;
     int unlucky_number() override { PYBIND11_OVERRIDE(int, B_Repeat, unlucky_number, ); }
-    std::string say_something(unsigned times) override { PYBIND11_OVERRIDE(std::string, B_Repeat, say_something, times); }
+    std::string say_something(unsigned times) override {
+        PYBIND11_OVERRIDE(std::string, B_Repeat, say_something, times);
+    }
     double lucky_number() override { PYBIND11_OVERRIDE(double, B_Repeat, lucky_number, ); }
 };
 class PyC_Repeat : public C_Repeat {
 public:
     using C_Repeat::C_Repeat;
     int unlucky_number() override { PYBIND11_OVERRIDE(int, C_Repeat, unlucky_number, ); }
-    std::string say_something(unsigned times) override { PYBIND11_OVERRIDE(std::string, C_Repeat, say_something, times); }
+    std::string say_something(unsigned times) override {
+        PYBIND11_OVERRIDE(std::string, C_Repeat, say_something, times);
+    }
     double lucky_number() override { PYBIND11_OVERRIDE(double, C_Repeat, lucky_number, ); }
 };
 class PyD_Repeat : public D_Repeat {
 public:
     using D_Repeat::D_Repeat;
     int unlucky_number() override { PYBIND11_OVERRIDE(int, D_Repeat, unlucky_number, ); }
-    std::string say_something(unsigned times) override { PYBIND11_OVERRIDE(std::string, D_Repeat, say_something, times); }
+    std::string say_something(unsigned times) override {
+        PYBIND11_OVERRIDE(std::string, D_Repeat, say_something, times);
+    }
     double lucky_number() override { PYBIND11_OVERRIDE(double, D_Repeat, lucky_number, ); }
 };
 
 // Inheritance approach 2: templated trampoline classes.
 //
 // Advantages:
-// - we have only 2 (template) class and 4 method declarations (one per virtual method, plus one for
-//   any override of a pure virtual method), versus 4 classes and 6 methods (MI) or 4 classes and 11
-//   methods (repeat).
-// - Compared to MI, we also don't have to change the non-trampoline inheritance to virtual, and can
+// - we have only 2 (template) class and 4 method declarations (one per virtual method, plus one
+// for
+//   any override of a pure virtual method), versus 4 classes and 6 methods (MI) or 4 classes and
+//   11 methods (repeat).
+// - Compared to MI, we also don't have to change the non-trampoline inheritance to virtual, and
+// can
 //   properly inherit constructors.
 //
 // Disadvantage:
@@ -443,22 +455,22 @@ public:
 //   required for the repeat approach) instead of the 6 required for MI.  (If there was no pure
 //   method (or no pure method override), the number would drop down to the same 11 as the repeat
 //   approach).
-template <class Base = A_Tpl>
-class PyA_Tpl : public Base {
+template <class Base = A_Tpl> class PyA_Tpl : public Base {
 public:
     using Base::Base; // Inherit constructors
     int unlucky_number() override { PYBIND11_OVERRIDE_PURE(int, Base, unlucky_number, ); }
-    std::string say_something(unsigned times) override { PYBIND11_OVERRIDE(std::string, Base, say_something, times); }
+    std::string say_something(unsigned times) override {
+        PYBIND11_OVERRIDE(std::string, Base, say_something, times);
+    }
 };
-template <class Base = B_Tpl>
-class PyB_Tpl : public PyA_Tpl<Base> {
+template <class Base = B_Tpl> class PyB_Tpl : public PyA_Tpl<Base> {
 public:
     using PyA_Tpl<Base>::PyA_Tpl; // Inherit constructors (via PyA_Tpl's inherited constructors)
     int unlucky_number() override { PYBIND11_OVERRIDE(int, Base, unlucky_number, ); }
     double lucky_number() override { PYBIND11_OVERRIDE(double, Base, lucky_number, ); }
 };
-// Since C_Tpl and D_Tpl don't declare any new virtual methods, we don't actually need these (we can
-// use PyB_Tpl<C_Tpl> and PyB_Tpl<D_Tpl> for the trampoline classes instead):
+// Since C_Tpl and D_Tpl don't declare any new virtual methods, we don't actually need these (we
+// can use PyB_Tpl<C_Tpl> and PyB_Tpl<D_Tpl> for the trampoline classes instead):
 /*
 template <class Base = C_Tpl> class PyC_Tpl : public PyB_Tpl<Base> {
 public:
@@ -482,10 +494,8 @@ void initialize_inherited_virtuals(py::module_ &m) {
     py::class_<B_Repeat, A_Repeat, PyB_Repeat>(m, "B_Repeat")
         .def(py::init<>())
         .def("lucky_number", &B_Repeat::lucky_number);
-    py::class_<C_Repeat, B_Repeat, PyC_Repeat>(m, "C_Repeat")
-        .def(py::init<>());
-    py::class_<D_Repeat, C_Repeat, PyD_Repeat>(m, "D_Repeat")
-        .def(py::init<>());
+    py::class_<C_Repeat, B_Repeat, PyC_Repeat>(m, "C_Repeat").def(py::init<>());
+    py::class_<D_Repeat, C_Repeat, PyD_Repeat>(m, "D_Repeat").def(py::init<>());
 
     // test_
     // Method 2: Templated trampolines
@@ -497,11 +507,8 @@ void initialize_inherited_virtuals(py::module_ &m) {
     py::class_<B_Tpl, A_Tpl, PyB_Tpl<>>(m, "B_Tpl")
         .def(py::init<>())
         .def("lucky_number", &B_Tpl::lucky_number);
-    py::class_<C_Tpl, B_Tpl, PyB_Tpl<C_Tpl>>(m, "C_Tpl")
-        .def(py::init<>());
-    py::class_<D_Tpl, C_Tpl, PyB_Tpl<D_Tpl>>(m, "D_Tpl")
-        .def(py::init<>());
-
+    py::class_<C_Tpl, B_Tpl, PyB_Tpl<C_Tpl>>(m, "C_Tpl").def(py::init<>());
+    py::class_<D_Tpl, C_Tpl, PyB_Tpl<D_Tpl>>(m, "D_Tpl").def(py::init<>());
 
     // Fix issue #1454 (crash when acquiring/releasing GIL on another thread in Python 2.7)
     m.def("test_gil", &test_gil);


### PR DESCRIPTION
**EXPERIMENTAL** integration of clang-format hook into pre-commit.
**NOT TO BE MERGED** until after the 2.7 release.

At the moment this DRAFT PR is is to see what's involved and what the result looks like.

Using the same docker container as used for clang-tidy (silkeh/clang:12).