### PR TITLE
Fixing select clang-tidy issues to reduce NOLINTNEXTLINE use.

### DIFF
--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -10,8 +10,11 @@
 #include "pybind11_tests.h"
 #include "local_bindings.h"
 #include "test_exceptions.h"
+
 #include <pybind11/stl_bind.h>
+
 #include <numeric>
+#include <utility>
 
 PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.doc() = "pybind11 cross-module test module";
@@ -104,9 +107,10 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.def("return_self", [](LocalVec *v) { return v; });
     m.def("return_copy", [](const LocalVec &v) { return LocalVec(v); });
 
-    // Changing this broke things with pygrep. TODO fix
-    // NOLINTNEXTLINE
-    class Dog : public pets::Pet { public: Dog(std::string name) : Pet(name) {}; };
+    class Dog : public pets::Pet {
+    public:
+        Dog(std::string name) : Pet(std::move(name)) {}
+    };
     py::class_<pets::Pet>(m, "Pet", py::module_local())
         .def("name", &pets::Pet::name);
     // Binding for local extending class:

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -151,10 +151,12 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("int_passthrough_noconvert", [](int arg) { return arg; }, py::arg{}.noconvert());
 
     // test_tuple
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("pair_passthrough", [](std::pair<bool, std::string> input) {
-        return std::make_pair(input.second, input.first);
-    }, "Return a pair in reversed order");
+    m.def(
+        "pair_passthrough",
+        [](const std::pair<bool, std::string> &input) {
+            return std::make_pair(input.second, input.first);
+        },
+        "Return a pair in reversed order");
     m.def("tuple_passthrough", [](std::tuple<bool, std::string, int> input) {
         return std::make_tuple(std::get<2>(input), std::get<1>(input), std::get<0>(input));
     }, "Return a triple in reversed order");

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -106,10 +106,15 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
             py::arg() = 3, "j"_a = 4, py::kw_only(), "k"_a = 5, "z"_a);
     m.def("kw_only_mixed", [](int i, int j) { return py::make_tuple(i, j); },
             "i"_a, py::kw_only(), "j"_a);
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("kw_only_plus_more", [](int i, int j, int k, py::kwargs kwargs) {
-            return py::make_tuple(i, j, k, kwargs); },
-            py::arg() /* positional */, py::arg("j") = -1 /* both */, py::kw_only(), py::arg("k") /* kw-only */);
+    m.def(
+        "kw_only_plus_more",
+        [](int i, int j, int k, const py::kwargs &kwargs) {
+            return py::make_tuple(i, j, k, kwargs);
+        },
+        py::arg() /* positional */,
+        py::arg("j") = -1 /* both */,
+        py::kw_only(),
+        py::arg("k") /* kw-only */);
 
     m.def("register_invalid_kw_only", [](py::module_ m) {
         m.def("bad_kw_only", [](int i, int j) { return py::make_tuple(i, j); },

--- a/tests/test_local_bindings.cpp
+++ b/tests/test_local_bindings.cpp
@@ -10,9 +10,12 @@
 
 #include "pybind11_tests.h"
 #include "local_bindings.h"
+
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
+
 #include <numeric>
+#include <utility>
 
 TEST_SUBMODULE(local_bindings, m) {
     // test_load_external
@@ -86,9 +89,10 @@ TEST_SUBMODULE(local_bindings, m) {
     m.def("return_self", [](LocalVec *v) { return v; });
     m.def("return_copy", [](const LocalVec &v) { return LocalVec(v); });
 
-    // Reformatting this class broke pygrep checks
-    // NOLINTNEXTLINE
-    class Cat : public pets::Pet { public: Cat(std::string name) : Pet(name) {}; };
+    class Cat : public pets::Pet {
+    public:
+        Cat(std::string name) : Pet(std::move(name)) {}
+    };
     py::class_<pets::Pet>(m, "Pet", py::module_local())
         .def("get_name", &pets::Pet::name);
     // Binding for local extending class:


### PR DESCRIPTION
This was really meant to be part of PR #3051 but was held back either out of an abundance of caution, or because of confusion caused by stray semicolons.

The particular `NOLINT`s removed here were stumbling stones for the ongoing work under PR #3078. Breaking out the fixes into a separate PR to disconnect them from other questions.

clang-format-diff was applied.