### PR TITLE
Prep-work for clang-format excluding `\rst`-related issues.

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -62,7 +62,8 @@ struct metaclass {
     handle value;
 
     PYBIND11_DEPRECATED("py::metaclass() is no longer required. It's turned on by default now.")
-    metaclass() { } // NOLINT(modernize-use-equals-default): breaks MSVC 2015 when adding an attribute
+    // NOLINTNEXTLINE(modernize-use-equals-default): breaks MSVC 2015 when adding an attribute
+    metaclass() {}
 
     /// Override pybind11's default metaclass
     explicit metaclass(handle value) : value(value) { }

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -801,7 +801,8 @@ struct nodelete { template <typename T> void operator()(T*) { } };
 PYBIND11_NAMESPACE_BEGIN(detail)
 template <typename... Args>
 struct overload_cast_impl {
-    constexpr overload_cast_impl() {}; // NOLINT(modernize-use-equals-default):  MSVC 2015 needs this
+    // NOLINTNEXTLINE(modernize-use-equals-default):  MSVC 2015 needs this
+    constexpr overload_cast_impl() {}
 
     template <typename Return>
     constexpr auto operator()(Return (*pf)(Args...)) const noexcept

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -1,10 +1,15 @@
 #pragma once
+
+// This must be kept first for MSVC 2015.
+// Do not remove the empty line between the #includes.
 #include <pybind11/pybind11.h>
+
 #include <pybind11/eval.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
 // We get some really long type names here which causes MSVC 2015 to emit warnings
-#  pragma warning(disable: 4503) // warning C4503: decorated name length exceeded, name was truncated
+#    pragma warning(                                                                              \
+        disable : 4503) // warning C4503: decorated name length exceeded, name was truncated
 #endif
 
 namespace py = pybind11;

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -154,7 +154,7 @@ TEST_SUBMODULE(buffers, m) {
                                    py::format_descriptor<int32_t>::format(), 1);
         }
 
-        ConstBuffer() : value(new int32_t{0}) { };
+        ConstBuffer() : value(new int32_t{0}) {}
     };
     py::class_<ConstBuffer>(m, "ConstBuffer", py::buffer_protocol())
         .def(py::init<>())

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -122,7 +122,7 @@ TEST_SUBMODULE(callbacks, m) {
         // [workaround(intel)] = default does not work here
         // Defaulting this destructor results in linking errors with the Intel compiler
         // (in Debug builds only, tested with icpc (ICC) 2021.1 Beta 20200827)
-        virtual ~AbstractBase() {};  // NOLINT(modernize-use-equals-default)
+        virtual ~AbstractBase() {} // NOLINT(modernize-use-equals-default)
         virtual unsigned int func() = 0;
     };
     m.def("func_accepting_func_accepting_base",

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -258,7 +258,10 @@ TEST_SUBMODULE(eigen, m) {
     m.def("dense_copy_r", [](const DenseMatrixR &m) -> DenseMatrixR { return m; });
     m.def("dense_copy_c", [](const DenseMatrixC &m) -> DenseMatrixC { return m; });
     // test_sparse, test_sparse_signature
-    m.def("sparse_r", [mat]() -> SparseMatrixR { return Eigen::SparseView<Eigen::MatrixXf>(mat); }); //NOLINT(clang-analyzer-core.uninitialized.UndefReturn)
+    m.def("sparse_r", [mat]() -> SparseMatrixR {
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+        return Eigen::SparseView<Eigen::MatrixXf>(mat);
+    });
     m.def("sparse_c", [mat]() -> SparseMatrixC { return Eigen::SparseView<Eigen::MatrixXf>(mat); });
     m.def("sparse_copy_r", [](const SparseMatrixR &m) -> SparseMatrixR { return m; });
     m.def("sparse_copy_c", [](const SparseMatrixC &m) -> SparseMatrixC { return m; });

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -123,7 +123,7 @@ class NoneCastTester {
 public:
     int answer = -1;
     NoneCastTester() = default;
-    NoneCastTester(int v) : answer(v) {};
+    NoneCastTester(int v) : answer(v) {}
 };
 
 struct StrIssue {
@@ -390,14 +390,14 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         .def("increase_value", &RegisteredDerived::increase_value)
         .def_readwrite("rw_value", &RegisteredDerived::rw_value)
         .def_readonly("ro_value", &RegisteredDerived::ro_value)
-        // These should trigger a static_assert if uncommented
-        //.def_readwrite("fails", &UserType::value) // should trigger a static_assert if uncommented
-        //.def_readonly("fails", &UserType::value) // should trigger a static_assert if uncommented
+        // Uncommenting the next line should trigger a static_assert:
+        // .def_readwrite("fails", &UserType::value)
+        // Uncommenting the next line should trigger a static_assert:
+        // .def_readonly("fails", &UserType::value)
         .def_property("rw_value_prop", &RegisteredDerived::get_int, &RegisteredDerived::set_int)
         .def_property_readonly("ro_value_prop", &RegisteredDerived::get_double)
         // This one is in the registered class:
-        .def("sum", &RegisteredDerived::sum)
-        ;
+        .def("sum", &RegisteredDerived::sum);
 
     using Adapted = decltype(py::method_adaptor<RegisteredDerived>(&RegisteredDerived::do_nothing));
     static_assert(std::is_same<Adapted, void (RegisteredDerived::*)() const>::value, "");

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -24,7 +24,7 @@ template <typename T> class huge_unique_ptr {
     std::unique_ptr<T> ptr;
     uint64_t padding[10];
 public:
-    huge_unique_ptr(T *p) : ptr(p) {};
+    huge_unique_ptr(T *p) : ptr(p) {}
     T *get() { return ptr.get(); }
 };
 


### PR DESCRIPTION
Prep-work to establish a clean base for clang-format or clang-format-diff (see **experimental/demo** PR #3074).

NO bulk changes in this PR, just minimal changes such that a global clang-format is stable after a single pass.

The demo PR #3074 has two automatic changes applied on top of this PR:
* Automatic insertion of `// clang-format off`, `on` pairs around `\rst`, `\endrst` comment blocks.
* Bulk global clang-format via pre-commit.
This is to prove that this prep work is the clean base we need.

This prep work was several hours of tedious work running clang-format & clang-tidy until both are stable. Breaking out as a separate PR so that these manual changes do not have to be maintained separately while we decide how to integrate clang-format or clang-format-diff into our GitHub Actions.

Notable steps:

* Removing stray semicolons (discovered by running clang-format v12 followed by tools/check-style.sh).

* Manually moving clang-tidy `// NOLINT` comments so that clang-format does not move them to the wrong places.

* Manually reformatting comments related to `static_assert`s so that clang-format does not need two passes.

* `git diff -U0 --no-color HEAD^ | python3 $HOME/clone/llvm-project/clang/tools/clang-format/clang-format-diff.py -p1 -style=file -i`

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Prep-work to establish a clean base for clang-format or clang-format-diff.
```
