### PR TITLE
Fix typos and docs style

### DIFF
--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -804,7 +804,7 @@ to bind these two functions:
             }
         ));
 
-The ``__setstate__`` part of the ``py::picke()`` definition follows the same
+The ``__setstate__`` part of the ``py::pickle()`` definition follows the same
 rules as the single-argument version of ``py::init()``. The return type can be
 a value, pointer or holder type. See :ref:`custom_constructors` for details.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -5,7 +5,7 @@ Frequently asked questions
 ===========================================================
 
 1. Make sure that the name specified in PYBIND11_MODULE is identical to the
-filename of the extension library (without suffixes such as .so)
+filename of the extension library (without suffixes such as ``.so``).
 
 2. If the above did not fix the issue, you are likely using an incompatible
 version of Python (for instance, the extension library was compiled against
@@ -170,7 +170,7 @@ complete independence of the symbols involved when not using
 ``-fvisibility=hidden``.
 
 Additionally, ``-fvisibility=hidden`` can deliver considerably binary size
-savings.  (See the following section for more details).
+savings. (See the following section for more details.)
 
 
 .. _`faq:symhidden`:


### PR DESCRIPTION
## Description

Found some typos and parentheses issues in docs.

<!-- If the upgrade guide needs updating, note that here too -->
