### PR TITLE
WIP: restoring valgrind CI on smart_holder branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,10 +175,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # valgrind started failing for the final version of PR #3023 (same gcc, python, valgrind as before).
         - python-version: 3.9
           python-debug: true
-          valgrind: false
+          valgrind: true
         - python-version: 3.10-dev
           python-debug: false
 

--- a/.github/workflows/ci_sh_def.yml
+++ b/.github/workflows/ci_sh_def.yml
@@ -189,10 +189,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # valgrind started failing for the final version of PR #3023 (same gcc, python, valgrind as before).
         - python-version: 3.9
           python-debug: true
-          valgrind: false
+          valgrind: true
         - python-version: 3.10-dev
           python-debug: false
 
@@ -402,7 +401,7 @@ jobs:
       run:  yum -y install https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc-20-9-20.9-1.x86_64.rpm https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc-2020-20.9-1.x86_64.rpm
 
     # On CentOS 7, we have to filter a few tests (compiler internal error)
-    # and allow deeper templete recursion (not needed on CentOS 8 with a newer
+    # and allow deeper template recursion (not needed on CentOS 8 with a newer
     # standard library). On some systems, you many need further workarounds:
     # https://github.com/pybind/pybind11/pull/2475
     - name: Configure

--- a/.github/workflows/ci_sh_def.yml.patch
+++ b/.github/workflows/ci_sh_def.yml.patch
@@ -1,5 +1,5 @@
---- ci.yml	2021-06-30 17:20:07.213156515 -0700
-+++ ci_sh_def.yml	2021-06-30 17:22:01.585076084 -0700
+--- ci.yml	2021-07-10 10:55:33.768884147 -0700
++++ ci_sh_def.yml	2021-07-10 10:56:02.326861782 -0700
 @@ -1,4 +1,16 @@
 -name: CI-SH-AVL
 +# PLEASE KEEP THIS GROUP OF FILES IN SYNC AT ALL TIMES:
@@ -34,7 +34,7 @@
          ${{ matrix.args }}
          ${{ matrix.args2 }}
  
-@@ -288,6 +302,7 @@
+@@ -287,6 +301,7 @@
          -DPYBIND11_WERROR=ON
          -DDOWNLOAD_CATCH=ON
          -DCMAKE_CXX_STANDARD=${{ matrix.std }}
@@ -42,7 +42,7 @@
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
      - name: Build
-@@ -317,7 +332,8 @@
+@@ -316,7 +331,8 @@
        run: apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y cmake git python3-dev python3-pytest python3-numpy
  
      - name: Configure
@@ -52,7 +52,7 @@
  
      - name: Build
        run: cmake --build build -j2 --verbose
-@@ -397,7 +413,7 @@
+@@ -396,7 +412,7 @@
          cmake3 -S . -B build -DDOWNLOAD_CATCH=ON \
                              -DCMAKE_CXX_STANDARD=11 \
                              -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") \
@@ -61,7 +61,7 @@
                              -DPYBIND11_TEST_FILTER="test_smart_ptr.cpp;test_virtual_functions.cpp"
  
      # Building before installing Pip should produce a warning but not an error
-@@ -456,6 +472,7 @@
+@@ -455,6 +471,7 @@
          -DPYBIND11_WERROR=ON
          -DDOWNLOAD_CATCH=ON
          -DCMAKE_CXX_STANDARD=${{ matrix.std }}
@@ -69,7 +69,7 @@
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
      - name: Build
-@@ -511,6 +528,7 @@
+@@ -510,6 +527,7 @@
          -DDOWNLOAD_CATCH=ON     \
          -DDOWNLOAD_EIGEN=OFF    \
          -DCMAKE_CXX_STANDARD=11             \
@@ -77,7 +77,7 @@
          -DCMAKE_CXX_COMPILER=$(which icpc)  \
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
-@@ -543,6 +561,7 @@
+@@ -542,6 +560,7 @@
          -DDOWNLOAD_CATCH=ON     \
          -DDOWNLOAD_EIGEN=OFF    \
          -DCMAKE_CXX_STANDARD=17             \
@@ -85,7 +85,7 @@
          -DCMAKE_CXX_COMPILER=$(which icpc)  \
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
-@@ -613,6 +632,7 @@
+@@ -612,6 +631,7 @@
          -DDOWNLOAD_CATCH=ON
          -DDOWNLOAD_EIGEN=ON
          -DCMAKE_CXX_STANDARD=11
@@ -93,7 +93,7 @@
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
      - name: Build
-@@ -663,6 +683,7 @@
+@@ -662,6 +682,7 @@
          cmake ../pybind11-tests
          -DDOWNLOAD_CATCH=ON
          -DPYBIND11_WERROR=ON
@@ -101,7 +101,7 @@
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
        working-directory: /build-tests
  
-@@ -758,6 +779,7 @@
+@@ -757,6 +778,7 @@
          -DPYBIND11_WERROR=ON
          -DDOWNLOAD_CATCH=OFF
          -DDOWNLOAD_EIGEN=ON
@@ -109,7 +109,7 @@
          ${{ matrix.args }}
      - name: Build C++11
        run: cmake --build build -j 2
-@@ -804,6 +826,7 @@
+@@ -803,6 +825,7 @@
          -DPYBIND11_WERROR=ON
          -DDOWNLOAD_CATCH=OFF
          -DDOWNLOAD_EIGEN=ON
@@ -117,7 +117,7 @@
  
      - name: Build C++14
        run: cmake --build build -j 2
-@@ -824,12 +847,13 @@
+@@ -823,12 +846,13 @@
            - 3.7
          std:
            - 14

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,8 +5,8 @@ numpy==1.19.3; (platform_python_implementation!="PyPy" or sys_platform=="linux")
 numpy==1.20.0; (platform_python_implementation!="PyPy" or sys_platform=="linux") and python_version>="3.7" and python_version<"3.10"
 pytest==4.6.9; python_version<"3.5"
 pytest==6.1.2; python_version=="3.5"
-pytest==6.2.1; python_version>="3.6" and python_version<="3.9"
-pytest @ git+https://github.com/pytest-dev/pytest@c117bc350ec1e570672fda3b2ad234fd52e72b53; python_version>="3.10"
+pytest==6.2.1; python_version>="3.6" and python_version<="3.8"
+pytest @ git+https://github.com/pytest-dev/pytest@5d8392cb68fe0b3d6aba3a351d76fc9f02297980; python_version>="3.9"
 pytest-timeout
 scipy==1.2.3; (platform_python_implementation!="PyPy" or sys_platform=="linux") and python_version<"3.6"
 scipy==1.5.4; (platform_python_implementation!="PyPy" or sys_platform=="linux") and python_version>="3.6" and python_version<"3.10"

--- a/tests/test_class_sh_trampoline_shared_from_this.py
+++ b/tests/test_class_sh_trampoline_shared_from_this.py
@@ -213,7 +213,7 @@ def test_multiple_registered_instances_for_same_pointee_recursive():
         break  # Comment out for manual leak checking (use `top` command).
 
 
-WORKAROUND_ENABLING_ROLLBACK_OF_PR3068 = env.LINUX
+WORKAROUND_ENABLING_ROLLBACK_OF_PR3068 = False  # env.LINUX
 
 
 def test_std_make_shared_factory():

--- a/tests/test_class_sh_trampoline_shared_from_this.py
+++ b/tests/test_class_sh_trampoline_shared_from_this.py
@@ -213,7 +213,8 @@ def test_multiple_registered_instances_for_same_pointee_recursive():
         break  # Comment out for manual leak checking (use `top` command).
 
 
-WORKAROUND_ENABLING_ROLLBACK_OF_PR3068 = False  # env.LINUX
+# As of 2021-07-10 the pybind11 GitHub Actions valgrind build uses Python 3.9.
+WORKAROUND_ENABLING_ROLLBACK_OF_PR3068 = env.LINUX and env.PY[:2] == (3, 9)
 
 
 def test_std_make_shared_factory():

--- a/tests/test_class_sh_trampoline_shared_from_this.py
+++ b/tests/test_class_sh_trampoline_shared_from_this.py
@@ -213,6 +213,9 @@ def test_multiple_registered_instances_for_same_pointee_recursive():
         break  # Comment out for manual leak checking (use `top` command).
 
 
+WORKAROUND_ENABLING_ROLLBACK_OF_PR3068 = env.LINUX
+
+
 def test_std_make_shared_factory():
     class PySftMakeShared(m.Sft):
         def __init__(self, history):
@@ -220,10 +223,19 @@ def test_std_make_shared_factory():
 
     obj = PySftMakeShared("PySftMakeShared")
     assert obj.history == "PySftMakeShared"
-    with pytest.raises(RuntimeError) as exc_info:
-        m.pass_through_shd_ptr(obj)
+    if WORKAROUND_ENABLING_ROLLBACK_OF_PR3068:
+        try:
+            m.pass_through_shd_ptr(obj)
+        except RuntimeError as e:
+            str_exc_info_value = str(e)
+        else:
+            str_exc_info_value = "RuntimeError NOT RAISED"
+    else:
+        with pytest.raises(RuntimeError) as exc_info:
+            m.pass_through_shd_ptr(obj)
+        str_exc_info_value = str(exc_info.value)
     assert (
-        str(exc_info.value)
+        str_exc_info_value
         == "smart_holder_type_casters loaded_as_shared_ptr failure: not implemented:"
         " trampoline-self-life-support for external shared_ptr to type inheriting"
         " from std::enable_shared_from_this."


### PR DESCRIPTION
* Rollback of PR #3068.

* Needs a `WORKAROUND_ENABLING_ROLLBACK_OF_PR3068` in test_class_sh_trampoline_shared_from_this.py

* Using latest pytest main branch for 3.9 and 3.10. This update turned out NOT to make a difference for the valgrind issue but it is preserved anyway, in case it turns out that the root cause is in pytest (maybe not most likely but it is a possibility).

Note: the `WORKAROUND_ENABLING_ROLLBACK_OF_PR3068` is known to also resolve the MSAN error reported under https://github.com/pybind/pybind11/pull/3068#issuecomment-877658470
