### PR TITLE
py::register_exception_translator with const & std::exception_ptr

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -100,7 +100,7 @@ struct internals {
     std::unordered_set<std::pair<const PyObject *, const char *>, override_hash> inactive_override_cache;
     type_map<std::vector<bool (*)(PyObject *, void *&)>> direct_conversions;
     std::unordered_map<const PyObject *, std::vector<PyObject *>> patients;
-    std::forward_list<void (*) (std::exception_ptr)> registered_exception_translators;
+    std::forward_list<void (*)(const std::exception_ptr &)> registered_exception_translators;
     std::unordered_map<std::string, void *> shared_data; // Custom data to be shared across extensions
     std::vector<PyObject *> loader_patient_stack; // Used by `loader_life_support`
     std::forward_list<std::string> static_strings; // Stores the std::strings backing detail::c_str()
@@ -223,7 +223,7 @@ inline internals **&get_internals_pp() {
     return internals_pp;
 }
 
-inline void translate_exception(std::exception_ptr p) {
+inline void translate_exception(const std::exception_ptr &p) {
     try {
         if (p) std::rethrow_exception(p);
     } catch (error_already_set &e)           { e.restore();                                    return;
@@ -243,7 +243,7 @@ inline void translate_exception(std::exception_ptr p) {
 }
 
 #if !defined(__GLIBCXX__)
-inline void translate_local_exception(std::exception_ptr p) {
+inline void translate_local_exception(const std::exception_ptr &p) {
     try {
         if (p) std::rethrow_exception(p);
     } catch (error_already_set &e)       { e.restore();   return;

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -34,7 +34,7 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
     m.def("throw_pybind_value_error", []() { throw py::value_error("pybind11 value error"); });
     m.def("throw_pybind_type_error", []() { throw py::type_error("pybind11 type error"); });
     m.def("throw_stop_iteration", []() { throw py::stop_iteration(); });
-    py::register_exception_translator([](std::exception_ptr p) {
+    py::register_exception_translator([](const std::exception_ptr &p) {
       try {
           if (p) std::rethrow_exception(p);
       } catch (const shared_exception &e) {

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -101,7 +101,7 @@ TEST_SUBMODULE(exceptions, m) {
 
     // make a new custom exception and use it as a translation target
     static py::exception<MyException> ex(m, "MyException");
-    py::register_exception_translator([](std::exception_ptr p) {
+    py::register_exception_translator([](const std::exception_ptr &p) {
         try {
             if (p) std::rethrow_exception(p);
         } catch (const MyException &e) {
@@ -113,7 +113,7 @@ TEST_SUBMODULE(exceptions, m) {
     // register new translator for MyException2
     // no need to store anything here because this type will
     // never by visible from Python
-    py::register_exception_translator([](std::exception_ptr p) {
+    py::register_exception_translator([](const std::exception_ptr &p) {
         try {
             if (p) std::rethrow_exception(p);
         } catch (const MyException2 &e) {
@@ -125,7 +125,7 @@ TEST_SUBMODULE(exceptions, m) {
     // register new translator for MyException4
     // which will catch it and delegate to the previously registered
     // translator for MyException by throwing a new exception
-    py::register_exception_translator([](std::exception_ptr p) {
+    py::register_exception_translator([](const std::exception_ptr &p) {
         try {
             if (p) std::rethrow_exception(p);
         } catch (const MyException4 &e) {


### PR DESCRIPTION
**ARCHIVING AN EXPERIMENT** NOT meant for merging.

Note: The CI succeeded on all platforms.

* Potential (probably very minor) performance optimization.
* But needs a **change to the internals**.
* Also breaks the API (see new `pybind11_fail` in pybind11.h) unless more changes are made to the internals.

Ralf's assessment: A missed opportunity with benefit / cost-for-fixing too small to be worth the trouble.