### PR TITLE
[smart_holder] WIP: Fix for Python 3.9 MSAN/valgrind errors.

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -422,7 +422,7 @@ extern "C" inline void pybind11_object_dealloc(PyObject *self) {
     auto type = Py_TYPE(self);
     type->tp_free(self);
 
-#if PY_VERSION_HEX < 0x03080000
+#if PY_VERSION_HEX < 0x03080000 || PY_VERSION_HEX >= 0x03090000
     // `type->tp_dealloc != pybind11_object_dealloc` means that we're being called
     // as part of a derived type's dealloc, in which case we're not allowed to decref
     // the type here. For cross-module compatibility, we shouldn't compare directly
@@ -431,7 +431,7 @@ extern "C" inline void pybind11_object_dealloc(PyObject *self) {
     if (type->tp_dealloc == pybind11_object_type->tp_dealloc)
         Py_DECREF(type);
 #else
-    // This was not needed before Python 3.8 (Python issue 35810)
+    // This was not needed before Python 3.8 (https://bugs.python.org/issue35810)
     // https://github.com/pybind/pybind11/issues/1946
     Py_DECREF(type);
 #endif

--- a/tests/test_class_sh_trampoline_shared_from_this.py
+++ b/tests/test_class_sh_trampoline_shared_from_this.py
@@ -213,10 +213,6 @@ def test_multiple_registered_instances_for_same_pointee_recursive():
         break  # Comment out for manual leak checking (use `top` command).
 
 
-# As of 2021-07-10 the pybind11 GitHub Actions valgrind build uses Python 3.9.
-WORKAROUND_ENABLING_ROLLBACK_OF_PR3068 = env.LINUX and env.PY[:2] == (3, 9)
-
-
 def test_std_make_shared_factory():
     class PySftMakeShared(m.Sft):
         def __init__(self, history):
@@ -224,19 +220,10 @@ def test_std_make_shared_factory():
 
     obj = PySftMakeShared("PySftMakeShared")
     assert obj.history == "PySftMakeShared"
-    if WORKAROUND_ENABLING_ROLLBACK_OF_PR3068:
-        try:
-            m.pass_through_shd_ptr(obj)
-        except RuntimeError as e:
-            str_exc_info_value = str(e)
-        else:
-            str_exc_info_value = "RuntimeError NOT RAISED"
-    else:
-        with pytest.raises(RuntimeError) as exc_info:
-            m.pass_through_shd_ptr(obj)
-        str_exc_info_value = str(exc_info.value)
+    with pytest.raises(RuntimeError) as exc_info:
+        m.pass_through_shd_ptr(obj)
     assert (
-        str_exc_info_value
+        str(exc_info.value)
         == "smart_holder_type_casters loaded_as_shared_ptr failure: not implemented:"
         " trampoline-self-life-support for external shared_ptr to type inheriting"
         " from std::enable_shared_from_this."


### PR DESCRIPTION
WIP — Currently this is NOT A FIX, just hoping to become one.