### PR TITLE
docs: fix script issues for changelog compilation

### DIFF
--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -27,7 +27,10 @@ print()
 
 api = ghapi.all.GhApi(owner="pybind", repo="pybind11")
 
-issues = api.issues.list_for_repo(labels="needs changelog", state="closed")
+issues_pages = ghapi.page.paged(
+    api.issues.list_for_repo, labels="needs changelog", state="closed"
+)
+issues = (issue for page in issues_pages for issue in page)
 missing = []
 
 for issue in issues:
@@ -41,7 +44,7 @@ for issue in issues:
 
         msg += f"\n  `#{issue.number} <{issue.html_url}>`_"
 
-        print(Syntax(msg, "rst", theme="ansi_light"))
+        print(Syntax(msg, "rst", theme="ansi_light", word_wrap=True))
         print()
 
     else:


### PR DESCRIPTION
This was buggy - it only worked for 1 page of results (30 or less), and it truncated really long lines. Fixed.
