### PR TITLE
chore: add nox support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@ CMakeLists.txt @henryiii
 *.yaml @henryiii
 /tools/ @henryiii
 /pybind11/ @henryiii
+noxfile.py @henryiii
+.clang-format @henryiii
+.clang-tidy @henryiii

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,6 +53,33 @@ derivative works thereof, in binary and source code form.
 
 ## Development of pybind11
 
+### Quick setup
+
+To setup a quick development environment, use [`nox`](https://nox.thea.codes).
+This will allow you to do some common tasks with minimal setup effort, but will
+take more time to run and be less flexible than a full development environment.
+If you use [`pipx run nox`](https://pipx.pypa.io), you don't even need to
+install `nox`. Examples:
+
+```bash
+# List all available sessions
+nox -l
+
+# Run linters
+nox -s lint
+
+# Run tests
+nox -s tests
+
+# Build and preview docs
+nox -s docs -- serve
+
+# Build SDists and wheels
+nox -s build
+```
+
+### Full setup
+
 To setup an ideal development environment, run the following commands on a
 system with CMake 3.14+:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
   - id: fix-encoding-pragma
+    exclude: ^noxfile.py$
 
 # Black, the code formatter, natively supports pre-commit
 - repo: https://github.com/psf/black

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,83 @@
+import nox
+
+
+nox.options.sessions = ["lint", "tests", "tests_packaging"]
+
+
+@nox.session(reuse_venv=True)
+def lint(session: nox.Session) -> None:
+    """
+    Lint the codebase (except for clang-format/tidy).
+    """
+    session.install("pre-commit")
+    session.run("pre-commit", "run", "-a")
+
+
+@nox.session
+def tests(session: nox.Session) -> None:
+    """
+    Run the tests (requires a compiler).
+    """
+    tmpdir = session.create_tmp()
+    session.install("pytest", "cmake")
+    session.run(
+        "cmake",
+        "-S",
+        ".",
+        "-B",
+        tmpdir,
+        "-DPYBIND11_WERROR=ON",
+        "-DDOWNLOAD_CATCH=ON",
+        "-DDOWNLOAD_EIGEN=ON",
+        *session.posargs
+    )
+    session.run("cmake", "--build", tmpdir)
+    session.run("cmake", "--build", tmpdir, "--config=Release", "--target", "check")
+
+
+@nox.session
+def tests_packaging(session: nox.Session) -> None:
+    """
+    Run the packaging tests.
+    """
+
+    session.install("-r", "tests/requirements.txt", "--prefer-binary")
+    session.run("pytest", "tests/extra_python_package")
+
+
+@nox.session(reuse_venv=True)
+def docs(session: nox.Session) -> None:
+    """
+    Build the docs. Pass "serve" to serve.
+    """
+
+    session.install("-r", "docs/requirements.txt")
+    session.chdir("docs")
+    session.run("sphinx-build", "-M", "html", ".", "_build")
+
+    if session.posargs:
+        if "serve" in session.posargs:
+            print("Launching docs at http://localhost:8000/ - use Ctrl-C to quit")
+            session.run("python", "-m", "http.server", "8000", "-d", "_build/html")
+        else:
+            print("Unsupported argument to docs")
+
+
+@nox.session(reuse_venv=True)
+def make_changelog(session: nox.Session) -> None:
+    """
+    Inspect the closed issues and make entries for a changelog.
+    """
+    session.install("ghapi", "rich")
+    session.run("python", "tools/make_changelog.py")
+
+
+@nox.session(reuse_venv=True)
+def build(session: nox.Session) -> None:
+    """
+    Build SDists and wheels.
+    """
+
+    session.install("build")
+    session.run("python", "-m", "build")
+    session.run("python", "-m", "build", env={"PYBIND11_GLOBAL_SDIST": "1"})

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ ignore =
     pybind11/include/**
     pybind11/share/**
     CMakeLists.txt
+    noxfile.py
 
 
 [flake8]


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

This adds a simple set of nox sessions. The main one I needed this for was the
changelog runner, which allows this script to automatically setup a venv with
the correct dependencies. But I think this could help new contributors too, so
I added a few common useful things. We could simplify the CI a bit by using nox
for package build and docs checks.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Added nox support for easier local testing and linting of contributions.
```

<!-- If the upgrade guide needs updating, note that here too -->
