### PR TITLE
Fixing spelling errors. 

### DIFF
--- a/docs/advanced/pycpp/utilities.rst
+++ b/docs/advanced/pycpp/utilities.rst
@@ -51,7 +51,7 @@ redirects output to the corresponding Python streams:
 
     The implementation in ``pybind11/iostream.h`` is NOT thread safe. Multiple
     threads writing to a redirected ostream concurrently cause data races
-    and potentially buffer overflows. Therefore it is currrently a requirement
+    and potentially buffer overflows. Therefore it is currently a requirement
     that all (possibly) concurrent redirected ostream writes are protected by
     a mutex. #HelpAppreciated: Work on iostream.h thread safety. For more
     background see the discussions under

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -8,7 +8,7 @@
 
     WARNING: The implementation in this file is NOT thread safe. Multiple
     threads writing to a redirected ostream concurrently cause data races
-    and potentially buffer overflows. Therefore it is currrently a requirement
+    and potentially buffer overflows. Therefore it is currently a requirement
     that all (possibly) concurrent redirected ostream writes are protected by
     a mutex.
     #HelpAppreciated: Work on iostream.h thread safety.


### PR DESCRIPTION
The errors went undetected because the pre-commit spell check was added only after the CI for PR #2995 last ran.
Sorry, silly accident.
I'll double-check the CI freshness more carefully in the future.