### PR TITLE
docs: reduce visibility of 3.9.0 warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,19 +13,6 @@
 
 .. start
 
-.. warning::
-
-   Combining older versions of pybind11 (< 2.6.0) with Python 3.9.0 will
-   trigger undefined behavior that typically manifests as crashes during
-   interpreter shutdown (but could also destroy your data. **You have been
-   warned.**)
-
-   We recommend that you update to the latest patch release of Python (3.9.1),
-   which includes a `fix <https://github.com/python/cpython/pull/22670>`_
-   that resolves this problem. If you do use Python 3.9.0, please update to
-   the latest version of pybind11 (2.6.0 or newer), which includes a temporary
-   workaround specifically when Python 3.9.0 is detected at runtime.
-
 
 **pybind11** is a lightweight header-only library that exposes C++ types
 in Python and vice versa, mainly to create Python bindings of existing
@@ -110,7 +97,7 @@ goodies:
   transparently applied to all entries of one or more NumPy array
   arguments.
 
-- Python’s slice-based access and assignment operations can be
+- Python's slice-based access and assignment operations can be
   supported with just a few lines of code.
 
 - Everything is contained in just a few header files; there is no need

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -57,16 +57,16 @@ clean, well written patch would likely be accepted to solve them.
 Python 3.9.0 warning
 ^^^^^^^^^^^^^^^^^^^^
 
-Combining older versions of pybind11 (< 2.6.0) with Python on 3.9.0 will
-trigger undefined behavior that typically manifests as crashes during
+Combining older versions of pybind11 (< 2.6.0) with Python on exactly 3.9.0
+will trigger undefined behavior that typically manifests as crashes during
 interpreter shutdown (but could also destroy your data. **You have been
 warned**).
 
-This issue has been
-`fixed in Python <https://github.com/python/cpython/pull/22670>`_.  As a
-mitigation until 3.9.1 is released and commonly used, pybind11 (2.6.0 or newer)
-includes a temporary workaround specifically when Python 3.9.0 is detected at
-runtime, leaking about 50 bytes of memory when a callback function is garbage
-collected. For reference; the pybind11 test suite has about 2,000 such
-callbacks, but only 49 are garbage collected before the end-of-process. Wheels
-built with Python 3.9.0 will correctly avoid the leak when run in Python 3.9.1.
+This issue was `fixed in Python <https://github.com/python/cpython/pull/22670>`_.
+As a mitigation for this bug, pybind11 2.6.0 or newer includes a workaround
+specifically when Python 3.9.0 is detected at runtime, leaking about 50 bytes
+of memory when a callback function is garbage collected.  For reference, the
+pybind11 test suite has about 2,000 such callbacks, but only 49 are garbage
+collected before the end-of-process. Wheels (even if built with Python 3.9.0)
+will correctly avoid the leak when run in Python 3.9.1, and this does not
+affect other 3.X versions.


### PR DESCRIPTION
3.9.0 shouldn't be that common, and most users should be using 2.6 or better (at least if they are reading the latest docs).
