### PR TITLE
Use cpp17 constexpr for casting

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -887,7 +887,6 @@ T cast(const handle &handle) { return T(reinterpret_borrow<object>(handle)); }
 template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
 object cast(T &&value, return_value_policy policy = return_value_policy::automatic_reference,
             handle parent = handle()) {
-    // using no_ref_T = PYBIND11_CPP17_CONSTEXPR std::remove_reference<T>::type;
     if (policy == return_value_policy::automatic) {
         if PYBIND11_CPP17_CONSTEXPR (std::is_pointer<std::remove_reference<T>>::value) {
             policy = return_value_policy::take_ownership;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -887,13 +887,24 @@ T cast(const handle &handle) { return T(reinterpret_borrow<object>(handle)); }
 template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
 object cast(T &&value, return_value_policy policy = return_value_policy::automatic_reference,
             handle parent = handle()) {
-    using no_ref_T = typename std::remove_reference<T>::type;
-    if (policy == return_value_policy::automatic)
-        policy = std::is_pointer<no_ref_T>::value ? return_value_policy::take_ownership :
-                 std::is_lvalue_reference<T>::value ? return_value_policy::copy : return_value_policy::move;
-    else if (policy == return_value_policy::automatic_reference)
-        policy = std::is_pointer<no_ref_T>::value ? return_value_policy::reference :
-                 std::is_lvalue_reference<T>::value ? return_value_policy::copy : return_value_policy::move;
+    // using no_ref_T = PYBIND11_CPP17_CONSTEXPR std::remove_reference<T>::type;
+    if (policy == return_value_policy::automatic) {
+        if PYBIND11_CPP17_CONSTEXPR (std::is_pointer<std::remove_reference<T>>::value) {
+            policy = return_value_policy::take_ownership;
+        } else if PYBIND11_CPP17_CONSTEXPR (std::is_lvalue_reference<T>::value) {
+            policy = return_value_policy::copy;
+        } else {
+            policy = return_value_policy::move;
+        }
+    } else if (policy == return_value_policy::automatic_reference) {
+        if PYBIND11_CPP17_CONSTEXPR (std::is_pointer<std::remove_reference<T>>::value) {
+            policy = return_value_policy::reference;
+        } else if PYBIND11_CPP17_CONSTEXPR (std::is_lvalue_reference<T>::value) {
+            policy = return_value_policy::copy;
+        } else {
+            policy = return_value_policy::move;
+        }
+    }
     return reinterpret_steal<object>(detail::make_caster<T>::cast(std::forward<T>(value), policy, parent));
 }
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -102,6 +102,12 @@
 #  define PYBIND11_MAYBE_UNUSED __attribute__ ((__unused__))
 #endif
 
+#if defined(PYBIND11_CPP17)
+#    define PYBIND11_CPP17_CONSTEXPR constexpr
+#else
+#    define PYBIND11_CPP17_CONSTEXPR
+#endif
+
 /* Don't let Python.h #define (v)snprintf as macro because they are implemented
    properly in Visual Studio since 2015. */
 #if defined(_MSC_VER) && _MSC_VER >= 1900


### PR DESCRIPTION
## Description
This is an attempt to modernize and revive: https://github.com/pybind/pybind11/pull/1589 for discussion. Particularly, the part about using constexpr for C++17 > . Closes #1589. This does increase the size of the so by about 224 bytes for C++17, but hopefully that will be worth it. I am using a lot of the STL I am unfamiliar with here. Open to closing this PR if it's determined to have no benefit or causes bizzarre compiler issues. Just wanted to start some machinery to use constexpr more aggressively in more modern C++ dialects that support
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Allows constexpr to be used during casting in C++17 or newer.
```

<!-- If the upgrade guide needs updating, note that here too -->
