### PR TITLE
feat(package): support pipx run

### DIFF
--- a/tools/setup_main.py.in
+++ b/tools/setup_main.py.in
@@ -32,6 +32,9 @@ setup(
     entry_points={
         "console_scripts": [
              "pybind11-config = pybind11.__main__:main",
+        ],
+        "pipx.run": [
+             "pybind11 = pybind11.__main__:main",
         ]
     },
     cmdclass=cmdclass


### PR DESCRIPTION
## Description

Very minor feature - support for pipx run! So `$(pipx run pybind11 --includes)`
can even be used to build an example by hand without installing anything! :)

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Support pipx run, such as `pipx run pybind11 --include` for a quick compile.
```

<!-- If the upgrade guide needs updating, note that here too -->
