### PR TITLE
Fix: RTD Docutils Build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,7 @@
 breathe==4.26.1
+# docutils 0.17 breaks HTML tags & RTD theme
+# https://github.com/sphinx-doc/sphinx/issues/9001
+docutils==0.16
 sphinx==3.3.1
 sphinx_rtd_theme==0.5.0
 sphinxcontrib-moderncmakedomain==3.17


### PR DESCRIPTION
## Description

The docutils 0.17+ release uses more semantic HTML5 tags, which
the RTD theme does not (yet) know.

This breaks side bar, lists and other elements.

<!-- Include relevant issues or PRs here, describe what changed and why -->

- https://github.com/sphinx-doc/sphinx/issues/9001
- https://twitter.com/readthedocs/status/1379897294435196929

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
- fix: avoid RTD style issue with docutils 0.17+
```

<!-- If the upgrade guide needs updating, note that here too -->
