### PR TITLE
Removing MSVC C4996 from pragma block at the top of pybind11.h

### DIFF
--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -164,7 +164,14 @@ public:
 
         // std::localtime returns a pointer to a static internal std::tm object on success,
         // or null pointer otherwise
+#if defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4996) // warning C4996: The POSIX name for this item is deprecated.
+#endif
         std::tm *localtime_ptr = std::localtime(&tt);
+#if defined(_MSC_VER)
+#    pragma warning(pop)
+#endif
         if (!localtime_ptr)
             throw cast_error("Unable to represent system_clock in local time");
 

--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <ctime>
 #include <mutex>
 
 #include <time.h>

--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -11,9 +11,13 @@
 #pragma once
 
 #include "pybind11.h"
-#include <cmath>
-#include <ctime>
+
 #include <chrono>
+#include <cmath>
+#include <mutex>
+
+#include <time.h>
+
 #include <datetime.h>
 
 // Backport the PyDateTime_DELTA functions from Python3.3 if required
@@ -95,6 +99,22 @@ public:
     PYBIND11_TYPE_CASTER(type, _("datetime.timedelta"));
 };
 
+inline std::tm *localtime_thread_safe(const std::time_t *time, std::tm *buf) {
+#if defined(__STDC_WANT_LIB_EXT1__) || defined(_MSC_VER)
+    if (localtime_s(buf, time))
+        return nullptr;
+    return buf;
+#else
+    static std::mutex mtx;
+    std::lock_guard<std::mutex> lock(mtx);
+    std::tm *tm_ptr = localtime(time);
+    if (tm_ptr != nullptr) {
+        *buf = *tm_ptr;
+    }
+    return tm_ptr;
+#endif
+}
+
 // This is for casting times on the system clock into datetime.datetime instances
 template <typename Duration> class type_caster<std::chrono::time_point<std::chrono::system_clock, Duration>> {
 public:
@@ -162,23 +182,10 @@ public:
         // (https://en.cppreference.com/w/cpp/chrono/system_clock/to_time_t)
         std::time_t tt = system_clock::to_time_t(time_point_cast<system_clock::duration>(src - us));
 
-        // std::localtime returns a pointer to a static internal std::tm object on success,
-        // or null pointer otherwise
-#if defined(_MSC_VER)
-#    pragma warning(push)
-#    pragma warning(disable : 4996) // warning C4996: The POSIX name for this item is deprecated.
-#endif
-        std::tm *localtime_ptr = std::localtime(&tt);
-#if defined(_MSC_VER)
-#    pragma warning(pop)
-#endif
+        std::tm localtime;
+        std::tm *localtime_ptr = localtime_thread_safe(&tt, &localtime);
         if (!localtime_ptr)
             throw cast_error("Unable to represent system_clock in local time");
-
-        // this function uses static memory so it's best to copy it out asap just in case
-        // otherwise other code that is using localtime may break this (not just python code)
-        std::tm localtime = *localtime_ptr;
-
         return PyDateTime_FromDateAndTime(localtime.tm_year + 1900,
                                           localtime.tm_mon + 1,
                                           localtime.tm_mday,

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -125,6 +125,11 @@
 #  endif
 #endif
 
+// https://en.cppreference.com/w/c/chrono/localtime
+#if defined(__STDC_LIB_EXT1__) && !defined(__STDC_WANT_LIB_EXT1__)
+#    define __STDC_WANT_LIB_EXT1__
+#endif
+
 #include <Python.h>
 #include <frameobject.h>
 #include <pythread.h>

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -78,14 +78,9 @@ inline bool apply_exception_translators(std::forward_list<ExceptionTranslator>& 
 }
 
 #if defined(_MSC_VER)
-#    pragma warning(push)
-#    pragma warning(disable : 4996) // warning C4996: The POSIX name for this item is deprecated.
-#endif
-
-inline char *strdup_helper(const char *s) { return strdup(s); }
-
-#if defined(_MSC_VER)
-#    pragma warning(pop)
+#    define PYBIND11_COMPAT_STRDUP _strdup
+#else
+#    define PYBIND11_COMPAT_STRDUP strdup
 #endif
 
 PYBIND11_NAMESPACE_END(detail)
@@ -287,7 +282,7 @@ protected:
                 std::free(s);
         }
         char *operator()(const char *s) {
-            auto t = detail::strdup_helper(s);
+            auto t = PYBIND11_COMPAT_STRDUP(s);
             strings.push_back(t);
             return t;
         }
@@ -532,7 +527,7 @@ protected:
         std::free(const_cast<char *>(func->m_ml->ml_doc));
         // Install docstring if it's non-empty (when at least one option is enabled)
         func->m_ml->ml_doc
-            = signatures.empty() ? nullptr : detail::strdup_helper(signatures.c_str());
+            = signatures.empty() ? nullptr : PYBIND11_COMPAT_STRDUP(signatures.c_str());
 
         if (rec->is_method) {
             m_ptr = PYBIND11_INSTANCE_METHOD_NEW(m_ptr, rec->scope.ptr());
@@ -1537,7 +1532,7 @@ public:
            detail::process_attributes<Extra...>::init(extra..., rec_fget);
            if (rec_fget->doc && rec_fget->doc != doc_prev) {
               free(doc_prev);
-              rec_fget->doc = detail::strdup_helper(rec_fget->doc);
+              rec_fget->doc = PYBIND11_COMPAT_STRDUP(rec_fget->doc);
            }
         }
         if (rec_fset) {
@@ -1545,7 +1540,7 @@ public:
             detail::process_attributes<Extra...>::init(extra..., rec_fset);
             if (rec_fset->doc && rec_fset->doc != doc_prev) {
                 free(doc_prev);
-                rec_fset->doc = detail::strdup_helper(rec_fset->doc);
+                rec_fset->doc = PYBIND11_COMPAT_STRDUP(rec_fset->doc);
             }
             if (! rec_active) rec_active = rec_fset;
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -19,7 +19,6 @@
 #  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
 #  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
 #  pragma warning(disable: 4800) // warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
-#  pragma warning(disable: 4996) // warning C4996: The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name
 #  pragma warning(disable: 4522) // warning C4522: multiple assignment operators specified
 #  pragma warning(disable: 4505) // warning C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
 #elif defined(__GNUG__) && !defined(__clang__)
@@ -42,6 +41,8 @@
 #include <vector>
 #include <string>
 #include <utility>
+
+#include <string.h>
 
 #if defined(__cpp_lib_launder) && !(defined(_MSC_VER) && (_MSC_VER < 1914))
 #  define PYBIND11_STD_LAUNDER std::launder
@@ -76,8 +77,18 @@ inline bool apply_exception_translators(std::forward_list<ExceptionTranslator>& 
     return false;
 }
 
-PYBIND11_NAMESPACE_END(detail)
+#if defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4996) // warning C4996: The POSIX name for this item is deprecated.
+#endif
 
+inline char *strdup_helper(const char *s) { return strdup(s); }
+
+#if defined(_MSC_VER)
+#    pragma warning(pop)
+#endif
+
+PYBIND11_NAMESPACE_END(detail)
 
 /// Wraps an arbitrary C++ function/method/lambda function/.. into a callable Python object
 class cpp_function : public function {
@@ -276,7 +287,7 @@ protected:
                 std::free(s);
         }
         char *operator()(const char *s) {
-            auto t = strdup(s);
+            auto t = detail::strdup_helper(s);
             strings.push_back(t);
             return t;
         }
@@ -520,7 +531,8 @@ protected:
         auto *func = (PyCFunctionObject *) m_ptr;
         std::free(const_cast<char *>(func->m_ml->ml_doc));
         // Install docstring if it's non-empty (when at least one option is enabled)
-        func->m_ml->ml_doc = signatures.empty() ? nullptr : strdup(signatures.c_str());
+        func->m_ml->ml_doc
+            = signatures.empty() ? nullptr : detail::strdup_helper(signatures.c_str());
 
         if (rec->is_method) {
             m_ptr = PYBIND11_INSTANCE_METHOD_NEW(m_ptr, rec->scope.ptr());
@@ -1525,7 +1537,7 @@ public:
            detail::process_attributes<Extra...>::init(extra..., rec_fget);
            if (rec_fget->doc && rec_fget->doc != doc_prev) {
               free(doc_prev);
-              rec_fget->doc = strdup(rec_fget->doc);
+              rec_fget->doc = detail::strdup_helper(rec_fget->doc);
            }
         }
         if (rec_fset) {
@@ -1533,7 +1545,7 @@ public:
             detail::process_attributes<Extra...>::init(extra..., rec_fset);
             if (rec_fset->doc && rec_fset->doc != doc_prev) {
                 free(doc_prev);
-                rec_fset->doc = strdup(rec_fset->doc);
+                rec_fset->doc = detail::strdup_helper(rec_fset->doc);
             }
             if (! rec_active) rec_active = rec_fset;
         }


### PR DESCRIPTION
Follow-on to PR #3127, based on results obtained under PR #3125.

The suggested changelog entry will be in the final PR of this cleanup series.