### PR TITLE
Fix Mingw64 build and add a CI job to test it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,3 +859,34 @@ jobs:
 
     - name: Run all checks
       run: cmake --build build -t check
+
+  mingw:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        install: >-
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-python-pip
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-make
+          mingw-w64-x86_64-python-pytest
+          mingw-w64-x86_64-eigen3
+          mingw-w64-x86_64-boost
+          mingw-w64-x86_64-catch
+
+    - uses: actions/checkout@v1
+
+    - name: Configure
+      # LTO leads to many undefined reference like
+      # `pybind11::detail::function_call::function_call(pybind11::detail::function_call&&)
+      run: cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -G "MinGW Makefiles" -S . -B build
+
+    - name: Build
+      run: cmake --build build -j 2
+
+    - name: Python tests
+      run: cmake --build build --target pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -883,7 +883,7 @@ jobs:
     - name: Configure
       # LTO leads to many undefined reference like
       # `pybind11::detail::function_call::function_call(pybind11::detail::function_call&&)
-      run: cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -G "MinGW Makefiles" -S . -B build
+      run: cmake -G "MinGW Makefiles" -S . -B build
 
     - name: Build
       run: cmake --build build -j 2

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -89,6 +89,16 @@
 #  endif
 #endif
 
+#if !defined(PYBIND11_EXPORT_EXCEPTION)
+#  ifdef __MINGW32__
+// workaround for:
+// error: 'dllexport' implies default visibility, but xxx has already been declared with a different visibility
+#    define PYBIND11_EXPORT_EXCEPTION
+#  else
+#    define PYBIND11_EXPORT_EXCEPTION PYBIND11_EXPORT
+#  endif
+#endif
+
 #if defined(_MSC_VER)
 #  define PYBIND11_NOINLINE __declspec(noinline)
 #else
@@ -740,7 +750,7 @@ PYBIND11_NAMESPACE_END(detail)
 #  pragma warning(disable: 4275) // warning C4275: An exported class was derived from a class that wasn't exported. Can be ignored when derived from a STL class.
 #endif
 /// C++ bindings of builtin Python exceptions
-class PYBIND11_EXPORT builtin_exception : public std::runtime_error {
+class PYBIND11_EXPORT_EXCEPTION builtin_exception : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
     /// Set the error using the Python C API
@@ -751,7 +761,7 @@ public:
 #endif
 
 #define PYBIND11_RUNTIME_EXCEPTION(name, type) \
-    class PYBIND11_EXPORT name : public builtin_exception { public: \
+    class PYBIND11_EXPORT_EXCEPTION name : public builtin_exception { public: \
         using builtin_exception::builtin_exception; \
         name() : name("") { } \
         void set_error() const override { PyErr_SetString(type, what()); } \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -105,7 +105,11 @@
 #  define PYBIND11_NOINLINE __attribute__ ((noinline))
 #endif
 
-#if defined(PYBIND11_CPP14)
+#if defined(__MINGW32__)
+// For unknown reasons all PYBIND11_DEPRECATED member trigger a warning when declared
+// whether it is used or not
+#  define PYBIND11_DEPRECATED(reason)
+#elif defined(PYBIND11_CPP14)
 #  define PYBIND11_DEPRECATED(reason) [[deprecated(reason)]]
 #else
 #  define PYBIND11_DEPRECATED(reason) __attribute__((deprecated(reason)))

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -327,7 +327,7 @@ PYBIND11_NAMESPACE_END(detail)
 /// thrown to propagate python-side errors back through C++ which can either be caught manually or
 /// else falls back to the function dispatcher (which then raises the captured error back to
 /// python).
-class PYBIND11_EXPORT error_already_set : public std::runtime_error {
+class PYBIND11_EXPORT_EXCEPTION error_already_set : public std::runtime_error {
 public:
     /// Constructs a new exception from the current Python error indicator, if any.  The current
     /// Python error indicator will be cleared.

--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -59,8 +59,7 @@ except ImportError:
 import distutils.errors
 import distutils.ccompiler
 
-
-WIN = sys.platform.startswith("win32") and sysconfig.get_platform() != "mingw"
+WIN = sys.platform.startswith("win32") and "mingw" not in sysconfig.get_platform()
 PY2 = sys.version_info[0] < 3
 MACOS = sys.platform.startswith("darwin")
 STD_TMPL = "/std:c++{}" if WIN else "-std=c++{}"

--- a/tests/test_exceptions.h
+++ b/tests/test_exceptions.h
@@ -4,7 +4,7 @@
 
 // shared exceptions for cross_module_tests
 
-class PYBIND11_EXPORT shared_exception : public pybind11::builtin_exception {
+class PYBIND11_EXPORT_EXCEPTION shared_exception : public pybind11::builtin_exception {
 public:
     using builtin_exception::builtin_exception;
     explicit shared_exception() : shared_exception("") {}

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -308,7 +308,7 @@ function(_pybind11_generate_lto target prefer_thin_lto)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT APPLE)
       # Clang Gold plugin does not support -Os; append -O3 to MinSizeRel builds to override it
       set(linker_append ";$<$<CONFIG:MinSizeRel>:-O3>")
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND NOT MINGW)
       set(cxx_append ";-fno-fat-lto-objects")
     endif()
 

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -302,6 +302,11 @@ function(_pybind11_return_if_cxx_and_linker_flags_work result cxxflags linkerfla
 endfunction()
 
 function(_pybind11_generate_lto target prefer_thin_lto)
+  if(MINGW)
+    message(STATUS "${target} disabled (problems with undefined symbols for MinGW for now)")
+    return()
+  endif()
+
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     set(cxx_append "")
     set(linker_append "")


### PR DESCRIPTION
This is a tentative to fix mingw64 build and add a CI job to test it. So far it does not work. I would need some help or explanation to fix it.
* A `__declspec(dllexport)` symbol cannot be hidden, it must have the default visibility (this is required by gcc). https://github.com/pybind/pybind11/commit/3ac690b88 make `builtin_exception` `__declspec(dllexport)` while the `pybind11` namespace is `visibility(hidden)`.
* I get a huge amount of deprecation like `warning: 'pybind11::object::object(pybind11::handle, bool)' is deprecated: Use reinterpret_borrow<object>() or reinterpret_steal<object>()`

This is the follow-up.
* https://github.com/pybind/pybind11/pull/2921
* https://github.com/pybind/python_example/pull/75


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fix Mingw64 and add to the CI testing matrix.
```