### PR TITLE
Specified encoding in setup.py calls of open()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import string
 import subprocess
 import sys
 import tempfile
+import io
 
 import setuptools.command.sdist
 
@@ -63,14 +64,14 @@ to_src = (
 )
 
 # Read the listed version
-with open("pybind11/_version.py", encoding="utf8") as f:
+with open("pybind11/_version.py") as f:
     code = compile(f.read(), "pybind11/_version.py", "exec")
 loc = {}
 exec(code, loc)
 version = loc["__version__"]
 
 # Verify that the version matches the one in C++
-with open("include/pybind11/detail/common.h", encoding="utf8") as f:
+with io.open("include/pybind11/detail/common.h", encoding="utf8") as f:
     matches = dict(VERSION_REGEX.findall(f.read()))
 cpp_version = "{MAJOR}.{MINOR}.{PATCH}".format(**matches)
 if version != cpp_version:

--- a/setup.py
+++ b/setup.py
@@ -63,14 +63,14 @@ to_src = (
 )
 
 # Read the listed version
-with open("pybind11/_version.py") as f:
+with open("pybind11/_version.py", encoding="utf8") as f:
     code = compile(f.read(), "pybind11/_version.py", "exec")
 loc = {}
 exec(code, loc)
 version = loc["__version__"]
 
 # Verify that the version matches the one in C++
-with open("include/pybind11/detail/common.h") as f:
+with open("include/pybind11/detail/common.h", encoding="utf8") as f:
     matches = dict(VERSION_REGEX.findall(f.read()))
 cpp_version = "{MAJOR}.{MINOR}.{PATCH}".format(**matches)
 if version != cpp_version:


### PR DESCRIPTION
## Description

The files of the project are encoded in UTF-8, yet the opening of files in the `setup.py` does not specify this encoding. When trying to install on a system with a non-UTF-8 locale using `pip install pybind11/.` the process fails with the the following error:

```
Processing /pybind11
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-mi6rymcm-build/setup.py", line 74, in <module>
        matches = dict(VERSION_REGEX.findall(f.read()))
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 16164: ordinal not in range(128)
```

Specifying that the files should be opened using UTF-8 encoding fixes the problem.

## Suggested changelog entry:

```rst
-  Specified UTF8-encoding in setup.py calls of open()
```