### PR TITLE
Removing MSVC C4800 from pragma block at the top of pybind11.h

### DIFF
--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -83,7 +83,7 @@ struct buffer_info {
             view->strides
             ? std::vector<ssize_t>(view->strides, view->strides + view->ndim)
             : detail::c_strides({view->shape, view->shape + view->ndim}, view->itemsize),
-            view->readonly) {
+            PYBIND11_COMPAT_BOOL_CAST(view->readonly)) {
         this->m_view = view;
         this->ownview = ownview;
     }

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -83,7 +83,7 @@ struct buffer_info {
             view->strides
             ? std::vector<ssize_t>(view->strides, view->strides + view->ndim)
             : detail::c_strides({view->shape, view->shape + view->ndim}, view->itemsize),
-            PYBIND11_COMPAT_BOOL_CAST(view->readonly)) {
+            (view->readonly != 0)) {
         this->m_view = view;
         this->ownview = ownview;
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -322,7 +322,7 @@ public:
             }
             #endif
             if (res == 0 || res == 1) {
-                value = PYBIND11_COMPAT_BOOL_CAST(res);
+                value = (res != 0);
                 return true;
             }
             PyErr_Clear();

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -322,7 +322,7 @@ public:
             }
             #endif
             if (res == 0 || res == 1) {
-                value = (bool) res;
+                value = PYBIND11_COMPAT_BOOL_CAST(res);
                 return true;
             }
             PyErr_Clear();

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -265,6 +265,10 @@ extern "C" {
 #define PYBIND11_ENSURE_INTERNALS_READY \
     pybind11::detail::get_internals();
 
+// Paying tribute to MSVC 2015 warning
+// C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
+#define PYBIND11_COMPAT_BOOL_CAST(...) ((__VA_ARGS__) ? true : false)
+
 #define PYBIND11_CHECK_PYTHON_VERSION \
     {                                                                          \
         const char *compiled_ver = PYBIND11_TOSTRING(PY_MAJOR_VERSION)         \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -265,10 +265,6 @@ extern "C" {
 #define PYBIND11_ENSURE_INTERNALS_READY \
     pybind11::detail::get_internals();
 
-// Paying tribute to MSVC 2015 warning
-// C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
-#define PYBIND11_COMPAT_BOOL_CAST(...) ((__VA_ARGS__) ? true : false)
-
 #define PYBIND11_CHECK_PYTHON_VERSION \
     {                                                                          \
         const char *compiled_ver = PYBIND11_TOSTRING(PY_MAJOR_VERSION)         \

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -252,8 +252,7 @@ struct value_and_holder {
     bool instance_registered() const {
         return inst->simple_layout
             ? inst->simple_instance_registered
-            : PYBIND11_COMPAT_BOOL_CAST(
-                  inst->nonsimple.status[index] & instance::status_instance_registered);
+            : (inst->nonsimple.status[index] & instance::status_instance_registered != 0);
     }
     void set_instance_registered(bool v = true) const {
         if (inst->simple_layout)

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -252,7 +252,7 @@ struct value_and_holder {
     bool instance_registered() const {
         return inst->simple_layout
             ? inst->simple_instance_registered
-            : (inst->nonsimple.status[index] & instance::status_instance_registered != 0);
+            : ((inst->nonsimple.status[index] & instance::status_instance_registered) != 0);
     }
     void set_instance_registered(bool v = true) const {
         if (inst->simple_layout)

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -231,7 +231,7 @@ struct value_and_holder {
         return reinterpret_cast<V *&>(vh[0]);
     }
     // True if this `value_and_holder` has a non-null value pointer
-    explicit operator bool() const { return value_ptr(); }
+    explicit operator bool() const { return value_ptr() != nullptr; }
 
     template <typename H> H &holder() const {
         return reinterpret_cast<H &>(vh[1]);
@@ -252,7 +252,8 @@ struct value_and_holder {
     bool instance_registered() const {
         return inst->simple_layout
             ? inst->simple_instance_registered
-            : inst->nonsimple.status[index] & instance::status_instance_registered;
+            : PYBIND11_COMPAT_BOOL_CAST(
+                  inst->nonsimple.status[index] & instance::status_instance_registered);
     }
     void set_instance_registered(bool v = true) const {
         if (inst->simple_layout)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -18,7 +18,6 @@
 #  pragma warning(push)
 #  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
 #  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
-#  pragma warning(disable: 4800) // warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
 #  pragma warning(disable: 4505) // warning C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
 #elif defined(__GNUG__) && !defined(__clang__)
 #  pragma GCC diagnostic push

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -368,7 +368,7 @@ public:
     /// subclass thereof).  May also be passed a tuple to search for any exception class matches in
     /// the given tuple.
     bool matches(handle exc) const {
-        return PYBIND11_COMPAT_BOOL_CAST(PyErr_GivenExceptionMatches(m_type.ptr(), exc.ptr()));
+        return (PyErr_GivenExceptionMatches(m_type.ptr(), exc.ptr()) != 0);
     }
 
     const object& type() const { return m_type; }
@@ -855,7 +855,7 @@ PYBIND11_NAMESPACE_END(detail)
         Name(handle h, borrowed_t) : Parent(h, borrowed_t{}) { } \
         Name(handle h, stolen_t) : Parent(h, stolen_t{}) { } \
         PYBIND11_DEPRECATED("Use py::isinstance<py::python_type>(obj) instead") \
-        bool check() const { return m_ptr != nullptr && PYBIND11_COMPAT_BOOL_CAST(CheckFun(m_ptr)); } \
+        bool check() const { return m_ptr != nullptr && (CheckFun(m_ptr) != 0); } \
         static bool check_(handle h) { return h.ptr() != nullptr && CheckFun(h.ptr()); } \
         template <typename Policy_> \
         Name(const ::pybind11::detail::accessor<Policy_> &a) : Name(object(a)) { }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -367,7 +367,9 @@ public:
     /// Check if the currently trapped error type matches the given Python exception class (or a
     /// subclass thereof).  May also be passed a tuple to search for any exception class matches in
     /// the given tuple.
-    bool matches(handle exc) const { return PyErr_GivenExceptionMatches(m_type.ptr(), exc.ptr()); }
+    bool matches(handle exc) const {
+        return PYBIND11_COMPAT_BOOL_CAST(PyErr_GivenExceptionMatches(m_type.ptr(), exc.ptr()));
+    }
 
     const object& type() const { return m_type; }
     const object& value() const { return m_value; }
@@ -853,7 +855,7 @@ PYBIND11_NAMESPACE_END(detail)
         Name(handle h, borrowed_t) : Parent(h, borrowed_t{}) { } \
         Name(handle h, stolen_t) : Parent(h, stolen_t{}) { } \
         PYBIND11_DEPRECATED("Use py::isinstance<py::python_type>(obj) instead") \
-        bool check() const { return m_ptr != nullptr && (bool) CheckFun(m_ptr); } \
+        bool check() const { return m_ptr != nullptr && PYBIND11_COMPAT_BOOL_CAST(CheckFun(m_ptr)); } \
         static bool check_(handle h) { return h.ptr() != nullptr && CheckFun(h.ptr()); } \
         template <typename Policy_> \
         Name(const ::pybind11::detail::accessor<Policy_> &a) : Name(object(a)) { }


### PR DESCRIPTION
Follow-on to PR #3127, based on results obtained under PR #3125.

The suggested changelog entry will be in the final PR of this cleanup series.
