### PR TITLE
fix: the Python package had a hard coded path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,12 @@ if(PYBIND11_INSTALL)
       "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME}"
       CACHE STRING "install path for pybind11Config.cmake")
 
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(pybind11_INCLUDEDIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+  else()
+    set(pybind11_INCLUDEDIR "\$\{PACKAGE_PREFIX_DIR\}/${CMAKE_INSTALL_INCLUDEDIR}")
+  endif()
+
   configure_package_config_file(
     tools/${PROJECT_NAME}Config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
     INSTALL_DESTINATION ${PYBIND11_CMAKECONFIG_INSTALL_DIR})

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -138,6 +138,16 @@ def test_build_sdist(monkeypatch, tmpdir):
         ) as f:
             pyproject_toml = f.read()
 
+        with contextlib.closing(
+            tar.extractfile(
+                tar.getmember(
+                    start + "pybind11/share/cmake/pybind11/pybind11Config.cmake"
+                )
+            )
+        ) as f:
+            contents = f.read().decode("utf8")
+        assert 'set(pybind11_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")' in contents
+
     files = {"pybind11/{}".format(n) for n in all_files}
     files |= sdist_files
     files |= {"pybind11{}".format(n) for n in local_sdist_files}
@@ -151,11 +161,11 @@ def test_build_sdist(monkeypatch, tmpdir):
             .substitute(version=version, extra_cmd="")
             .encode()
         )
-        assert setup_py == contents
+    assert setup_py == contents
 
     with open(os.path.join(MAIN_DIR, "tools", "pyproject.toml"), "rb") as f:
         contents = f.read()
-        assert pyproject_toml == contents
+    assert pyproject_toml == contents
 
 
 def test_build_global_dist(monkeypatch, tmpdir):

--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -201,7 +201,8 @@ Using ``find_package`` with version info is not recommended except for release v
 @PACKAGE_INIT@
 
 # Location of pybind11/pybind11.h
-set(pybind11_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
+# This will be relative unless explicitly set as absolute
+set(pybind11_INCLUDE_DIR "@pybind11_INCLUDEDIR@")
 
 set(pybind11_LIBRARY "")
 set(pybind11_DEFINITIONS USING_pybind11)


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Fix #3136 - regression in #3005.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fix regression in CMake Python package config: improper use of absolute path.
```

<!-- If the upgrade guide needs updating, note that here too -->
