### PR TITLE
Removing MSVC C4100 from pragma block at the top of pybind11.h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         ${{ matrix.args }}
 
     - name: Build C++11
-      run: cmake --build . -j 2
+      run: cmake --build . -j 2 -- --keep-going
 
     - name: Python tests C++11
       run: cmake --build . --target pytest -j 2
@@ -114,10 +114,10 @@ jobs:
     - name: C++11 tests
       # TODO: Figure out how to load the DLL on Python 3.8+
       if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9 || matrix.python == '3.10-dev'))"
-      run: cmake --build .  --target cpptest -j 2
+      run: cmake --build .  --target cpptest -j 2 -- --keep-going
 
     - name: Interface test C++11
-      run: cmake --build . --target test_cmake_build
+      run: cmake --build . --target test_cmake_build -- --keep-going
 
     - name: Clean directory
       run: git clean -fdx
@@ -134,7 +134,7 @@ jobs:
         ${{ matrix.args2 }}
 
     - name: Build
-      run: cmake --build build2 -j 2
+      run: cmake --build build2 -j 2 -- --keep-going
 
     - name: Python tests
       run: cmake --build build2 --target pytest
@@ -142,10 +142,10 @@ jobs:
     - name: C++ tests
       # TODO: Figure out how to load the DLL on Python 3.8+
       if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9 || matrix.python == '3.10-dev'))"
-      run: cmake --build build2 --target cpptest
+      run: cmake --build build2 --target cpptest -- --keep-going
 
     - name: Interface test
-      run: cmake --build build2 --target test_cmake_build
+      run: cmake --build build2 --target test_cmake_build -- --keep-going
 
     # Eventually Microsoft might have an action for setting up
     # MSVC, but for now, this action works:
@@ -234,13 +234,13 @@ jobs:
         -DCMAKE_CXX_STANDARD=17
 
     - name: Build
-      run: cmake --build build -j 2
+      run: cmake --build build -j 2 -- --keep-going
 
     - name: Python tests
       run: cmake --build build --target pytest
 
     - name: C++ tests
-      run: cmake --build build --target cpptest
+      run: cmake --build build --target cpptest -- --keep-going
 
     - name: Run Valgrind on Python tests
       if: matrix.valgrind
@@ -289,16 +289,16 @@ jobs:
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build
-      run: cmake --build build -j 2
+      run: cmake --build build -j 2 -- --keep-going
 
     - name: Python tests
       run: cmake --build build --target pytest
 
     - name: C++ tests
-      run: cmake --build build --target cpptest
+      run: cmake --build build --target cpptest -- --keep-going
 
     - name: Interface test
-      run: cmake --build build --target test_cmake_build
+      run: cmake --build build --target test_cmake_build -- --keep-going
 
 
   # Testing NVCC; forces sources to behave like .cu files
@@ -318,7 +318,7 @@ jobs:
       run: cmake -S . -B build -DPYBIND11_CUDA_TESTS=ON -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON
 
     - name: Build
-      run: cmake --build build -j2 --verbose
+      run: cmake --build build -j2 --verbose -- --keep-going
 
     - name: Python tests
       run: cmake --build build --target pytest
@@ -400,7 +400,7 @@ jobs:
 
     # Building before installing Pip should produce a warning but not an error
     - name: Build
-      run: cmake3 --build build -j 2 --verbose
+      run: cmake3 --build build -j 2 --verbose -- --keep-going
 
     - name: Install CMake with pip
       run: |
@@ -411,10 +411,10 @@ jobs:
       run: cmake3 --build build --target pytest
 
     - name: C++ tests
-      run: cmake3 --build build --target cpptest
+      run: cmake3 --build build --target cpptest -- --keep-going
 
     - name: Interface test
-      run: cmake3 --build build --target test_cmake_build
+      run: cmake3 --build build --target test_cmake_build -- --keep-going
 
 
   # Testing on GCC using the GCC docker images (only recent images supported)
@@ -457,16 +457,16 @@ jobs:
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build
-      run: cmake --build build -j 2
+      run: cmake --build build -j 2 -- --keep-going
 
     - name: Python tests
       run: cmake --build build --target pytest
 
     - name: C++ tests
-      run: cmake --build build --target cpptest
+      run: cmake --build build --target cpptest -- --keep-going
 
     - name: Interface test
-      run: cmake --build build --target test_cmake_build
+      run: cmake --build build --target test_cmake_build -- --keep-going
 
 
   # Testing on ICC using the oneAPI apt repo
@@ -515,7 +515,7 @@ jobs:
     - name: Build C++11
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-11 -j 2 -v
+        cmake --build build-11 -j 2 -v -- --keep-going
 
     - name: Python tests C++11
       run: |
@@ -526,12 +526,12 @@ jobs:
     - name: C++ tests C++11
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-11 --target cpptest
+        cmake --build build-11 --target cpptest -- --keep-going
 
     - name: Interface test C++11
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-11 --target test_cmake_build
+        cmake --build build-11 --target test_cmake_build -- --keep-going
 
     - name: Configure C++17
       run: |
@@ -547,7 +547,7 @@ jobs:
     - name: Build C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-17 -j 2 -v
+        cmake --build build-17 -j 2 -v -- --keep-going
 
     - name: Python tests C++17
       run: |
@@ -558,12 +558,12 @@ jobs:
     - name: C++ tests C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-17 --target cpptest
+        cmake --build build-17 --target cpptest -- --keep-going
 
     - name: Interface test C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-17 --target test_cmake_build
+        cmake --build build-17 --target test_cmake_build -- --keep-going
 
 
   # Testing on CentOS (manylinux uses a centos base, and this is an easy way
@@ -614,16 +614,16 @@ jobs:
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build
-      run: cmake --build build -j 2
+      run: cmake --build build -j 2 -- --keep-going
 
     - name: Python tests
       run: cmake --build build --target pytest
 
     - name: C++ tests
-      run: cmake --build build --target cpptest
+      run: cmake --build build --target cpptest -- --keep-going
 
     - name: Interface test
-      run: cmake --build build --target test_cmake_build
+      run: cmake --build build --target test_cmake_build -- --keep-going
 
 
   # This tests an "install" with the CMake tools
@@ -758,7 +758,7 @@ jobs:
         -DDOWNLOAD_EIGEN=ON
         ${{ matrix.args }}
     - name: Build C++11
-      run: cmake --build build -j 2
+      run: cmake --build build -j 2 -- --keep-going
 
     - name: Run tests
       run: cmake --build build -t pytest
@@ -804,7 +804,7 @@ jobs:
         -DDOWNLOAD_EIGEN=ON
 
     - name: Build C++14
-      run: cmake --build build -j 2
+      run: cmake --build build -j 2 -- --keep-going
 
     - name: Run all checks
       run: cmake --build build -t check
@@ -855,7 +855,7 @@ jobs:
         ${{ matrix.args }}
 
     - name: Build ${{ matrix.std }}
-      run: cmake --build build -j 2
+      run: cmake --build build -j 2 -- --keep-going
 
     - name: Run all checks
       run: cmake --build build -t check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         ${{ matrix.args }}
 
     - name: Build C++11
-      run: cmake --build . -j 2 -- --keep-going
+      run: cmake --build . -j 2
 
     - name: Python tests C++11
       run: cmake --build . --target pytest -j 2
@@ -114,10 +114,10 @@ jobs:
     - name: C++11 tests
       # TODO: Figure out how to load the DLL on Python 3.8+
       if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9 || matrix.python == '3.10-dev'))"
-      run: cmake --build .  --target cpptest -j 2 -- --keep-going
+      run: cmake --build .  --target cpptest -j 2
 
     - name: Interface test C++11
-      run: cmake --build . --target test_cmake_build -- --keep-going
+      run: cmake --build . --target test_cmake_build
 
     - name: Clean directory
       run: git clean -fdx
@@ -134,7 +134,7 @@ jobs:
         ${{ matrix.args2 }}
 
     - name: Build
-      run: cmake --build build2 -j 2 -- --keep-going
+      run: cmake --build build2 -j 2
 
     - name: Python tests
       run: cmake --build build2 --target pytest
@@ -142,10 +142,10 @@ jobs:
     - name: C++ tests
       # TODO: Figure out how to load the DLL on Python 3.8+
       if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9 || matrix.python == '3.10-dev'))"
-      run: cmake --build build2 --target cpptest -- --keep-going
+      run: cmake --build build2 --target cpptest
 
     - name: Interface test
-      run: cmake --build build2 --target test_cmake_build -- --keep-going
+      run: cmake --build build2 --target test_cmake_build
 
     # Eventually Microsoft might have an action for setting up
     # MSVC, but for now, this action works:
@@ -234,13 +234,13 @@ jobs:
         -DCMAKE_CXX_STANDARD=17
 
     - name: Build
-      run: cmake --build build -j 2 -- --keep-going
+      run: cmake --build build -j 2
 
     - name: Python tests
       run: cmake --build build --target pytest
 
     - name: C++ tests
-      run: cmake --build build --target cpptest -- --keep-going
+      run: cmake --build build --target cpptest
 
     - name: Run Valgrind on Python tests
       if: matrix.valgrind
@@ -289,16 +289,16 @@ jobs:
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build
-      run: cmake --build build -j 2 -- --keep-going
+      run: cmake --build build -j 2
 
     - name: Python tests
       run: cmake --build build --target pytest
 
     - name: C++ tests
-      run: cmake --build build --target cpptest -- --keep-going
+      run: cmake --build build --target cpptest
 
     - name: Interface test
-      run: cmake --build build --target test_cmake_build -- --keep-going
+      run: cmake --build build --target test_cmake_build
 
 
   # Testing NVCC; forces sources to behave like .cu files
@@ -318,7 +318,7 @@ jobs:
       run: cmake -S . -B build -DPYBIND11_CUDA_TESTS=ON -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON
 
     - name: Build
-      run: cmake --build build -j2 --verbose -- --keep-going
+      run: cmake --build build -j2 --verbose
 
     - name: Python tests
       run: cmake --build build --target pytest
@@ -400,7 +400,7 @@ jobs:
 
     # Building before installing Pip should produce a warning but not an error
     - name: Build
-      run: cmake3 --build build -j 2 --verbose -- --keep-going
+      run: cmake3 --build build -j 2 --verbose
 
     - name: Install CMake with pip
       run: |
@@ -411,10 +411,10 @@ jobs:
       run: cmake3 --build build --target pytest
 
     - name: C++ tests
-      run: cmake3 --build build --target cpptest -- --keep-going
+      run: cmake3 --build build --target cpptest
 
     - name: Interface test
-      run: cmake3 --build build --target test_cmake_build -- --keep-going
+      run: cmake3 --build build --target test_cmake_build
 
 
   # Testing on GCC using the GCC docker images (only recent images supported)
@@ -457,16 +457,16 @@ jobs:
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build
-      run: cmake --build build -j 2 -- --keep-going
+      run: cmake --build build -j 2
 
     - name: Python tests
       run: cmake --build build --target pytest
 
     - name: C++ tests
-      run: cmake --build build --target cpptest -- --keep-going
+      run: cmake --build build --target cpptest
 
     - name: Interface test
-      run: cmake --build build --target test_cmake_build -- --keep-going
+      run: cmake --build build --target test_cmake_build
 
 
   # Testing on ICC using the oneAPI apt repo
@@ -515,7 +515,7 @@ jobs:
     - name: Build C++11
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-11 -j 2 -v -- --keep-going
+        cmake --build build-11 -j 2 -v
 
     - name: Python tests C++11
       run: |
@@ -526,12 +526,12 @@ jobs:
     - name: C++ tests C++11
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-11 --target cpptest -- --keep-going
+        cmake --build build-11 --target cpptest
 
     - name: Interface test C++11
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-11 --target test_cmake_build -- --keep-going
+        cmake --build build-11 --target test_cmake_build
 
     - name: Configure C++17
       run: |
@@ -547,7 +547,7 @@ jobs:
     - name: Build C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-17 -j 2 -v -- --keep-going
+        cmake --build build-17 -j 2 -v
 
     - name: Python tests C++17
       run: |
@@ -558,12 +558,12 @@ jobs:
     - name: C++ tests C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-17 --target cpptest -- --keep-going
+        cmake --build build-17 --target cpptest
 
     - name: Interface test C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-17 --target test_cmake_build -- --keep-going
+        cmake --build build-17 --target test_cmake_build
 
 
   # Testing on CentOS (manylinux uses a centos base, and this is an easy way
@@ -614,16 +614,16 @@ jobs:
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build
-      run: cmake --build build -j 2 -- --keep-going
+      run: cmake --build build -j 2
 
     - name: Python tests
       run: cmake --build build --target pytest
 
     - name: C++ tests
-      run: cmake --build build --target cpptest -- --keep-going
+      run: cmake --build build --target cpptest
 
     - name: Interface test
-      run: cmake --build build --target test_cmake_build -- --keep-going
+      run: cmake --build build --target test_cmake_build
 
 
   # This tests an "install" with the CMake tools
@@ -758,7 +758,7 @@ jobs:
         -DDOWNLOAD_EIGEN=ON
         ${{ matrix.args }}
     - name: Build C++11
-      run: cmake --build build -j 2 -- --keep-going
+      run: cmake --build build -j 2
 
     - name: Run tests
       run: cmake --build build -t pytest
@@ -804,7 +804,7 @@ jobs:
         -DDOWNLOAD_EIGEN=ON
 
     - name: Build C++14
-      run: cmake --build build -j 2 -- --keep-going
+      run: cmake --build build -j 2
 
     - name: Run all checks
       run: cmake --build build -t check
@@ -855,7 +855,7 @@ jobs:
         ${{ matrix.args }}
 
     - name: Build ${{ matrix.std }}
-      run: cmake --build build -j 2 -- --keep-going
+      run: cmake --build build -j 2
 
     - name: Run all checks
       run: cmake --build build -t check

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -516,18 +516,22 @@ template <size_t Nurse, size_t Patient> struct process_attribute<keep_alive<Nurs
 /// Recursively iterate over variadic template arguments
 template <typename... Args> struct process_attributes {
     static void init(const Args&... args, function_record *r) {
+        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0) ... };
         ignore_unused(unused);
     }
     static void init(const Args&... args, type_record *r) {
+        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0) ... };
         ignore_unused(unused);
     }
     static void precall(function_call &call) {
+        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::precall(call), 0) ... };
         ignore_unused(unused);
     }
     static void postcall(function_call &call, handle fn_ret) {
+        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call, fn_ret);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::postcall(call, fn_ret), 0) ... };
         ignore_unused(unused);
     }
@@ -545,6 +549,7 @@ template <typename... Extra,
           size_t named = constexpr_sum(std::is_base_of<arg, Extra>::value...),
           size_t self  = constexpr_sum(std::is_same<is_method, Extra>::value...)>
 constexpr bool expected_num_args(size_t nargs, bool has_args, bool has_kwargs) {
+    PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(nargs, has_args, has_kwargs);
     return named == 0 || (self + named + size_t(has_args) + size_t(has_kwargs)) == nargs;
 }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -605,6 +605,7 @@ protected:
     /* Implementation: Convert a C++ tuple into a Python tuple */
     template <typename T, size_t... Is>
     static handle cast_impl(T &&src, return_value_policy policy, handle parent, index_sequence<Is...>) {
+        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(src, policy, parent);
         std::array<object, size> entries{{
             reinterpret_steal<object>(make_caster<Ts>::cast(std::get<Is>(std::forward<T>(src)), policy, parent))...
         }};

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -914,11 +914,14 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 }
 
 #if defined(_MSC_VER) && _MSC_VER <= 1916
+
 // warning C4100: Unreferenced formal parameter
 template <typename... Args>
 inline constexpr void workaround_incorrect_msvc_c4100(Args &&...) {}
+
 #    define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...)                                         \
         detail::workaround_incorrect_msvc_c4100(__VA_ARGS__)
+
 #else
 #    define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...)
 #endif

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -914,6 +914,7 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 }
 
 #if defined(_MSC_VER) && _MSC_VER <= 1916
+// warning C4100: Unreferenced formal parameter
 template <typename... Args>
 inline constexpr void workaround_incorrect_msvc_c4100(Args &&...) {}
 #    define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...)                                         \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -913,11 +913,12 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 #endif
 }
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER <= 1916
 inline constexpr void workaround_incorrect_msvc_c4100(...) {}
-#define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...) detail::workaround_incorrect_msvc_c4100(__VA_ARGS__)
+#    define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...)                                         \
+        detail::workaround_incorrect_msvc_c4100(__VA_ARGS__)
 #else
-#define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...)
+#    define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...)
 #endif
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -914,7 +914,8 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 }
 
 #if defined(_MSC_VER) && _MSC_VER <= 1916
-inline constexpr void workaround_incorrect_msvc_c4100(...) {}
+template <typename... Args>
+inline constexpr void workaround_incorrect_msvc_c4100(Args &&...) {}
 #    define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...)                                         \
         detail::workaround_incorrect_msvc_c4100(__VA_ARGS__)
 #else

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -913,5 +913,12 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 #endif
 }
 
+#if defined(_MSC_VER)
+inline constexpr void workaround_incorrect_msvc_c4100(...) {}
+#define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...) detail::workaround_incorrect_msvc_c4100(__VA_ARGS__)
+#else
+#define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...)
+#endif
+
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -42,6 +42,7 @@ struct descr {
 template <size_t N1, size_t N2, typename... Ts1, typename... Ts2, size_t... Is1, size_t... Is2>
 constexpr descr<N1 + N2, Ts1..., Ts2...> plus_impl(const descr<N1, Ts1...> &a, const descr<N2, Ts2...> &b,
                                                    index_sequence<Is1...>, index_sequence<Is2...>) {
+    PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(b);
     return {a.text[Is1]..., b.text[Is2]...};
 }
 

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -94,6 +94,7 @@ void construct(...) {
 // construct an Alias from the returned base instance.
 template <typename Class>
 void construct(value_and_holder &v_h, Cpp<Class> *ptr, bool need_alias) {
+    PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(need_alias);
     no_nullptr(ptr);
     if (Class::has_alias && need_alias && !is_alias<Class>(ptr)) {
         // We're going to try to construct an alias by moving the cpp type.  Whether or not
@@ -131,6 +132,7 @@ void construct(value_and_holder &v_h, Alias<Class> *alias_ptr, bool) {
 // derived type (through those holder's implicit conversion from derived class holder constructors).
 template <typename Class>
 void construct(value_and_holder &v_h, Holder<Class> holder, bool need_alias) {
+    PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(need_alias);
     auto *ptr = holder_helper<Holder<Class>>::get(holder);
     no_nullptr(ptr);
     // If we need an alias, check that the held pointer is actually an alias instance
@@ -148,6 +150,7 @@ void construct(value_and_holder &v_h, Holder<Class> holder, bool need_alias) {
 // need it, we simply move-construct the cpp value into a new instance.
 template <typename Class>
 void construct(value_and_holder &v_h, Cpp<Class> &&result, bool need_alias) {
+    PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(need_alias);
     static_assert(std::is_move_constructible<Cpp<Class>>::value,
         "pybind11::init() return-by-value factory function requires a movable class");
     if (Class::has_alias && need_alias)

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -930,6 +930,7 @@ protected:
        does not have a private operator new implementation. */
     template <typename T, typename = enable_if_t<is_copy_constructible<T>::value>>
     static auto make_copy_constructor(const T *x) -> decltype(new T(*x), Constructor{}) {
+        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(x);
         return [](const void *arg) -> void * {
             return new T(*reinterpret_cast<const T *>(arg));
         };
@@ -937,6 +938,7 @@ protected:
 
     template <typename T, typename = enable_if_t<std::is_move_constructible<T>::value>>
     static auto make_move_constructor(const T *x) -> decltype(new T(std::move(*const_cast<T *>(x))), Constructor{}) {
+        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(x);
         return [](const void *arg) -> void * {
             return new T(std::move(*const_cast<T *>(reinterpret_cast<const T *>(arg))));
         };

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -12,7 +12,6 @@
 
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #  pragma warning(push)
-#  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
 #  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
 #  pragma warning(disable: 4505) // warning C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
 #elif defined(__GNUG__) && !defined(__clang__) && !defined(__INTEL_COMPILER)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1387,12 +1387,14 @@ public:
 
     template <typename... Args, typename... Extra>
     class_ &def(const detail::initimpl::constructor<Args...> &init, const Extra&... extra) {
+        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(init);
         init.execute(*this, extra...);
         return *this;
     }
 
     template <typename... Args, typename... Extra>
     class_ &def(const detail::initimpl::alias_constructor<Args...> &init, const Extra&... extra) {
+        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(init);
         init.execute(*this, extra...);
         return *this;
     }


### PR DESCRIPTION
Follow-on to PR #3127, based on results obtained under PR #3125.

The suggested changelog entry will be in the final PR of this cleanup series.

**[Worksheet](https://docs.google.com/spreadsheets/d/1XDKkq1w7d9f2dPcVsn-vmZHleMWQkVCl7xb4cilpGiI/edit#gid=1527078177)**