### PR TITLE
Always check __STDC_LIB_EXT1__ before __STDC_WANT_LIB_EXT1__

### DIFF
--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -101,7 +101,7 @@ public:
 };
 
 inline std::tm *localtime_thread_safe(const std::time_t *time, std::tm *buf) {
-#if defined(__STDC_WANT_LIB_EXT1__) || defined(_MSC_VER)
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || defined(_MSC_VER)
     if (localtime_s(buf, time))
         return nullptr;
     return buf;


### PR DESCRIPTION
Accommodating environments that define `__STDC_WANT_LIB_EXT1__` even if `__STDC_LIB_EXT1__` is not defined by the implementation.

Follow-on to PR #3129.

Fixes Google-internal macos builds, but this is generally more correct.

Changelog not needed: (PR #3129 was not released yet.