### PR TITLE
Moving pragma for MSVC warning C4505 from pybind11.h to existing list in detail/common.h

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -121,7 +121,7 @@
 #    define HAVE_ROUND 1
 #  endif
 #  pragma warning(push)
-#  pragma warning(disable: 4510 4610 4512 4005)
+#  pragma warning(disable: 4510 4610 4512 4005 4505)
 #  if defined(_DEBUG) && !defined(Py_DEBUG)
 #    define PYBIND11_DEBUG_MARKER
 #    undef _DEBUG

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -121,7 +121,12 @@
 #    define HAVE_ROUND 1
 #  endif
 #  pragma warning(push)
-#  pragma warning(disable: 4510 4610 4512 4005 4505)
+// C4005: TODO
+// C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
+// C4510: TODO
+// C4512: TODO
+// C4610: TODO
+#  pragma warning(disable: 4505)
 #  if defined(_DEBUG) && !defined(Py_DEBUG)
 #    define PYBIND11_DEBUG_MARKER
 #    undef _DEBUG

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -121,11 +121,7 @@
 #    define HAVE_ROUND 1
 #  endif
 #  pragma warning(push)
-// C4005: TODO
 // C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
-// C4510: TODO
-// C4512: TODO
-// C4610: TODO
 #  pragma warning(disable: 4505)
 #  if defined(_DEBUG) && !defined(Py_DEBUG)
 #    define PYBIND11_DEBUG_MARKER

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -13,7 +13,6 @@
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #  pragma warning(push)
 #  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
-#  pragma warning(disable: 4505) // warning C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
 #elif defined(__GNUG__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wunused-but-set-parameter"


### PR DESCRIPTION
Follow-on to PR #3127, based on results obtained under PR #3125.

The suggested changelog entry will be in the final PR of this cleanup series.

**[Worksheet](https://docs.google.com/spreadsheets/d/1XDKkq1w7d9f2dPcVsn-vmZHleMWQkVCl7xb4cilpGiI/edit#gid=1527078177)**