### PR TITLE
Limiting pragma for ignoring GCC 7 -Wnoexcept-type to the scope of pybind11.h.

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -50,9 +50,7 @@
    It is only actually needed in a couple places, but apparently GCC 7 "generates this warning if
    and only if the first template instantiation ... involves noexcept" [stackoverflow], therefore
    it could get triggered from seemingly random places, depending on user code.
-   It seems very unlikely that this warning will be useful to anyone (no other GCC version
-   generates it), but to be maximally accommodating we turn it off here instead of using a
-   command line option.
+   No other GCC version generates this warning.
  */
 #if defined(__GNUC__) && __GNUC__ == 7
 #    pragma GCC diagnostic push

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -991,6 +991,10 @@ public:
 #endif
     }
 
+#if defined(__GNUC__) && __GNUC__ == 7
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wnoexcept-type"
+#endif
     /** \rst
         Create Python binding for a new function within the module scope. ``Func``
         can be a plain C++ function, a function pointer, or a lambda function. For
@@ -1005,6 +1009,9 @@ public:
         add_object(name_, func, true /* overwrite */);
         return *this;
     }
+#if defined(__GNUC__) && __GNUC__ == 7
+#    pragma GCC diagnostic pop
+#endif
 
     /** \rst
         Create and return a new Python submodule with the given name and docstring.

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -18,9 +18,6 @@
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
 #  pragma GCC diagnostic ignored "-Wattributes"
-#  if __GNUC__ >= 7
-#    pragma GCC diagnostic ignored "-Wnoexcept-type"
-#  endif
 #endif
 
 #include "attr.h"
@@ -1355,6 +1352,10 @@ public:
     template <typename Base, detail::enable_if_t<!is_base<Base>::value, int> = 0>
     static void add_base(detail::type_record &) { }
 
+#if defined(__GNUC__) && __GNUC__ == 7
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wnoexcept-type"
+#endif
     template <typename Func, typename... Extra>
     class_ &def(const char *name_, Func&& f, const Extra&... extra) {
         cpp_function cf(method_adaptor<type>(std::forward<Func>(f)), name(name_), is_method(*this),
@@ -1362,6 +1363,9 @@ public:
         add_class_method(*this, name_, cf);
         return *this;
     }
+#if defined(__GNUC__) && __GNUC__ == 7
+#    pragma GCC diagnostic pop
+#endif
 
     template <typename Func, typename... Extra> class_ &
     def_static(const char *name_, Func &&f, const Extra&... extra) {


### PR DESCRIPTION
Follow-on to PR #3127, based on results obtained under PR #3125.

Note that the pragma for `-Wnoexcept-type` is moved from above to below all `#include`s. This unblocks refactoring and IWYU cleanup (and eventually merging the smart_holder branch).

It is somewhat of a coincidence that the moved pragma is still in the same header file. Potentially, the pragma for `-Wnoexcept-type` may need to be copied to refactored header files, but that's the price we have to pay for improved code organization with the added requirement to not suppress warnings from the command line (for portability).

The suggested changelog entry will be in the final PR of this cleanup series.

**[Worksheet](https://docs.google.com/spreadsheets/d/1XDKkq1w7d9f2dPcVsn-vmZHleMWQkVCl7xb4cilpGiI/edit#gid=1527078177)**