### PR TITLE
Removing GCC -Wunused-but-set-parameter from pragma block at the top of pybind11.h

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -517,13 +517,13 @@ template <size_t Nurse, size_t Patient> struct process_attribute<keep_alive<Nurs
 template <typename... Args> struct process_attributes {
     static void init(const Args&... args, function_record *r) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
-        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(r);
+        PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(r);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0) ... };
         silence_unused_warnings(unused);
     }
     static void init(const Args&... args, type_record *r) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
-        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(r);
+        PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(r);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0) ... };
         silence_unused_warnings(unused);
     }
@@ -534,7 +534,7 @@ template <typename... Args> struct process_attributes {
     }
     static void postcall(function_call &call, handle fn_ret) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call, fn_ret);
-        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(fn_ret);
+        PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(fn_ret);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::postcall(call, fn_ret), 0) ... };
         silence_unused_warnings(unused);
     }

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -518,26 +518,26 @@ template <typename... Args> struct process_attributes {
     static void init(const Args&... args, function_record *r) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
         PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(r);
-        int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0) ... };
-        silence_unused_warnings(unused);
+        PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(
+            {0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0)...});
     }
     static void init(const Args&... args, type_record *r) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
         PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(r);
-        int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0) ... };
-        silence_unused_warnings(unused);
+        PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(
+            {0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0)...});
     }
     static void precall(function_call &call) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call);
-        // int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::precall(call), 0) ... };
-        // silence_unused_warnings(unused);
-        (int []) { 0, (process_attribute<typename std::decay<Args>::type>::precall(call), 0) ... };
+        PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(
+            {0, (process_attribute<typename std::decay<Args>::type>::precall(call), 0)...});
     }
     static void postcall(function_call &call, handle fn_ret) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call, fn_ret);
         PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(fn_ret);
-        int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::postcall(call, fn_ret), 0) ... };
-        silence_unused_warnings(unused);
+        PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(
+            {0,
+             (process_attribute<typename std::decay<Args>::type>::postcall(call, fn_ret), 0)...});
     }
 };
 

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -517,23 +517,26 @@ template <size_t Nurse, size_t Patient> struct process_attribute<keep_alive<Nurs
 template <typename... Args> struct process_attributes {
     static void init(const Args&... args, function_record *r) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
+        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(r);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0) ... };
-        ignore_unused(unused);
+        silence_unused_warnings(unused);
     }
     static void init(const Args&... args, type_record *r) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
+        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(r);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0) ... };
-        ignore_unused(unused);
+        silence_unused_warnings(unused);
     }
     static void precall(function_call &call) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::precall(call), 0) ... };
-        ignore_unused(unused);
+        silence_unused_warnings(unused);
     }
     static void postcall(function_call &call, handle fn_ret) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call, fn_ret);
+        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(fn_ret);
         int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::postcall(call, fn_ret), 0) ... };
-        ignore_unused(unused);
+        silence_unused_warnings(unused);
     }
 };
 

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -517,14 +517,14 @@ template <size_t Nurse, size_t Patient> struct process_attribute<keep_alive<Nurs
 template <typename... Args> struct process_attributes {
     static void init(const Args&... args, function_record *r) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
-        PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(r);
+        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(r);
         using expander = int[];
         (void) expander{
             0, ((void) process_attribute<typename std::decay<Args>::type>::init(args, r), 0)...};
     }
     static void init(const Args&... args, type_record *r) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
-        PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(r);
+        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(r);
         using expander = int[];
         (void) expander{0,
                         (process_attribute<typename std::decay<Args>::type>::init(args, r), 0)...};
@@ -537,7 +537,7 @@ template <typename... Args> struct process_attributes {
     }
     static void postcall(function_call &call, handle fn_ret) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call, fn_ret);
-        PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(fn_ret);
+        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(fn_ret);
         using expander = int[];
         (void) expander{
             0, (process_attribute<typename std::decay<Args>::type>::postcall(call, fn_ret), 0)...};

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -529,8 +529,9 @@ template <typename... Args> struct process_attributes {
     }
     static void precall(function_call &call) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call);
-        int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::precall(call), 0) ... };
-        silence_unused_warnings(unused);
+        // int unused[] = { 0, (process_attribute<typename std::decay<Args>::type>::precall(call), 0) ... };
+        // silence_unused_warnings(unused);
+        (int []) { 0, (process_attribute<typename std::decay<Args>::type>::precall(call), 0) ... };
     }
     static void postcall(function_call &call, handle fn_ret) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call, fn_ret);

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -518,26 +518,29 @@ template <typename... Args> struct process_attributes {
     static void init(const Args&... args, function_record *r) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
         PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(r);
-        PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(
-            {0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0)...});
+        using expander = int[];
+        (void) expander{
+            0, ((void) process_attribute<typename std::decay<Args>::type>::init(args, r), 0)...};
     }
     static void init(const Args&... args, type_record *r) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(r);
         PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(r);
-        PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(
-            {0, (process_attribute<typename std::decay<Args>::type>::init(args, r), 0)...});
+        using expander = int[];
+        (void) expander{0,
+                        (process_attribute<typename std::decay<Args>::type>::init(args, r), 0)...};
     }
     static void precall(function_call &call) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call);
-        PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(
-            {0, (process_attribute<typename std::decay<Args>::type>::precall(call), 0)...});
+        using expander = int[];
+        (void) expander{0,
+                        (process_attribute<typename std::decay<Args>::type>::precall(call), 0)...};
     }
     static void postcall(function_call &call, handle fn_ret) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(call, fn_ret);
         PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(fn_ret);
-        PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(
-            {0,
-             (process_attribute<typename std::decay<Args>::type>::postcall(call, fn_ret), 0)...});
+        using expander = int[];
+        (void) expander{
+            0, (process_attribute<typename std::decay<Args>::type>::postcall(call, fn_ret), 0)...};
     }
 };
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -609,7 +609,7 @@ protected:
     template <typename T, size_t... Is>
     static handle cast_impl(T &&src, return_value_policy policy, handle parent, index_sequence<Is...>) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(src, policy, parent);
-        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(policy, parent);
+        PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(policy, parent);
         std::array<object, size> entries{{
             reinterpret_steal<object>(make_caster<Ts>::cast(std::get<Is>(std::forward<T>(src)), policy, parent))...
         }};

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -609,7 +609,7 @@ protected:
     template <typename T, size_t... Is>
     static handle cast_impl(T &&src, return_value_policy policy, handle parent, index_sequence<Is...>) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(src, policy, parent);
-        PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(policy, parent);
+        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(policy, parent);
         std::array<object, size> entries{{
             reinterpret_steal<object>(make_caster<Ts>::cast(std::get<Is>(std::forward<T>(src)), policy, parent))...
         }};

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1236,8 +1236,8 @@ public:
         // Tuples aren't (easily) resizable so a list is needed for collection,
         // but the actual function call strictly requires a tuple.
         auto args_list = list();
-        PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(
-            {0, (process(args_list, std::forward<Ts>(values)), 0)...});
+        using expander = int[];
+        (void) expander{0, (process(args_list, std::forward<Ts>(values)), 0)...};
 
         m_args = std::move(args_list);
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1236,8 +1236,8 @@ public:
         // Tuples aren't (easily) resizable so a list is needed for collection,
         // but the actual function call strictly requires a tuple.
         auto args_list = list();
-        int unused[] = { 0, (process(args_list, std::forward<Ts>(values)), 0)... };
-        silence_unused_warnings(unused);
+        PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(
+            {0, (process(args_list, std::forward<Ts>(values)), 0)...});
 
         m_args = std::move(args_list);
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -609,6 +609,7 @@ protected:
     template <typename T, size_t... Is>
     static handle cast_impl(T &&src, return_value_policy policy, handle parent, index_sequence<Is...>) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(src, policy, parent);
+        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(policy, parent);
         std::array<object, size> entries{{
             reinterpret_steal<object>(make_caster<Ts>::cast(std::get<Is>(std::forward<T>(src)), policy, parent))...
         }};
@@ -1235,8 +1236,8 @@ public:
         // Tuples aren't (easily) resizable so a list is needed for collection,
         // but the actual function call strictly requires a tuple.
         auto args_list = list();
-        int _[] = { 0, (process(args_list, std::forward<Ts>(values)), 0)... };
-        ignore_unused(_);
+        int unused[] = { 0, (process(args_list, std::forward<Ts>(values)), 0)... };
+        silence_unused_warnings(unused);
 
         m_args = std::move(args_list);
     }

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -927,6 +927,7 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 // For silencing "unused" compiler warnings in special situations.
 template <typename... Args>
 inline constexpr void silence_unused_warnings(Args &&...) {}
+inline void silence_unused_warnings(const int *) {}
 
 // MSVC warning C4100: Unreferenced formal parameter
 #if defined(_MSC_VER) && _MSC_VER <= 1916

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -939,7 +939,7 @@ inline void silence_unused_warnings(Args &&...) {}
 #    define PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(...)
 #endif
 
-// GCC -Wunused-but-set-parameter
+// GCC -Wunused-but-set-parameter  All GCC versions (as of July 2021).
 #if defined(__GNUG__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #    define PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(...)                   \
         detail::silence_unused_warnings(__VA_ARGS__)

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -954,17 +954,6 @@ inline void silence_unused_warnings(Args &&...) {}
 #    define PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(...)
 #endif
 
-// MSVC error C4576: a parenthesized type followed by an initializer list is a
-//                   non-standard explicit type conversion syntax
-// clang: expression result unused [-Wunused-value]
-#if defined(_MSC_VER) || defined(__clang__) // All versions (as of July 2021).
-#    define PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(...)                              \
-        int dummy[] = __VA_ARGS__;                                                                \
-        detail::silence_unused_warnings(dummy)
-#else
-#    define PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(...) (int[]) __VA_ARGS__
-#endif
-
 #if defined(_MSC_VER) // All versions (as of July 2021).
 
 // warning C4127: Conditional expression is constant

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -943,7 +943,7 @@ inline void silence_unused_warnings(Args &&...) {}
 #if defined(__GNUG__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #    define PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(...)                   \
         detail::silence_unused_warnings(__VA_ARGS__)
-#    if defined(__GNUC__) && __GNUC__ <= 7
+#    if defined(__GNUC__) && __GNUC__ <= 2
 #        define PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(...)               \
             detail::silence_unused_warnings(__VA_ARGS__)
 #    else

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -943,15 +943,8 @@ inline void silence_unused_warnings(Args &&...) {}
 #if defined(__GNUG__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #    define PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(...)                   \
         detail::silence_unused_warnings(__VA_ARGS__)
-#    if defined(__GNUC__) && __GNUC__ <= 5 // 4 is certain, 5 unknown, 6 is certain
-#        define PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(...)               \
-            detail::silence_unused_warnings(__VA_ARGS__)
-#    else
-#        define PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(...)
-#    endif
 #else
 #    define PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(...)
-#    define PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(...)
 #endif
 
 #if defined(_MSC_VER) // All versions (as of July 2021).

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -943,7 +943,7 @@ inline void silence_unused_warnings(Args &&...) {}
 #if defined(__GNUG__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #    define PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(...)                   \
         detail::silence_unused_warnings(__VA_ARGS__)
-#    if defined(__GNUC__) && __GNUC__ <= 2
+#    if defined(__GNUC__) && __GNUC__ <= 5 // 4 is certain, 5 unknown, 6 is certain
 #        define PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(...)               \
             detail::silence_unused_warnings(__VA_ARGS__)
 #    else

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -926,12 +926,12 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 
 // For silencing "unused" compiler warnings in special situations.
 template <typename... Args>
+inline
 #if defined(_MSC_VER) && _MSC_VER >= 1910 && _MSC_VER < 1920  // MSVC 2017
-inline constexpr void silence_unused_warnings(Args &&...) {}
-#else
-inline void silence_unused_warnings(Args &&...) {}
+constexpr
 #endif
-inline void silence_unused_warnings(const int *) {}
+void silence_unused_warnings(Args &&...) {}
+// XXX XXX XXX inline void silence_unused_warnings(const int *) {}
 
 // MSVC warning C4100: Unreferenced formal parameter
 #if defined(_MSC_VER) && _MSC_VER <= 1916

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -926,7 +926,11 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 
 // For silencing "unused" compiler warnings in special situations.
 template <typename... Args>
+#if defined(_MSC_VER) && _MSC_VER >= 1910 && _MSC_VER < 1920  // MSVC 2017
+inline constexpr void silence_unused_warnings(Args &&...) {}
+#else
 inline void silence_unused_warnings(Args &&...) {}
+#endif
 inline void silence_unused_warnings(const int *) {}
 
 // MSVC warning C4100: Unreferenced formal parameter

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -926,7 +926,7 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 
 // For silencing "unused" compiler warnings in special situations.
 template <typename... Args>
-inline constexpr void silence_unused_warnings(Args &&...) {}
+inline void silence_unused_warnings(Args &&...) {}
 inline void silence_unused_warnings(const int *) {}
 
 // MSVC warning C4100: Unreferenced formal parameter

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -926,12 +926,10 @@ inline static std::shared_ptr<T> try_get_shared_from_this(std::enable_shared_fro
 
 // For silencing "unused" compiler warnings in special situations.
 template <typename... Args>
-inline
-#if defined(_MSC_VER) && _MSC_VER >= 1910 && _MSC_VER < 1920  // MSVC 2017
+#if defined(_MSC_VER) && _MSC_VER >= 1910 && _MSC_VER < 1920 // MSVC 2017
 constexpr
 #endif
-void silence_unused_warnings(Args &&...) {}
-// XXX XXX XXX inline void silence_unused_warnings(const int *) {}
+inline void silence_unused_warnings(Args &&...) {}
 
 // MSVC warning C4100: Unreferenced formal parameter
 #if defined(_MSC_VER) && _MSC_VER <= 1916
@@ -943,10 +941,17 @@ void silence_unused_warnings(Args &&...) {}
 
 // GCC -Wunused-but-set-parameter
 #if defined(__GNUG__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
-#    define PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(...)                                         \
+#    define PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(...)                   \
         detail::silence_unused_warnings(__VA_ARGS__)
+#    if defined(__GNUC__) && __GNUC__ <= 7
+#        define PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(...)               \
+            detail::silence_unused_warnings(__VA_ARGS__)
+#    else
+#        define PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(...)
+#    endif
 #else
-#    define PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(...)
+#    define PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(...)
+#    define PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(...)
 #endif
 
 #if defined(_MSC_VER) // All versions (as of July 2021).

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -954,6 +954,17 @@ inline void silence_unused_warnings(Args &&...) {}
 #    define PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(...)
 #endif
 
+// MSVC error C4576: a parenthesized type followed by an initializer list is a
+//                   non-standard explicit type conversion syntax
+// clang: expression result unused [-Wunused-value]
+#if defined(_MSC_VER) || defined(__clang__) // All versions (as of July 2021).
+#    define PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(...)                              \
+        int dummy[] = __VA_ARGS__;                                                                \
+        detail::silence_unused_warnings(dummy)
+#else
+#    define PYBIND11_INT_ARRAY_WORKING_AROUND_MSVC_CLANG_ISSUES(...) (int[]) __VA_ARGS__
+#endif
+
 #if defined(_MSC_VER) // All versions (as of July 2021).
 
 // warning C4127: Conditional expression is constant

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -941,10 +941,10 @@ inline void silence_unused_warnings(Args &&...) {}
 
 // GCC -Wunused-but-set-parameter
 #if defined(__GNUG__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
-#    define PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(...)                   \
+#    define PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(...)                   \
         detail::silence_unused_warnings(__VA_ARGS__)
 #else
-#    define PYBIND11_WORKAROUND_INCORRECT_ALL_GCC_UNUSED_BUT_SET_PARAMETER(...)
+#    define PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(...)
 #endif
 
 #if defined(_MSC_VER) // All versions (as of July 2021).

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -931,6 +931,7 @@ protected:
     template <typename T, typename = enable_if_t<is_copy_constructible<T>::value>>
     static auto make_copy_constructor(const T *x) -> decltype(new T(*x), Constructor{}) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(x);
+        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(x);  // TODO GCC < ?
         return [](const void *arg) -> void * {
             return new T(*reinterpret_cast<const T *>(arg));
         };
@@ -939,6 +940,7 @@ protected:
     template <typename T, typename = enable_if_t<std::is_move_constructible<T>::value>>
     static auto make_move_constructor(const T *x) -> decltype(new T(std::move(*const_cast<T *>(x))), Constructor{}) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(x);
+        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(x);  // TODO GCC < ?
         return [](const void *arg) -> void * {
             return new T(std::move(*const_cast<T *>(reinterpret_cast<const T *>(arg))));
         };

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -931,7 +931,7 @@ protected:
     template <typename T, typename = enable_if_t<is_copy_constructible<T>::value>>
     static auto make_copy_constructor(const T *x) -> decltype(new T(*x), Constructor{}) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(x);
-        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(x);  // TODO GCC < ?
+        PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(x);
         return [](const void *arg) -> void * {
             return new T(*reinterpret_cast<const T *>(arg));
         };
@@ -940,7 +940,7 @@ protected:
     template <typename T, typename = enable_if_t<std::is_move_constructible<T>::value>>
     static auto make_move_constructor(const T *x) -> decltype(new T(std::move(*const_cast<T *>(x))), Constructor{}) {
         PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(x);
-        PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER(x);  // TODO GCC < ?
+        PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(x);
         return [](const void *arg) -> void * {
             return new T(std::move(*const_cast<T *>(reinterpret_cast<const T *>(arg))));
         };

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -927,20 +927,17 @@ protected:
     using Constructor = void *(*)(const void *);
 
     /* Only enabled when the types are {copy,move}-constructible *and* when the type
-       does not have a private operator new implementation. */
+       does not have a private operator new implementation. A comma operator is used in the decltype
+       argument to apply SFINAE to the public copy/move constructors.*/
     template <typename T, typename = enable_if_t<is_copy_constructible<T>::value>>
-    static auto make_copy_constructor(const T *x) -> decltype(new T(*x), Constructor{}) {
-        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(x);
-        PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(x);
+    static auto make_copy_constructor(const T *) -> decltype(new T(std::declval<const T>()), Constructor{}) {
         return [](const void *arg) -> void * {
             return new T(*reinterpret_cast<const T *>(arg));
         };
     }
 
     template <typename T, typename = enable_if_t<std::is_move_constructible<T>::value>>
-    static auto make_move_constructor(const T *x) -> decltype(new T(std::move(*const_cast<T *>(x))), Constructor{}) {
-        PYBIND11_WORKAROUND_INCORRECT_MSVC_C4100(x);
-        PYBIND11_WORKAROUND_INCORRECT_OLD_GCC_UNUSED_BUT_SET_PARAMETER(x);
+    static auto make_move_constructor(const T *) -> decltype(new T(std::declval<T&&>()), Constructor{}) {
         return [](const void *arg) -> void * {
             return new T(std::move(*const_cast<T *>(reinterpret_cast<const T *>(arg))));
         };

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -12,10 +12,12 @@
 #include "numpy.h"
 
 #if defined(__INTEL_COMPILER)
-#  pragma warning(disable: 1682) // implicit conversion of a 64-bit integral type to a smaller integral type (potential portability problem)
+#  pragma warning push
+#  pragma warning disable 1682 // implicit conversion of a 64-bit integral type to a smaller integral type (potential portability problem)
 #elif defined(__GNUG__) || defined(__clang__)
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wconversion"
+#  pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #  ifdef __clang__
 //   Eigen generates a bunch of implicit-copy-constructor-is-deprecated warnings with -Wdeprecated
@@ -25,9 +27,7 @@
 #  if __GNUC__ >= 7
 #    pragma GCC diagnostic ignored "-Wint-in-bool-context"
 #  endif
-#endif
-
-#if defined(_MSC_VER)
+#elif defined(_MSC_VER)
 #  pragma warning(push)
 #  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
 #  pragma warning(disable: 4996) // warning C4996: std::unary_negate is deprecated in C++17
@@ -597,7 +597,9 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
 
-#if defined(__GNUG__) || defined(__clang__)
+#if defined(__INTEL_COMPILER)
+#  pragma warning pop
+#elif defined(__GNUG__) || defined(__clang__)
 #  pragma GCC diagnostic pop
 #elif defined(_MSC_VER)
 #  pragma warning(pop)

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -12,12 +12,10 @@
 #include "numpy.h"
 
 #if defined(__INTEL_COMPILER)
-#  pragma warning push
-#  pragma warning disable 1682 // implicit conversion of a 64-bit integral type to a smaller integral type (potential portability problem)
+#  pragma warning(disable: 1682) // implicit conversion of a 64-bit integral type to a smaller integral type (potential portability problem)
 #elif defined(__GNUG__) || defined(__clang__)
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #  ifdef __clang__
 //   Eigen generates a bunch of implicit-copy-constructor-is-deprecated warnings with -Wdeprecated
@@ -27,7 +25,9 @@
 #  if __GNUC__ >= 7
 #    pragma GCC diagnostic ignored "-Wint-in-bool-context"
 #  endif
-#elif defined(_MSC_VER)
+#endif
+
+#if defined(_MSC_VER)
 #  pragma warning(push)
 #  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
 #  pragma warning(disable: 4996) // warning C4996: std::unary_negate is deprecated in C++17
@@ -597,9 +597,7 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
 
-#if defined(__INTEL_COMPILER)
-#  pragma warning pop
-#elif defined(__GNUG__) || defined(__clang__)
+#if defined(__GNUG__) || defined(__clang__)
 #  pragma GCC diagnostic pop
 #elif defined(_MSC_VER)
 #  pragma warning(pop)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -12,7 +12,6 @@
 
 #if defined(__GNUG__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
 #  pragma GCC diagnostic ignored "-Wattributes"
 #endif
 


### PR DESCRIPTION
Follow-on to PR #3127, based on results obtained under PR #3125.

Consolidating the new warning suppressions for MSVC & GCC and the existing `ignore_unused()` function.

Introducing a new macro `PYBIND11_WORKAROUND_INCORRECT_GCC_UNUSED_BUT_SET_PARAMETER`, similar to the existing one for `MSVC`.

This PR is mostly trivial, but includes an important commit by @henryiii that is more-or-less independent (but significantly reduces the required workarounds):

https://github.com/pybind/pybind11/pull/3164/commits/218732d402c80c9ce6308e52a63e1378a067da24

The suggested changelog entry will be in the final PR of this cleanup series.

**[Worksheet](https://docs.google.com/spreadsheets/d/1XDKkq1w7d9f2dPcVsn-vmZHleMWQkVCl7xb4cilpGiI/edit#gid=1527078177)**