### PR TITLE
Fix func_handle for rule of two

### DIFF
--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -70,9 +70,11 @@ public:
         struct func_handle {
             function f;
             func_handle(function &&f_) noexcept : f(std::move(f_)) {}
-            func_handle(const func_handle& f_) {
+            func_handle(const func_handle &f_) { operator=(f_); }
+            func_handle &operator=(const func_handle &f_) {
                 gil_scoped_acquire acq;
                 f = f_.f;
+                return &this;
             }
             ~func_handle() {
                 gil_scoped_acquire acq;

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -74,7 +74,7 @@ public:
             func_handle &operator=(const func_handle &f_) {
                 gil_scoped_acquire acq;
                 f = f_.f;
-                return &this;
+                return *this;
             }
             ~func_handle() {
                 gil_scoped_acquire acq;


### PR DESCRIPTION
## Description
If the copy constructor is defined, the copy assignment constructor should also be defined. Found in #3070 but that was never merged. Found in LGTM static analysis. https://lgtm.com/projects/g/pybind/pybind11/ I looked into turning the clang-tidy check for this, but the only clang-tidy check is way too noisy and will give way too many false positive (only rule of 5 is implemented, ie all constructors, dtor, and assignment operators have to be explicitly defined or defaulted which seem excessive). 
The effect is that if we do anything more complex with this struct later, the code will be more maintainable.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->


<!-- If the upgrade guide needs updating, note that here too -->
