### PR TITLE
Consistent CI step name "Python tests".

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -664,7 +664,7 @@ jobs:
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
       working-directory: /build-tests
 
-    - name: Run tests
+    - name: Python tests
       run: make pytest -j 2
       working-directory: /build-tests
 
@@ -760,7 +760,7 @@ jobs:
     - name: Build C++11
       run: cmake --build build -j 2
 
-    - name: Run tests
+    - name: Python tests
       run: cmake --build build -t pytest
 
   win32-msvc2015:


### PR DESCRIPTION
Consistent naming makes it easy to pin-point where Python tests are run, to apply temporary changes.

See PR #3106 for how that might be useful (running tests repeatedly for deflaking).