### PR TITLE
Improved workaround for Centos 8 failure (follow-on to PR #3030).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,11 +592,21 @@ jobs:
     - name: Install dependencies
       run: python3 -m pip install cmake -r tests/requirements.txt --prefer-binary
 
+    - name: VAR_BUILD_TYPE 7
+      if: matrix.centos == 7
+      run: echo MinSizeRel > VAR_BUILD_TYPE
+
+    # Using Release to avoid segfault that appeared around 2021-06-04,
+    # apparently when the gcc version changed from 8.3 to 8.4.
+    - name: VAR_BUILD_TYPE 8
+      if: matrix.centos == 8
+      run: echo Release > VAR_BUILD_TYPE
+
     - name: Configure
       shell: bash
       run: >
         cmake -S . -B build
-        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_BUILD_TYPE=$(cat VAR_BUILD_TYPE)
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,6 +596,7 @@ jobs:
       shell: bash
       run: >
         cmake -S . -B build
+        -DCMAKE_BUILD_TYPE=Release
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,21 +592,10 @@ jobs:
     - name: Install dependencies
       run: python3 -m pip install cmake -r tests/requirements.txt --prefer-binary
 
-    - name: VAR_BUILD_TYPE 7
-      if: matrix.centos == 7
-      run: echo Release > VAR_BUILD_TYPE
-
-    # Using Debug to avoid segfault that appeared around 2021-06-04,
-    # apparently when the gcc version changed from 8.3 to 8.4.
-    - name: VAR_BUILD_TYPE 8
-      if: matrix.centos == 8
-      run: echo Debug > VAR_BUILD_TYPE
-
     - name: Configure
       shell: bash
       run: >
         cmake -S . -B build
-        -DCMAKE_BUILD_TYPE=$(cat VAR_BUILD_TYPE)
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON

--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -147,7 +147,7 @@ Add a module and setup all helpers. You can select the type of the library; the
 default is ``MODULE``. There are several options:
 
 ``OPT_SIZE``
-  Optimize for size, even if the ``CMAKE_BUILD_TYPE`` is not ``RelSize``.
+  Optimize for size, even if the ``CMAKE_BUILD_TYPE`` is not ``MinSizeRel``.
 ``THIN_LTO``
   Use thin TLO instead of regular if there's a choice (pybind11's selection
   is disabled if ``CMAKE_INTERPROCEDURAL_OPTIMIZATIONS`` is set).


### PR DESCRIPTION
The Centos 8 failure first observed back in June still exists, but somewhat coincidentally it was discovered that `-DCMAKE_BUILD_TYPE=Release` works (the default is `MinSizeRel`).

Also fixing a minor documentation bug.