### PR TITLE
[Bugfix] Fix errant const methods

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -507,7 +507,7 @@ struct instance {
     void allocate_layout();
 
     /// Destroys/deallocates all of the above
-    void deallocate_layout() const;
+    void deallocate_layout();
 
     /// Returns the value_and_holder wrapper for the given type (or the first, if `find_type`
     /// omitted).  Returns a default-constructed (with `.inst = nullptr`) object on failure if

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -241,7 +241,7 @@ struct value_and_holder {
                    ? inst->simple_holder_constructed
                    : (inst->nonsimple.status[index] & instance::status_holder_constructed) != 0u;
     }
-    //NOLINTNEXTLINE(readability-make-member-function-const)
+    // NOLINTNEXTLINE(readability-make-member-function-const)
     void set_holder_constructed(bool v = true) {
         if (inst->simple_layout)
             inst->simple_holder_constructed = v;
@@ -255,7 +255,7 @@ struct value_and_holder {
             ? inst->simple_instance_registered
             : ((inst->nonsimple.status[index] & instance::status_instance_registered) != 0);
     }
-    //NOLINTNEXTLINE(readability-make-member-function-const)
+    // NOLINTNEXTLINE(readability-make-member-function-const)
     void set_instance_registered(bool v = true) {
         if (inst->simple_layout)
             inst->simple_instance_registered = v;
@@ -399,7 +399,7 @@ PYBIND11_NOINLINE void instance::allocate_layout() {
     owned = true;
 }
 
-//NOLINTNEXTLINE(readability-make-member-function-const)
+// NOLINTNEXTLINE(readability-make-member-function-const)
 PYBIND11_NOINLINE void instance::deallocate_layout() {
     if (!simple_layout)
         PyMem_Free(nonsimple.values_and_holders);

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -241,7 +241,8 @@ struct value_and_holder {
                    ? inst->simple_holder_constructed
                    : (inst->nonsimple.status[index] & instance::status_holder_constructed) != 0u;
     }
-    void set_holder_constructed(bool v = true) const {
+    //NOLINTNEXTLINE(readability-make-member-function-const)
+    void set_holder_constructed(bool v = true) {
         if (inst->simple_layout)
             inst->simple_holder_constructed = v;
         else if (v)
@@ -254,7 +255,8 @@ struct value_and_holder {
             ? inst->simple_instance_registered
             : ((inst->nonsimple.status[index] & instance::status_instance_registered) != 0);
     }
-    void set_instance_registered(bool v = true) const {
+    //NOLINTNEXTLINE(readability-make-member-function-const)
+    void set_instance_registered(bool v = true) {
         if (inst->simple_layout)
             inst->simple_instance_registered = v;
         else if (v)
@@ -397,7 +399,8 @@ PYBIND11_NOINLINE inline void instance::allocate_layout() {
     owned = true;
 }
 
-PYBIND11_NOINLINE inline void instance::deallocate_layout() const {
+//NOLINTNEXTLINE(readability-make-member-function-const)
+PYBIND11_NOINLINE inline void instance::deallocate_layout() {
     if (!simple_layout)
         PyMem_Free(nonsimple.values_and_holders);
 }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1393,7 +1393,7 @@ public:
     bool empty() const { return size() == 0; }
     detail::dict_iterator begin() const { return {*this, 0}; }
     detail::dict_iterator end() const { return {}; }
-    void clear() { PyDict_Clear(ptr()); }
+    void clear() /* py-non-const */ { PyDict_Clear(ptr()); }
     template <typename T> bool contains(T &&key) const {
         return PyDict_Contains(m_ptr, detail::object_or_cast(std::forward<T>(key)).ptr()) == 1;
     }
@@ -1435,10 +1435,10 @@ public:
     detail::item_accessor operator[](handle h) const { return object::operator[](h); }
     detail::list_iterator begin() const { return {*this, 0}; }
     detail::list_iterator end() const { return {*this, PyList_GET_SIZE(m_ptr)}; }
-    template <typename T> void append(T &&val) {
+    template <typename T> void append(T &&val) /* py-non-const */ {
         PyList_Append(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr());
     }
-    template <typename T> void insert(size_t index, T &&val) {
+    template <typename T> void insert(size_t index, T &&val) /* py-non-const */ {
         PyList_Insert(m_ptr, static_cast<ssize_t>(index),
             detail::object_or_cast(std::forward<T>(val)).ptr());
     }
@@ -1455,10 +1455,10 @@ public:
     }
     size_t size() const { return (size_t) PySet_Size(m_ptr); }
     bool empty() const { return size() == 0; }
-    template <typename T> bool add(T &&val) {
+    template <typename T> bool add(T &&val) /* py-non-const */ {
         return PySet_Add(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 0;
     }
-    void clear() { PySet_Clear(m_ptr); }
+    void clear() /* py-non-const */ { PySet_Clear(m_ptr); }
     template <typename T> bool contains(T &&val) const {
         return PySet_Contains(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 1;
     }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1393,7 +1393,8 @@ public:
     bool empty() const { return size() == 0; }
     detail::dict_iterator begin() const { return {*this, 0}; }
     detail::dict_iterator end() const { return {}; }
-    void clear() const { PyDict_Clear(ptr()); }
+    //NOLINTNEXTLINE(readability-make-member-function-const)
+    void clear() { PyDict_Clear(ptr()); }
     template <typename T> bool contains(T &&key) const {
         return PyDict_Contains(m_ptr, detail::object_or_cast(std::forward<T>(key)).ptr()) == 1;
     }
@@ -1435,10 +1436,12 @@ public:
     detail::item_accessor operator[](handle h) const { return object::operator[](h); }
     detail::list_iterator begin() const { return {*this, 0}; }
     detail::list_iterator end() const { return {*this, PyList_GET_SIZE(m_ptr)}; }
-    template <typename T> void append(T &&val) const {
+    //NOLINTNEXTLINE(readability-make-member-function-const)
+    template <typename T> void append(T &&val) {
         PyList_Append(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr());
     }
-    template <typename T> void insert(size_t index, T &&val) const {
+    //NOLINTNEXTLINE(readability-make-member-function-const)
+    template <typename T> void insert(size_t index, T &&val) {
         PyList_Insert(m_ptr, static_cast<ssize_t>(index),
             detail::object_or_cast(std::forward<T>(val)).ptr());
     }
@@ -1455,9 +1458,11 @@ public:
     }
     size_t size() const { return (size_t) PySet_Size(m_ptr); }
     bool empty() const { return size() == 0; }
-    template <typename T> bool add(T &&val) const {
+    //NOLINTNEXTLINE(readability-make-member-function-const)
+    template <typename T> bool add(T &&val) {
         return PySet_Add(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 0;
     }
+    //NOLINTNEXTLINE(readability-make-member-function-const)
     void clear() const { PySet_Clear(m_ptr); }
     template <typename T> bool contains(T &&val) const {
         return PySet_Contains(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 1;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1393,7 +1393,6 @@ public:
     bool empty() const { return size() == 0; }
     detail::dict_iterator begin() const { return {*this, 0}; }
     detail::dict_iterator end() const { return {}; }
-    //NOLINTNEXTLINE(readability-make-member-function-const)
     void clear() { PyDict_Clear(ptr()); }
     template <typename T> bool contains(T &&key) const {
         return PyDict_Contains(m_ptr, detail::object_or_cast(std::forward<T>(key)).ptr()) == 1;
@@ -1436,11 +1435,9 @@ public:
     detail::item_accessor operator[](handle h) const { return object::operator[](h); }
     detail::list_iterator begin() const { return {*this, 0}; }
     detail::list_iterator end() const { return {*this, PyList_GET_SIZE(m_ptr)}; }
-    //NOLINTNEXTLINE(readability-make-member-function-const)
     template <typename T> void append(T &&val) {
         PyList_Append(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr());
     }
-    //NOLINTNEXTLINE(readability-make-member-function-const)
     template <typename T> void insert(size_t index, T &&val) {
         PyList_Insert(m_ptr, static_cast<ssize_t>(index),
             detail::object_or_cast(std::forward<T>(val)).ptr());
@@ -1458,11 +1455,9 @@ public:
     }
     size_t size() const { return (size_t) PySet_Size(m_ptr); }
     bool empty() const { return size() == 0; }
-    //NOLINTNEXTLINE(readability-make-member-function-const)
     template <typename T> bool add(T &&val) {
         return PySet_Add(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 0;
     }
-    //NOLINTNEXTLINE(readability-make-member-function-const)
     void clear() const { PySet_Clear(m_ptr); }
     template <typename T> bool contains(T &&val) const {
         return PySet_Contains(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 1;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1458,7 +1458,7 @@ public:
     template <typename T> bool add(T &&val) {
         return PySet_Add(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 0;
     }
-    void clear() const { PySet_Clear(m_ptr); }
+    void clear() { PySet_Clear(m_ptr); }
     template <typename T> bool contains(T &&val) const {
         return PySet_Contains(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 1;
     }


### PR DESCRIPTION
## Description
* Clang-Tidy accidentally declared some methods const that shouldn't be because the underlying ptr was edited, but not the object itself. I am not sure if there is a better way to fix this warning (ie. with a mutable keyword or something on the ptr, but open to ideas). I just went through manually and suppressed the const functions that didn't make sense.
* Please let me know if I missed any.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Remove const modifier from certain C++ methods on python collections (list, set, dict) such as  (clear(), append(), insert(), etc...) since they were not logically const.
```

<!-- If the upgrade guide needs updating, note that here too -->
