### PR TITLE
maint(precommit): Apply isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,14 @@ repos:
     exclude: ^noxfile.py$
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.23.0
+  rev: v2.23.3
   hooks:
   - id: pyupgrade
+
+- repo: https://github.com/PyCQA/isort
+  rev: 5.9.3
+  hooks:
+  - id: isort
 
 # Black, the code formatter, natively supports pre-commit
 - repo: https://github.com/psf/black

--- a/docs/benchmark.py
+++ b/docs/benchmark.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import random
-import os
-import time
 import datetime as dt
+import os
+import random
+import time
 
 nfns = 4  # Functions per class
 nargs = 4  # Arguments per function

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,12 +13,12 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import re
 import shlex
 import subprocess
+import sys
 from pathlib import Path
-import re
 
 DIR = Path(__file__).parent.resolve()
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,5 @@
 import nox
 
-
 nox.options.sessions = ["lint", "tests", "tests_packaging"]
 
 

--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from ._version import version_info, __version__
-from .commands import get_include, get_cmake_dir
-
+from ._version import __version__, version_info
+from .commands import get_cmake_dir, get_include
 
 __all__ = (
     "version_info",

--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -5,7 +5,7 @@ import argparse
 import sys
 import sysconfig
 
-from .commands import get_include, get_cmake_dir
+from .commands import get_cmake_dir, get_include
 
 
 def print_includes():

--- a/pybind11/_version.pyi
+++ b/pybind11/_version.pyi
@@ -1,4 +1,4 @@
-from typing import Union, Tuple
+from typing import Tuple, Union
 
 def _to_int(s: str) -> Union[int, str]: ...
 

--- a/pybind11/commands.py
+++ b/pybind11/commands.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 
-
 DIR = os.path.abspath(os.path.dirname(__file__))
 
 

--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -41,23 +41,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import contextlib
 import os
+import platform
 import shutil
 import sys
+import sysconfig
 import tempfile
 import threading
-import platform
 import warnings
-import sysconfig
 
 try:
-    from setuptools.command.build_ext import build_ext as _build_ext
     from setuptools import Extension as _Extension
+    from setuptools.command.build_ext import build_ext as _build_ext
 except ImportError:
     from distutils.command.build_ext import build_ext as _build_ext
     from distutils.extension import Extension as _Extension
 
-import distutils.errors
 import distutils.ccompiler
+import distutils.errors
 
 WIN = sys.platform.startswith("win32") and "mingw" not in sysconfig.get_platform()
 PY2 = sys.version_info[0] < 3

--- a/pybind11/setup_helpers.pyi
+++ b/pybind11/setup_helpers.pyi
@@ -1,13 +1,12 @@
 # IMPORTANT: Should stay in sync with setup_helpers.py (mostly checked by CI /
 # pre-commit).
 
-from typing import Any, Callable, Dict, Iterator, List, Optional, Type, TypeVar, Union
-from types import TracebackType
-
+import contextlib
+import distutils.ccompiler
 from distutils.command.build_ext import build_ext as _build_ext  # type: ignore
 from distutils.extension import Extension as _Extension
-import distutils.ccompiler
-import contextlib
+from types import TracebackType
+from typing import Any, Callable, Dict, Iterator, List, Optional, Type, TypeVar, Union
 
 WIN: bool
 PY2: bool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ ignore = [
 
 [tool.isort]
 known_first_party = "env,pybind11_cross_module_tests,pybind11_tests,"
+# For black compatibility
 profile = "black"
+multi_line_output = 3
 
 [tool.mypy]
 files = "pybind11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ ignore = [
 ]
 
 [tool.isort]
-known_first_party = "env,pybind11_tests,"
+known_first_party = "env,pybind11_cross_module_tests,pybind11_tests,"
 profile = "black"
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ ignore = [
 ]
 
 [tool.isort]
+# Needs the compiled .so modules and env.py from tests
 known_first_party = "env,pybind11_cross_module_tests,pybind11_tests,"
 # For black compatibility
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ ignore = [
     "noxfile.py",
 ]
 
+[tool.isort]
+profile = 'black'
+
 [tool.mypy]
 files = "pybind11"
 python_version = "2.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ ignore = [
 known_first_party = "env,pybind11_cross_module_tests,pybind11_tests,"
 # For black compatibility
 profile = "black"
-multi_line_output = 3
 
 [tool.mypy]
 files = "pybind11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ ignore = [
 ]
 
 [tool.isort]
-known_first_party = "pybind11_tests,"
+known_first_party = "env,pybind11_tests,"
 profile = "black"
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ ignore = [
 ]
 
 [tool.isort]
-profile = 'black'
+known_first_party = "pybind11_tests,"
+profile = "black"
 
 [tool.mypy]
 files = "pybind11"

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 # Setup script for PyPI; use CMakeFile.txt to build extension modules
 
 import contextlib
+import io
 import os
 import re
 import shutil
@@ -11,7 +12,6 @@ import string
 import subprocess
 import sys
 import tempfile
-import io
 
 import setuptools.command.sdist
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,9 @@ import gc
 import re
 import textwrap
 
-import env
 import pytest
+
+import env
 
 # Early diagnostic for failed imports
 import pybind11_tests  # noqa: F401

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,10 @@ import re
 import textwrap
 
 import env
+import pytest
 
 # Early diagnostic for failed imports
 import pybind11_tests  # noqa: F401
-import pytest
 
 _unicode_marker = re.compile(r"u(\'[^\']*\')")
 _long_marker = re.compile(r"([0-9])L")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,11 @@ import gc
 import re
 import textwrap
 
-import pytest
-
 import env
 
 # Early diagnostic for failed imports
 import pybind11_tests  # noqa: F401
+import pytest
 
 _unicode_marker = re.compile(r"u(\'[^\']*\')")
 _long_marker = re.compile(r"([0-9])L")

--- a/tests/extra_setuptools/test_setuphelper.py
+++ b/tests/extra_setuptools/test_setuphelper.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
 import subprocess
+import sys
 from textwrap import dedent
 
 import pytest

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -5,6 +5,7 @@ import struct
 
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import ConstructorStats
 from pybind11_tests import buffers as m
 

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -3,9 +3,9 @@ import ctypes
 import io
 import struct
 
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import ConstructorStats
 from pybind11_tests import buffers as m
 

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
+import ctypes
 import io
 import struct
-import ctypes
-
-import pytest
 
 import env  # noqa: F401
-
-from pybind11_tests import buffers as m
+import pytest
 from pybind11_tests import ConstructorStats
+from pybind11_tests import buffers as m
 
 np = pytest.importorskip("numpy")
 

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import IncType, UserType
 from pybind11_tests import builtin_casters as m
 

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
-
+import pytest
+from pybind11_tests import IncType, UserType
 from pybind11_tests import builtin_casters as m
-from pybind11_tests import UserType, IncType
 
 
 def test_simple_string():

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import IncType, UserType
 from pybind11_tests import builtin_casters as m
 

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import ConstructorStats
 from pybind11_tests import call_policies as m
 

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import ConstructorStats
 from pybind11_tests import call_policies as m
 

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
-
-from pybind11_tests import call_policies as m
+import pytest
 from pybind11_tests import ConstructorStats
+from pybind11_tests import call_policies as m
 
 
 @pytest.mark.xfail("env.PYPY", reason="sometimes comes out 1 off on PyPy", strict=False)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -4,6 +4,7 @@ from threading import Thread
 
 import env  # NOQA: F401
 import pytest
+
 from pybind11_tests import callbacks as m
 
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -2,9 +2,9 @@
 import time
 from threading import Thread
 
-import env  # NOQA: F401
 import pytest
 
+import env  # NOQA: F401
 from pybind11_tests import callbacks as m
 
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+import time
+from threading import Thread
+
+import env  # NOQA: F401
 import pytest
 from pybind11_tests import callbacks as m
-from threading import Thread
-import time
-import env  # NOQA: F401
 
 
 def test_callbacks():

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from pybind11_tests import chrono as m
 import datetime
-import pytest
 
 import env  # noqa: F401
+import pytest
+from pybind11_tests import chrono as m
 
 
 def test_chrono_system_clock():

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -3,6 +3,7 @@ import datetime
 
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import chrono as m
 
 

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import datetime
 
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import chrono as m
 
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import class_ as m
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import class_ as m
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
-
+import pytest
+from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import class_ as m
-from pybind11_tests import UserType, ConstructorStats
 
 
 def test_repr():

--- a/tests/test_cmake_build/test.py
+++ b/tests/test_cmake_build/test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
+
 import test_cmake_build
 
 assert test_cmake_build.add(1, 2) == 3

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pybind11_tests import copy_move_policies as m
 
 

--- a/tests/test_custom_type_casters.py
+++ b/tests/test_custom_type_casters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pybind11_tests import custom_type_casters as m
 
 

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pybind11_tests import ConstructorStats
 
 np = pytest.importorskip("numpy")

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pybind11_tests import enums as m
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
 
-import pytest
-
 import env  # noqa: F401
-
+import pytest
 from pybind11_tests import eval_ as m
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
 
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import eval_ as m
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -3,6 +3,7 @@ import os
 
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import eval_ as m
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,6 +4,7 @@ import sys
 import env  # noqa: F401
 import pybind11_cross_module_tests as cm
 import pytest
+
 from pybind11_tests import exceptions as m
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 import sys
 
-import pytest
-
 import env  # noqa: F401
-
-from pybind11_tests import exceptions as m
 import pybind11_cross_module_tests as cm
+import pytest
+from pybind11_tests import exceptions as m
 
 
 def test_std_exception(msg):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import sys
 
-import pybind11_cross_module_tests as cm
 import pytest
 
 import env  # noqa: F401
+import pybind11_cross_module_tests as cm
 from pybind11_tests import exceptions as m
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import sys
 
-import env  # noqa: F401
 import pybind11_cross_module_tests as cm
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import exceptions as m
 
 

--- a/tests/test_factory_constructors.py
+++ b/tests/test_factory_constructors.py
@@ -3,6 +3,7 @@ import re
 
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import ConstructorStats
 from pybind11_tests import factory_constructors as m
 from pybind11_tests.factory_constructors import tag

--- a/tests/test_factory_constructors.py
+++ b/tests/test_factory_constructors.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-import pytest
 import re
 
 import env  # noqa: F401
-
+import pytest
+from pybind11_tests import ConstructorStats
 from pybind11_tests import factory_constructors as m
 from pybind11_tests.factory_constructors import tag
-from pybind11_tests import ConstructorStats
 
 
 def test_init_factory_basic():

--- a/tests/test_factory_constructors.py
+++ b/tests/test_factory_constructors.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import re
 
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import ConstructorStats
 from pybind11_tests import factory_constructors as m
 from pybind11_tests.factory_constructors import tag

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from pybind11_tests import iostream as m
 import sys
-
 from contextlib import contextmanager
+
+from pybind11_tests import iostream as m
 
 try:
     # Python 3

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import kwargs_and_defaults as m
 
 

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
-
+import pytest
 from pybind11_tests import kwargs_and_defaults as m
 
 

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import kwargs_and_defaults as m
 
 

--- a/tests/test_local_bindings.py
+++ b/tests/test_local_bindings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import local_bindings as m
 
 

--- a/tests/test_local_bindings.py
+++ b/tests/test_local_bindings.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
-
+import pytest
 from pybind11_tests import local_bindings as m
 
 

--- a/tests/test_local_bindings.py
+++ b/tests/test_local_bindings.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import local_bindings as m
 
 

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import ConstructorStats
 from pybind11_tests import methods_and_attributes as m
 

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
-
-from pybind11_tests import methods_and_attributes as m
+import pytest
 from pybind11_tests import ConstructorStats
+from pybind11_tests import methods_and_attributes as m
 
 
 def test_methods_and_attributes():

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import ConstructorStats
 from pybind11_tests import methods_and_attributes as m
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
+from pybind11_tests import ConstructorStats
 from pybind11_tests import modules as m
 from pybind11_tests.modules import subsubmodule as ms
-from pybind11_tests import ConstructorStats
 
 
 def test_nested_modules():
@@ -54,8 +54,9 @@ def test_reference_internal():
 
 
 def test_importing():
-    from pybind11_tests.modules import OD
     from collections import OrderedDict
+
+    from pybind11_tests.modules import OD
 
     assert OD is OrderedDict
     assert str(OD([(1, "a"), (2, "b")])) == "OrderedDict([(1, 'a'), (2, 'b')])"
@@ -63,8 +64,9 @@ def test_importing():
 
 def test_pydoc():
     """Pydoc needs to be able to provide help() for everything inside a pybind11 module"""
-    import pybind11_tests
     import pydoc
+
+    import pybind11_tests
 
     assert pybind11_tests.__name__ == "pybind11_tests"
     assert pybind11_tests.__doc__ == "pybind11 test module"

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import ConstructorStats
 from pybind11_tests import multiple_inheritance as m
 

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import ConstructorStats
 from pybind11_tests import multiple_inheritance as m
 

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
-
+import pytest
 from pybind11_tests import ConstructorStats
 from pybind11_tests import multiple_inheritance as m
 

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
-
+import pytest
 from pybind11_tests import numpy_array as m
 
 np = pytest.importorskip("numpy")

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import numpy_array as m
 
 np = pytest.importorskip("numpy")

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import numpy_array as m
 
 np = pytest.importorskip("numpy")

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -3,6 +3,7 @@ import re
 
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import numpy_dtypes as m
 
 np = pytest.importorskip("numpy")

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import re
 
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import numpy_dtypes as m
 
 np = pytest.importorskip("numpy")

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 import re
 
-import pytest
-
 import env  # noqa: F401
-
+import pytest
 from pybind11_tests import numpy_dtypes as m
 
 np = pytest.importorskip("numpy")

--- a/tests/test_numpy_vectorize.py
+++ b/tests/test_numpy_vectorize.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pybind11_tests import numpy_vectorize as m
 
 np = pytest.importorskip("numpy")

--- a/tests/test_opaque_types.py
+++ b/tests/test_opaque_types.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import opaque_types as m
 

--- a/tests/test_opaque_types.py
+++ b/tests/test_opaque_types.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
-from pybind11_tests import opaque_types as m
 from pybind11_tests import ConstructorStats, UserType
+from pybind11_tests import opaque_types as m
 
 
 def test_string_list():

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
-from pybind11_tests import operators as m
 from pybind11_tests import ConstructorStats
+from pybind11_tests import operators as m
 
 
 def test_operator_overloading():

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pybind11_tests import ConstructorStats
 from pybind11_tests import operators as m
 

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
-
+import pytest
 from pybind11_tests import pickling as m
 
 try:

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import pickling as m
 
 try:

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import pickling as m
 
 try:

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -5,6 +5,7 @@ import sys
 
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import debug_enabled
 from pybind11_tests import pytypes as m
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
-import pytest
+
 import sys
 
 import env  # noqa: F401
-
-from pybind11_tests import pytypes as m
+import pytest
 from pybind11_tests import debug_enabled
+from pybind11_tests import pytypes as m
 
 
 def test_int(doc):

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -3,9 +3,9 @@ from __future__ import division
 
 import sys
 
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import debug_enabled
 from pybind11_tests import pytypes as m
 

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pybind11_tests import ConstructorStats
 from pybind11_tests import sequences_and_iterators as m
 

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
-from pybind11_tests import sequences_and_iterators as m
 from pybind11_tests import ConstructorStats
+from pybind11_tests import sequences_and_iterators as m
 
 
 def isclose(a, b, rel_tol=1e-05, abs_tol=0.0):

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
-
+from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import stl as m
-from pybind11_tests import UserType
-from pybind11_tests import ConstructorStats
 
 
 def test_vector(doc):

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import stl as m
 

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import env  # noqa: F401
 import pytest
+
 from pybind11_tests import stl_binders as m
 
 

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
-
+import pytest
 from pybind11_tests import stl_binders as m
 
 

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import stl_binders as m
 
 

--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import env  # noqa: F401
+import pytest
 
 m = pytest.importorskip("pybind11_tests.virtual_functions")
 from pybind11_tests import ConstructorStats  # noqa: E402

--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-import env  # noqa: F401
 import pytest
+
+import env  # noqa: F401
 
 m = pytest.importorskip("pybind11_tests.virtual_functions")
 from pybind11_tests import ConstructorStats  # noqa: E402

--- a/tools/libsize.py
+++ b/tools/libsize.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, division
+from __future__ import division, print_function
+
 import os
 import sys
 

--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -4,10 +4,8 @@
 import re
 
 import ghapi.all
-
 from rich import print
 from rich.syntax import Syntax
-
 
 ENTRY = re.compile(
     r"""


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
* Applies the isort formatter to the repo and enables the pre-commit hook for it. It is a simple formatter which is compatible with black and ensure that all imports in the repo occur in a standard (alphabetical) order unless otherwise indicated. It also otherwise can format the imports and ensure standard, third party, and first party libraries all go in their standard order. The ordering is automatically applied and enforced with a pre-commit hook.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Format pybind11 with isort consistent ordering of imports
* Enable isort pre-commit hook
```

<!-- If the upgrade guide needs updating, note that here too -->
