### PR TITLE
extend msys2 mingw CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -911,17 +911,35 @@ jobs:
     - name: Clean directory
       run: git clean -fdx
 
-    - name: Configure C++17
-      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=17 -S . -B build2
+    - name: Configure C++14
+      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=14 -S . -B build2
 
-    - name: Build C++17
+    - name: Build C++14
       run: cmake --build build2 -j 2
 
-    - name: Python tests C++17
+    - name: Python tests C++14
       run: cmake --build build2 --target pytest -j 2
 
-    - name: C++17 tests
+    - name: C++14 tests
       run: cmake --build build2 --target cpptest -j 2
 
-    - name: Interface test C++17
+    - name: Interface test C++14
       run: cmake --build build2 --target test_cmake_build
+
+    - name: Clean directory
+      run: git clean -fdx
+
+    - name: Configure C++17
+      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=17 -S . -B build3
+
+    - name: Build C++17
+      run: cmake --build build3 -j 2
+
+    - name: Python tests C++17
+      run: cmake --build build3 --target pytest -j 2
+
+    - name: C++17 tests
+      run: cmake --build build3 --target cpptest -j 2
+
+    - name: Interface test C++17
+      run: cmake --build build3 --target test_cmake_build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -861,32 +861,67 @@ jobs:
       run: cmake --build build -t check
 
   mingw:
+    name: "🐍 3 • windows-latest • ${{ matrix.sys }}"
     runs-on: windows-latest
     defaults:
       run:
         shell: msys2 {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
     steps:
     - uses: msys2/setup-msys2@v2
       with:
+        msystem: ${{matrix.sys}}
         install: >-
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-python-pip
-          mingw-w64-x86_64-cmake
-          mingw-w64-x86_64-make
-          mingw-w64-x86_64-python-pytest
-          mingw-w64-x86_64-eigen3
-          mingw-w64-x86_64-boost
-          mingw-w64-x86_64-catch
+          git
+          mingw-w64-${{matrix.env}}-gcc
+          mingw-w64-${{matrix.env}}-python-pip
+          mingw-w64-${{matrix.env}}-python-numpy
+          mingw-w64-${{matrix.env}}-python-scipy
+          mingw-w64-${{matrix.env}}-cmake
+          mingw-w64-${{matrix.env}}-make
+          mingw-w64-${{matrix.env}}-python-pytest
+          mingw-w64-${{matrix.env}}-eigen3
+          mingw-w64-${{matrix.env}}-boost
+          mingw-w64-${{matrix.env}}-catch
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
-    - name: Configure
+    - name: Configure C++11
       # LTO leads to many undefined reference like
       # `pybind11::detail::function_call::function_call(pybind11::detail::function_call&&)
-      run: cmake -G "MinGW Makefiles" -S . -B build
+      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=11 -S . -B build
 
-    - name: Build
+    - name: Build C++11
       run: cmake --build build -j 2
 
-    - name: Python tests
-      run: cmake --build build --target pytest
+    - name: Python tests C++11
+      run: cmake --build build --target pytest -j 2
+
+    - name: C++11 tests
+      run: cmake --build build --target cpptest -j 2
+
+    - name: Interface test C++11
+      run: cmake --build build --target test_cmake_build
+
+    - name: Clean directory
+      run: git clean -fdx
+
+    - name: Configure C++17
+      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=17 -S . -B build2
+
+    - name: Build C++17
+      run: cmake --build build2 -j 2
+
+    - name: Python tests C++17
+      run: cmake --build build2 --target pytest -j 2
+
+    - name: C++17 tests
+      run: cmake --build build2 --target cpptest -j 2
+
+    - name: Interface test C++17
+      run: cmake --build build2 --target test_cmake_build

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -63,14 +63,18 @@ def partial_ld_offset():
 def partial_dtype_fmt():
     ld = np.dtype("longdouble")
     partial_ld_off = partial_ld_offset()
-    return dt_fmt().format(ld.itemsize, partial_ld_off, partial_ld_off + ld.itemsize)
+    partial_size = partial_ld_off + ld.itemsize
+    partial_end_padding = partial_size % np.dtype("uint64").alignment
+    return dt_fmt().format(ld.itemsize, partial_ld_off, partial_size + partial_end_padding)
 
 
 def partial_nested_fmt():
     ld = np.dtype("longdouble")
     partial_nested_off = 8 + 8 * (ld.alignment > 8)
     partial_ld_off = partial_ld_offset()
-    partial_nested_size = partial_nested_off * 2 + partial_ld_off + ld.itemsize
+    partial_size = partial_ld_off + ld.itemsize
+    partial_end_padding = partial_size % np.dtype("uint64").alignment
+    partial_nested_size = partial_nested_off * 2 + partial_size + partial_end_padding
     return "{{'names':['a'], 'formats':[{}], 'offsets':[{}], 'itemsize':{}}}".format(
         partial_dtype_fmt(), partial_nested_off, partial_nested_size
     )
@@ -91,10 +95,11 @@ def test_format_descriptors():
     ldbl_fmt = ("4x" if ld.alignment > 4 else "") + ld.char
     ss_fmt = "^T{?:bool_:3xI:uint_:f:float_:" + ldbl_fmt + ":ldbl_:}"
     dbl = np.dtype("double")
+    end_padding = ld.itemsize % np.dtype("uint64").alignment
     partial_fmt = (
         "^T{?:bool_:3xI:uint_:f:float_:"
         + str(4 * (dbl.alignment > 4) + dbl.itemsize + 8 * (ld.alignment > 8))
-        + "xg:ldbl_:}"
+        + "xg:ldbl_:" + (str(end_padding) + "x}" if end_padding > 0 else "}")
     )
     nested_extra = str(max(8, ld.alignment))
     assert m.print_format_descriptors() == [

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -65,7 +65,9 @@ def partial_dtype_fmt():
     partial_ld_off = partial_ld_offset()
     partial_size = partial_ld_off + ld.itemsize
     partial_end_padding = partial_size % np.dtype("uint64").alignment
-    return dt_fmt().format(ld.itemsize, partial_ld_off, partial_size + partial_end_padding)
+    return dt_fmt().format(
+        ld.itemsize, partial_ld_off, partial_size + partial_end_padding
+    )
 
 
 def partial_nested_fmt():
@@ -99,7 +101,8 @@ def test_format_descriptors():
     partial_fmt = (
         "^T{?:bool_:3xI:uint_:f:float_:"
         + str(4 * (dbl.alignment > 4) + dbl.itemsize + 8 * (ld.alignment > 8))
-        + "xg:ldbl_:" + (str(end_padding) + "x}" if end_padding > 0 else "}")
+        + "xg:ldbl_:"
+        + (str(end_padding) + "x}" if end_padding > 0 else "}")
     )
     nested_extra = str(max(8, ld.alignment))
     assert m.print_format_descriptors() == [


### PR DESCRIPTION
## Description

extension of #3132 with

- additional 32-bit mingw CI job
- c++11/17 c++/interface tests copied from standard ci
- numpy/scipy installed to also run these tests

note: 32-bit numpy tests are currently failing due to a difference in the padding of structs

## Suggested changelog entry:

<!-- If the upgrade guide needs updating, note that here too -->
