### PR TITLE
maint(clang-tidy): Enable cpp-coreguideline slicing checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,8 @@
 FormatStyle: file
 
 Checks: '
-*bugprone*,
 cppcoreguidelines-init-variables,
+cppcoreguidelines-slicing,
 clang-analyzer-optin.cplusplus.VirtualCall,
 llvm-namespace-comment,
 misc-misplaced-const,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 FormatStyle: file
 
 Checks: '
+*bugprone*,
 cppcoreguidelines-init-variables,
 cppcoreguidelines-slicing,
 clang-analyzer-optin.cplusplus.VirtualCall,

--- a/README.rst
+++ b/README.rst
@@ -134,9 +134,9 @@ About
 This project was created by `Wenzel
 Jakob <http://rgl.epfl.ch/people/wjakob>`_. Significant features and/or
 improvements to the code were contributed by Jonas Adler, Lori A. Burns,
-Sylvain Corlay, Eric Cousineau, Ralf Grosse-Kunstleve, Trent Houliston, Axel
+Sylvain Corlay, Eric Cousineau, Aaron Gokaslan, Ralf Grosse-Kunstleve, Trent Houliston, Axel
 Huebl, @hulucc, Yannick Jadoul, Sergey Lyskov Johan Mabille, Tomasz Miąsko,
-Dean Moldovan, Ben Pritchard, Jason Rhinelander, Boris Schäling,  Pim
+Dean Moldovan, Ben Pritchard, Jason Rhinelander, Boris Schäling, Pim
 Schellart, Henry Schreiner, Ivan Smirnov, Boris Staletic, and Patrick Stewart.
 
 We thank Google for a generous financial contribution to the continuous

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1664,7 +1664,7 @@ inline str enum_name(handle arg) {
 }
 
 struct enum_base {
-    enum_base(handle base, handle parent) : m_base(base), m_parent(parent) { }
+    enum_base(const handle &base, const handle &parent) : m_base(base), m_parent(parent) { }
 
     PYBIND11_NOINLINE void init(bool is_arithmetic, bool is_convertible) {
         m_base.attr("__entries") = dict();


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
* This enable an additional clang-tidy check that checks for potentially bugprone [inheritance slicing behavior](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-slicing.html) and automatically warns if it is encountered. There is only one class the currently exhibits this behavior, and this PR fixes this potentially buggy behavior.

## Suggested changelog entry:
```rst
* Enable clang-tidy check to guard against inheritance slicing
```

<!-- If the upgrade guide needs updating, note that here too -->
