### PR TITLE
chore: support targeting different Python versions with nox

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,8 +68,8 @@ nox -l
 # Run linters
 nox -s lint
 
-# Run tests
-nox -s tests
+# Run tests on Python 3.9
+nox -s tests-3.9
 
 # Build and preview docs
 nox -s docs -- serve

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,8 @@ import nox
 
 nox.options.sessions = ["lint", "tests", "tests_packaging"]
 
+PYTHON_VERISONS = ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+
 
 @nox.session(reuse_venv=True)
 def lint(session: nox.Session) -> None:
@@ -12,7 +14,7 @@ def lint(session: nox.Session) -> None:
     session.run("pre-commit", "run", "-a")
 
 
-@nox.session
+@nox.session(python=PYTHON_VERISONS)
 def tests(session: nox.Session) -> None:
     """
     Run the tests (requires a compiler).


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Small quality-of-life upgrade; you can now run the Python 2 tests with `nox -s python-2.7`, for example.

