### PR TITLE
fix: memory leak in cpp_function (#3228)

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -175,7 +175,7 @@ protected:
 #endif
             // UB without std::launder, but without breaking ABI and/or
             // a significant refactoring it's "impossible" to solve.
-            if (!std::is_trivially_destructible<Func>::value)
+            if (!std::is_trivially_destructible<capture>::value)
                 rec->free_data = [](function_record *r) {
                     auto data = PYBIND11_STD_LAUNDER((capture *) &r->data);
                     (void) data;

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -81,14 +81,53 @@ TEST_SUBMODULE(callbacks, m) {
     };
     // Export the payload constructor statistics for testing purposes:
     m.def("payload_cstats", &ConstructorStats::get<Payload>);
-    /* Test cleanup of lambda closure */
-    m.def("test_cleanup", []() -> std::function<void()> {
+    m.def("test_lambda_closure_cleanup", []() -> std::function<void()> {
         Payload p;
 
+        // In this situation, `Func` in the implementation of
+        // `cpp_function::initialize` is NOT trivially destructible.
         return [p]() {
             /* p should be cleaned up when the returned function is garbage collected */
             (void) p;
         };
+    });
+
+    class CppCallable {
+    public:
+        CppCallable() { track_default_created(this); }
+        ~CppCallable() { track_destroyed(this); }
+        CppCallable(const CppCallable &) { track_copy_created(this); }
+        CppCallable(CppCallable &&) noexcept { track_move_created(this); }
+        void operator()() {}
+    };
+
+    m.def("test_cpp_callable_cleanup", []() {
+        // Related issue: https://github.com/pybind/pybind11/issues/3228
+        // Related PR: https://github.com/pybind/pybind11/pull/3229
+        py::list alive_counts;
+        ConstructorStats &stat = ConstructorStats::get<CppCallable>();
+        alive_counts.append(stat.alive());
+        {
+            CppCallable cpp_callable;
+            alive_counts.append(stat.alive());
+            {
+                // In this situation, `Func` in the implementation of
+                // `cpp_function::initialize` IS trivially destructible,
+                // only `capture` is not.
+                py::cpp_function py_func(cpp_callable);
+                py_func();
+                alive_counts.append(stat.alive());
+            }
+            alive_counts.append(stat.alive());
+            {
+                py::cpp_function py_func(std::move(cpp_callable));
+                py_func();
+                alive_counts.append(stat.alive());
+            }
+            alive_counts.append(stat.alive());
+        }
+        alive_counts.append(stat.alive());
+        return alive_counts;
     });
 
     // test_cpp_function_roundtrip

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -115,13 +115,13 @@ TEST_SUBMODULE(callbacks, m) {
                 // `cpp_function::initialize` IS trivially destructible,
                 // only `capture` is not.
                 py::cpp_function py_func(cpp_callable);
-                py_func();
+                py::detail::silence_unused_warnings(py_func);
                 alive_counts.append(stat.alive());
             }
             alive_counts.append(stat.alive());
             {
                 py::cpp_function py_func(std::move(cpp_callable));
-                py_func();
+                py::detail::silence_unused_warnings(py_func);
                 alive_counts.append(stat.alive());
             }
             alive_counts.append(stat.alive());

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -79,11 +79,16 @@ def test_keyword_args_and_generalized_unpacking():
 
 
 def test_lambda_closure_cleanup():
-    m.test_cleanup()
+    m.test_lambda_closure_cleanup()
     cstats = m.payload_cstats()
     assert cstats.alive() == 0
     assert cstats.copy_constructions == 1
     assert cstats.move_constructions >= 1
+
+
+def test_cpp_callable_cleanup():
+    alive_counts = m.test_cpp_callable_cleanup()
+    assert alive_counts == [0, 1, 2, 1, 2, 1, 0]
 
 
 def test_cpp_function_roundtrip():

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -341,12 +341,14 @@ TEST_CASE("Check objects are deconstructed in cpp_function") {
     ConstructorStats &stat = ConstructorStats::get<MyFunctionObject>();
     {
         py::cpp_function func(func_obj);
-        (void)func;
+        func();
+        CHECK(stat.alive() == 2);
     }
     CHECK(stat.alive() == 1);
     {
         py::cpp_function func(std::move(func_obj));
-        (void)func;
+        func();
+        CHECK(stat.alive() == 2);
     }
     CHECK(stat.alive() == 1);
 }

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -327,9 +327,9 @@ TEST_CASE("sys.argv gets initialized properly") {
 
 class MyFunctionObject {
 public:
-    MyFunctionObject() noexcept { track_default_created(this); }
-    ~MyFunctionObject() noexcept { track_destroyed(this); }
-    MyFunctionObject(const MyFunctionObject &) noexcept { track_copy_created(this); }
+    MyFunctionObject() { track_default_created(this); }
+    ~MyFunctionObject() { track_destroyed(this); }
+    MyFunctionObject(const MyFunctionObject &) { track_copy_created(this); }
     MyFunctionObject(MyFunctionObject &&) noexcept { track_move_created(this); }
     void operator()() { }
 };


### PR DESCRIPTION
## Description

The PR is related to #3228, and may be related to #1510 and pytorch/pytorch#5161.

Let's focus on `pybind11::cpp_function::initialize`. If the first argument is lvalue reference, the type `Func` is deduced to lvalue reference (according to [Template argument deduction](https://en.cppreference.com/w/cpp/language/template_argument_deduction)). In this case, `std::is_trivially_destructible<Func>` is always true, therefore `rec->data` will never be deconstructed.

To solve this issue, we should determine whether `rec->data` should be deconstructed according whether the type of `rec->data` (i.e., `capsule`) is trivially destructible.