### PR TITLE
Minor tweaks.

### DIFF
--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -1,10 +1,7 @@
 #pragma once
 
-// This must be kept first for MSVC 2015.
-// Do not remove the empty line between the #includes.
-#include <pybind11/pybind11.h>
-
 #include <pybind11/eval.h>
+#include <pybind11/pybind11.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
 // We get some really long type names here which causes MSVC 2015 to emit warnings
@@ -29,13 +26,13 @@ public:
     void test_submodule_##name(py::module_ &(variable))
 
 /// Dummy type which is not exported anywhere -- something to trigger a conversion error
-struct UnregisteredType { };
+struct UnregisteredType {};
 
 /// A user-defined type which is exported and can be used by any test
 class UserType {
 public:
     UserType() = default;
-    UserType(int i) : i(i) { }
+    UserType(int i) : i(i) {}
 
     int value() const { return i; }
     void set(int set) { i = set; }
@@ -49,7 +46,7 @@ class IncType : public UserType {
 public:
     using UserType::UserType;
     IncType() = default;
-    IncType(const IncType &other) : IncType(other.value() + 1) { }
+    IncType(const IncType &other) : IncType(other.value() + 1) {}
     IncType(IncType &&) = delete;
     IncType &operator=(const IncType &) = delete;
     IncType &operator=(IncType &&) = delete;
@@ -61,16 +58,21 @@ union IntFloat {
     float f;
 };
 
-/// Custom cast-only type that casts to a string "rvalue" or "lvalue" depending on the cast context.
-/// Used to test recursive casters (e.g. std::tuple, stl containers).
+/// Custom cast-only type that casts to a string "rvalue" or "lvalue" depending on the cast
+/// context. Used to test recursive casters (e.g. std::tuple, stl containers).
 struct RValueCaster {};
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
-template<> class type_caster<RValueCaster> {
+template <>
+class type_caster<RValueCaster> {
 public:
     PYBIND11_TYPE_CASTER(RValueCaster, _("RValueCaster"));
-    static handle cast(RValueCaster &&, return_value_policy, handle) { return py::str("rvalue").release(); }
-    static handle cast(const RValueCaster &, return_value_policy, handle) { return py::str("lvalue").release(); }
+    static handle cast(RValueCaster &&, return_value_policy, handle) {
+        return py::str("rvalue").release();
+    }
+    static handle cast(const RValueCaster &, return_value_policy, handle) {
+        return py::str("lvalue").release();
+    }
 };
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(pybind11)
@@ -84,5 +86,6 @@ void ignoreOldStyleInitWarnings(F &&body) {
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=message, category=FutureWarning)
         body()
-    )", py::dict(py::arg("body") = py::cpp_function(body)));
+    )",
+             py::dict(py::arg("body") = py::cpp_function(body)));
 }

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <pybind11/eval.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/eval.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
 // We get some really long type names here which causes MSVC 2015 to emit warnings
@@ -26,13 +26,13 @@ public:
     void test_submodule_##name(py::module_ &(variable))
 
 /// Dummy type which is not exported anywhere -- something to trigger a conversion error
-struct UnregisteredType {};
+struct UnregisteredType { };
 
 /// A user-defined type which is exported and can be used by any test
 class UserType {
 public:
     UserType() = default;
-    UserType(int i) : i(i) {}
+    UserType(int i) : i(i) { }
 
     int value() const { return i; }
     void set(int set) { i = set; }
@@ -46,7 +46,7 @@ class IncType : public UserType {
 public:
     using UserType::UserType;
     IncType() = default;
-    IncType(const IncType &other) : IncType(other.value() + 1) {}
+    IncType(const IncType &other) : IncType(other.value() + 1) { }
     IncType(IncType &&) = delete;
     IncType &operator=(const IncType &) = delete;
     IncType &operator=(IncType &&) = delete;
@@ -58,21 +58,16 @@ union IntFloat {
     float f;
 };
 
-/// Custom cast-only type that casts to a string "rvalue" or "lvalue" depending on the cast
-/// context. Used to test recursive casters (e.g. std::tuple, stl containers).
+/// Custom cast-only type that casts to a string "rvalue" or "lvalue" depending on the cast context.
+/// Used to test recursive casters (e.g. std::tuple, stl containers).
 struct RValueCaster {};
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
-template <>
-class type_caster<RValueCaster> {
+template<> class type_caster<RValueCaster> {
 public:
     PYBIND11_TYPE_CASTER(RValueCaster, _("RValueCaster"));
-    static handle cast(RValueCaster &&, return_value_policy, handle) {
-        return py::str("rvalue").release();
-    }
-    static handle cast(const RValueCaster &, return_value_policy, handle) {
-        return py::str("lvalue").release();
-    }
+    static handle cast(RValueCaster &&, return_value_policy, handle) { return py::str("rvalue").release(); }
+    static handle cast(const RValueCaster &, return_value_policy, handle) { return py::str("lvalue").release(); }
 };
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(pybind11)
@@ -86,6 +81,5 @@ void ignoreOldStyleInitWarnings(F &&body) {
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=message, category=FutureWarning)
         body()
-    )",
-             py::dict(py::arg("body") = py::cpp_function(body)));
+    )", py::dict(py::arg("body") = py::cpp_function(body)));
 }

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -238,13 +238,13 @@ def test_duplicate_enum_name():
 
 def test_char_underlying_enum():  # Issue #1331/PR #1334:
     assert type(m.ScopedCharEnum.Positive.__int__()) is int
-    assert int(m.ScopedChar16Enum.Zero) == 0
+    assert int(m.ScopedChar16Enum.Zero) == 0  # int() call should successfully return
     assert hash(m.ScopedChar32Enum.Positive) == 1
-    assert m.ScopedCharEnum.Positive.__getstate__() == 1
+    assert m.ScopedCharEnum.Positive.__getstate__() == 1  # return type is long in py2.x
     assert m.ScopedWCharEnum(1) == m.ScopedWCharEnum.Positive
     with pytest.raises(TypeError):
-        # Even if the underlying type is char, only an int can be used to construct the enum:
-        m.ScopedCharEnum("0")
+        # Enum should construct with a int, even with char underlying type
+        m.ScopedWCharEnum("0")
 
 
 def test_bool_underlying_enum():

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -238,13 +238,13 @@ def test_duplicate_enum_name():
 
 def test_char_underlying_enum():  # Issue #1331/PR #1334:
     assert type(m.ScopedCharEnum.Positive.__int__()) is int
-    assert int(m.ScopedChar16Enum.Zero) == 0  # int() call should successfully return
+    assert int(m.ScopedChar16Enum.Zero) == 0
     assert hash(m.ScopedChar32Enum.Positive) == 1
-    assert m.ScopedCharEnum.Positive.__getstate__() == 1  # return type is long in py2.x
+    assert m.ScopedCharEnum.Positive.__getstate__() == 1
     assert m.ScopedWCharEnum(1) == m.ScopedWCharEnum.Positive
     with pytest.raises(TypeError):
-        # Enum should construct with a int, even with char underlying type
-        m.ScopedWCharEnum("0")
+        # Even if the underlying type is char, only an int can be used to construct the enum:
+        m.ScopedCharEnum("0")
 
 
 def test_bool_underlying_enum():


### PR DESCRIPTION
This PR just removes an obsolete/now-incorrect comment and an empty line that were added in PR pybind#3087; those were made obsolete by the pragma cleanup that concluded with PR pybind#3186.

Change validated by applying `clang-format`, running the CI, then un-doing the `clang-format`ing.


