### PR TITLE
Minor follow-on to PR #1334 (Fix enum value's __int__ returning non-int when underlying type is bool or of char type)

### DIFF
--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -1,10 +1,7 @@
 #pragma once
 
-// This must be kept first for MSVC 2015.
-// Do not remove the empty line between the #includes.
-#include <pybind11/pybind11.h>
-
 #include <pybind11/eval.h>
+#include <pybind11/pybind11.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
 // We get some really long type names here which causes MSVC 2015 to emit warnings
@@ -29,13 +26,13 @@ public:
     void test_submodule_##name(py::module_ &(variable))
 
 /// Dummy type which is not exported anywhere -- something to trigger a conversion error
-struct UnregisteredType { };
+struct UnregisteredType {};
 
 /// A user-defined type which is exported and can be used by any test
 class UserType {
 public:
     UserType() = default;
-    UserType(int i) : i(i) { }
+    UserType(int i) : i(i) {}
 
     int value() const { return i; }
     void set(int set) { i = set; }
@@ -49,7 +46,7 @@ class IncType : public UserType {
 public:
     using UserType::UserType;
     IncType() = default;
-    IncType(const IncType &other) : IncType(other.value() + 1) { }
+    IncType(const IncType &other) : IncType(other.value() + 1) {}
     IncType(IncType &&) = delete;
     IncType &operator=(const IncType &) = delete;
     IncType &operator=(IncType &&) = delete;
@@ -61,16 +58,21 @@ union IntFloat {
     float f;
 };
 
-/// Custom cast-only type that casts to a string "rvalue" or "lvalue" depending on the cast context.
-/// Used to test recursive casters (e.g. std::tuple, stl containers).
+/// Custom cast-only type that casts to a string "rvalue" or "lvalue" depending on the cast
+/// context. Used to test recursive casters (e.g. std::tuple, stl containers).
 struct RValueCaster {};
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
-template<> class type_caster<RValueCaster> {
+template <>
+class type_caster<RValueCaster> {
 public:
     PYBIND11_TYPE_CASTER(RValueCaster, _("RValueCaster"));
-    static handle cast(RValueCaster &&, return_value_policy, handle) { return py::str("rvalue").release(); }
-    static handle cast(const RValueCaster &, return_value_policy, handle) { return py::str("lvalue").release(); }
+    static handle cast(RValueCaster &&, return_value_policy, handle) {
+        return py::str("rvalue").release();
+    }
+    static handle cast(const RValueCaster &, return_value_policy, handle) {
+        return py::str("lvalue").release();
+    }
 };
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(pybind11)
@@ -84,5 +86,6 @@ void ignoreOldStyleInitWarnings(F &&body) {
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=message, category=FutureWarning)
         body()
-    )", py::dict(py::arg("body") = py::cpp_function(body)));
+    )",
+             py::dict(py::arg("body") = py::cpp_function(body)));
 }

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <pybind11/eval.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/eval.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
 // We get some really long type names here which causes MSVC 2015 to emit warnings
@@ -26,13 +26,13 @@ public:
     void test_submodule_##name(py::module_ &(variable))
 
 /// Dummy type which is not exported anywhere -- something to trigger a conversion error
-struct UnregisteredType {};
+struct UnregisteredType { };
 
 /// A user-defined type which is exported and can be used by any test
 class UserType {
 public:
     UserType() = default;
-    UserType(int i) : i(i) {}
+    UserType(int i) : i(i) { }
 
     int value() const { return i; }
     void set(int set) { i = set; }
@@ -46,7 +46,7 @@ class IncType : public UserType {
 public:
     using UserType::UserType;
     IncType() = default;
-    IncType(const IncType &other) : IncType(other.value() + 1) {}
+    IncType(const IncType &other) : IncType(other.value() + 1) { }
     IncType(IncType &&) = delete;
     IncType &operator=(const IncType &) = delete;
     IncType &operator=(IncType &&) = delete;
@@ -58,21 +58,16 @@ union IntFloat {
     float f;
 };
 
-/// Custom cast-only type that casts to a string "rvalue" or "lvalue" depending on the cast
-/// context. Used to test recursive casters (e.g. std::tuple, stl containers).
+/// Custom cast-only type that casts to a string "rvalue" or "lvalue" depending on the cast context.
+/// Used to test recursive casters (e.g. std::tuple, stl containers).
 struct RValueCaster {};
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
-template <>
-class type_caster<RValueCaster> {
+template<> class type_caster<RValueCaster> {
 public:
     PYBIND11_TYPE_CASTER(RValueCaster, _("RValueCaster"));
-    static handle cast(RValueCaster &&, return_value_policy, handle) {
-        return py::str("rvalue").release();
-    }
-    static handle cast(const RValueCaster &, return_value_policy, handle) {
-        return py::str("lvalue").release();
-    }
+    static handle cast(RValueCaster &&, return_value_policy, handle) { return py::str("rvalue").release(); }
+    static handle cast(const RValueCaster &, return_value_policy, handle) { return py::str("lvalue").release(); }
 };
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(pybind11)
@@ -86,6 +81,5 @@ void ignoreOldStyleInitWarnings(F &&body) {
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=message, category=FutureWarning)
         body()
-    )",
-             py::dict(py::arg("body") = py::cpp_function(body)));
+    )", py::dict(py::arg("body") = py::cpp_function(body)));
 }

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+import env
 from pybind11_tests import enums as m
 
 
@@ -240,7 +241,10 @@ def test_char_underlying_enum():  # Issue #1331/PR #1334:
     assert type(m.ScopedCharEnum.Positive.__int__()) is int
     assert int(m.ScopedChar16Enum.Zero) == 0
     assert hash(m.ScopedChar32Enum.Positive) == 1
-    assert m.ScopedCharEnum.Positive.__getstate__() == 1
+    if env.PY2:
+        assert m.ScopedCharEnum.Positive.__getstate__() == 1  # long
+    else:
+        assert type(m.ScopedCharEnum.Positive.__getstate__()) is int
     assert m.ScopedWCharEnum(1) == m.ScopedWCharEnum.Positive
     with pytest.raises(TypeError):
         # Even if the underlying type is char, only an int can be used to construct the enum:
@@ -251,7 +255,10 @@ def test_bool_underlying_enum():
     assert type(m.ScopedBoolEnum.TRUE.__int__()) is int
     assert int(m.ScopedBoolEnum.FALSE) == 0
     assert hash(m.ScopedBoolEnum.TRUE) == 1
-    assert m.ScopedBoolEnum.TRUE.__getstate__() == 1
+    if env.PY2:
+        assert m.ScopedBoolEnum.TRUE.__getstate__() == 1  # long
+    else:
+        assert type(m.ScopedBoolEnum.TRUE.__getstate__()) is int
     assert m.ScopedBoolEnum(1) == m.ScopedBoolEnum.TRUE
     # Enum could construct with a bool
     # (bool is a strict subclass of int, and False will be converted to 0)

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -238,13 +238,13 @@ def test_duplicate_enum_name():
 
 def test_char_underlying_enum():  # Issue #1331/PR #1334:
     assert type(m.ScopedCharEnum.Positive.__int__()) is int
-    assert int(m.ScopedChar16Enum.Zero) == 0  # int() call should successfully return
+    assert int(m.ScopedChar16Enum.Zero) == 0
     assert hash(m.ScopedChar32Enum.Positive) == 1
-    assert m.ScopedCharEnum.Positive.__getstate__() == 1  # return type is long in py2.x
+    assert m.ScopedCharEnum.Positive.__getstate__() == 1
     assert m.ScopedWCharEnum(1) == m.ScopedWCharEnum.Positive
     with pytest.raises(TypeError):
-        # Enum should construct with a int, even with char underlying type
-        m.ScopedWCharEnum("0")
+        # Even if the underlying type is char, only an int can be used to construct the enum:
+        m.ScopedCharEnum("0")
 
 
 def test_bool_underlying_enum():


### PR DESCRIPTION
This PR just removes two comments, changes one, and tweaks a test for consistency with a comment.

The main motivation for creating this PR was this comment:
```
    assert m.ScopedCharEnum.Positive.__getstate__() == 1  # return type is long in py2.x
```
The comment made me wonder if the `.__getstate__()` is an accommodation for Python 2 (that we'd need to take care of later when we purge Python 2 support).
But replacing it with `int(assert m.ScopedCharEnum.Positive) == 1` and running the CI also works on all platforms.
Therefore I'm now thinking that the intent was to actually exercise `.__getstate__()`. **Is that correct?**
In that case I think the comment is misleading and better removed.

While I was at it:

This comment seems completely redundant (therefore more likely to be confusing than helpful):
```
assert int(m.ScopedChar16Enum.Zero) == 0  # int() call should successfully return
```

I made this change because the original comment seemed unclear to me:
```diff
-        # Enum should construct with a int, even with char underlying type
-        m.ScopedWCharEnum("0")
+        # Even if the underlying type is char, only an int can be used to construct the enum:
+        m.ScopedCharEnum("0")
```

I rewrote it according to my understanding. **Is that correct?**
While I was at that, I removed the `W` in `WChar`, to make the test match the comment more closely.
