### PR TITLE
fix: Set __file__ constant when using eval_file (#1300)

### DIFF
--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -136,16 +136,14 @@ object eval_file(str fname, object global = globals(), object local = object()) 
         pybind11_fail("File \"" + fname_str + "\" could not be opened!");
     }
 
-    if (!global.contains("__file__")) {
+    // In Python2, this should be encoded by getfilesystemencoding.
+    // We don't boher setting it since Python2 is past EOL anyway.
+    // See PR#3233
 #if PY_VERSION_HEX >= 0x03000000
+    if (!global.contains("__file__")) {
         global["__file__"] = std::move(fname);
-#else
-        // In Python2, this should be encoded by getfilesystemencoding.
-        // We are just assuming it's UTF-8 since Python2 is past EOL anyway.
-        // See PR#3233
-        global["__file__"] = bytes(fname);
-#endif
     }
+#endif
 
 #if PY_VERSION_HEX < 0x03000000 && defined(PYPY_VERSION)
     PyObject *result = PyRun_File(f, fname_str.c_str(), start, global.ptr(),

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -88,20 +88,20 @@ void exec(const char (&s)[N], object global = globals(), object local = object()
 
 #if defined(PYPY_VERSION) && PY_VERSION_HEX >= 0x03000000
 template <eval_mode mode = eval_statements>
-object eval_file(str, object, object) {
+object eval_file(const str&, object, object) {
     pybind11_fail("eval_file not supported in PyPy3. Use eval");
 }
 template <eval_mode mode = eval_statements>
-object eval_file(str, object) {
+object eval_file(const str&, object) {
     pybind11_fail("eval_file not supported in PyPy3. Use eval");
 }
 template <eval_mode mode = eval_statements>
-object eval_file(str) {
+object eval_file(const str&) {
     pybind11_fail("eval_file not supported in PyPy3. Use eval");
 }
 #else
 template <eval_mode mode = eval_statements>
-object eval_file(str fname, object global = globals(), object local = object()) {
+object eval_file(const str &fname, object global = globals(), object local = object()) {
     if (!local)
         local = global;
 

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -115,6 +115,10 @@ object eval_file(str fname, object global = globals(), object local = object()) 
         default: pybind11_fail("invalid evaluation mode");
     }
 
+    if (!global.contains("__file__")) {
+        global["__file__"] = fname;
+    }
+
     int closeFile = 1;
     std::string fname_str = (std::string) fname;
 #if PY_VERSION_HEX >= 0x03040000

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -140,6 +140,10 @@ object eval_file(str fname, object global = globals(), object local = object()) 
         global["__file__"] = std::move(fname);
     }
 
+#if PY_VERSION_HEX < 0x03000000
+    global["__file__"] = bytes(global["__file__"]);
+#endif
+
 #if PY_VERSION_HEX < 0x03000000 && defined(PYPY_VERSION)
     PyObject *result = PyRun_File(f, fname_str.c_str(), start, global.ptr(),
                                   local.ptr());

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -88,20 +88,20 @@ void exec(const char (&s)[N], object global = globals(), object local = object()
 
 #if defined(PYPY_VERSION) && PY_VERSION_HEX >= 0x03000000
 template <eval_mode mode = eval_statements>
-object eval_file(const str&, object, object) {
+object eval_file(str, object, object) {
     pybind11_fail("eval_file not supported in PyPy3. Use eval");
 }
 template <eval_mode mode = eval_statements>
-object eval_file(const str&, object) {
+object eval_file(str, object) {
     pybind11_fail("eval_file not supported in PyPy3. Use eval");
 }
 template <eval_mode mode = eval_statements>
-object eval_file(const str&) {
+object eval_file(str) {
     pybind11_fail("eval_file not supported in PyPy3. Use eval");
 }
 #else
 template <eval_mode mode = eval_statements>
-object eval_file(const str &fname, object global = globals(), object local = object()) {
+object eval_file(str fname, object global = globals(), object local = object()) {
     if (!local)
         local = global;
 
@@ -113,10 +113,6 @@ object eval_file(const str &fname, object global = globals(), object local = obj
         case eval_single_statement: start = Py_single_input; break;
         case eval_statements:       start = Py_file_input;   break;
         default: pybind11_fail("invalid evaluation mode");
-    }
-
-    if (!global.contains("__file__")) {
-        global["__file__"] = fname;
     }
 
     int closeFile = 1;
@@ -138,6 +134,10 @@ object eval_file(const str &fname, object global = globals(), object local = obj
     if (!f) {
         PyErr_Clear();
         pybind11_fail("File \"" + fname_str + "\" could not be opened!");
+    }
+
+    if (!global.contains("__file__")) {
+        global["__file__"] = std::move(fname);
     }
 
 #if PY_VERSION_HEX < 0x03000000 && defined(PYPY_VERSION)

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -136,7 +136,8 @@ object eval_file(str fname, object global = globals(), object local = object()) 
         pybind11_fail("File \"" + fname_str + "\" could not be opened!");
     }
 
-//Python2 API requires this to be encoded to syslocale so we don't support it.
+// Python2 API requires this to be encoded to filesystemencoding.
+// Therefore, we don't bother supporting it.
 #if PY_VERSION_HEX >= 0x03000000
     if (!global.contains("__file__")) {
         global["__file__"] = std::move(fname);

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -136,12 +136,11 @@ object eval_file(str fname, object global = globals(), object local = object()) 
         pybind11_fail("File \"" + fname_str + "\" could not be opened!");
     }
 
+//Python2 API requires this to be encoded to syslocale so we don't support it.
+#if PY_VERSION_HEX >= 0x03000000
     if (!global.contains("__file__")) {
         global["__file__"] = std::move(fname);
     }
-
-#if PY_VERSION_HEX < 0x03000000
-    global["__file__"] = bytes(global["__file__"]);
 #endif
 
 #if PY_VERSION_HEX < 0x03000000 && defined(PYPY_VERSION)

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -137,12 +137,13 @@ object eval_file(str fname, object global = globals(), object local = object()) 
     }
 
     if (!global.contains("__file__")) {
+#if PY_VERSION_HEX >= 0x03000000
         global["__file__"] = std::move(fname);
-#if PY_VERSION_HEX < 0x03000000
+#else
         // In Python2, this should be encoded by getfilesystemencoding.
         // We are just assuming it's UTF-8 since Python2 is past EOL anyway.
         // See PR#3233
-        global["__file__"] = bytes(global["__file__"]);
+        global["__file__"] = bytes(fname);
 #endif
     }
 

--- a/tests/test_cmake_build/test.py
+++ b/tests/test_cmake_build/test.py
@@ -3,7 +3,10 @@ import sys
 
 import test_cmake_build
 
-assert isinstance(__file__, str)  # Test this is properly set
+from .. import env
+
+if env.PY3:
+    assert isinstance(__file__, str)  # Test this is properly set
 
 assert test_cmake_build.add(1, 2) == 3
 print("{} imports, runs, and adds: 1 + 2 = 3".format(sys.argv[1]))

--- a/tests/test_cmake_build/test.py
+++ b/tests/test_cmake_build/test.py
@@ -3,9 +3,7 @@ import sys
 
 import test_cmake_build
 
-from .. import env
-
-if env.PY3:
+if str is not bytes:  # If not Python2
     assert isinstance(__file__, str)  # Test this is properly set
 
 assert test_cmake_build.add(1, 2) == 3

--- a/tests/test_cmake_build/test.py
+++ b/tests/test_cmake_build/test.py
@@ -3,5 +3,7 @@ import sys
 
 import test_cmake_build
 
+__file__  # Test this is properly set
+
 assert test_cmake_build.add(1, 2) == 3
 print("{} imports, runs, and adds: 1 + 2 = 3".format(sys.argv[1]))

--- a/tests/test_cmake_build/test.py
+++ b/tests/test_cmake_build/test.py
@@ -3,7 +3,7 @@ import sys
 
 import test_cmake_build
 
-__file__  # Test this is properly set
+assert isinstance(__file__, str)  # Test this is properly set
 
 assert test_cmake_build.add(1, 2) == 3
 print("{} imports, runs, and adds: 1 + 2 = 3".format(sys.argv[1]))

--- a/tests/test_cmake_build/test.py
+++ b/tests/test_cmake_build/test.py
@@ -3,10 +3,7 @@ import sys
 
 import test_cmake_build
 
-from .. import env
-
-if env.PY3:
-    assert isinstance(__file__, str)  # Test this is properly set
+assert isinstance(__file__, str)  # Test this is properly set
 
 assert test_cmake_build.add(1, 2) == 3
 print("{} imports, runs, and adds: 1 + 2 = 3".format(sys.argv[1]))

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -69,7 +69,7 @@ TEST_SUBMODULE(eval_, m) {
         int val_out = 0;
         local["call_test2"] = py::cpp_function([&](int value) { val_out = value; });
 
-        auto result = py::eval_file(std::move(filename), global, local);
+        auto result = py::eval_file(filename, global, local);
         return val_out == 43 && result.is_none();
     });
 

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -69,7 +69,7 @@ TEST_SUBMODULE(eval_, m) {
         int val_out = 0;
         local["call_test2"] = py::cpp_function([&](int value) { val_out = value; });
 
-        auto result = py::eval_file(filename, global, local);
+        auto result = py::eval_file(std::move(filename), global, local);
         return val_out == 43 && result.is_none();
     });
 


### PR DESCRIPTION
## Description
Closes #1300 by setting the `__file__` constant when running eval_file.
<!-- Include relevant issues or PRs here, describe what changed and why -->

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Sets __file__ constant when running eval_file in an embedded interpreter.
```

<!-- If the upgrade guide needs updating, note that here too -->
