### PR TITLE
(perf): Add a missing noexcept to a pytype constructor

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -336,7 +336,7 @@ public:
     }
 
     error_already_set(const error_already_set &) = default;
-    error_already_set(error_already_set &&) noexcept = default;
+    error_already_set(error_already_set &&) = default;
 
     inline ~error_already_set() override;
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -336,7 +336,7 @@ public:
     }
 
     error_already_set(const error_already_set &) = default;
-    error_already_set(error_already_set &&) = default;
+    error_already_set(error_already_set &&) noexcept = default;
 
     inline ~error_already_set() override;
 
@@ -761,7 +761,7 @@ template <typename T>
 struct arrow_proxy {
     T value;
 
-    arrow_proxy(T &&value) : value(std::move(value)) { }
+    arrow_proxy(T &&value) noexcept : value(std::move(value)) { }
     T *operator->() const { return &value; }
 };
 


### PR DESCRIPTION
Adds a missing noexcept to a PyType constructors for perf reasons.

## Description
* I noticed a move constructor that didn't have noexcept which prevents it from being used in certain contexts (like being moved into a STL vector), this rectifies that issue.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Perf: Mark a pytype move constructor as noexcept
```

<!-- If the upgrade guide needs updating, note that here too -->
