### PR TITLE
CodeHealth: Enabling clang-tidy google-explicit-constructor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: '
 cppcoreguidelines-init-variables,
 cppcoreguidelines-slicing,
 clang-analyzer-optin.cplusplus.VirtualCall,
+google-explicit-constructor,
 llvm-namespace-comment,
 misc-misplaced-const,
 misc-non-copyable-objects,

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -18,7 +18,9 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 /// @{
 
 /// Annotation for methods
-struct is_method { handle class_; is_method(const handle &c) : class_(c) { } };
+struct is_method { handle class_;
+    explicit is_method(const handle &c) : class_(c) {}
+};
 
 /// Annotation for operators
 struct is_operator { };
@@ -27,16 +29,24 @@ struct is_operator { };
 struct is_final { };
 
 /// Annotation for parent scope
-struct scope { handle value; scope(const handle &s) : value(s) { } };
+struct scope { handle value;
+    explicit scope(const handle &s) : value(s) {}
+};
 
 /// Annotation for documentation
-struct doc { const char *value; doc(const char *value) : value(value) { } };
+struct doc { const char *value;
+    explicit doc(const char *value) : value(value) {}
+};
 
 /// Annotation for function names
-struct name { const char *value; name(const char *value) : value(value) { } };
+struct name { const char *value;
+    explicit name(const char *value) : value(value) {}
+};
 
 /// Annotation indicating that a function is an overload associated with a given "sibling"
-struct sibling { handle value; sibling(const handle &value) : value(value.ptr()) { } };
+struct sibling { handle value;
+    explicit sibling(const handle &value) : value(value.ptr()) {}
+};
 
 /// Annotation indicating that a class derives from another given type
 template <typename T> struct base {
@@ -70,7 +80,9 @@ struct metaclass {
 };
 
 /// Annotation that marks a class as local to the module:
-struct module_local { const bool value; constexpr module_local(bool v = true) : value(v) { } };
+struct module_local { const bool value;
+    constexpr explicit module_local(bool v = true) : value(v) {}
+};
 
 /// Annotation to mark enums as an arithmetic type
 struct arithmetic { };

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -82,7 +82,7 @@ public:
         return caster_t::cast(&src.get(), policy, parent);
     }
     template <typename T> using cast_op_type = std::reference_wrapper<type>;
-    operator std::reference_wrapper<type>() { return cast_op<type &>(subcaster); }
+    explicit operator std::reference_wrapper<type>() { return cast_op<type &>(subcaster); }
 };
 
 #define PYBIND11_TYPE_CASTER(type, py_name)                                                       \
@@ -279,7 +279,7 @@ public:
     }
 
     template <typename T> using cast_op_type = void*&;
-    operator void *&() { return value; }
+    explicit operator void *&() { return value; }
     static constexpr auto name = _("capsule");
 private:
     void *value = nullptr;
@@ -487,8 +487,10 @@ public:
         return StringCaster::cast(StringType(1, src), policy, parent);
     }
 
-    operator CharT*() { return none ? nullptr : const_cast<CharT *>(static_cast<StringType &>(str_caster).c_str()); }
-    operator CharT&() {
+    explicit operator CharT *() {
+        return none ? nullptr : const_cast<CharT *>(static_cast<StringType &>(str_caster).c_str());
+    }
+    explicit operator CharT &() {
         if (none)
             throw value_error("Cannot convert None to a character");
 
@@ -581,8 +583,8 @@ public:
 
     template <typename T> using cast_op_type = type;
 
-    operator type() & { return implicit_cast(indices{}); }
-    operator type() && { return std::move(*this).implicit_cast(indices{}); }
+    explicit operator type() & { return implicit_cast(indices{}); }
+    explicit operator type() && { return std::move(*this).implicit_cast(indices{}); }
 
 protected:
     template <size_t... Is>

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -918,6 +918,7 @@ public:
 
     // Implicit conversion constructor from any arbitrary container type with values convertible to T
     template <typename Container, typename = enable_if_t<std::is_convertible<decltype(*std::begin(std::declval<const Container &>())), T>::value>>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     any_container(const Container &c) : any_container(std::begin(c), std::end(c)) { }
 
     // initializer_list's aren't deducible, so don't get matched by the above template; we need this
@@ -926,9 +927,11 @@ public:
     any_container(const std::initializer_list<TIn> &c) : any_container(c.begin(), c.end()) { }
 
     // Avoid copying if given an rvalue vector of the correct type.
+    // NOLINTNEXTLINE(google-explicit-constructor)
     any_container(std::vector<T> &&v) : v(std::move(v)) { }
 
     // Moves the vector out of an rvalue any_container
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator std::vector<T> &&() && { return std::move(v); }
 
     // Dereferencing obtains a reference to the underlying vector

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -26,12 +26,14 @@ struct descr {
     char text[N + 1]{'\0'};
 
     constexpr descr() = default;
+    // NOLINTNEXTLINE(google-explicit-constructor)
     constexpr descr(char const (&s)[N+1]) : descr(s, make_index_sequence<N>()) { }
 
     template <size_t... Is>
     constexpr descr(char const (&s)[N+1], index_sequence<Is...>) : text{s[Is]..., '\0'} { }
 
     template <typename... Chars>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     constexpr descr(char c, Chars... cs) : text{c, static_cast<char>(cs)..., '\0'} { }
 
     static constexpr std::array<const std::type_info *, sizeof...(Ts) + 1> types() {

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -23,7 +23,7 @@ public:
     }
 
     template <typename> using cast_op_type = value_and_holder &;
-    operator value_and_holder &() { return *value; }
+    explicit operator value_and_holder &() { return *value; }
     static constexpr auto name = _<value_and_holder>();
 
 private:
@@ -222,7 +222,8 @@ template <typename Func, typename Return, typename... Args>
 struct factory<Func, void_type (*)(), Return(Args...)> {
     remove_reference_t<Func> class_factory;
 
-    factory(Func &&f) : class_factory(std::forward<Func>(f)) { }
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    factory(Func &&f) : class_factory(std::forward<Func>(f)) {}
 
     // The given class either has no alias or has no separate alias factory;
     // this always constructs the class itself.  If the class is registered with an alias

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -225,7 +225,7 @@ struct value_and_holder {
     value_and_holder() = default;
 
     // Used for past-the-end iterator
-    value_and_holder(size_t index) : index{index} {}
+    explicit value_and_holder(size_t index) : index{index} {}
 
     template <typename V = void> V *&value_ptr() const {
         return reinterpret_cast<V *&>(vh[0]);
@@ -274,7 +274,8 @@ private:
     const type_vec &tinfo;
 
 public:
-    values_and_holders(instance *inst) : inst{inst}, tinfo(all_type_info(Py_TYPE(inst))) {}
+    explicit values_and_holders(instance *inst)
+        : inst{inst}, tinfo(all_type_info(Py_TYPE(inst))) {}
 
     struct iterator {
     private:
@@ -290,7 +291,8 @@ public:
                  0 /* index */)
         {}
         // Past-the-end iterator:
-        iterator(size_t end) : curr(end) {}
+        explicit iterator(size_t end) : curr(end) {}
+
     public:
         bool operator==(const iterator &other) const { return curr.index == other.curr.index; }
         bool operator!=(const iterator &other) const { return curr.index != other.curr.index; }
@@ -491,11 +493,11 @@ inline PyObject *make_new_instance(PyTypeObject *type);
 
 class type_caster_generic {
 public:
-    PYBIND11_NOINLINE type_caster_generic(const std::type_info &type_info)
-        : typeinfo(get_type_info(type_info)), cpptype(&type_info) { }
+    PYBIND11_NOINLINE explicit type_caster_generic(const std::type_info &type_info)
+        : typeinfo(get_type_info(type_info)), cpptype(&type_info) {}
 
-    type_caster_generic(const type_info *typeinfo)
-        : typeinfo(typeinfo), cpptype(typeinfo ? typeinfo->cpptype : nullptr) { }
+    explicit type_caster_generic(const type_info *typeinfo)
+        : typeinfo(typeinfo), cpptype(typeinfo ? typeinfo->cpptype : nullptr) {}
 
     bool load(handle src, bool convert) {
         return load_impl<type_caster_generic>(src, convert);
@@ -923,7 +925,9 @@ public:
 
     template <typename T> using cast_op_type = detail::cast_op_type<T>;
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator itype*() { return (type *) value; }
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator itype&() { if (!value) throw reference_cast_error(); return *((itype *) value); }
 
 protected:

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -61,6 +61,7 @@ template <bool EigenRowMajor> struct EigenConformable {
     EigenDStride stride{0, 0};      // Only valid if negativestrides is false!
     bool negativestrides = false;   // If true, do not use stride!
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     EigenConformable(bool fits = false) : conformable{fits} {}
     // Matrix type:
     EigenConformable(EigenIndex r, EigenIndex c,
@@ -88,6 +89,7 @@ template <bool EigenRowMajor> struct EigenConformable {
             (props::outer_stride == Eigen::Dynamic || props::outer_stride == stride.outer() ||
                 (EigenRowMajor ? rows : cols) == 1);
     }
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator bool() const { return conformable; }
 };
 
@@ -326,8 +328,11 @@ public:
 
     static constexpr auto name = props::descriptor;
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator Type*() { return &value; }
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator Type&() { return value; }
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator Type&&() && { return std::move(value); }
     template <typename T> using cast_op_type = movable_cast_op_type<T>;
 
@@ -451,7 +456,9 @@ public:
         return true;
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator Type*() { return ref.get(); }
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator Type&() { return *ref; }
     template <typename _T> using cast_op_type = pybind11::detail::cast_op_type<_T>;
 

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -260,10 +260,10 @@ inline void finalize_interpreter() {
  \endrst */
 class scoped_interpreter {
 public:
-    scoped_interpreter(bool init_signal_handlers = true,
-                       int argc = 0,
-                       const char *const *argv = nullptr,
-                       bool add_program_dir_to_path = true) {
+    explicit scoped_interpreter(bool init_signal_handlers = true,
+                                int argc = 0,
+                                const char *const *argv = nullptr,
+                                bool add_program_dir_to_path = true) {
         initialize_interpreter(init_signal_handlers, argc, argv, add_program_dir_to_path);
     }
 

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -69,7 +69,7 @@ public:
         // ensure GIL is held during functor destruction
         struct func_handle {
             function f;
-            func_handle(function &&f_) noexcept : f(std::move(f_)) {}
+            explicit func_handle(function &&f_) noexcept : f(std::move(f_)) {}
             func_handle(const func_handle &f_) { operator=(f_); }
             func_handle &operator=(const func_handle &f_) {
                 gil_scoped_acquire acq;
@@ -85,7 +85,7 @@ public:
         // to emulate 'move initialization capture' in C++11
         struct func_wrapper {
             func_handle hfunc;
-            func_wrapper(func_handle &&hf) noexcept : hfunc(std::move(hf)) {}
+            explicit func_wrapper(func_handle &&hf) noexcept : hfunc(std::move(hf)) {}
             Return operator()(Args... args) const {
                 gil_scoped_acquire acq;
                 object retval(hfunc.f(std::forward<Args>(args)...));

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -69,7 +69,11 @@ public:
         // ensure GIL is held during functor destruction
         struct func_handle {
             function f;
-            explicit func_handle(function &&f_) noexcept : f(std::move(f_)) {}
+#if !(defined(_MSC_VER) && _MSC_VER == 1916 && defined(PYBIND11_CPP17) && PY_MAJOR_VERSION < 3)
+            // This triggers a syntax error under very special conditions (very weird indeed).
+            explicit
+#endif
+            func_handle(function &&f_) noexcept : f(std::move(f_)) {}
             func_handle(const func_handle &f_) { operator=(f_); }
             func_handle &operator=(const func_handle &f_) {
                 gil_scoped_acquire acq;

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -123,7 +123,7 @@ private:
     }
 
 public:
-    pythonbuf(const object &pyostream, size_t buffer_size = 1024)
+    explicit pythonbuf(const object &pyostream, size_t buffer_size = 1024)
         : buf_size(buffer_size), d_buffer(new char[buf_size]), pywrite(pyostream.attr("write")),
           pyflush(pyostream.attr("flush")) {
         setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
@@ -171,8 +171,9 @@ protected:
     detail::pythonbuf buffer;
 
 public:
-    scoped_ostream_redirect(std::ostream &costream  = std::cout,
-                            const object &pyostream = module_::import("sys").attr("stdout"))
+    explicit scoped_ostream_redirect(std::ostream &costream = std::cout,
+                                     const object &pyostream
+                                     = module_::import("sys").attr("stdout"))
         : costream(costream), buffer(pyostream) {
         old = costream.rdbuf(&buffer);
     }
@@ -201,8 +202,9 @@ public:
 \endrst */
 class scoped_estream_redirect : public scoped_ostream_redirect {
 public:
-    scoped_estream_redirect(std::ostream &costream  = std::cerr,
-                            const object &pyostream = module_::import("sys").attr("stderr"))
+    explicit scoped_estream_redirect(std::ostream &costream = std::cerr,
+                                     const object &pyostream
+                                     = module_::import("sys").attr("stderr"))
         : scoped_ostream_redirect(costream, pyostream) {}
 };
 
@@ -217,7 +219,7 @@ class OstreamRedirect {
     std::unique_ptr<scoped_estream_redirect> redirect_stderr;
 
 public:
-    OstreamRedirect(bool do_stdout = true, bool do_stderr = true)
+    explicit OstreamRedirect(bool do_stdout = true, bool do_stderr = true)
         : do_stdout_(do_stdout), do_stderr_(do_stderr) {}
 
     void enter() {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -477,7 +477,7 @@ public:
         m_ptr = from_args(pybind11::str(format)).release().ptr();
     }
 
-    dtype(const char *format) : dtype(std::string(format)) { }
+    explicit dtype(const char *format) : dtype(std::string(format)) {}
 
     dtype(list names, list formats, list offsets, ssize_t itemsize) {
         dict args;
@@ -894,6 +894,7 @@ public:
         if (!is_borrowed) Py_XDECREF(h.ptr());
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     array_t(const object &o) : array(raw_array_t(o.ptr()), stolen_t{}) {
         if (!m_ptr) throw error_already_set();
     }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -81,10 +81,12 @@ PYBIND11_NAMESPACE_END(detail)
 class cpp_function : public function {
 public:
     cpp_function() = default;
+    // NOLINTNEXTLINE(google-explicit-constructor)
     cpp_function(std::nullptr_t) { }
 
     /// Construct a cpp_function from a vanilla function pointer
     template <typename Return, typename... Args, typename... Extra>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     cpp_function(Return (*f)(Args...), const Extra&... extra) {
         initialize(f, f, extra...);
     }
@@ -92,6 +94,7 @@ public:
     /// Construct a cpp_function from a lambda function (possibly with internal state)
     template <typename Func, typename... Extra,
               typename = detail::enable_if_t<detail::is_lambda<Func>::value>>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     cpp_function(Func &&f, const Extra&... extra) {
         initialize(std::forward<Func>(f),
                    (detail::function_signature_t<Func> *) nullptr, extra...);
@@ -99,6 +102,7 @@ public:
 
     /// Construct a cpp_function from a class method (non-const, no ref-qualifier)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     cpp_function(Return (Class::*f)(Arg...), const Extra&... extra) {
         initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
                    (Return (*) (Class *, Arg...)) nullptr, extra...);
@@ -108,6 +112,7 @@ public:
     /// A copy of the overload for non-const functions without explicit ref-qualifier
     /// but with an added `&`.
     template <typename Return, typename Class, typename... Arg, typename... Extra>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     cpp_function(Return (Class::*f)(Arg...)&, const Extra&... extra) {
         initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(args...); },
                    (Return (*) (Class *, Arg...)) nullptr, extra...);
@@ -115,6 +120,7 @@ public:
 
     /// Construct a cpp_function from a class method (const, no ref-qualifier)
     template <typename Return, typename Class, typename... Arg, typename... Extra>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     cpp_function(Return (Class::*f)(Arg...) const, const Extra&... extra) {
         initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
                    (Return (*)(const Class *, Arg ...)) nullptr, extra...);
@@ -124,6 +130,7 @@ public:
     /// A copy of the overload for const functions without explicit ref-qualifier
     /// but with an added `&`.
     template <typename Return, typename Class, typename... Arg, typename... Extra>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     cpp_function(Return (Class::*f)(Arg...) const&, const Extra&... extra) {
         initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(args...); },
                    (Return (*)(const Class *, Arg ...)) nullptr, extra...);
@@ -2034,7 +2041,7 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
 template <typename InputType, typename OutputType> void implicitly_convertible() {
     struct set_flag {
         bool &flag;
-        set_flag(bool &flag_) : flag(flag_) { flag_ = true; }
+        explicit set_flag(bool &flag_) : flag(flag_) { flag_ = true; }
         ~set_flag() { flag = false; }
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -178,6 +178,7 @@ public:
     /// The default constructor creates a handle with a ``nullptr``-valued pointer
     handle() = default;
     /// Creates a ``handle`` from the given raw Python object pointer
+    // NOLINTNEXTLINE(google-explicit-constructor)
     handle(PyObject *ptr) : m_ptr(ptr) { } // Allow implicit conversion from PyObject*
 
     /// Return the underlying ``PyObject *`` pointer
@@ -612,6 +613,7 @@ public:
         return obj.contains(key);
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator object() const { return get_cache(); }
     PyObject *ptr() const { return get_cache().ptr(); }
     template <typename T> T cast() const { return get_cache().template cast<T>(); }
@@ -761,6 +763,7 @@ template <typename T>
 struct arrow_proxy {
     T value;
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     arrow_proxy(T &&value) noexcept : value(std::move(value)) { }
     T *operator->() const { return &value; }
 };
@@ -909,14 +912,17 @@ PYBIND11_NAMESPACE_END(detail)
         bool check() const { return m_ptr != nullptr && (CheckFun(m_ptr) != 0); } \
         static bool check_(handle h) { return h.ptr() != nullptr && CheckFun(h.ptr()); } \
         template <typename Policy_> \
+        /* NOLINTNEXTLINE(google-explicit-constructor) */ \
         Name(const ::pybind11::detail::accessor<Policy_> &a) : Name(object(a)) { }
 
 #define PYBIND11_OBJECT_CVT(Name, Parent, CheckFun, ConvertFun) \
     PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun) \
     /* This is deliberately not 'explicit' to allow implicit conversion from object: */ \
+    /* NOLINTNEXTLINE(google-explicit-constructor) */ \
     Name(const object &o) \
     : Parent(check_(o) ? o.inc_ref().ptr() : ConvertFun(o.ptr()), stolen_t{}) \
     { if (!m_ptr) throw error_already_set(); } \
+    /* NOLINTNEXTLINE(google-explicit-constructor) */ \
     Name(object &&o) \
     : Parent(check_(o) ? o.release().ptr() : ConvertFun(o.ptr()), stolen_t{}) \
     { if (!m_ptr) throw error_already_set(); }
@@ -933,8 +939,10 @@ PYBIND11_NAMESPACE_END(detail)
 #define PYBIND11_OBJECT(Name, Parent, CheckFun) \
     PYBIND11_OBJECT_COMMON(Name, Parent, CheckFun) \
     /* This is deliberately not 'explicit' to allow implicit conversion from object: */ \
+    /* NOLINTNEXTLINE(google-explicit-constructor) */ \
     Name(const object &o) : Parent(o) \
     { if (m_ptr && !check_(m_ptr)) throw PYBIND11_OBJECT_CHECK_FAILED(Name, m_ptr); } \
+    /* NOLINTNEXTLINE(google-explicit-constructor) */ \
     Name(object &&o) : Parent(std::move(o)) \
     { if (m_ptr && !check_(m_ptr)) throw PYBIND11_OBJECT_CHECK_FAILED(Name, m_ptr); }
 
@@ -1056,11 +1064,13 @@ public:
     }
 
     // 'explicit' is explicitly omitted from the following constructors to allow implicit conversion to py::str from C++ string-like objects
+    // NOLINTNEXTLINE(google-explicit-constructor)
     str(const char *c = "")
         : object(PyUnicode_FromString(c), stolen_t{}) {
         if (!m_ptr) pybind11_fail("Could not allocate string object!");
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     str(const std::string &s) : str(s.data(), s.size()) { }
 
     explicit str(const bytes &b);
@@ -1071,6 +1081,7 @@ public:
     \endrst */
     explicit str(handle h) : object(raw_str(h.ptr()), stolen_t{}) { if (!m_ptr) throw error_already_set(); }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator std::string() const {
         object temp = *this;
         if (PyUnicode_Check(m_ptr)) {
@@ -1118,6 +1129,7 @@ public:
     PYBIND11_OBJECT(bytes, object, PYBIND11_BYTES_CHECK)
 
     // Allow implicit conversion:
+    // NOLINTNEXTLINE(google-explicit-constructor)
     bytes(const char *c = "")
         : object(PYBIND11_BYTES_FROM_STRING(c), stolen_t{}) {
         if (!m_ptr) pybind11_fail("Could not allocate bytes object!");
@@ -1130,10 +1142,12 @@ public:
     }
 
     // Allow implicit conversion:
+    // NOLINTNEXTLINE(google-explicit-constructor)
     bytes(const std::string &s) : bytes(s.data(), s.size()) { }
 
     explicit bytes(const pybind11::str &s);
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator std::string() const {
         char *buffer = nullptr;
         ssize_t length = 0;
@@ -1222,7 +1236,9 @@ public:
     PYBIND11_OBJECT_CVT(bool_, object, PyBool_Check, raw_bool)
     bool_() : object(Py_False, borrowed_t{}) { }
     // Allow implicit conversion from and to `bool`:
+    // NOLINTNEXTLINE(google-explicit-constructor)
     bool_(bool value) : object(value ? Py_True : Py_False, borrowed_t{}) { }
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator bool() const { return (m_ptr != nullptr) && PyLong_AsLong(m_ptr) != 0; }
 
 private:
@@ -1261,6 +1277,7 @@ public:
     // Allow implicit conversion from C++ integral types:
     template <typename T,
               detail::enable_if_t<std::is_integral<T>::value, int> = 0>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     int_(T value) {
         if (PYBIND11_SILENCE_MSVC_C4127(sizeof(T) <= sizeof(long))) {
             if (std::is_signed<T>::value)
@@ -1278,6 +1295,7 @@ public:
 
     template <typename T,
               detail::enable_if_t<std::is_integral<T>::value, int> = 0>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator T() const {
         return std::is_unsigned<T>::value
             ? detail::as_unsigned<T>(m_ptr)
@@ -1291,13 +1309,17 @@ class float_ : public object {
 public:
     PYBIND11_OBJECT_CVT(float_, object, PyFloat_Check, PyNumber_Float)
     // Allow implicit conversion from float/double:
+    // NOLINTNEXTLINE(google-explicit-constructor)
     float_(float value) : object(PyFloat_FromDouble((double) value), stolen_t{}) {
         if (!m_ptr) pybind11_fail("Could not allocate float object!");
     }
+    // NOLINTNEXTLINE(google-explicit-constructor)
     float_(double value = .0) : object(PyFloat_FromDouble((double) value), stolen_t{}) {
         if (!m_ptr) pybind11_fail("Could not allocate float object!");
     }
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator float() const { return (float) PyFloat_AsDouble(m_ptr); }
+    // NOLINTNEXTLINE(google-explicit-constructor)
     operator double() const { return (double) PyFloat_AsDouble(m_ptr); }
 };
 
@@ -1372,7 +1394,7 @@ public:
             pybind11_fail("Could not set capsule context!");
     }
 
-    capsule(void (*destructor)()) {
+    explicit capsule(void (*destructor)()) {
         m_ptr = PyCapsule_New(reinterpret_cast<void *>(destructor), nullptr, [](PyObject *o) {
             auto destructor = reinterpret_cast<void (*)()>(PyCapsule_GetPointer(o, nullptr));
             destructor();
@@ -1382,6 +1404,7 @@ public:
             pybind11_fail("Could not allocate capsule object!");
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     template <typename T> operator T *() const {
         return get_pointer<T>();
     }

--- a/tests/local_bindings.h
+++ b/tests/local_bindings.h
@@ -6,7 +6,7 @@
 /// Simple class used to test py::local:
 template <int> class LocalBase {
 public:
-    LocalBase(int i) : i(i) { }
+    explicit LocalBase(int i) : i(i) { }
     int i = -1;
 };
 
@@ -75,11 +75,11 @@ py::class_<T> bind_local(Args && ...args) {
 namespace pets {
 class Pet {
 public:
-    Pet(std::string name) : name_(std::move(name)) {}
+    explicit Pet(std::string name) : name_(std::move(name)) {}
     std::string name_;
     const std::string &name() const { return name_; }
 };
 } // namespace pets
 
-struct MixGL { int i; MixGL(int i) : i{i} {} };
-struct MixGL2 { int i; MixGL2(int i) : i{i} {} };
+struct MixGL { int i; explicit MixGL(int i) : i{i} {} };
+struct MixGL2 { int i; explicit MixGL2(int i) : i{i} {} };

--- a/tests/object.h
+++ b/tests/object.h
@@ -65,7 +65,7 @@ public:
     ref() : m_ptr(nullptr) { print_default_created(this); track_default_created((ref_tag*) this); }
 
     /// Construct a reference from a pointer
-    ref(T *ptr) : m_ptr(ptr) {
+    explicit ref(T *ptr) : m_ptr(ptr) {
         if (m_ptr) ((Object *) m_ptr)->incRef();
 
         print_created(this, "from pointer", m_ptr); track_created((ref_tag*) this, "from pointer");
@@ -165,7 +165,7 @@ public:
     const T& operator*() const { return *m_ptr; }
 
     /// Return a pointer to the referenced object
-    operator T* () { return m_ptr; }
+    explicit operator T* () { return m_ptr; }
 
     /// Return a const pointer to the referenced object
     T* get_ptr() { return m_ptr; }

--- a/tests/pybind11_cross_module_tests.cpp
+++ b/tests/pybind11_cross_module_tests.cpp
@@ -123,7 +123,7 @@ PYBIND11_MODULE(pybind11_cross_module_tests, m) {
 
     class Dog : public pets::Pet {
     public:
-        Dog(std::string name) : Pet(std::move(name)) {}
+        explicit Dog(std::string name) : Pet(std::move(name)) {}
     };
     py::class_<pets::Pet>(m, "Pet", py::module_local())
         .def("name", &pets::Pet::name);

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -16,7 +16,7 @@ class test_initializer {
     using Initializer = void (*)(py::module_ &);
 
 public:
-    test_initializer(Initializer init);
+    explicit test_initializer(Initializer init);
     test_initializer(const char *submodule_name, Initializer init);
 };
 
@@ -32,7 +32,7 @@ struct UnregisteredType { };
 class UserType {
 public:
     UserType() = default;
-    UserType(int i) : i(i) { }
+    explicit UserType(int i) : i(i) { }
 
     int value() const { return i; }
     void set(int set) { i = set; }

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -122,7 +122,7 @@ TEST_SUBMODULE(buffers, m) {
     // test_inherited_protocol
     class SquareMatrix : public Matrix {
     public:
-        SquareMatrix(py::ssize_t n) : Matrix(n, n) { }
+        explicit SquareMatrix(py::ssize_t n) : Matrix(n, n) {}
     };
     // Derived classes inherit the buffer protocol and the buffer access function
     py::class_<SquareMatrix, Matrix>(m, "SquareMatrix")
@@ -173,7 +173,7 @@ TEST_SUBMODULE(buffers, m) {
 
     struct BufferReadOnly {
         const uint8_t value = 0;
-        BufferReadOnly(uint8_t value): value(value) {}
+        explicit BufferReadOnly(uint8_t value) : value(value) {}
 
         py::buffer_info get_buffer_info() {
             return py::buffer_info(&value, 1);

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -25,16 +25,28 @@ class type_caster<ConstRefCasted> {
   // cast operator.
   bool load(handle, bool) { return true; }
 
-  operator ConstRefCasted &&() {
+  explicit operator ConstRefCasted &&() {
       value = {1};
       // NOLINTNEXTLINE(performance-move-const-arg)
       return std::move(value);
   }
-  operator ConstRefCasted&() { value = {2}; return value; }
-  operator ConstRefCasted*() { value = {3}; return &value; }
+  explicit operator ConstRefCasted &() {
+      value = {2};
+      return value;
+  }
+  explicit operator ConstRefCasted *() {
+      value = {3};
+      return &value;
+  }
 
-  operator const ConstRefCasted&() { value = {4}; return value; }
-  operator const ConstRefCasted*() { value = {5}; return &value; }
+  explicit operator const ConstRefCasted &() {
+      value = {4};
+      return value;
+  }
+  explicit operator const ConstRefCasted *() {
+      value = {5};
+      return &value;
+  }
 
   // custom cast_op to explicitly propagate types to the conversion operators.
   template <typename T_>

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -27,7 +27,7 @@
 
 // test_brace_initialization
 struct NoBraceInitialization {
-    NoBraceInitialization(std::vector<int> v) : vec{std::move(v)} {}
+    explicit NoBraceInitialization(std::vector<int> v) : vec{std::move(v)} {}
     template <typename T>
     NoBraceInitialization(std::initializer_list<T> l) : vec(l) {}
 
@@ -65,18 +65,18 @@ TEST_SUBMODULE(class_, m) {
 
     class Dog : public Pet {
     public:
-        Dog(const std::string &name) : Pet(name, "dog") {}
+        explicit Dog(const std::string &name) : Pet(name, "dog") {}
         std::string bark() const { return "Woof!"; }
     };
 
     class Rabbit : public Pet {
     public:
-        Rabbit(const std::string &name) : Pet(name, "parrot") {}
+        explicit Rabbit(const std::string &name) : Pet(name, "parrot") {}
     };
 
     class Hamster : public Pet {
     public:
-        Hamster(const std::string &name) : Pet(name, "rodent") {}
+        explicit Hamster(const std::string &name) : Pet(name, "rodent") {}
     };
 
     class Chimera : public Pet {
@@ -208,7 +208,7 @@ TEST_SUBMODULE(class_, m) {
     struct ConvertibleFromUserType {
         int i;
 
-        ConvertibleFromUserType(UserType u) : i(u.value()) { }
+        explicit ConvertibleFromUserType(UserType u) : i(u.value()) {}
     };
 
     py::class_<ConvertibleFromUserType>(m, "AcceptsUserType")
@@ -263,7 +263,7 @@ TEST_SUBMODULE(class_, m) {
     };
     struct PyAliasedHasOpNewDelSize : AliasedHasOpNewDelSize {
         PyAliasedHasOpNewDelSize() = default;
-        PyAliasedHasOpNewDelSize(int) { }
+        explicit PyAliasedHasOpNewDelSize(int) {}
         std::uint64_t j;
     };
     struct HasOpNewDelBoth {

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -37,7 +37,7 @@ template <> lacking_move_ctor empty<lacking_move_ctor>::instance_ = {};
 class MoveOnlyInt {
 public:
     MoveOnlyInt() { print_default_created(this); }
-    MoveOnlyInt(int v) : value{v} { print_created(this, value); }
+    explicit MoveOnlyInt(int v) : value{v} { print_created(this, value); }
     MoveOnlyInt(MoveOnlyInt &&m) noexcept {
         print_move_created(this, m.value);
         std::swap(value, m.value);
@@ -56,7 +56,7 @@ public:
 class MoveOrCopyInt {
 public:
     MoveOrCopyInt() { print_default_created(this); }
-    MoveOrCopyInt(int v) : value{v} { print_created(this, value); }
+    explicit MoveOrCopyInt(int v) : value{v} { print_created(this, value); }
     MoveOrCopyInt(MoveOrCopyInt &&m) noexcept {
         print_move_created(this, m.value);
         std::swap(value, m.value);
@@ -75,7 +75,7 @@ public:
 class CopyOnlyInt {
 public:
     CopyOnlyInt() { print_default_created(this); }
-    CopyOnlyInt(int v) : value{v} { print_created(this, value); }
+    explicit CopyOnlyInt(int v) : value{v} { print_created(this, value); }
     CopyOnlyInt(const CopyOnlyInt &c) { print_copy_created(this, c.value); value = c.value; }
     CopyOnlyInt &operator=(const CopyOnlyInt &c) { print_copy_assigned(this, c.value); value = c.value; return *this; }
     ~CopyOnlyInt() { print_destroyed(this); }
@@ -107,8 +107,8 @@ public:
         if (!src) return none().release();
         return cast(*src, policy, parent);
     }
-    operator CopyOnlyInt*() { return &value; }
-    operator CopyOnlyInt&() { return value; }
+    explicit operator CopyOnlyInt *() { return &value; }
+    explicit operator CopyOnlyInt &() { return value; }
     template <typename T> using cast_op_type = pybind11::detail::cast_op_type<T>;
 };
 PYBIND11_NAMESPACE_END(detail)
@@ -219,7 +219,7 @@ TEST_SUBMODULE(copy_move_policies, m) {
     // #389: rvp::move should fall-through to copy on non-movable objects
     struct MoveIssue1 {
         int v;
-        MoveIssue1(int v) : v{v} {}
+        explicit MoveIssue1(int v) : v{v} {}
         MoveIssue1(const MoveIssue1 &c) = default;
         MoveIssue1(MoveIssue1 &&) = delete;
     };
@@ -227,7 +227,7 @@ TEST_SUBMODULE(copy_move_policies, m) {
 
     struct MoveIssue2 {
         int v;
-        MoveIssue2(int v) : v{v} {}
+        explicit MoveIssue2(int v) : v{v} {}
         MoveIssue2(MoveIssue2 &&) = default;
     };
     py::class_<MoveIssue2>(m, "MoveIssue2").def(py::init<int>()).def_readwrite("value", &MoveIssue2::v);

--- a/tests/test_embed/external_module.cpp
+++ b/tests/test_embed/external_module.cpp
@@ -9,7 +9,7 @@ namespace py = pybind11;
 PYBIND11_MODULE(external_module, m) {
     class A {
     public:
-        A(int value) : v{value} {};
+        explicit A(int value) : v{value} {};
         int v;
     };
 

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -18,7 +18,7 @@ using namespace py::literals;
 
 class Widget {
 public:
-    Widget(std::string message) : message(std::move(message)) {}
+    explicit Widget(std::string message) : message(std::move(message)) {}
     virtual ~Widget() = default;
 
     std::string the_message() const { return message; }

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -81,7 +81,7 @@ private:
 
 
 struct PythonCallInDestructor {
-    PythonCallInDestructor(const py::dict &d) : d(d) {}
+    explicit PythonCallInDestructor(const py::dict &d) : d(d) {}
     ~PythonCallInDestructor() { d["good"] = true; }
 
     py::dict d;
@@ -90,7 +90,7 @@ struct PythonCallInDestructor {
 
 
 struct PythonAlreadySetInDestructor {
-    PythonAlreadySetInDestructor(const py::str &s) : s(s) {}
+    explicit PythonAlreadySetInDestructor(const py::str &s) : s(s) {}
     ~PythonAlreadySetInDestructor() {
         py::dict foo;
         try {

--- a/tests/test_local_bindings.cpp
+++ b/tests/test_local_bindings.cpp
@@ -91,7 +91,7 @@ TEST_SUBMODULE(local_bindings, m) {
 
     class Cat : public pets::Pet {
     public:
-        Cat(std::string name) : Pet(std::move(name)) {}
+        explicit Cat(std::string name) : Pet(std::move(name)) {}
     };
     py::class_<pets::Pet>(m, "Pet", py::module_local())
         .def("get_name", &pets::Pet::name);

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -19,9 +19,9 @@ using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
 class ExampleMandA {
 public:
     ExampleMandA() { print_default_created(this); }
-    ExampleMandA(int value) : value(value) { print_created(this, value); }
+    explicit ExampleMandA(int value) : value(value) { print_created(this, value); }
     ExampleMandA(const ExampleMandA &e) : value(e.value) { print_copy_created(this); }
-    ExampleMandA(std::string&&) {}
+    explicit ExampleMandA(std::string &&) {}
     ExampleMandA(ExampleMandA &&e) noexcept : value(e.value) { print_move_created(this); }
     ~ExampleMandA() { print_destroyed(this); }
 
@@ -124,14 +124,14 @@ class NoneCastTester {
 public:
     int answer = -1;
     NoneCastTester() = default;
-    NoneCastTester(int v) : answer(v) {}
+    explicit NoneCastTester(int v) : answer(v) {}
 };
 
 struct StrIssue {
     int val = -1;
 
     StrIssue() = default;
-    StrIssue(int i) : val{i} {}
+    explicit StrIssue(int i) : val{i} {}
 };
 
 // Issues #854, #910: incompatible function args when member function/pointer is in unregistered base class

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -20,7 +20,7 @@ TEST_SUBMODULE(modules, m) {
     // test_reference_internal
     class A {
     public:
-        A(int v) : v(v) { print_created(this, v); }
+        explicit A(int v) : v(v) { print_created(this, v); }
         ~A() { print_destroyed(this); }
         A(const A&) { print_copy_created(this); }
         A& operator=(const A &copy) { print_copy_assigned(this); v = copy.v; return *this; }

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -16,7 +16,7 @@ namespace {
 // Many bases for testing that multiple inheritance from many classes (i.e. requiring extra
 // space for holder constructed flags) works.
 template <int N> struct BaseN {
-    BaseN(int i) : i(i) { }
+    explicit BaseN(int i) : i(i) {}
     int i;
 };
 
@@ -47,12 +47,12 @@ int VanillaStaticMix2::static_value = 12;
 
 // test_multiple_inheritance_virtbase
 struct Base1a {
-    Base1a(int i) : i(i) { }
+    explicit Base1a(int i) : i(i) {}
     int foo() const { return i; }
     int i;
 };
 struct Base2a {
-    Base2a(int i) : i(i) { }
+    explicit Base2a(int i) : i(i) {}
     int bar() const { return i; }
     int i;
 };
@@ -77,7 +77,7 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     // test_multiple_inheritance_mix1
     // test_multiple_inheritance_mix2
     struct Base1 {
-        Base1(int i) : i(i) { }
+        explicit Base1(int i) : i(i) {}
         int foo() const { return i; }
         int i;
     };
@@ -86,7 +86,7 @@ TEST_SUBMODULE(multiple_inheritance, m) {
       .def("foo", &Base1::foo);
 
     struct Base2 {
-        Base2(int i) : i(i) { }
+        explicit Base2(int i) : i(i) {}
         int bar() const { return i; }
         int i;
     };

--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -52,7 +52,7 @@ TEST_SUBMODULE(numpy_vectorize, m) {
     // Passthrough test: references and non-pod types should be automatically passed through (in the
     // function definition below, only `b`, `d`, and `g` are vectorized):
     struct NonPODClass {
-        NonPODClass(int v) : value{v} {}
+        explicit NonPODClass(int v) : value{v} {}
         int value;
     };
     py::class_<NonPODClass>(m, "NonPODClass")
@@ -71,7 +71,7 @@ TEST_SUBMODULE(numpy_vectorize, m) {
 
     // test_method_vectorization
     struct VectorizeTestClass {
-        VectorizeTestClass(int v) : value{v} {};
+        explicit VectorizeTestClass(int v) : value{v} {};
         float method(int x, float y) const { return y + (float) (x + value); }
         int value = 0;
     };

--- a/tests/test_pickling.cpp
+++ b/tests/test_pickling.cpp
@@ -67,7 +67,7 @@ TEST_SUBMODULE(pickling, m) {
     // test_roundtrip
     class Pickleable {
     public:
-        Pickleable(const std::string &value) : m_value(value) { }
+        explicit Pickleable(const std::string &value) : m_value(value) { }
         const std::string &value() const { return m_value; }
 
         void setExtra1(int extra1) { m_extra1 = extra1; }
@@ -132,7 +132,7 @@ TEST_SUBMODULE(pickling, m) {
     // test_roundtrip_with_dict
     class PickleableWithDict {
     public:
-        PickleableWithDict(const std::string &value) : value(value) { }
+        explicit PickleableWithDict(const std::string &value) : value(value) { }
 
         std::string value;
         int extra;

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -20,7 +20,7 @@ template<typename T>
 class NonZeroIterator {
     const T* ptr_;
 public:
-    NonZeroIterator(const T* ptr) : ptr_(ptr) {}
+    explicit NonZeroIterator(const T *ptr) : ptr_(ptr) {}
     const T& operator*() const { return *ptr_; }
     NonZeroIterator& operator++() { ++ptr_; return *this; }
 };
@@ -77,9 +77,9 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
     // test_sliceable
     class Sliceable{
     public:
-      Sliceable(int n): size(n) {}
-      int start,stop,step;
-      int size;
+        explicit Sliceable(int n) : size(n) {}
+        int start, stop, step;
+        int size;
     };
     py::class_<Sliceable>(m, "Sliceable")
         .def(py::init<int>())
@@ -96,12 +96,12 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
     // test_sequence
     class Sequence {
     public:
-        Sequence(size_t size) : m_size(size) {
+        explicit Sequence(size_t size) : m_size(size) {
             print_created(this, "of size", m_size);
             m_data = new float[size];
             memset(m_data, 0, sizeof(float) * size);
         }
-        Sequence(const std::vector<float> &value) : m_size(value.size()) {
+        explicit Sequence(const std::vector<float> &value) : m_size(value.size()) {
             print_created(this, "of size", m_size, "from std::vector");
             m_data = new float[m_size];
             memcpy(m_data, &value[0], sizeof(float) * m_size);
@@ -239,7 +239,7 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
     class StringMap {
     public:
         StringMap() = default;
-        StringMap(std::unordered_map<std::string, std::string> init)
+        explicit StringMap(std::unordered_map<std::string, std::string> init)
             : map(std::move(init)) {}
 
         void set(const std::string &key, std::string val) { map[key] = std::move(val); }
@@ -276,7 +276,7 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
     // test_generalized_iterators
     class IntPairs {
     public:
-        IntPairs(std::vector<std::pair<int, int>> data) : data_(std::move(data)) {}
+        explicit IntPairs(std::vector<std::pair<int, int>> data) : data_(std::move(data)) {}
         const std::pair<int, int>* begin() const { return data_.data(); }
     private:
         std::vector<std::pair<int, int>> data_;

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -24,7 +24,7 @@ template <typename T> class huge_unique_ptr {
     std::unique_ptr<T> ptr;
     uint64_t padding[10];
 public:
-    huge_unique_ptr(T *p) : ptr(p) {}
+    explicit huge_unique_ptr(T *p) : ptr(p) {}
     T *get() { return ptr.get(); }
 };
 
@@ -33,7 +33,7 @@ template <typename T>
 class custom_unique_ptr {
     std::unique_ptr<T> impl;
 public:
-    custom_unique_ptr(T* p) : impl(p) { }
+    explicit custom_unique_ptr(T *p) : impl(p) {}
     T* get() const { return impl.get(); }
     T* release_ptr() { return impl.release(); }
 };
@@ -46,7 +46,7 @@ class shared_ptr_with_addressof_operator {
     std::shared_ptr<T> impl;
 public:
     shared_ptr_with_addressof_operator( ) = default;
-    shared_ptr_with_addressof_operator(T* p) : impl(p) { }
+    explicit shared_ptr_with_addressof_operator(T *p) : impl(p) {}
     T* get() const { return impl.get(); }
     T** operator&() { throw std::logic_error("Call of overloaded operator& is not expected"); }
 };
@@ -59,7 +59,7 @@ class unique_ptr_with_addressof_operator {
     std::unique_ptr<T> impl;
 public:
     unique_ptr_with_addressof_operator() = default;
-    unique_ptr_with_addressof_operator(T* p) : impl(p) { }
+    explicit unique_ptr_with_addressof_operator(T *p) : impl(p) {}
     T* get() const { return impl.get(); }
     T* release_ptr() { return impl.release(); }
     T** operator&() { throw std::logic_error("Call of overloaded operator& is not expected"); }
@@ -68,7 +68,7 @@ public:
 // Custom object with builtin reference counting (see 'object.h' for the implementation)
 class MyObject1 : public Object {
 public:
-    MyObject1(int value) : value(value) { print_created(this, toString()); }
+    explicit MyObject1(int value) : value(value) { print_created(this, toString()); }
     std::string toString() const override { return "MyObject1[" + std::to_string(value) + "]"; }
 protected:
     ~MyObject1() override { print_destroyed(this); }
@@ -80,7 +80,7 @@ private:
 class MyObject2 {
 public:
     MyObject2(const MyObject2 &) = default;
-    MyObject2(int value) : value(value) { print_created(this, toString()); }
+    explicit MyObject2(int value) : value(value) { print_created(this, toString()); }
     std::string toString() const { return "MyObject2[" + std::to_string(value) + "]"; }
     virtual ~MyObject2() { print_destroyed(this); }
 private:
@@ -91,7 +91,7 @@ private:
 class MyObject3 : public std::enable_shared_from_this<MyObject3> {
 public:
     MyObject3(const MyObject3 &) = default;
-    MyObject3(int value) : value(value) { print_created(this, toString()); }
+    explicit MyObject3(int value) : value(value) { print_created(this, toString()); }
     std::string toString() const { return "MyObject3[" + std::to_string(value) + "]"; }
     virtual ~MyObject3() { print_destroyed(this); }
 private:
@@ -104,7 +104,7 @@ class MyObject4;
 std::unordered_set<MyObject4 *> myobject4_instances;
 class MyObject4 {
 public:
-    MyObject4(int value) : value{value} {
+    explicit MyObject4(int value) : value{value} {
         print_created(this);
         myobject4_instances.insert(this);
     }
@@ -130,7 +130,7 @@ class MyObject4a;
 std::unordered_set<MyObject4a *> myobject4a_instances;
 class MyObject4a {
 public:
-    MyObject4a(int i) {
+    explicit MyObject4a(int i) {
         value = i;
         print_created(this);
         myobject4a_instances.insert(this);
@@ -153,14 +153,14 @@ protected:
 // Object derived but with public destructor and no Deleter in default holder
 class MyObject4b : public MyObject4a {
 public:
-    MyObject4b(int i) : MyObject4a(i) { print_created(this); }
+    explicit MyObject4b(int i) : MyObject4a(i) { print_created(this); }
     ~MyObject4b() override { print_destroyed(this); }
 };
 
 // test_large_holder
 class MyObject5 { // managed by huge_unique_ptr
 public:
-    MyObject5(int value) : value{value} { print_created(this); }
+    explicit MyObject5(int value) : value{value} { print_created(this); }
     ~MyObject5() { print_destroyed(this); }
     int value;
 };
@@ -222,7 +222,7 @@ struct TypeForHolderWithAddressOf {
 
 // test_move_only_holder_with_addressof_operator
 struct TypeForMoveOnlyHolderWithAddressOf {
-    TypeForMoveOnlyHolderWithAddressOf(int value) : value{value} { print_created(this); }
+    explicit TypeForMoveOnlyHolderWithAddressOf(int value) : value{value} { print_created(this); }
     ~TypeForMoveOnlyHolderWithAddressOf() { print_destroyed(this); }
     std::string toString() const {
         return "MoveOnlyHolderWithAddressOf[" + std::to_string(value) + "]";
@@ -242,7 +242,7 @@ struct ElementBase {
 };
 
 struct ElementA : ElementBase {
-    ElementA(int v) : v(v) { }
+    explicit ElementA(int v) : v(v) {}
     int value() const { return v; }
     int v;
 };

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -291,9 +291,9 @@ TEST_SUBMODULE(smart_ptr, m) {
     py::implicitly_convertible<py::int_, MyObject1>();
 
     m.def("make_object_1", []() -> Object * { return new MyObject1(1); });
-    m.def("make_object_2", []() -> ref<Object> { return new MyObject1(2); });
+    m.def("make_object_2", []() -> ref<Object> { return ref<Object>(new MyObject1(2)); });
     m.def("make_myobject1_1", []() -> MyObject1 * { return new MyObject1(4); });
-    m.def("make_myobject1_2", []() -> ref<MyObject1> { return new MyObject1(5); });
+    m.def("make_myobject1_2", []() -> ref<MyObject1> { return ref<MyObject1>(new MyObject1(5)); });
     m.def("print_object_1", [](const Object *obj) { py::print(obj->toString()); });
     m.def("print_object_2", [](ref<Object> obj) { py::print(obj->toString()); });
     m.def("print_object_3", [](const ref<Object> &obj) { py::print(obj->toString()); });
@@ -328,7 +328,7 @@ TEST_SUBMODULE(smart_ptr, m) {
 
     // test_smart_ptr_refcounting
     m.def("test_object1_refcounting", []() {
-        ref<MyObject1> o = new MyObject1(0);
+        auto o = ref<MyObject1>(new MyObject1(0));
         bool good = o->getRefCount() == 1;
         py::object o2 = py::cast(o, py::return_value_policy::reference);
         // always request (partial) ownership for objects with intrusive

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -45,7 +45,8 @@ PYBIND11_MAKE_OPAQUE(std::vector<std::string, std::allocator<std::string>>);
 
 /// Issue #528: templated constructor
 struct TplCtorClass {
-    template <typename T> TplCtorClass(const T &) { }
+    template <typename T>
+    explicit TplCtorClass(const T &) {}
     bool operator==(const TplCtorClass &) const { return true; }
 };
 

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -18,7 +18,7 @@
 class El {
 public:
     El() = delete;
-    El(int v) : a(v) { }
+    explicit El(int v) : a(v) {}
 
     int a;
 };

--- a/tests/test_tagbased_polymorphic.cpp
+++ b/tests/test_tagbased_polymorphic.cpp
@@ -37,33 +37,35 @@ struct Animal
 
 struct Dog : Animal
 {
-    Dog(const std::string& _name, Kind _kind = Kind::Dog) : Animal(_name, _kind) {}
+    explicit Dog(const std::string &_name, Kind _kind = Kind::Dog) : Animal(_name, _kind) {}
     std::string bark() const { return name_of_kind(kind) + " " + name + " goes " + sound; }
     std::string sound = "WOOF!";
 };
 
 struct Labrador : Dog
 {
-    Labrador(const std::string& _name, int _excitement = 9001)
+    explicit Labrador(const std::string &_name, int _excitement = 9001)
         : Dog(_name, Kind::Labrador), excitement(_excitement) {}
     int excitement;
 };
 
 struct Chihuahua : Dog
 {
-    Chihuahua(const std::string& _name) : Dog(_name, Kind::Chihuahua) { sound = "iyiyiyiyiyi"; }
+    explicit Chihuahua(const std::string &_name) : Dog(_name, Kind::Chihuahua) {
+        sound = "iyiyiyiyiyi";
+    }
     std::string bark() const { return Dog::bark() + " and runs in circles"; }
 };
 
 struct Cat : Animal
 {
-    Cat(const std::string& _name, Kind _kind = Kind::Cat) : Animal(_name, _kind) {}
+    explicit Cat(const std::string &_name, Kind _kind = Kind::Cat) : Animal(_name, _kind) {}
     std::string purr() const { return "mrowr"; }
 };
 
 struct Panther : Cat
 {
-    Panther(const std::string& _name) : Cat(_name, Kind::Panther) {}
+    explicit Panther(const std::string &_name) : Cat(_name, Kind::Panther) {}
     std::string purr() const { return "mrrrRRRRRR"; }
 };
 

--- a/tests/test_virtual_functions.cpp
+++ b/tests/test_virtual_functions.cpp
@@ -15,7 +15,7 @@
 /* This is an example class that we'll want to be able to extend from Python */
 class ExampleVirt  {
 public:
-    ExampleVirt(int state) : state(state) { print_created(this, state); }
+    explicit ExampleVirt(int state) : state(state) { print_created(this, state); }
     ExampleVirt(const ExampleVirt &e) : state(e.state) { print_copy_created(this); }
     ExampleVirt(ExampleVirt &&e) noexcept : state(e.state) {
         print_move_created(this);


### PR DESCRIPTION
## Description
The main change is the one-line addition of `google-explicit-constructor` in .clang-tidy:

https://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html

This enforces the use of `explicit`, unless disabled with `NOLINT`. In other words, bug-prone implicit conversions are made opt-in rather than opt-out.

Apart from the entertaining `#ifdef` in include/pybind11/functional.h, the rest of this PR is extremely dull. It is the result of ~20 iterations of running clang-tidy, and manually sorting through the automatic changes, inserting
```
// NOLINTNEXTLINE(google-explicit-constructor)
```
as needed. Final change stats are:

* 27 `explicit` added under include/pybind11/
* 46 `NOLINT` added under include/pybind11/
* 92 `explicit` added under tests/
* 0 `NOLINT` added under tests/

The only code changes beyond these are in tests/test_smart_ptr.cpp, one of them
```diff
-    m.def("make_object_2", []() -> ref<Object> { return new MyObject1(2); });
+    m.def("make_object_2", []() -> ref<Object> { return ref<Object>(new MyObject1(2)); });
```
and two similar changes.

It is possible that some `NOLINT` under include/pybind11/ could be removed, with corresponding code changes elsewhere, but those are likely more involved and best left for separate PRs, so that they don't get drowned in the sea of boilerplate changes under this PR.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
The clang-tidy `google-explicit-constructor` option was enabled.
```

<!-- If the upgrade guide needs updating, note that here too -->
PR #3250 added a number of `explicit` keywords to improve general code health. It is not expected that this affects user code, but it is a possibility. Insert explicit constructors in your code as needed, or if that is not feasible, please send a PR to replace the problematic `explicit` keywords with `// NOLINTNEXTLINE(google-explicit-constructor)` directives, including a unit test reflecting your use case.