### PR TITLE
Follow-on to PR #3254, to address user code breakages.

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1987,7 +1987,7 @@ iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
                     throw stop_iteration();
                 }
                 return *s.it;
-            // NOLINTNEXTLINE(readability-const-return-type)
+            // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
             }, std::forward<Extra>(extra)..., Policy);
     }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1987,6 +1987,7 @@ iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
                     throw stop_iteration();
                 }
                 return *s.it;
+            // NOLINTNEXTLINE(readability-const-return-type)
             }, std::forward<Extra>(extra)..., Policy);
     }
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -733,7 +733,9 @@ public:
     generic_iterator() = default;
     generic_iterator(handle seq, ssize_t index) : Policy(seq, index) { }
 
+    // NOLINTNEXTLINE(readability-const-return-type)
     reference operator*() const { return Policy::dereference(); }
+    // NOLINTNEXTLINE(readability-const-return-type)
     reference operator[](difference_type n) const { return *(*this + n); }
     pointer operator->() const { return **this; }
 
@@ -778,6 +780,7 @@ protected:
 
     sequence_fast_readonly(handle obj, ssize_t n) : ptr(PySequence_Fast_ITEMS(obj.ptr()) + n) { }
 
+    // NOLINTNEXTLINE(readability-const-return-type)
     reference dereference() const { return *ptr; }
     void increment() { ++ptr; }
     void decrement() { --ptr; }
@@ -822,6 +825,7 @@ protected:
     dict_readonly() = default;
     dict_readonly(handle obj, ssize_t pos) : obj(obj), pos(pos) { increment(); }
 
+    // NOLINTNEXTLINE(readability-const-return-type)
     reference dereference() const { return {key, value}; }
     void increment() {
         if (PyDict_Next(obj.ptr(), &pos, &key, &value) == 0) {
@@ -982,6 +986,7 @@ public:
         return rv;
     }
 
+    // NOLINTNEXTLINE(readability-const-return-type)
     reference operator*() const {
         if (m_ptr && !value.ptr()) {
             auto& self = const_cast<iterator &>(*this);

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -733,9 +733,9 @@ public:
     generic_iterator() = default;
     generic_iterator(handle seq, ssize_t index) : Policy(seq, index) { }
 
-    // NOLINTNEXTLINE(readability-const-return-type)
+    // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
     reference operator*() const { return Policy::dereference(); }
-    // NOLINTNEXTLINE(readability-const-return-type)
+    // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
     reference operator[](difference_type n) const { return *(*this + n); }
     pointer operator->() const { return **this; }
 
@@ -775,12 +775,12 @@ class sequence_fast_readonly {
 protected:
     using iterator_category = std::random_access_iterator_tag;
     using value_type = handle;
-    using reference = const handle;
+    using reference = const handle; // PR #3263
     using pointer = arrow_proxy<const handle>;
 
     sequence_fast_readonly(handle obj, ssize_t n) : ptr(PySequence_Fast_ITEMS(obj.ptr()) + n) { }
 
-    // NOLINTNEXTLINE(readability-const-return-type)
+    // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
     reference dereference() const { return *ptr; }
     void increment() { ++ptr; }
     void decrement() { --ptr; }
@@ -819,13 +819,13 @@ class dict_readonly {
 protected:
     using iterator_category = std::forward_iterator_tag;
     using value_type = std::pair<handle, handle>;
-    using reference = const value_type;
+    using reference = const value_type; // PR #3263
     using pointer = arrow_proxy<const value_type>;
 
     dict_readonly() = default;
     dict_readonly(handle obj, ssize_t pos) : obj(obj), pos(pos) { increment(); }
 
-    // NOLINTNEXTLINE(readability-const-return-type)
+    // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
     reference dereference() const { return {key, value}; }
     void increment() {
         if (PyDict_Next(obj.ptr(), &pos, &key, &value) == 0) {
@@ -970,7 +970,7 @@ public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = ssize_t;
     using value_type = handle;
-    using reference = const handle;
+    using reference = const handle; // PR #3263
     using pointer = const handle *;
 
     PYBIND11_OBJECT_DEFAULT(iterator, object, PyIter_Check)
@@ -986,7 +986,7 @@ public:
         return rv;
     }
 
-    // NOLINTNEXTLINE(readability-const-return-type)
+    // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
     reference operator*() const {
         if (m_ptr && !value.ptr()) {
             auto& self = const_cast<iterator &>(*this);

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -773,7 +773,7 @@ class sequence_fast_readonly {
 protected:
     using iterator_category = std::random_access_iterator_tag;
     using value_type = handle;
-    using reference = handle;
+    using reference = const handle;
     using pointer = arrow_proxy<const handle>;
 
     sequence_fast_readonly(handle obj, ssize_t n) : ptr(PySequence_Fast_ITEMS(obj.ptr()) + n) { }
@@ -816,7 +816,7 @@ class dict_readonly {
 protected:
     using iterator_category = std::forward_iterator_tag;
     using value_type = std::pair<handle, handle>;
-    using reference = value_type;
+    using reference = const value_type;
     using pointer = arrow_proxy<const value_type>;
 
     dict_readonly() = default;
@@ -966,7 +966,7 @@ public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = ssize_t;
     using value_type = handle;
-    using reference = handle;
+    using reference = const handle;
     using pointer = const handle *;
 
     PYBIND11_OBJECT_DEFAULT(iterator, object, PyIter_Check)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -464,15 +464,17 @@ TEST_SUBMODULE(pytypes, m) {
 
 // See https://github.com/pybind/pybind11/pull/3263 for background.
 #if (defined(__APPLE__) && defined(__clang__)) || defined(PYPY_VERSION)
-#    define PYBIND11_CONST_FOR_STRICT_PLATFORMS const
+// This is "most correct" and enforced on these platforms.
+#    define PYBIND11_AUTO_IT auto it
 #else
-#    define PYBIND11_CONST_FOR_STRICT_PLATFORMS
+// This works on many platforms and is reflective of existing user code.
+#    define PYBIND11_AUTO_IT auto &it
 #endif
 
     m.def("tuple_iterator", []() {
         auto tup = py::make_tuple(5, 7);
         int tup_sum = 0;
-        for (PYBIND11_CONST_FOR_STRICT_PLATFORMS auto &it : tup) {
+        for (PYBIND11_AUTO_IT : tup) {
             tup_sum += it.cast<int>();
         }
         return tup_sum;
@@ -483,7 +485,7 @@ TEST_SUBMODULE(pytypes, m) {
         dct[py::int_(3)] = 5;
         dct[py::int_(7)] = 11;
         int kv_sum = 0;
-        for (PYBIND11_CONST_FOR_STRICT_PLATFORMS auto &it : dct) {
+        for (PYBIND11_AUTO_IT : dct) {
             kv_sum += it.first.cast<int>() * 100 + it.second.cast<int>();
         }
         return kv_sum;
@@ -491,13 +493,13 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.def("passed_iterator", [](const py::iterator &py_it) {
         int elem_sum = 0;
-        for (PYBIND11_CONST_FOR_STRICT_PLATFORMS auto &it : py_it) {
+        for (PYBIND11_AUTO_IT : py_it) {
             elem_sum += it.cast<int>();
         }
         return elem_sum;
     });
 
-#undef PYBIND11_CONST_FOR_STRICT_PLATFORMS
+#undef PYBIND11_AUTO_IT
 
     // Tests below this line are for pybind11 IMPLEMENTATION DETAILS:
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -463,7 +463,7 @@ TEST_SUBMODULE(pytypes, m) {
           [](py::object o, py::function f) { return py::weakref(std::move(o), std::move(f)); });
 
 // See https://github.com/pybind/pybind11/pull/3263 for background.
-#if (defined(__clang__) && defined(__apple_build_version__)) || defined(PYPY_VERSION)
+#if (defined(__APPLE__) && defined(__clang__)) || defined(PYPY_VERSION)
 #    define PYBIND11_CONST_FOR_STRICT_PLATFORMS const
 #else
 #    define PYBIND11_CONST_FOR_STRICT_PLATFORMS

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -463,11 +463,15 @@ TEST_SUBMODULE(pytypes, m) {
           [](py::object o, py::function f) { return py::weakref(std::move(o), std::move(f)); });
 
 // See https://github.com/pybind/pybind11/pull/3263 for background.
+// pytypes.h could be changed to enforce the "most correct" user code below, by removing
+// `const` from iterator `reference` using type aliases, but that will break existing
+// user code.
 #if (defined(__APPLE__) && defined(__clang__)) || defined(PYPY_VERSION)
 // This is "most correct" and enforced on these platforms.
 #    define PYBIND11_AUTO_IT auto it
 #else
-// This works on many platforms and is reflective of existing user code.
+// This works on many platforms and is (unfortunately) reflective of existing user code.
+// NOLINTNEXTLINE(bugprone-macro-parentheses)
 #    define PYBIND11_AUTO_IT auto &it
 #endif
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -482,7 +482,7 @@ TEST_SUBMODULE(pytypes, m) {
         return kv_sum;
     });
 
-    m.def("passed_iterator", [](py::iterator py_it) {
+    m.def("passed_iterator", [](const py::iterator &py_it) {
         int elem_sum = 0;
         for (auto &it : py_it) {
             elem_sum += it.cast<int>();

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -462,6 +462,34 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("weakref_from_object_and_function",
           [](py::object o, py::function f) { return py::weakref(std::move(o), std::move(f)); });
 
+    m.def("tuple_iterator", []() {
+        auto tup = py::make_tuple(5, 7);
+        int tup_sum = 0;
+        for (auto &it : tup) {
+            tup_sum += it.cast<int>();
+        }
+        return tup_sum;
+    });
+
+    m.def("dict_iterator", []() {
+        py::dict dct;
+        dct[py::int_(3)] = 5;
+        dct[py::int_(7)] = 11;
+        int kv_sum = 0;
+        for (auto &it : dct) {
+            kv_sum += it.first.cast<int>() * 100 + it.second.cast<int>();
+        }
+        return kv_sum;
+    });
+
+    m.def("passed_iterator", [](py::iterator py_it) {
+        int elem_sum = 0;
+        for (auto &it : py_it) {
+            elem_sum += it.cast<int>();
+        }
+        return elem_sum;
+    });
+
     // Tests below this line are for pybind11 IMPLEMENTATION DETAILS:
 
     m.def("sequence_item_get_ssize_t", [](const py::object &o) {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -462,7 +462,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("weakref_from_object_and_function",
           [](py::object o, py::function f) { return py::weakref(std::move(o), std::move(f)); });
 
-// See https://github.com/pybind/pybind11/pull/3263 for background.
+// See PR #3263 for background (https://github.com/pybind/pybind11/pull/3263):
 // pytypes.h could be changed to enforce the "most correct" user code below, by removing
 // `const` from iterator `reference` using type aliases, but that will break existing
 // user code.

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -623,6 +623,12 @@ def test_weakref(create_weakref, create_weakref_with_callback):
     assert callback.called
 
 
+def test_cpp_iterators():
+    assert m.tuple_iterator() == 12
+    assert m.dict_iterator() == 305 + 711
+    assert m.passed_iterator(iter((-7, 3))) == -4
+
+
 def test_implementation_details():
     lst = [39, 43, 92, 49, 22, 29, 93, 98, 26, 57, 8]
     tup = tuple(lst)


### PR DESCRIPTION
Google-internal testing after merging PR #3254 came back with ~560 build breakages, going back to ~9 root causes. The tests added in this PR are reflective of the broken user code.

One way to fix the breakages is to remove `&` in user code, e.g.
```diff
-        for (auto &it : tup) {
+        for (auto it : tup) {
```

Strictly speaking that's an API break. Managing such sprawling fixes has a high cost.

To avoid the API break, this PR restores the `const` removed from pytypes.h in PR #3254 and adds 6 `// NOLINTNEXTLINE(readability-const-return-type)`. This decouples activating the clang-tidy feature from the API break.