### PR TITLE
Enable defining custom __new__

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -416,7 +416,7 @@ protected:
         detail::function_record *chain = nullptr, *chain_start = rec;
         if (rec->sibling) {
             if (PyCFunction_Check(rec->sibling.ptr())) {
-                auto self = PyCFunction_GET_SELF(rec->sibling.ptr());
+                auto *self = PyCFunction_GET_SELF(rec->sibling.ptr());
                 capsule rec_capsule;
                 if (isinstance<capsule>(self)) {
                     rec_capsule = reinterpret_borrow<capsule>(self);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -322,7 +322,6 @@ protected:
         rec->is_constructor
             = (strcmp(rec->name, "__init__") == 0) || (strcmp(rec->name, "__setstate__") == 0);
 
-#define PYBIND11_DISABLE_NEW_STYLE_INIT_WARNING
 #if !defined(NDEBUG) && !defined(PYBIND11_DISABLE_NEW_STYLE_INIT_WARNING)
         if (rec->is_constructor && !rec->is_new_style_constructor) {
             const auto class_name = detail::get_fully_qualified_tp_name((PyTypeObject *) rec->scope.ptr());

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -322,6 +322,7 @@ protected:
         rec->is_constructor
             = (strcmp(rec->name, "__init__") == 0) || (strcmp(rec->name, "__setstate__") == 0);
 
+#define PYBIND11_DISABLE_NEW_STYLE_INIT_WARNING
 #if !defined(NDEBUG) && !defined(PYBIND11_DISABLE_NEW_STYLE_INIT_WARNING)
         if (rec->is_constructor && !rec->is_new_style_constructor) {
             const auto class_name = detail::get_fully_qualified_tp_name((PyTypeObject *) rec->scope.ptr());

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -417,12 +417,7 @@ protected:
         if (rec->sibling) {
             if (PyCFunction_Check(rec->sibling.ptr())) {
                 auto *self = PyCFunction_GET_SELF(rec->sibling.ptr());
-                capsule rec_capsule;
-                if (isinstance<capsule>(self)) {
-                    rec_capsule = reinterpret_borrow<capsule>(self);
-                } else {
-                    rec_capsule = capsule(self);
-                }
+                capsule rec_capsule = isinstance<capsule>(self) ? reinterpret_borrow<capsule>(self) : capsule(self);
                 chain = (detail::function_record *) rec_capsule;
                 /* Never append a method to an overload chain of a parent class;
                    instead, hide the parent's overloads in this case */

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -416,7 +416,13 @@ protected:
         detail::function_record *chain = nullptr, *chain_start = rec;
         if (rec->sibling) {
             if (PyCFunction_Check(rec->sibling.ptr())) {
-                auto rec_capsule = reinterpret_borrow<capsule>(PyCFunction_GET_SELF(rec->sibling.ptr()));
+                auto self = PyCFunction_GET_SELF(rec->sibling.ptr());
+                capsule rec_capsule;
+                if (isinstance<capsule>(self)) {
+                    rec_capsule = reinterpret_borrow<capsule>(self);
+                } else {
+                    rec_capsule = capsule(self);
+                }
                 chain = (detail::function_record *) rec_capsule;
                 /* Never append a method to an overload chain of a parent class;
                    instead, hide the parent's overloads in this case */

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -63,8 +63,8 @@ TEST_SUBMODULE(class_, m) {
         .def_static("new_instance", &NoConstructor::new_instance, "Return an instance");
 
     py::class_<NoConstructorNew>(m, "NoConstructorNew")
-    .def(py::init([](NoConstructorNew *self) { return self; })) // Need a NOOP __init__
-    .def_static("__new__", [](const py::object *) { return NoConstructorNew::new_instance(); } );
+        .def(py::init([](NoConstructorNew *self) { return self; })) // Need a NOOP __init__
+        .def_static("__new__", [](const py::object *) { return NoConstructorNew::new_instance(); } );
 
     // test_inheritance
     class Pet {

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -63,7 +63,7 @@ TEST_SUBMODULE(class_, m) {
         .def_static("new_instance", &NoConstructor::new_instance, "Return an instance");
 
     py::class_<NoConstructorNew>(m, "NoConstructorNew")
-        .def("__init__", [](const NoConstructorNew &self) { return self; }) // Need a NOOP __init__
+        .def("__init__", [](NoConstructorNew *self) { return self; }) // Need a NOOP __init__
         .def_property_readonly_static("__new__",
                                       [](const py::object &) { // define __new__ class method
                                           return py::cpp_function([](const py::object &) {

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -63,13 +63,8 @@ TEST_SUBMODULE(class_, m) {
         .def_static("new_instance", &NoConstructor::new_instance, "Return an instance");
 
     py::class_<NoConstructorNew>(m, "NoConstructorNew")
-        .def(py::init([](NoConstructorNew *self) { return self; })) // Need a NOOP __init__
-        .def_property_readonly_static("__new__",
-                                      [](const py::object &) { // define __new__ class method
-                                          return py::cpp_function([](const py::object &) {
-                                              return NoConstructorNew::new_instance();
-                                          });
-                                      });
+    .def(py::init([](NoConstructorNew *self) { return self; })) // Need a NOOP __init__
+    .def_static("__new__", [](const py::object *) { return NoConstructorNew::new_instance(); } );
 
     // test_inheritance
     class Pet {

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -63,7 +63,7 @@ TEST_SUBMODULE(class_, m) {
         .def_static("new_instance", &NoConstructor::new_instance, "Return an instance");
 
     py::class_<NoConstructorNew>(m, "NoConstructorNew")
-        .def("__init__", [](NoConstructorNew *self) { return self; }) // Need a NOOP __init__
+        .def(py::init([](NoConstructorNew *self) { return self; })) // Need a NOOP __init__
         .def_property_readonly_static("__new__",
                                       [](const py::object &) { // define __new__ class method
                                           return py::cpp_function([](const py::object &) {

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -25,7 +25,6 @@ def test_instance(msg):
     assert cstats.alive() == 0
 
 
-@pytest.mark.xfail("env.PY2")
 def test_instance_new(msg):
     instance = m.NoConstructorNew()  # .__new__(m.NoConstructor.__class__)
     cstats = ConstructorStats.get(m.NoConstructorNew)

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -25,6 +25,15 @@ def test_instance(msg):
     assert cstats.alive() == 0
 
 
+@pytest.mark.xfail("env.PY2")
+def test_instance_new(msg):
+    instance = m.NoConstructorNew()  # .__new__(m.NoConstructor.__class__)
+    cstats = ConstructorStats.get(m.NoConstructorNew)
+    assert cstats.alive() == 1
+    del instance
+    assert cstats.alive() == 0
+
+
 def test_type():
     assert m.check_type(1) == m.DerivedClass1
     with pytest.raises(RuntimeError) as execinfo:


### PR DESCRIPTION
## Description
<!-- Include relevant issues or PRs here, describe what changed and why -->
* This solves the bugs preventing us from defining our own __new__ methods on classes that was brought up in #3253 .

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Enable defining custom __new__ methods on classes.
* Fixes bug preventing overriding methods if they have non-pybind11 siblings.
```

<!-- If the upgrade guide needs updating, note that here too -->
