### PR TITLE
Add make_value_iterator

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -63,6 +63,9 @@ Convenience functions converting to Python types
 .. doxygenfunction:: make_key_iterator(Iterator, Sentinel, Extra &&...)
 .. doxygenfunction:: make_key_iterator(Type &, Extra&&...)
 
+.. doxygenfunction:: make_value_iterator(Iterator, Sentinel, Extra &&...)
+.. doxygenfunction:: make_value_iterator(Type &, Extra&&...)
+
 .. _extras:
 
 Passing extra arguments to ``def`` or ``class_``

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1965,22 +1965,25 @@ struct iterator_state {
 // iterators in the wild can't be dereferenced when const.
 template <typename Iterator>
 struct iterator_access {
+    using result_type = decltype((*std::declval<Iterator>()));
     // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
-    decltype((*std::declval<Iterator>())) operator()(Iterator &it) const {
+    result_type operator()(Iterator &it) const {
         return *it;
     }
 };
 
 template <typename Iterator>
 struct iterator_key_access {
-    decltype(((*std::declval<Iterator>()).first)) operator()(Iterator &it) const {
+    using result_type = decltype(((*std::declval<Iterator>()).first));
+    result_type operator()(Iterator &it) const {
         return (*it).first;
     }
 };
 
 template <typename Iterator>
 struct iterator_value_access {
-    decltype(((*std::declval<Iterator>()).second)) operator()(Iterator &it) const {
+    using result_type = decltype(((*std::declval<Iterator>()).second));
+    result_type operator()(Iterator &it) const {
         return (*it).second;
     }
 };
@@ -2022,7 +2025,7 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Iterator,
           typename Sentinel,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
-          typename ValueType = decltype(*std::declval<Iterator>()),
+          typename ValueType = typename detail::iterator_access<Iterator>::result_type,
 #endif
           typename... Extra>
 iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
@@ -2041,7 +2044,7 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Iterator,
           typename Sentinel,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
-          typename KeyType = decltype(((*std::declval<Iterator>()).first)),
+          typename KeyType = typename detail::iterator_key_access<Iterator>::result_type,
 #endif
           typename... Extra>
 iterator make_key_iterator(Iterator first, Sentinel last, Extra &&...extra) {
@@ -2060,7 +2063,7 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Iterator,
           typename Sentinel,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
-          typename ValueType = decltype(((*std::declval<Iterator>()).second)),
+          typename ValueType = typename detail::iterator_value_access<Iterator>::result_type,
 #endif
           typename... Extra>
 iterator make_value_iterator(Iterator first, Sentinel last, Extra &&...extra) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2024,9 +2024,7 @@ PYBIND11_NAMESPACE_END(detail)
 template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Iterator,
           typename Sentinel,
-#ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
           typename ValueType = typename detail::iterator_access<Iterator>::result_type,
-#endif
           typename... Extra>
 iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
     return detail::make_iterator_impl<
@@ -2043,9 +2041,7 @@ iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
 template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Iterator,
           typename Sentinel,
-#ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
           typename KeyType = typename detail::iterator_key_access<Iterator>::result_type,
-#endif
           typename... Extra>
 iterator make_key_iterator(Iterator first, Sentinel last, Extra &&...extra) {
     return detail::make_iterator_impl<
@@ -2062,9 +2058,7 @@ iterator make_key_iterator(Iterator first, Sentinel last, Extra &&...extra) {
 template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Iterator,
           typename Sentinel,
-#ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
           typename ValueType = typename detail::iterator_value_access<Iterator>::result_type,
-#endif
           typename... Extra>
 iterator make_value_iterator(Iterator first, Sentinel last, Extra &&...extra) {
     return detail::make_iterator_impl<

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1963,21 +1963,21 @@ struct iterator_state {
 
 template <typename Iterator>
 struct iterator_access {
-    decltype(*std::declval<Iterator>()) operator()(const Iterator it) {
+    detail::remove_cv_t<decltype(*std::declval<Iterator>())> operator()(const Iterator it) {
         return *it;
     }
 };
 
 template <typename Iterator>
 struct iterator_key_access {
-    decltype((*std::declval<Iterator>()).first) operator()(const Iterator it) {
+    detail::remove_cv_t<decltype((*std::declval<Iterator>()).first)> operator()(const Iterator it) {
         return (*it).first;
     }
 };
 
 template <typename Iterator>
 struct iterator_value_access {
-    decltype((*std::declval<Iterator>()).second) operator()(const Iterator it) {
+    detail::remove_cv_t<decltype((*std::declval<Iterator>()).second)> operator()(const Iterator it) {
         return (*it).second;
     }
 };

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1965,6 +1965,7 @@ struct iterator_state {
 // iterators in the wild can't be dereferenced when const.
 template <typename Iterator>
 struct iterator_access {
+    // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
     decltype((*std::declval<Iterator>())) operator()(Iterator &it) {
         return *it;
     }
@@ -2007,6 +2008,7 @@ iterator make_iterator_impl(Iterator first, Sentinel last, Extra &&... extra) {
                     throw stop_iteration();
                 }
                 return Access()(s.it);
+            // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
             }, std::forward<Extra>(extra)..., Policy);
     }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1954,12 +1954,62 @@ inline std::pair<decltype(internals::registered_types_py)::iterator, bool> all_t
     return res;
 }
 
-template <typename Iterator, typename Sentinel, bool KeyIterator, return_value_policy Policy>
+template <typename Access, return_value_policy Policy, typename Iterator, typename Sentinel, typename ValueType, typename... Extra>
 struct iterator_state {
     Iterator it;
     Sentinel end;
     bool first_or_done;
 };
+
+template <typename Iterator>
+struct iterator_access {
+    decltype(*std::declval<Iterator>()) operator()(const Iterator it) {
+        return *it;
+    }
+};
+
+template <typename Iterator>
+struct iterator_key_access {
+    decltype((*std::declval<Iterator>()).first) operator()(const Iterator it) {
+        return (*it).first;
+    }
+};
+
+template <typename Iterator>
+struct iterator_value_access {
+    decltype((*std::declval<Iterator>()).second) operator()(const Iterator it) {
+        return (*it).second;
+    }
+};
+
+template <typename Access,
+          return_value_policy Policy,
+          typename Iterator,
+          typename Sentinel,
+          typename ValueType,
+          typename... Extra>
+iterator make_iterator_impl(Iterator first, Sentinel last, Extra &&... extra) {
+    using state = detail::iterator_state<Access, Policy, Iterator, Sentinel, ValueType, Extra...>;
+    // TODO: state captures only the types of Extra, not the values
+
+    if (!detail::get_type_info(typeid(state), false)) {
+        class_<state>(handle(), "iterator", pybind11::module_local())
+            .def("__iter__", [](state &s) -> state& { return s; })
+            .def("__next__", [](state &s) -> detail::remove_cv_t<ValueType> {
+                if (!s.first_or_done)
+                    ++s.it;
+                else
+                    s.first_or_done = false;
+                if (s.it == s.end) {
+                    s.first_or_done = true;
+                    throw stop_iteration();
+                }
+                return Access()(s.it);
+            }, std::forward<Extra>(extra)..., Policy);
+    }
+
+    return cast(state{first, last, true});
+}
 
 PYBIND11_NAMESPACE_END(detail)
 
@@ -1972,29 +2022,16 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
 #endif
           typename... Extra>
 iterator make_iterator(Iterator first, Sentinel last, Extra &&... extra) {
-    using state = detail::iterator_state<Iterator, Sentinel, false, Policy>;
-
-    if (!detail::get_type_info(typeid(state), false)) {
-        class_<state>(handle(), "iterator", pybind11::module_local())
-            .def("__iter__", [](state &s) -> state& { return s; })
-            .def("__next__", [](state &s) -> ValueType {
-                if (!s.first_or_done)
-                    ++s.it;
-                else
-                    s.first_or_done = false;
-                if (s.it == s.end) {
-                    s.first_or_done = true;
-                    throw stop_iteration();
-                }
-                return *s.it;
-            // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
-            }, std::forward<Extra>(extra)..., Policy);
-    }
-
-    return cast(state{first, last, true});
+    return detail::make_iterator_impl<
+        detail::iterator_access<Iterator>,
+        Policy,
+        Iterator,
+        Sentinel,
+        ValueType,
+        Extra...>(first, last, std::forward<Extra>(extra)...);
 }
 
-/// Makes an python iterator over the keys (`.first`) of a iterator over pairs from a
+/// Makes a python iterator over the keys (`.first`) of a iterator over pairs from a
 /// first and past-the-end InputIterator.
 template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Iterator,
@@ -2004,25 +2041,31 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
 #endif
           typename... Extra>
 iterator make_key_iterator(Iterator first, Sentinel last, Extra &&...extra) {
-    using state = detail::iterator_state<Iterator, Sentinel, true, Policy>;
+    return detail::make_iterator_impl<
+        detail::iterator_key_access<Iterator>,
+        Policy,
+        Iterator,
+        Sentinel,
+        KeyType,
+        Extra...>(first, last, std::forward<Extra>(extra)...);
+}
 
-    if (!detail::get_type_info(typeid(state), false)) {
-        class_<state>(handle(), "iterator", pybind11::module_local())
-            .def("__iter__", [](state &s) -> state& { return s; })
-            .def("__next__", [](state &s) -> detail::remove_cv_t<KeyType> {
-                if (!s.first_or_done)
-                    ++s.it;
-                else
-                    s.first_or_done = false;
-                if (s.it == s.end) {
-                    s.first_or_done = true;
-                    throw stop_iteration();
-                }
-                return (*s.it).first;
-            }, std::forward<Extra>(extra)..., Policy);
-    }
-
-    return cast(state{first, last, true});
+/// Makes a python iterator over the values (`.second`) of a iterator over pairs from a
+/// first and past-the-end InputIterator.
+template <return_value_policy Policy = return_value_policy::reference_internal,
+          typename Iterator,
+          typename Sentinel,
+#ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
+          typename ValueType = decltype((*std::declval<Iterator>()).second),
+#endif
+          typename... Extra>
+iterator make_value_iterator(Iterator first, Sentinel last, Extra &&...extra) {
+    return detail::make_iterator_impl<
+        detail::iterator_value_access<Iterator>,
+        Policy, Iterator,
+        Sentinel,
+        ValueType,
+        Extra...>(first, last, std::forward<Extra>(extra)...);
 }
 
 /// Makes an iterator over values of an stl container or other container supporting
@@ -2037,6 +2080,13 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
 template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Type, typename... Extra> iterator make_key_iterator(Type &value, Extra&&... extra) {
     return make_key_iterator<Policy>(std::begin(value), std::end(value), extra...);
+}
+
+/// Makes an iterator over the values (`.second`) of a stl map-like container supporting
+/// `std::begin()`/`std::end()`
+template <return_value_policy Policy = return_value_policy::reference_internal,
+          typename Type, typename... Extra> iterator make_value_iterator(Type &value, Extra&&... extra) {
+    return make_value_iterator<Policy>(std::begin(value), std::end(value), extra...);
 }
 
 template <typename InputType, typename OutputType> void implicitly_convertible() {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1961,23 +1961,25 @@ struct iterator_state {
     bool first_or_done;
 };
 
+// Note: these helpers take the iterator by non-const reference because some
+// iterators in the wild can't be dereferenced when const.
 template <typename Iterator>
 struct iterator_access {
-    detail::remove_cv_t<decltype(*std::declval<Iterator>())> operator()(const Iterator it) {
+    detail::remove_cv_t<decltype(*std::declval<Iterator>())> operator()(Iterator &it) {
         return *it;
     }
 };
 
 template <typename Iterator>
 struct iterator_key_access {
-    detail::remove_cv_t<decltype((*std::declval<Iterator>()).first)> operator()(const Iterator it) {
+    detail::remove_cv_t<decltype((*std::declval<Iterator>()).first)> operator()(Iterator &it) {
         return (*it).first;
     }
 };
 
 template <typename Iterator>
 struct iterator_value_access {
-    detail::remove_cv_t<decltype((*std::declval<Iterator>()).second)> operator()(const Iterator it) {
+    detail::remove_cv_t<decltype((*std::declval<Iterator>()).second)> operator()(Iterator &it) {
         return (*it).second;
     }
 };

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1954,6 +1954,9 @@ inline std::pair<decltype(internals::registered_types_py)::iterator, bool> all_t
     return res;
 }
 
+/* There are a large number of apparently unused template arguments because
+ * each combination requires a separate py::class_ registration.
+ */
 template <typename Access, return_value_policy Policy, typename Iterator, typename Sentinel, typename ValueType, typename... Extra>
 struct iterator_state {
     Iterator it;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1965,21 +1965,21 @@ struct iterator_state {
 // iterators in the wild can't be dereferenced when const.
 template <typename Iterator>
 struct iterator_access {
-    detail::remove_cv_t<decltype(*std::declval<Iterator>())> operator()(Iterator &it) {
+    decltype((*std::declval<Iterator>())) operator()(Iterator &it) {
         return *it;
     }
 };
 
 template <typename Iterator>
 struct iterator_key_access {
-    detail::remove_cv_t<decltype((*std::declval<Iterator>()).first)> operator()(Iterator &it) {
+    decltype(((*std::declval<Iterator>()).first)) operator()(Iterator &it) {
         return (*it).first;
     }
 };
 
 template <typename Iterator>
 struct iterator_value_access {
-    detail::remove_cv_t<decltype((*std::declval<Iterator>()).second)> operator()(Iterator &it) {
+    decltype(((*std::declval<Iterator>()).second)) operator()(Iterator &it) {
         return (*it).second;
     }
 };
@@ -1997,7 +1997,7 @@ iterator make_iterator_impl(Iterator first, Sentinel last, Extra &&... extra) {
     if (!detail::get_type_info(typeid(state), false)) {
         class_<state>(handle(), "iterator", pybind11::module_local())
             .def("__iter__", [](state &s) -> state& { return s; })
-            .def("__next__", [](state &s) -> detail::remove_cv_t<ValueType> {
+            .def("__next__", [](state &s) -> ValueType {
                 if (!s.first_or_done)
                     ++s.it;
                 else
@@ -2039,7 +2039,7 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Iterator,
           typename Sentinel,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
-          typename KeyType = decltype((*std::declval<Iterator>()).first),
+          typename KeyType = decltype(((*std::declval<Iterator>()).first)),
 #endif
           typename... Extra>
 iterator make_key_iterator(Iterator first, Sentinel last, Extra &&...extra) {
@@ -2058,7 +2058,7 @@ template <return_value_policy Policy = return_value_policy::reference_internal,
           typename Iterator,
           typename Sentinel,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS  // Issue in breathe 4.26.1
-          typename ValueType = decltype((*std::declval<Iterator>()).second),
+          typename ValueType = decltype(((*std::declval<Iterator>()).second)),
 #endif
           typename... Extra>
 iterator make_value_iterator(Iterator first, Sentinel last, Extra &&...extra) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1966,21 +1966,21 @@ struct iterator_state {
 template <typename Iterator>
 struct iterator_access {
     // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
-    decltype((*std::declval<Iterator>())) operator()(Iterator &it) {
+    decltype((*std::declval<Iterator>())) operator()(Iterator &it) const {
         return *it;
     }
 };
 
 template <typename Iterator>
 struct iterator_key_access {
-    decltype(((*std::declval<Iterator>()).first)) operator()(Iterator &it) {
+    decltype(((*std::declval<Iterator>()).first)) operator()(Iterator &it) const {
         return (*it).first;
     }
 };
 
 template <typename Iterator>
 struct iterator_value_access {
-    decltype(((*std::declval<Iterator>()).second)) operator()(Iterator &it) {
+    decltype(((*std::declval<Iterator>()).second)) operator()(Iterator &it) const {
         return (*it).second;
     }
 };

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <utility>
+#include <vector>
 
 template<typename T>
 class NonZeroIterator {
@@ -31,6 +32,29 @@ template<typename A, typename B>
 bool operator==(const NonZeroIterator<std::pair<A, B>>& it, const NonZeroSentinel&) {
     return !(*it).first || !(*it).second;
 }
+
+class NonCopyableInt {
+public:
+    NonCopyableInt(int value) : value_(value) {}
+    NonCopyableInt(const NonCopyableInt &) = delete;
+    NonCopyableInt(NonCopyableInt &&other) noexcept : value_(other.value_) {
+        other.value_ = -1;  // detect when an unwanted move occurs
+    }
+    NonCopyableInt &operator=(const NonCopyableInt &) = delete;
+    NonCopyableInt &operator=(NonCopyableInt &&other) noexcept {
+        value_ = other.value_;
+        other.value_ = -1;  // detect when an unwanted move occurs
+        return *this;
+    }
+    int get() const { return value_; }
+    void set(int value) { value_ = value; }
+    ~NonCopyableInt() = default;
+private:
+    int value_;
+};
+using NonCopyableIntPair = std::pair<NonCopyableInt, NonCopyableInt>;
+PYBIND11_MAKE_OPAQUE(std::vector<NonCopyableInt>);
+PYBIND11_MAKE_OPAQUE(std::vector<NonCopyableIntPair>);
 
 template <typename PythonType>
 py::list test_random_access_iterator(PythonType x) {
@@ -298,6 +322,33 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
         }, py::keep_alive<0, 1>())
         ;
 
+    // test_iterater_referencing
+    py::class_<NonCopyableInt>(m, "NonCopyableInt")
+        .def(py::init<int>())
+        .def("set", &NonCopyableInt::set)
+        .def("__int__", &NonCopyableInt::get)
+        ;
+    py::class_<std::vector<NonCopyableInt>>(m, "VectorNonCopyableInt")
+        .def(py::init<>())
+        .def("append", [](std::vector<NonCopyableInt> &vec, int value) {
+            vec.emplace_back(value);
+        })
+        .def("__iter__", [](std::vector<NonCopyableInt> &vec) {
+            return py::make_iterator(vec.begin(), vec.end());
+        })
+        ;
+    py::class_<std::vector<NonCopyableIntPair>>(m, "VectorNonCopyableIntPair")
+        .def(py::init<>())
+        .def("append", [](std::vector<NonCopyableIntPair> &vec, const std::pair<int, int> &value) {
+            vec.emplace_back(value.first, value.second);
+        })
+        .def("keys", [](std::vector<NonCopyableIntPair> &vec) {
+            return py::make_key_iterator(vec.begin(), vec.end());
+        })
+        .def("values", [](std::vector<NonCopyableIntPair> &vec) {
+            return py::make_value_iterator(vec.begin(), vec.end());
+        })
+        ;
 
 #if 0
     // Obsolete: special data structure for exposing custom iterator types to python

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -271,6 +271,10 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
         .def(
             "items",
             [](const StringMap &map) { return py::make_iterator(map.begin(), map.end()); },
+            py::keep_alive<0, 1>())
+        .def(
+            "values",
+            [](const StringMap &map) { return py::make_value_iterator(map.begin(), map.end()); },
             py::keep_alive<0, 1>());
 
     // test_generalized_iterators
@@ -288,6 +292,9 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
         }, py::keep_alive<0, 1>())
         .def("nonzero_keys", [](const IntPairs& s) {
             return py::make_key_iterator(NonZeroIterator<std::pair<int, int>>(s.begin()), NonZeroSentinel());
+        }, py::keep_alive<0, 1>())
+        .def("nonzero_values", [](const IntPairs& s) {
+            return py::make_value_iterator(NonZeroIterator<std::pair<int, int>>(s.begin()), NonZeroSentinel());
         }, py::keep_alive<0, 1>())
         ;
 

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -35,7 +35,7 @@ bool operator==(const NonZeroIterator<std::pair<A, B>>& it, const NonZeroSentine
 
 class NonCopyableInt {
 public:
-    NonCopyableInt(int value) : value_(value) {}
+    explicit NonCopyableInt(int value) : value_(value) {}
     NonCopyableInt(const NonCopyableInt &) = delete;
     NonCopyableInt(NonCopyableInt &&other) noexcept : value_(other.value_) {
         other.value_ = -1;  // detect when an unwanted move occurs

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -340,7 +340,7 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
     py::class_<std::vector<NonCopyableIntPair>>(m, "VectorNonCopyableIntPair")
         .def(py::init<>())
         .def("append", [](std::vector<NonCopyableIntPair> &vec, const std::pair<int, int> &value) {
-            vec.emplace_back(value.first, value.second);
+            vec.emplace_back(NonCopyableInt(value.first), NonCopyableInt(value.second));
         })
         .def("keys", [](std::vector<NonCopyableIntPair> &vec) {
             return py::make_key_iterator(vec.begin(), vec.end());

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -25,6 +25,10 @@ def test_generalized_iterators():
     assert list(m.IntPairs([(1, 2), (2, 0), (0, 3), (4, 5)]).nonzero_keys()) == [1]
     assert list(m.IntPairs([(0, 3), (1, 2), (3, 4)]).nonzero_keys()) == []
 
+    assert list(m.IntPairs([(1, 2), (3, 4), (0, 5)]).nonzero_values()) == [2, 4]
+    assert list(m.IntPairs([(1, 2), (2, 0), (0, 3), (4, 5)]).nonzero_values()) == [2]
+    assert list(m.IntPairs([(0, 3), (1, 2), (3, 4)]).nonzero_values()) == []
+
     # __next__ must continue to raise StopIteration
     it = m.IntPairs([(0, 0)]).nonzero()
     for _ in range(3):
@@ -140,6 +144,7 @@ def test_map_iterator():
         assert sm[k] == expected[k]
     for k, v in sm.items():
         assert v == expected[k]
+    assert list(sm.values()) == [expected[k] for k in sm]
 
     it = iter(m.StringMap({}))
     for _ in range(3):  # __next__ must continue to raise StopIteration

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -41,6 +41,30 @@ def test_generalized_iterators():
             next(it)
 
 
+def test_iterator_referencing():
+    """Test that iterators reference rather than copy their referents."""
+    vec = m.VectorNonCopyableInt()
+    vec.append(3)
+    vec.append(5)
+    assert [int(x) for x in vec] == [3, 5]
+    # Increment everything to make sure the referents can be mutated
+    for x in vec:
+        x.set(int(x) + 1)
+    assert [int(x) for x in vec] == [4, 6]
+
+    vec = m.VectorNonCopyableIntPair()
+    vec.append([3, 4])
+    vec.append([5, 7])
+    assert [int(x) for x in vec.keys()] == [3, 5]
+    assert [int(x) for x in vec.values()] == [4, 7]
+    for x in vec.keys():
+        x.set(int(x) + 1)
+    for x in vec.values():
+        x.set(int(x) + 10)
+    assert [int(x) for x in vec.keys()] == [4, 6]
+    assert [int(x) for x in vec.values()] == [14, 17]
+
+
 def test_sliceable():
     sliceable = m.Sliceable(100)
     assert sliceable[::] == (0, 100, 1)


### PR DESCRIPTION
## Description

This is the counterpart to make_key_iterator, and will allow
implementing a `value` method in `bind_map` (although doing so is left
for a subsequent PR).

I made a few design changes to reduce copy-and-paste boilerplate.
Previously detail::iterator_state had a boolean template parameter to
indicate whether it was being used for make_iterator or
make_key_iterator. I replaced the boolean with a class that determines
how to dereference the iterator. This allows for a generic
implementation of `__next__`.

I also added the ValueType and Extra... parameters to the iterator_state
template args, because I think it was a bug that they were missing: if
make_iterator is called twice with different values of these, only the
first set has effect (because the state class is only registered once).
There is still a potential issue in that the *values* of the extra
arguments are latched on the first call, but since most policies are
empty classes this should be even less common.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
- Add ``make_value_iterator()``.
- Fix ``make_key_iterator()`` to return references instead of copies.
```