### PR TITLE
Add ability to remove nurse/patient relationship

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -12,6 +12,8 @@
 #include "../attr.h"
 #include "../options.h"
 
+#include <algorithm>
+
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -366,6 +366,25 @@ inline void add_patient(PyObject *nurse, PyObject *patient) {
     internals.patients[nurse].push_back(patient);
 }
 
+inline void remove_patient(PyObject *nurse, PyObject *patient) {
+    auto &internals = get_internals();
+    auto instance = reinterpret_cast<detail::instance *>(nurse);
+    if (!instance->has_patients) {
+        return;
+    }
+
+    auto &patients = internals.patients[nurse];
+    auto pos = std::find(patients.begin(), patients.end(), patient);
+    if (pos == patients.end()) {
+        return;
+    }
+
+    patients.erase(pos);
+    Py_DECREF(patient);
+
+    instance->has_patients = !patients.empty();
+}
+
 inline void clear_patients(PyObject *self) {
     auto instance = reinterpret_cast<detail::instance *>(self);
     auto &internals = get_internals();

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -49,6 +49,7 @@ TEST_SUBMODULE(call_policies, m) {
         Parent(const Parent& parent) = default;
         ~Parent() { py::print("Releasing parent."); }
         void addChild(Child *) { }
+        void detachChild(Child *) { }
         Child *returnChild() { return new Child(); }
         Child *returnNullChild() { return nullptr; }
         static Child *staticFunction(Parent*) { return new Child(); }
@@ -62,6 +63,7 @@ TEST_SUBMODULE(call_policies, m) {
         .def("returnChildKeepAlive", &Parent::returnChild, py::keep_alive<1, 0>())
         .def("returnNullChildKeepAliveChild", &Parent::returnNullChild, py::keep_alive<1, 0>())
         .def("returnNullChildKeepAliveParent", &Parent::returnNullChild, py::keep_alive<0, 1>())
+        .def("detachChild", &Parent::detachChild, py::unplug_patient<1, 2>())
         .def_static(
             "staticFunction", &Parent::staticFunction, py::keep_alive<1, 0>());
 


### PR DESCRIPTION

## Description

This adds a `pybind11::unplug_patient<Nurse, Patient>` extra attr
to pybind11 that allows to unplug/deregister a Nurse <-> Patient
relationship that was previously set using `pybind11::keep_alive<Nurse, Patient>`.

I recently came to need this feature to bind a tree-like c++ data struct that
allows to get a child of a node ( a `getChild(index) -> *child` function for which bindings are using `reference_internal`  return policy so the child nurses its parent to keep it alive).
But that data structure also alows to 'detach' a child from its parent, so a way to remove the nurse <-> patient relationship is needed otherwise after detaching a child from its parent, the parent is still being nursed by its former child and the memory consumption could be higher than expected.

A similar feature was requested in #1708 (although, I think the example given in that issue could be implemented
without resorting to the nursery system but using `inc_ref` and `dec_ref`).

A few points:
- I'm not sure if `unplug` is a good name for this.
- I did not implement the `unplugging` of a nurse <-> patient if the nurse is not a pybind11-registered type
  as I don't quite grasp what's happening in the `keep_alive_impl` for the same case.
- the `struct process_attribute<unplug_patient<Nurse, Patient>>` is the exact same as
  `struct process_attribute<keep_alive<Nurse, Patient>>` but I don't know how to best share the code here.

- [ ] If this is going to be accepted, the documentation needs to mention the new attr
