### PR TITLE
CMake: react to python version changes

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -82,6 +82,14 @@ if(NOT DEFINED ${_Python}_EXECUTABLE)
 
 endif()
 
+if (NOT ${_Python}_EXECUTABLE STREQUAL ${_Python}_EXECUTABLE_LAST)
+  # Detect changes to the Python version/binary in subsequent CMake runs, and refresh config if needed
+  unset(PYTHON_IS_DEBUG CACHE)
+  unset(PYTHON_MODULE_EXTENSION CACHE)
+  set(${_Python}_EXECUTABLE_LAST "${${_Python}_EXECUTABLE}"
+    CACHE INTERNAL "Python executable during the last CMake run")
+endif()
+
 if(NOT DEFINED PYTHON_IS_DEBUG)
   # Debug check - see https://stackoverflow.com/questions/646518/python-how-to-detect-debug-Interpreter
   execute_process(

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -82,11 +82,11 @@ if(NOT DEFINED ${_Python}_EXECUTABLE)
 
 endif()
 
-if(NOT ${_Python}_EXECUTABLE STREQUAL ${_Python}_EXECUTABLE_LAST)
+if(NOT ${_Python}_EXECUTABLE STREQUAL PYTHON_EXECUTABLE_LAST)
   # Detect changes to the Python version/binary in subsequent CMake runs, and refresh config if needed
   unset(PYTHON_IS_DEBUG CACHE)
   unset(PYTHON_MODULE_EXTENSION CACHE)
-  set(${_Python}_EXECUTABLE_LAST
+  set(PYTHON_EXECUTABLE_LAST
       "${${_Python}_EXECUTABLE}"
       CACHE INTERNAL "Python executable during the last CMake run")
 endif()

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -82,12 +82,13 @@ if(NOT DEFINED ${_Python}_EXECUTABLE)
 
 endif()
 
-if (NOT ${_Python}_EXECUTABLE STREQUAL ${_Python}_EXECUTABLE_LAST)
+if(NOT ${_Python}_EXECUTABLE STREQUAL ${_Python}_EXECUTABLE_LAST)
   # Detect changes to the Python version/binary in subsequent CMake runs, and refresh config if needed
   unset(PYTHON_IS_DEBUG CACHE)
   unset(PYTHON_MODULE_EXTENSION CACHE)
-  set(${_Python}_EXECUTABLE_LAST "${${_Python}_EXECUTABLE}"
-    CACHE INTERNAL "Python executable during the last CMake run")
+  set(${_Python}_EXECUTABLE_LAST
+      "${${_Python}_EXECUTABLE}"
+      CACHE INTERNAL "Python executable during the last CMake run")
 endif()
 
 if(NOT DEFINED PYTHON_IS_DEBUG)


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

The new FindPython-based variant of the CMake scripts caches information
about the chosen Python version that can become stale. For example,
suppose I configure a simple pybind11-based project as follows

```
cmake -S . -B build -GNinja -DPython_ROOT=<path to python 3.8>
```

which will generate `my_extension.cpython-38-x86_64-linux-gnu.so`.
A subsequent change to the python version like

```
cmake -S . -B build -GNinja -DPython_ROOT=<path to python 3.9>
```

does not update all necessary build system information. In particular,
the compiled file is still called
`my_extension.cpython-38-x86_64-linux-gnu.so`.

This commit fixes the problem by detecting changes in
`Python_EXECUTABLE` and re-running Python as needed.

Note that the previous way of detecting Python does not seem to be
affected, it always specifies the right suffix.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
- Cached Python version information could become stale when CMake was re-run with a different Python version. The  build system now detects this and updates this information.
```
