### PR TITLE
fix(cmake): reduce chance for variable collision

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -82,11 +82,11 @@ if(NOT DEFINED ${_Python}_EXECUTABLE)
 
 endif()
 
-if(NOT ${_Python}_EXECUTABLE STREQUAL PYTHON_EXECUTABLE_LAST)
+if(NOT ${_Python}_EXECUTABLE STREQUAL PYBIND11_PYTHON_EXECUTABLE_LAST)
   # Detect changes to the Python version/binary in subsequent CMake runs, and refresh config if needed
   unset(PYTHON_IS_DEBUG CACHE)
   unset(PYTHON_MODULE_EXTENSION CACHE)
-  set(PYTHON_EXECUTABLE_LAST
+  set(PYBIND11_PYTHON_EXECUTABLE_LAST
       "${${_Python}_EXECUTABLE}"
       CACHE INTERNAL "Python executable during the last CMake run")
 endif()


### PR DESCRIPTION
## Description

Suggested in a comment by @skoslowski in #3299. This is an internal global variable, so best to keep it "hidden" behind a namespace.
