### PR TITLE
docs: mention title conventions in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+<!--
+Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
+It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
+-->
 ## Description
 
 <!-- Include relevant issues or PRs here, describe what changed and why -->


### PR DESCRIPTION
Follow-up to #3311. `stable` should never change between releases, and making a PR to `stable` is really hard to notice in the GitHub UI. If there's a way to enforce this, that would be nice, but I'm only aware of a way to enforce conventionalcommits, not target branch title prefixes. Making it impossible to target `stable` in PRs would be nice, too.