### PR TITLE
Docs: Demonstrate non-enum internal types in example

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -446,8 +446,7 @@ you can use ``py::detail::overload_cast_impl`` with an additional set of parenth
 Enumerations and internal types
 ===============================
 
-Let's now suppose that the example class contains an internal enumeration type,
-e.g.:
+Let's now suppose that the example class contains internal types like enumerations, e.g.:
 
 .. code-block:: cpp
 
@@ -456,11 +455,16 @@ e.g.:
             Dog = 0,
             Cat
         };
+        
+        struct Attributes {
+            float age = 0;
+        };
 
         Pet(const std::string &name, Kind type) : name(name), type(type) { }
 
         std::string name;
         Kind type;
+        Attributes attr;
     };
 
 The binding code for this example looks as follows:
@@ -471,15 +475,21 @@ The binding code for this example looks as follows:
 
     pet.def(py::init<const std::string &, Pet::Kind>())
         .def_readwrite("name", &Pet::name)
-        .def_readwrite("type", &Pet::type);
+        .def_readwrite("type", &Pet::type)
+        .def_readwrite("attr", &Pet::attr);
 
     py::enum_<Pet::Kind>(pet, "Kind")
         .value("Dog", Pet::Kind::Dog)
         .value("Cat", Pet::Kind::Cat)
         .export_values();
+        
+    py::class_<Pet::Attributes> attributes(pet, "Attributes")
+        .def(py::init<>())
+        .def_readwrite("age", &Pet::Attributes::age);
+    
 
-To ensure that the ``Kind`` type is created within the scope of ``Pet``, the
-``pet`` :class:`class_` instance must be supplied to the :class:`enum_`.
+To ensure that the nested types ``Kind`` and ``Attributes`` are created within the scope of ``Pet``, the
+``pet`` :class:`class_` instance must be supplied to the :class:`enum_` and :class:`class_`
 constructor. The :func:`enum_::export_values` function exports the enum entries
 into the parent scope, which should be skipped for newer C++11-style strongly
 typed enums.

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -455,7 +455,7 @@ Let's now suppose that the example class contains internal types like enumeratio
             Dog = 0,
             Cat
         };
-        
+
         struct Attributes {
             float age = 0;
         };
@@ -482,11 +482,11 @@ The binding code for this example looks as follows:
         .value("Dog", Pet::Kind::Dog)
         .value("Cat", Pet::Kind::Cat)
         .export_values();
-        
+
     py::class_<Pet::Attributes> attributes(pet, "Attributes")
         .def(py::init<>())
         .def_readwrite("age", &Pet::Attributes::age);
-    
+
 
 To ensure that the nested types ``Kind`` and ``Attributes`` are created within the scope of ``Pet``, the
 ``pet`` :class:`class_` instance must be supplied to the :class:`enum_` and :class:`class_`


### PR DESCRIPTION
## Description

From the docs it is unclear how to bind internal types as the example only demonstrated an internal enumeration type. 
To show that it works the same way for other internal types, the example was updated with an additional simple Pet::Attributes struct type.
The concept of "internal type" is also known as "nested type". 
To make it easier finding the relevant part in the documentation, the wording is slightly changed to include "internal type" and "nested type".

Previously discussed at
https://github.com/pybind/pybind11/pull/2585#issuecomment-707928732

