### PR TITLE
fix: replace free() with std::free()

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1536,7 +1536,7 @@ public:
            char *doc_prev = rec_fget->doc; /* 'extra' field may include a property-specific documentation string */
            detail::process_attributes<Extra...>::init(extra..., rec_fget);
            if (rec_fget->doc && rec_fget->doc != doc_prev) {
-              free(doc_prev);
+              std::free(doc_prev);
               rec_fget->doc = PYBIND11_COMPAT_STRDUP(rec_fget->doc);
            }
         }
@@ -1544,7 +1544,7 @@ public:
             char *doc_prev = rec_fset->doc;
             detail::process_attributes<Extra...>::init(extra..., rec_fset);
             if (rec_fset->doc && rec_fset->doc != doc_prev) {
-                free(doc_prev);
+                std::free(doc_prev);
                 rec_fset->doc = PYBIND11_COMPAT_STRDUP(rec_fset->doc);
             }
             if (! rec_active) rec_active = rec_fset;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -16,6 +16,7 @@
 #include "detail/class.h"
 #include "detail/init.h"
 
+#include <cstdlib>
 #include <memory>
 #include <new>
 #include <vector>

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -315,7 +315,7 @@ TEST_CASE("sys.argv gets initialized properly") {
     {
         char *argv[] = {strdup("a.out")};
         py::scoped_interpreter argv_scope(true, 1, argv);
-        free(argv[0]);
+        std::free(argv[0]);
         auto module = py::module::import("test_interpreter");
         auto py_widget = module.attr("DerivedWidget")("The question");
         const auto &cpp_widget = py_widget.cast<const Widget &>();

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -8,6 +8,7 @@
 
 #include <catch.hpp>
 
+#include <cstdlib>
 #include <fstream>
 #include <functional>
 #include <thread>


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Closes #3315 . Use std::free instead of the ambiguous free().
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Ensure that std::free() is used consistently throughout the code base.
```

<!-- If the upgrade guide needs updating, note that here too -->
