### PR TITLE
tests: allow Eigen repo and version to be overridden

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
+        -DPYBIND11_EIGEN_REPO=https://gitlab.com/libeigen/eigen-backup
         -DCMAKE_CXX_STANDARD=11
         ${{ matrix.args }}
 
@@ -129,6 +130,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
+        -DPYBIND11_EIGEN_REPO=https://gitlab.com/libeigen/eigen-backup
         -DCMAKE_CXX_STANDARD=17
         ${{ matrix.args }}
         ${{ matrix.args2 }}
@@ -151,6 +153,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
+        -DPYBIND11_EIGEN_REPO=https://gitlab.com/libeigen/eigen-backup
         -DCMAKE_CXX_STANDARD=17
         -DPYBIND11_INTERNALS_VERSION=10000000
         "-DPYBIND11_TEST_OVERRIDE=test_call_policies.cpp;test_gil_scoped.cpp;test_thread.cpp"
@@ -249,6 +252,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
+        -DPYBIND11_EIGEN_REPO=https://gitlab.com/libeigen/eigen-backup
         -DCMAKE_CXX_STANDARD=17
 
     - name: Build
@@ -628,6 +632,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
+        -DPYBIND11_EIGEN_REPO=https://gitlab.com/libeigen/eigen-backup
         -DCMAKE_CXX_STANDARD=11
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
@@ -774,6 +779,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
+        -DPYBIND11_EIGEN_REPO=https://gitlab.com/libeigen/eigen-backup
         ${{ matrix.args }}
     - name: Build C++11
       run: cmake --build build -j 2
@@ -820,6 +826,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
+        -DPYBIND11_EIGEN_REPO=https://gitlab.com/libeigen/eigen-backup
 
     - name: Build C++14
       run: cmake --build build -j 2
@@ -869,6 +876,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
+        -DPYBIND11_EIGEN_REPO=https://gitlab.com/libeigen/eigen-backup
         -DCMAKE_CXX_STANDARD=${{ matrix.std }}
         ${{ matrix.args }}
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -41,6 +41,7 @@ jobs:
         cmake -S . -B build
         -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy)"
         -DDOWNLOAD_EIGEN=ON
+        -DPYBIND11_EIGEN_REPO=https://gitlab.com/libeigen/eigen-backup
         -DDOWNLOAD_CATCH=ON
         -DCMAKE_CXX_STANDARD=17
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -171,6 +171,14 @@ set(PYBIND11_CROSS_MODULE_TESTS test_exceptions.py test_local_bindings.py test_s
 
 set(PYBIND11_CROSS_MODULE_GIL_TESTS test_gil_scoped.py)
 
+set(PYBIND11_EIGEN_REPO
+    "https://gitlab.com/libeigen/eigen.git"
+    CACHE STRING "Eigen repository to use for tests")
+# This hash is for 3.3.8, using a hash for security reasons
+set(PYBIND11_EIGEN_VERSION
+    "dc252fbf00079ccab57948a164b1421703fe4361"
+    CACHE STRING "Eigen version to use for tests")
+
 # Check if Eigen is available; if not, remove from PYBIND11_TEST_FILES (but
 # keep it in PYBIND11_PYTEST_FILES, so that we get the "eigen is not installed"
 # skip message).
@@ -184,13 +192,11 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
       message(FATAL_ERROR "CMake 3.11+ required when using DOWNLOAD_EIGEN")
     endif()
 
-    set(EIGEN3_VERSION_STRING "3.3.8")
-
     include(FetchContent)
     FetchContent_Declare(
       eigen
-      GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-      GIT_TAG ${EIGEN3_VERSION_STRING})
+      GIT_REPOSITORY "${PYBIND11_EIGEN_REPO}"
+      GIT_TAG "${PYBIND11_EIGEN_VERSION}")
 
     FetchContent_GetProperties(eigen)
     if(NOT eigen_POPULATED)


### PR DESCRIPTION
To work around gitlab eigen outage.

The eigen repo is still unavailable (seems to be 2+ days now):

<img width="853" alt="Screen Shot 2021-10-04 at 06 11 00" src="https://user-images.githubusercontent.com/740480/135857346-7403106f-c13d-40b7-903b-e2c0e718e47a.png">
