### PR TITLE
fix: Fix STL optional casting issue

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -252,8 +252,8 @@ template<typename T> struct optional_caster {
     static handle cast(T_ &&src, return_value_policy policy, handle parent) {
         if (!src)
             return none().inc_ref();
-        if (!std::is_lvalue_reference<T>::value) {
-            policy = return_value_policy_override<T>::policy(policy);
+        if (!std::is_lvalue_reference<T_>::value) {
+            policy = return_value_policy_override<typename T::value_type>::policy(policy);
         }
         return value_conv::cast(*std::forward<T_>(src), policy, parent);
     }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Fixes #3330 . boost::optional could have the wrong return 
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fixes a bug that could cause non-stdlib optionals to have the wrong return policy applied.
```

<!-- If the upgrade guide needs updating, note that here too -->
