### PR TITLE
Test recursive dispatch using visitor pattern.

### DIFF
--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -257,6 +257,39 @@ def test_dispatch_issue(msg):
     assert m.dispatch_issue_go(b) == "Yay.."
 
 
+def test_recursive_dispatch_issue(msg):
+    """#3357: Recursive dispatch fails to find python function override"""
+
+    class Data(m.Data):
+        def __init__(self, value):
+            super(Data, self).__init__()
+            self.value = value
+
+    class Adder(m.Adder):
+        def __call__(self, first, second, visitor):
+            # lambda is a workaround, which adds extra frame to the
+            # current CPython thread. Removing lambda reveals the bug
+            # [https://github.com/pybind/pybind11/issues/3357]
+            (lambda: visitor(Data(first.value + second.value)))()
+
+    class StoreResultVisitor:
+        def __init__(self):
+            self.result = None
+
+        def __call__(self, data):
+            self.result = data.value
+
+    store = StoreResultVisitor()
+
+    m.add2(Data(1), Data(2), Adder(), store)
+    assert store.result == 3
+
+    # without lambda in Adder class, this function fails with
+    # RuntimeError: Tried to call pure virtual function "AdderBase::__call__"
+    m.add3(Data(1), Data(2), Data(3), Adder(), store)
+    assert store.result == 6
+
+
 def test_override_ref():
     """#392/397: overriding reference-returning functions"""
     o = m.OverrideTest("asdf")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Implemented unit test aims at replicating BUG #3357. The implementation defines abstract C++ class that performs an operation on abstract member Data class and sends the result to a visitor. A trampoline class is used to bind Adder python class. Additionally two algorithms that use previously defined abstractions to perform operation on two or three objects. These algorithms are tested using a concrete python implementation. The recursive dispatch of overloaded operator fails in the case of algorithm that uses three objects. When calling a visitor indirectly from lambda function inside overloaded  operation, the expected functionality is restored.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
- implement tests for recursive dispatch using visitor pattern
```

<!-- If the upgrade guide needs updating, note that here too -->
