### PR TITLE
docs: fix minor typo

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -518,7 +518,7 @@ public:
     }
 
     /// Single-character for dtype's type.
-    /// For example, ``float`` is 'f', ``double`` 'd', ``int`` 'i', and ``long`` 'd'.
+    /// For example, ``float`` is 'f', ``double`` 'd', ``int`` 'i', and ``long`` 'l'.
     char char_() const {
         // Note: The signature, `dtype::char_` follows the naming of NumPy's
         // public Python API (i.e., ``dtype.char``), rather than its internal


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Small docstring fix to accurately reflect the `char` attribute for numpy's ``long`` dtype.

```python
>>> import numpy as np
>>> np.dtype("long").char
'l'
>>> np.dtype("double").char
'd'
```

## Suggested changelog entry:

None
