### PR TITLE
style: drop pycln

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,12 +61,6 @@ repos:
   hooks:
   - id: remove-tabs
 
-# Autoremoves unused imports
-- repo: https://github.com/hadialqattan/pycln
-  rev: v1.0.3
-  hooks:
-  - id: pycln
-
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.9.0
   hooks:


### PR DESCRIPTION
Reverting part of https://github.com/pybind/pybind11/pull/3292

PyCln artificially version-caps Python to <3.10, which broke when pre-commit.ci updated to 3.10 earlier today. I hadn't noticed this, because locally I installed with 3.9, then when brew updated pre-commit to 3.10, it just kept working, because pycln actually supports 3.10, it just follows the horrific practice of adding upper version limits as pushed by Poetry. If the version caps are removed, we can restore this to pre-commit. Otherwise, this will cause extra headaches every Python upgrade.  hadialqattan/pycln#81
