### PR TITLE
fix(build): support conan's multiple includes of all files

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -20,6 +20,7 @@ Adds the following functions::
 #]======================================================]
 
 # CMake 3.10 has an include_guard command, but we can't use that yet
+# include_guard(global) (pre-CMake 3.10)
 if(TARGET pybind11::lto)
   return()
 endif()

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -5,6 +5,12 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
+if(CMAKE_VERSION VERSION_LESS 3.12)
+  message(FATAL_ERROR "You cannot use the new FindPython module with CMake < 3.12")
+endif()
+
+include_guard(GLOBAL)
+
 get_property(
   is_config
   TARGET pybind11::headers
@@ -14,10 +20,6 @@ if(pybind11_FIND_QUIETLY)
   set(_pybind11_quiet QUIET)
 else()
   set(_pybind11_quiet "")
-endif()
-
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  message(FATAL_ERROR "You cannot use the new FindPython module with CMake < 3.12")
 endif()
 
 if(NOT Python_FOUND

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -5,6 +5,11 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
+# include_guard(global) (pre-CMake 3.10)
+if(TARGET pybind11::python_headers)
+  return()
+endif()
+
 # Built-in in CMake 3.5+
 include(CMakeParseArguments)
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Conan wasn't supported, now it is. Closes #3388.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Support multiple raw inclusion of CMake helper files (Conan.io does this for multi-config generators).
```

<!-- If the upgrade guide needs updating, note that here too -->
