### PR TITLE
fix: avoiding usage of _ if already defined

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Setup Boost (Linux)
-      if: runner.os == 'Linux'
+      # Can't use boost + define _
+      if: runner.os == 'Linux' && matrix.python != '3.6'
       run: sudo apt-get install libboost-dev
 
     - name: Setup Boost (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
             python: '3.6'
             args: >
               -DPYBIND11_FINDPYTHON=ON
+              -DCMAKE_CXX_FLAGS="-D_=1"
           - runs-on: windows-latest
             python: '3.6'
             args: >

--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -46,7 +46,7 @@ type is explicitly allowed.
              * function signatures and declares a local variable
              * 'value' of type inty
              */
-            PYBIND11_TYPE_CASTER(inty, _("inty"));
+            PYBIND11_TYPE_CASTER(inty, const_str("inty"));
 
             /**
              * Conversion part 1 (Python->C++): convert a PyObject into a inty

--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -46,7 +46,7 @@ type is explicitly allowed.
              * function signatures and declares a local variable
              * 'value' of type inty
              */
-            PYBIND11_TYPE_CASTER(inty, const_str("inty"));
+            PYBIND11_TYPE_CASTER(inty, const_name("inty"));
 
             /**
              * Conversion part 1 (Python->C++): convert a PyObject into a inty

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -17,6 +17,10 @@ v2.9
   converted to using ``py::module_::import("types").attr("SimpleNamespace")``
   instead.
 
+* The use of ``_`` in custom type casters can now be replaced with the more
+  readable ``const_str`` instead. The old ``_`` shortcut has been retained
+  unless it is being used as a macro (like for gettext).
+
 
 .. _upgrade-guide-2.7:
 

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -18,7 +18,7 @@ v2.9
   instead.
 
 * The use of ``_`` in custom type casters can now be replaced with the more
-  readable ``const_str`` instead. The old ``_`` shortcut has been retained
+  readable ``const_name`` instead. The old ``_`` shortcut has been retained
   unless it is being used as a macro (like for gettext).
 
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -208,7 +208,7 @@ public:
         return PyLong_FromUnsignedLongLong((unsigned long long) src);
     }
 
-    PYBIND11_TYPE_CASTER(T, _<std::is_integral<T>::value>("int", "float"));
+    PYBIND11_TYPE_CASTER(T, const_str<std::is_integral<T>::value>("int", "float"));
 };
 
 template<typename T> struct void_caster {
@@ -221,7 +221,7 @@ public:
     static handle cast(T, return_value_policy /* policy */, handle /* parent */) {
         return none().inc_ref();
     }
-    PYBIND11_TYPE_CASTER(T, _("None"));
+    PYBIND11_TYPE_CASTER(T, const_str("None"));
 };
 
 template <> class type_caster<void_type> : public void_caster<void_type> {};
@@ -264,7 +264,7 @@ public:
 
     template <typename T> using cast_op_type = void*&;
     explicit operator void *&() { return value; }
-    static constexpr auto name = _("capsule");
+    static constexpr auto name = const_str("capsule");
 private:
     void *value = nullptr;
 };
@@ -315,7 +315,7 @@ public:
     static handle cast(bool src, return_value_policy /* policy */, handle /* parent */) {
         return handle(src ? Py_True : Py_False).inc_ref();
     }
-    PYBIND11_TYPE_CASTER(bool, _("bool"));
+    PYBIND11_TYPE_CASTER(bool, const_str("bool"));
 };
 
 // Helper class for UTF-{8,16,32} C++ stl strings:
@@ -405,7 +405,7 @@ template <typename StringType, bool IsView = false> struct string_caster {
         return s;
     }
 
-    PYBIND11_TYPE_CASTER(StringType, _(PYBIND11_STRING_NAME));
+    PYBIND11_TYPE_CASTER(StringType, const_str(PYBIND11_STRING_NAME));
 
 private:
     static handle decode_utfN(const char *buffer, ssize_t nbytes) {
@@ -542,7 +542,7 @@ public:
         return one_char;
     }
 
-    static constexpr auto name = _(PYBIND11_STRING_NAME);
+    static constexpr auto name = const_str(PYBIND11_STRING_NAME);
     template <typename _T> using cast_op_type = pybind11::detail::cast_op_type<_T>;
 };
 
@@ -579,7 +579,7 @@ public:
         return cast(*src, policy, parent);
     }
 
-    static constexpr auto name = _("Tuple[") + concat(make_caster<Ts>::name...) + _("]");
+    static constexpr auto name = const_str("Tuple[") + concat(make_caster<Ts>::name...) + const_str("]");
 
     template <typename T> using cast_op_type = type;
 
@@ -764,14 +764,14 @@ template <typename base, typename holder> struct is_holder_type :
 template <typename base, typename deleter> struct is_holder_type<base, std::unique_ptr<base, deleter>> :
     std::true_type {};
 
-template <typename T> struct handle_type_name { static constexpr auto name = _<T>(); };
-template <> struct handle_type_name<bytes> { static constexpr auto name = _(PYBIND11_BYTES_NAME); };
-template <> struct handle_type_name<int_> { static constexpr auto name = _("int"); };
-template <> struct handle_type_name<iterable> { static constexpr auto name = _("Iterable"); };
-template <> struct handle_type_name<iterator> { static constexpr auto name = _("Iterator"); };
-template <> struct handle_type_name<none> { static constexpr auto name = _("None"); };
-template <> struct handle_type_name<args> { static constexpr auto name = _("*args"); };
-template <> struct handle_type_name<kwargs> { static constexpr auto name = _("**kwargs"); };
+template <typename T> struct handle_type_name { static constexpr auto name = const_str<T>(); };
+template <> struct handle_type_name<bytes> { static constexpr auto name = const_str(PYBIND11_BYTES_NAME); };
+template <> struct handle_type_name<int_> { static constexpr auto name = const_str("int"); };
+template <> struct handle_type_name<iterable> { static constexpr auto name = const_str("Iterable"); };
+template <> struct handle_type_name<iterator> { static constexpr auto name = const_str("Iterator"); };
+template <> struct handle_type_name<none> { static constexpr auto name = const_str("None"); };
+template <> struct handle_type_name<args> { static constexpr auto name = const_str("*args"); };
+template <> struct handle_type_name<kwargs> { static constexpr auto name = const_str("**kwargs"); };
 
 template <typename type>
 struct pyobject_caster {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -208,7 +208,7 @@ public:
         return PyLong_FromUnsignedLongLong((unsigned long long) src);
     }
 
-    PYBIND11_TYPE_CASTER(T, const_str<std::is_integral<T>::value>("int", "float"));
+    PYBIND11_TYPE_CASTER(T, const_name<std::is_integral<T>::value>("int", "float"));
 };
 
 template<typename T> struct void_caster {
@@ -221,7 +221,7 @@ public:
     static handle cast(T, return_value_policy /* policy */, handle /* parent */) {
         return none().inc_ref();
     }
-    PYBIND11_TYPE_CASTER(T, const_str("None"));
+    PYBIND11_TYPE_CASTER(T, const_name("None"));
 };
 
 template <> class type_caster<void_type> : public void_caster<void_type> {};
@@ -264,7 +264,7 @@ public:
 
     template <typename T> using cast_op_type = void*&;
     explicit operator void *&() { return value; }
-    static constexpr auto name = const_str("capsule");
+    static constexpr auto name = const_name("capsule");
 private:
     void *value = nullptr;
 };
@@ -315,7 +315,7 @@ public:
     static handle cast(bool src, return_value_policy /* policy */, handle /* parent */) {
         return handle(src ? Py_True : Py_False).inc_ref();
     }
-    PYBIND11_TYPE_CASTER(bool, const_str("bool"));
+    PYBIND11_TYPE_CASTER(bool, const_name("bool"));
 };
 
 // Helper class for UTF-{8,16,32} C++ stl strings:
@@ -405,7 +405,7 @@ template <typename StringType, bool IsView = false> struct string_caster {
         return s;
     }
 
-    PYBIND11_TYPE_CASTER(StringType, const_str(PYBIND11_STRING_NAME));
+    PYBIND11_TYPE_CASTER(StringType, const_name(PYBIND11_STRING_NAME));
 
 private:
     static handle decode_utfN(const char *buffer, ssize_t nbytes) {
@@ -542,7 +542,7 @@ public:
         return one_char;
     }
 
-    static constexpr auto name = const_str(PYBIND11_STRING_NAME);
+    static constexpr auto name = const_name(PYBIND11_STRING_NAME);
     template <typename _T> using cast_op_type = pybind11::detail::cast_op_type<_T>;
 };
 
@@ -579,7 +579,7 @@ public:
         return cast(*src, policy, parent);
     }
 
-    static constexpr auto name = const_str("Tuple[") + concat(make_caster<Ts>::name...) + const_str("]");
+    static constexpr auto name = const_name("Tuple[") + concat(make_caster<Ts>::name...) + const_name("]");
 
     template <typename T> using cast_op_type = type;
 
@@ -764,14 +764,14 @@ template <typename base, typename holder> struct is_holder_type :
 template <typename base, typename deleter> struct is_holder_type<base, std::unique_ptr<base, deleter>> :
     std::true_type {};
 
-template <typename T> struct handle_type_name { static constexpr auto name = const_str<T>(); };
-template <> struct handle_type_name<bytes> { static constexpr auto name = const_str(PYBIND11_BYTES_NAME); };
-template <> struct handle_type_name<int_> { static constexpr auto name = const_str("int"); };
-template <> struct handle_type_name<iterable> { static constexpr auto name = const_str("Iterable"); };
-template <> struct handle_type_name<iterator> { static constexpr auto name = const_str("Iterator"); };
-template <> struct handle_type_name<none> { static constexpr auto name = const_str("None"); };
-template <> struct handle_type_name<args> { static constexpr auto name = const_str("*args"); };
-template <> struct handle_type_name<kwargs> { static constexpr auto name = const_str("**kwargs"); };
+template <typename T> struct handle_type_name { static constexpr auto name = const_name<T>(); };
+template <> struct handle_type_name<bytes> { static constexpr auto name = const_name(PYBIND11_BYTES_NAME); };
+template <> struct handle_type_name<int_> { static constexpr auto name = const_name("int"); };
+template <> struct handle_type_name<iterable> { static constexpr auto name = const_name("Iterable"); };
+template <> struct handle_type_name<iterator> { static constexpr auto name = const_name("Iterator"); };
+template <> struct handle_type_name<none> { static constexpr auto name = const_name("None"); };
+template <> struct handle_type_name<args> { static constexpr auto name = const_name("*args"); };
+template <> struct handle_type_name<kwargs> { static constexpr auto name = const_name("**kwargs"); };
 
 template <typename type>
 struct pyobject_caster {

--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -97,7 +97,7 @@ public:
         return PyDelta_FromDSU(dd.count(), ss.count(), us.count());
     }
 
-    PYBIND11_TYPE_CASTER(type, _("datetime.timedelta"));
+    PYBIND11_TYPE_CASTER(type, const_str("datetime.timedelta"));
 };
 
 inline std::tm *localtime_thread_safe(const std::time_t *time, std::tm *buf) {
@@ -195,7 +195,7 @@ public:
                                           localtime.tm_sec,
                                           us.count());
     }
-    PYBIND11_TYPE_CASTER(type, _("datetime.datetime"));
+    PYBIND11_TYPE_CASTER(type, const_str("datetime.datetime"));
 };
 
 // Other clocks that are not the system clock are not measured as datetime.datetime objects

--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -97,7 +97,7 @@ public:
         return PyDelta_FromDSU(dd.count(), ss.count(), us.count());
     }
 
-    PYBIND11_TYPE_CASTER(type, const_str("datetime.timedelta"));
+    PYBIND11_TYPE_CASTER(type, const_name("datetime.timedelta"));
 };
 
 inline std::tm *localtime_thread_safe(const std::time_t *time, std::tm *buf) {
@@ -195,7 +195,7 @@ public:
                                           localtime.tm_sec,
                                           us.count());
     }
-    PYBIND11_TYPE_CASTER(type, const_str("datetime.datetime"));
+    PYBIND11_TYPE_CASTER(type, const_name("datetime.datetime"));
 };
 
 // Other clocks that are not the system clock are not measured as datetime.datetime objects

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -59,7 +59,7 @@ public:
         return PyComplex_FromDoubles((double) src.real(), (double) src.imag());
     }
 
-    PYBIND11_TYPE_CASTER(std::complex<T>, _("complex"));
+    PYBIND11_TYPE_CASTER(std::complex<T>, const_str("complex"));
 };
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -59,7 +59,7 @@ public:
         return PyComplex_FromDoubles((double) src.real(), (double) src.imag());
     }
 
-    PYBIND11_TYPE_CASTER(std::complex<T>, const_str("complex"));
+    PYBIND11_TYPE_CASTER(std::complex<T>, const_name("complex"));
 };
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -58,6 +58,7 @@ constexpr descr<N - 1> const_str(char const(&text)[N]) { return descr<N - 1>(tex
 constexpr descr<0> const_str(char const(&)[1]) { return {}; }
 
 // The "_" might be defined as a macro - don't define it if so.
+// Repeating the const_str code to avoid introducing a #define.
 #ifndef _
 template <size_t N>
 constexpr descr<N - 1> _(char const(&text)[N]) { return descr<N - 1>(text); }

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -54,11 +54,11 @@ constexpr descr<N1 + N2, Ts1..., Ts2...> operator+(const descr<N1, Ts1...> &a, c
 }
 
 template <size_t N>
-constexpr descr<N - 1> const_str(char const(&text)[N]) { return descr<N - 1>(text); }
-constexpr descr<0> const_str(char const(&)[1]) { return {}; }
+constexpr descr<N - 1> const_name(char const(&text)[N]) { return descr<N - 1>(text); }
+constexpr descr<0> const_name(char const(&)[1]) { return {}; }
 
 // The "_" might be defined as a macro - don't define it if so.
-// Repeating the const_str code to avoid introducing a #define.
+// Repeating the const_name code to avoid introducing a #define.
 #ifndef _
 template <size_t N>
 constexpr descr<N - 1> _(char const(&text)[N]) { return descr<N - 1>(text); }
@@ -72,25 +72,25 @@ template <size_t...Digits> struct int_to_str<0, Digits...> {
 
 // Ternary description (like std::conditional)
 template <bool B, size_t N1, size_t N2>
-constexpr enable_if_t<B, descr<N1 - 1>> const_str(char const(&text1)[N1], char const(&)[N2]) {
-    return const_str(text1);
+constexpr enable_if_t<B, descr<N1 - 1>> const_name(char const(&text1)[N1], char const(&)[N2]) {
+    return const_name(text1);
 }
 template <bool B, size_t N1, size_t N2>
-constexpr enable_if_t<!B, descr<N2 - 1>> const_str(char const(&)[N1], char const(&text2)[N2]) {
-    return const_str(text2);
+constexpr enable_if_t<!B, descr<N2 - 1>> const_name(char const(&)[N1], char const(&text2)[N2]) {
+    return const_name(text2);
 }
 
 template <bool B, typename T1, typename T2>
-constexpr enable_if_t<B, T1> const_str(const T1 &d, const T2 &) { return d; }
+constexpr enable_if_t<B, T1> const_name(const T1 &d, const T2 &) { return d; }
 template <bool B, typename T1, typename T2>
-constexpr enable_if_t<!B, T2> const_str(const T1 &, const T2 &d) { return d; }
+constexpr enable_if_t<!B, T2> const_name(const T1 &, const T2 &d) { return d; }
 
 template <size_t Size>
-auto constexpr const_str() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
+auto constexpr const_name() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
     return int_to_str<Size / 10, Size % 10>::digits;
 }
 
-template <typename Type> constexpr descr<1, Type> const_str() { return {'%'}; }
+template <typename Type> constexpr descr<1, Type> const_name() { return {'%'}; }
 
 constexpr descr<0> concat() { return {}; }
 
@@ -100,12 +100,12 @@ constexpr descr<N, Ts...> concat(const descr<N, Ts...> &descr) { return descr; }
 template <size_t N, typename... Ts, typename... Args>
 constexpr auto concat(const descr<N, Ts...> &d, const Args &...args)
     -> decltype(std::declval<descr<N + 2, Ts...>>() + concat(args...)) {
-    return d + const_str(", ") + concat(args...);
+    return d + const_name(", ") + concat(args...);
 }
 
 template <size_t N, typename... Ts>
 constexpr descr<N + 2, Ts...> type_descr(const descr<N, Ts...> &descr) {
-    return const_str("{") + descr + const_str("}");
+    return const_name("{") + descr + const_name("}");
 }
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -54,8 +54,15 @@ constexpr descr<N1 + N2, Ts1..., Ts2...> operator+(const descr<N1, Ts1...> &a, c
 }
 
 template <size_t N>
+constexpr descr<N - 1> const_str(char const(&text)[N]) { return descr<N - 1>(text); }
+constexpr descr<0> const_str(char const(&)[1]) { return {}; }
+
+// The "_" might be defined as a macro - don't define it if so.
+#ifndef _
+template <size_t N>
 constexpr descr<N - 1> _(char const(&text)[N]) { return descr<N - 1>(text); }
 constexpr descr<0> _(char const(&)[1]) { return {}; }
+#endif
 
 template <size_t Rem, size_t... Digits> struct int_to_str : int_to_str<Rem/10, Rem%10, Digits...> { };
 template <size_t...Digits> struct int_to_str<0, Digits...> {
@@ -64,25 +71,25 @@ template <size_t...Digits> struct int_to_str<0, Digits...> {
 
 // Ternary description (like std::conditional)
 template <bool B, size_t N1, size_t N2>
-constexpr enable_if_t<B, descr<N1 - 1>> _(char const(&text1)[N1], char const(&)[N2]) {
-    return _(text1);
+constexpr enable_if_t<B, descr<N1 - 1>> const_str(char const(&text1)[N1], char const(&)[N2]) {
+    return const_str(text1);
 }
 template <bool B, size_t N1, size_t N2>
-constexpr enable_if_t<!B, descr<N2 - 1>> _(char const(&)[N1], char const(&text2)[N2]) {
-    return _(text2);
+constexpr enable_if_t<!B, descr<N2 - 1>> const_str(char const(&)[N1], char const(&text2)[N2]) {
+    return const_str(text2);
 }
 
 template <bool B, typename T1, typename T2>
-constexpr enable_if_t<B, T1> _(const T1 &d, const T2 &) { return d; }
+constexpr enable_if_t<B, T1> const_str(const T1 &d, const T2 &) { return d; }
 template <bool B, typename T1, typename T2>
-constexpr enable_if_t<!B, T2> _(const T1 &, const T2 &d) { return d; }
+constexpr enable_if_t<!B, T2> const_str(const T1 &, const T2 &d) { return d; }
 
 template <size_t Size>
-auto constexpr _() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
+auto constexpr const_str() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
     return int_to_str<Size / 10, Size % 10>::digits;
 }
 
-template <typename Type> constexpr descr<1, Type> _() { return {'%'}; }
+template <typename Type> constexpr descr<1, Type> const_str() { return {'%'}; }
 
 constexpr descr<0> concat() { return {}; }
 
@@ -92,12 +99,12 @@ constexpr descr<N, Ts...> concat(const descr<N, Ts...> &descr) { return descr; }
 template <size_t N, typename... Ts, typename... Args>
 constexpr auto concat(const descr<N, Ts...> &d, const Args &...args)
     -> decltype(std::declval<descr<N + 2, Ts...>>() + concat(args...)) {
-    return d + _(", ") + concat(args...);
+    return d + const_str(", ") + concat(args...);
 }
 
 template <size_t N, typename... Ts>
 constexpr descr<N + 2, Ts...> type_descr(const descr<N, Ts...> &descr) {
-    return _("{") + descr + _("}");
+    return const_str("{") + descr + const_str("}");
 }
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -24,7 +24,7 @@ public:
 
     template <typename> using cast_op_type = value_and_holder &;
     explicit operator value_and_holder &() { return *value; }
-    static constexpr auto name = _<value_and_holder>();
+    static constexpr auto name = const_str<value_and_holder>();
 
 private:
     value_and_holder *value = nullptr;

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -24,7 +24,7 @@ public:
 
     template <typename> using cast_op_type = value_and_holder &;
     explicit operator value_and_holder &() { return *value; }
-    static constexpr auto name = const_str<value_and_holder>();
+    static constexpr auto name = const_name<value_and_holder>();
 
 private:
     value_and_holder *value = nullptr;

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -897,7 +897,7 @@ template <typename type> class type_caster_base : public type_caster_generic {
     using itype = intrinsic_t<type>;
 
 public:
-    static constexpr auto name = _<type>();
+    static constexpr auto name = const_str<type>();
 
     type_caster_base() : type_caster_base(typeid(type)) { }
     explicit type_caster_base(const std::type_info &info) : type_caster_generic(info) { }

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -897,7 +897,7 @@ template <typename type> class type_caster_base : public type_caster_generic {
     using itype = intrinsic_t<type>;
 
 public:
-    static constexpr auto name = const_str<type>();
+    static constexpr auto name = const_name<type>();
 
     type_caster_base() : type_caster_base(typeid(type)) { }
     explicit type_caster_base(const std::type_info &info) : type_caster_generic(info) { }

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -192,20 +192,20 @@ template <typename Type_> struct EigenProps {
     static constexpr bool show_f_contiguous = !show_c_contiguous && show_order && requires_col_major;
 
     static constexpr auto descriptor =
-        _("numpy.ndarray[") + npy_format_descriptor<Scalar>::name +
-        _("[")  + _<fixed_rows>(_<(size_t) rows>(), _("m")) +
-        _(", ") + _<fixed_cols>(_<(size_t) cols>(), _("n")) +
-        _("]") +
+        const_str("numpy.ndarray[") + npy_format_descriptor<Scalar>::name +
+        const_str("[")  + const_str<fixed_rows>(const_str<(size_t) rows>(), const_str("m")) +
+        const_str(", ") + const_str<fixed_cols>(const_str<(size_t) cols>(), const_str("n")) +
+        const_str("]") +
         // For a reference type (e.g. Ref<MatrixXd>) we have other constraints that might need to be
         // satisfied: writeable=True (for a mutable reference), and, depending on the map's stride
         // options, possibly f_contiguous or c_contiguous.  We include them in the descriptor output
         // to provide some hint as to why a TypeError is occurring (otherwise it can be confusing to
         // see that a function accepts a 'numpy.ndarray[float64[3,2]]' and an error message that you
         // *gave* a numpy.ndarray of the right type and dimensions.
-        _<show_writeable>(", flags.writeable", "") +
-        _<show_c_contiguous>(", flags.c_contiguous", "") +
-        _<show_f_contiguous>(", flags.f_contiguous", "") +
-        _("]");
+        const_str<show_writeable>(", flags.writeable", "") +
+        const_str<show_c_contiguous>(", flags.c_contiguous", "") +
+        const_str<show_f_contiguous>(", flags.f_contiguous", "") +
+        const_str("]");
 };
 
 // Casts an Eigen type to numpy array.  If given a base, the numpy array references the src data,
@@ -600,8 +600,8 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
         ).release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, _<(Type::IsRowMajor) != 0>("scipy.sparse.csr_matrix[", "scipy.sparse.csc_matrix[")
-            + npy_format_descriptor<Scalar>::name + _("]"));
+    PYBIND11_TYPE_CASTER(Type, const_str<(Type::IsRowMajor) != 0>("scipy.sparse.csr_matrix[", "scipy.sparse.csc_matrix[")
+            + npy_format_descriptor<Scalar>::name + const_str("]"));
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -192,20 +192,20 @@ template <typename Type_> struct EigenProps {
     static constexpr bool show_f_contiguous = !show_c_contiguous && show_order && requires_col_major;
 
     static constexpr auto descriptor =
-        const_str("numpy.ndarray[") + npy_format_descriptor<Scalar>::name +
-        const_str("[")  + const_str<fixed_rows>(const_str<(size_t) rows>(), const_str("m")) +
-        const_str(", ") + const_str<fixed_cols>(const_str<(size_t) cols>(), const_str("n")) +
-        const_str("]") +
+        const_name("numpy.ndarray[") + npy_format_descriptor<Scalar>::name +
+        const_name("[")  + const_name<fixed_rows>(const_name<(size_t) rows>(), const_name("m")) +
+        const_name(", ") + const_name<fixed_cols>(const_name<(size_t) cols>(), const_name("n")) +
+        const_name("]") +
         // For a reference type (e.g. Ref<MatrixXd>) we have other constraints that might need to be
         // satisfied: writeable=True (for a mutable reference), and, depending on the map's stride
         // options, possibly f_contiguous or c_contiguous.  We include them in the descriptor output
         // to provide some hint as to why a TypeError is occurring (otherwise it can be confusing to
         // see that a function accepts a 'numpy.ndarray[float64[3,2]]' and an error message that you
         // *gave* a numpy.ndarray of the right type and dimensions.
-        const_str<show_writeable>(", flags.writeable", "") +
-        const_str<show_c_contiguous>(", flags.c_contiguous", "") +
-        const_str<show_f_contiguous>(", flags.f_contiguous", "") +
-        const_str("]");
+        const_name<show_writeable>(", flags.writeable", "") +
+        const_name<show_c_contiguous>(", flags.c_contiguous", "") +
+        const_name<show_f_contiguous>(", flags.f_contiguous", "") +
+        const_name("]");
 };
 
 // Casts an Eigen type to numpy array.  If given a base, the numpy array references the src data,
@@ -600,8 +600,8 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
         ).release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, const_str<(Type::IsRowMajor) != 0>("scipy.sparse.csr_matrix[", "scipy.sparse.csc_matrix[")
-            + npy_format_descriptor<Scalar>::name + const_str("]"));
+    PYBIND11_TYPE_CASTER(Type, const_name<(Type::IsRowMajor) != 0>("scipy.sparse.csr_matrix[", "scipy.sparse.csc_matrix[")
+            + npy_format_descriptor<Scalar>::name + const_name("]"));
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -113,8 +113,8 @@ public:
         return cpp_function(std::forward<Func>(f_), policy).release();
     }
 
-    PYBIND11_TYPE_CASTER(type, _("Callable[[") + concat(make_caster<Args>::name...) + _("], ")
-                               + make_caster<retval_type>::name + _("]"));
+    PYBIND11_TYPE_CASTER(type, const_str("Callable[[") + concat(make_caster<Args>::name...) + const_str("], ")
+                               + make_caster<retval_type>::name + const_str("]"));
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -113,8 +113,8 @@ public:
         return cpp_function(std::forward<Func>(f_), policy).release();
     }
 
-    PYBIND11_TYPE_CASTER(type, const_str("Callable[[") + concat(make_caster<Args>::name...) + const_str("], ")
-                               + make_caster<retval_type>::name + const_str("]"));
+    PYBIND11_TYPE_CASTER(type, const_name("Callable[[") + concat(make_caster<Args>::name...) + const_name("], ")
+                               + make_caster<retval_type>::name + const_name("]"));
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -39,7 +39,7 @@ class array; // Forward declaration
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-template <> struct handle_type_name<array> { static constexpr auto name = _("numpy.ndarray"); };
+template <> struct handle_type_name<array> { static constexpr auto name = const_str("numpy.ndarray"); };
 
 template <typename type, typename SFINAE = void> struct npy_format_descriptor;
 
@@ -290,7 +290,7 @@ template <typename T> struct array_info_scalar {
     using type = T;
     static constexpr bool is_array = false;
     static constexpr bool is_empty = false;
-    static constexpr auto extents = _("");
+    static constexpr auto extents = const_str("");
     static void append_extents(list& /* shape */) { }
 };
 // Computes underlying type and a comma-separated list of extents for array
@@ -309,8 +309,8 @@ template <typename T, size_t N> struct array_info<std::array<T, N>> {
         array_info<T>::append_extents(shape);
     }
 
-    static constexpr auto extents = _<array_info<T>::is_array>(
-        concat(_<N>(), array_info<T>::extents), _<N>()
+    static constexpr auto extents = const_str<array_info<T>::is_array>(
+        concat(const_str<N>(), array_info<T>::extents), const_str<N>()
     );
 };
 // For numpy we have special handling for arrays of characters, so we don't include
@@ -1021,7 +1021,7 @@ template <typename T>
 struct format_descriptor<T, detail::enable_if_t<detail::array_info<T>::is_array>> {
     static std::string format() {
         using namespace detail;
-        static constexpr auto extents = _("(") + array_info<T>::extents + _(")");
+        static constexpr auto extents = const_str("(") + array_info<T>::extents + const_str(")");
         return extents.text + format_descriptor<remove_all_extents_t<T>>::format();
     }
 };
@@ -1056,28 +1056,28 @@ struct npy_format_descriptor_name;
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_integral<T>::value>> {
-    static constexpr auto name = _<std::is_same<T, bool>::value>(
-        _("bool"), _<std::is_signed<T>::value>("numpy.int", "numpy.uint") + _<sizeof(T)*8>()
+    static constexpr auto name = const_str<std::is_same<T, bool>::value>(
+        const_str("bool"), const_str<std::is_signed<T>::value>("numpy.int", "numpy.uint") + const_str<sizeof(T)*8>()
     );
 };
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_floating_point<T>::value>> {
-    static constexpr auto name = _<std::is_same<T, float>::value
+    static constexpr auto name = const_str<std::is_same<T, float>::value
                                    || std::is_same<T, const float>::value
                                    || std::is_same<T, double>::value
                                    || std::is_same<T, const double>::value>(
-        _("numpy.float") + _<sizeof(T)*8>(), _("numpy.longdouble")
+        const_str("numpy.float") + const_str<sizeof(T)*8>(), const_str("numpy.longdouble")
     );
 };
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<is_complex<T>::value>> {
-    static constexpr auto name = _<std::is_same<typename T::value_type, float>::value
+    static constexpr auto name = const_str<std::is_same<typename T::value_type, float>::value
                                    || std::is_same<typename T::value_type, const float>::value
                                    || std::is_same<typename T::value_type, double>::value
                                    || std::is_same<typename T::value_type, const double>::value>(
-        _("numpy.complex") + _<sizeof(typename T::value_type)*16>(), _("numpy.longcomplex")
+        const_str("numpy.complex") + const_str<sizeof(typename T::value_type)*16>(), const_str("numpy.longcomplex")
     );
 };
 
@@ -1105,7 +1105,7 @@ public:
 };
 
 #define PYBIND11_DECL_CHAR_FMT \
-    static constexpr auto name = _("S") + _<N>(); \
+    static constexpr auto name = const_str("S") + const_str<N>(); \
     static pybind11::dtype dtype() { return pybind11::dtype(std::string("S") + std::to_string(N)); }
 template <size_t N> struct npy_format_descriptor<char[N]> { PYBIND11_DECL_CHAR_FMT };
 template <size_t N> struct npy_format_descriptor<std::array<char, N>> { PYBIND11_DECL_CHAR_FMT };
@@ -1117,7 +1117,7 @@ private:
 public:
     static_assert(!array_info<T>::is_empty, "Zero-sized arrays are not supported");
 
-    static constexpr auto name = _("(") + array_info<T>::extents + _(")") + base_descr::name;
+    static constexpr auto name = const_str("(") + array_info<T>::extents + const_str(")") + base_descr::name;
     static pybind11::dtype dtype() {
         list shape;
         array_info<T>::append_extents(shape);
@@ -1705,7 +1705,7 @@ vectorize_extractor(const Func &f, Return (*) (Args ...)) {
 }
 
 template <typename T, int Flags> struct handle_type_name<array_t<T, Flags>> {
-    static constexpr auto name = _("numpy.ndarray[") + npy_format_descriptor<T>::name + _("]");
+    static constexpr auto name = const_str("numpy.ndarray[") + npy_format_descriptor<T>::name + const_str("]");
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -39,7 +39,7 @@ class array; // Forward declaration
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-template <> struct handle_type_name<array> { static constexpr auto name = const_str("numpy.ndarray"); };
+template <> struct handle_type_name<array> { static constexpr auto name = const_name("numpy.ndarray"); };
 
 template <typename type, typename SFINAE = void> struct npy_format_descriptor;
 
@@ -290,7 +290,7 @@ template <typename T> struct array_info_scalar {
     using type = T;
     static constexpr bool is_array = false;
     static constexpr bool is_empty = false;
-    static constexpr auto extents = const_str("");
+    static constexpr auto extents = const_name("");
     static void append_extents(list& /* shape */) { }
 };
 // Computes underlying type and a comma-separated list of extents for array
@@ -309,8 +309,8 @@ template <typename T, size_t N> struct array_info<std::array<T, N>> {
         array_info<T>::append_extents(shape);
     }
 
-    static constexpr auto extents = const_str<array_info<T>::is_array>(
-        concat(const_str<N>(), array_info<T>::extents), const_str<N>()
+    static constexpr auto extents = const_name<array_info<T>::is_array>(
+        concat(const_name<N>(), array_info<T>::extents), const_name<N>()
     );
 };
 // For numpy we have special handling for arrays of characters, so we don't include
@@ -1021,7 +1021,7 @@ template <typename T>
 struct format_descriptor<T, detail::enable_if_t<detail::array_info<T>::is_array>> {
     static std::string format() {
         using namespace detail;
-        static constexpr auto extents = const_str("(") + array_info<T>::extents + const_str(")");
+        static constexpr auto extents = const_name("(") + array_info<T>::extents + const_name(")");
         return extents.text + format_descriptor<remove_all_extents_t<T>>::format();
     }
 };
@@ -1056,28 +1056,28 @@ struct npy_format_descriptor_name;
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_integral<T>::value>> {
-    static constexpr auto name = const_str<std::is_same<T, bool>::value>(
-        const_str("bool"), const_str<std::is_signed<T>::value>("numpy.int", "numpy.uint") + const_str<sizeof(T)*8>()
+    static constexpr auto name = const_name<std::is_same<T, bool>::value>(
+        const_name("bool"), const_name<std::is_signed<T>::value>("numpy.int", "numpy.uint") + const_name<sizeof(T)*8>()
     );
 };
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_floating_point<T>::value>> {
-    static constexpr auto name = const_str<std::is_same<T, float>::value
+    static constexpr auto name = const_name<std::is_same<T, float>::value
                                    || std::is_same<T, const float>::value
                                    || std::is_same<T, double>::value
                                    || std::is_same<T, const double>::value>(
-        const_str("numpy.float") + const_str<sizeof(T)*8>(), const_str("numpy.longdouble")
+        const_name("numpy.float") + const_name<sizeof(T)*8>(), const_name("numpy.longdouble")
     );
 };
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<is_complex<T>::value>> {
-    static constexpr auto name = const_str<std::is_same<typename T::value_type, float>::value
+    static constexpr auto name = const_name<std::is_same<typename T::value_type, float>::value
                                    || std::is_same<typename T::value_type, const float>::value
                                    || std::is_same<typename T::value_type, double>::value
                                    || std::is_same<typename T::value_type, const double>::value>(
-        const_str("numpy.complex") + const_str<sizeof(typename T::value_type)*16>(), const_str("numpy.longcomplex")
+        const_name("numpy.complex") + const_name<sizeof(typename T::value_type)*16>(), const_name("numpy.longcomplex")
     );
 };
 
@@ -1105,7 +1105,7 @@ public:
 };
 
 #define PYBIND11_DECL_CHAR_FMT \
-    static constexpr auto name = const_str("S") + const_str<N>(); \
+    static constexpr auto name = const_name("S") + const_name<N>(); \
     static pybind11::dtype dtype() { return pybind11::dtype(std::string("S") + std::to_string(N)); }
 template <size_t N> struct npy_format_descriptor<char[N]> { PYBIND11_DECL_CHAR_FMT };
 template <size_t N> struct npy_format_descriptor<std::array<char, N>> { PYBIND11_DECL_CHAR_FMT };
@@ -1117,7 +1117,7 @@ private:
 public:
     static_assert(!array_info<T>::is_empty, "Zero-sized arrays are not supported");
 
-    static constexpr auto name = const_str("(") + array_info<T>::extents + const_str(")") + base_descr::name;
+    static constexpr auto name = const_name("(") + array_info<T>::extents + const_name(")") + base_descr::name;
     static pybind11::dtype dtype() {
         list shape;
         array_info<T>::append_extents(shape);
@@ -1705,7 +1705,7 @@ vectorize_extractor(const Func &f, Return (*) (Args ...)) {
 }
 
 template <typename T, int Flags> struct handle_type_name<array_t<T, Flags>> {
-    static constexpr auto name = const_str("numpy.ndarray[") + npy_format_descriptor<T>::name + const_str("]");
+    static constexpr auto name = const_name("numpy.ndarray[") + npy_format_descriptor<T>::name + const_name("]");
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -262,7 +262,7 @@ protected:
         }
 
         /* Generate a readable signature describing the function's arguments and return value types */
-        static constexpr auto signature = _("(") + cast_in::arg_names + _(") -> ") + cast_out::name;
+        static constexpr auto signature = const_str("(") + cast_in::arg_names + const_str(") -> ") + cast_out::name;
         PYBIND11_DESCR_CONSTEXPR auto types = decltype(signature)::types();
 
         /* Register the function with Python from generic (non-templated) code */

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -262,7 +262,7 @@ protected:
         }
 
         /* Generate a readable signature describing the function's arguments and return value types */
-        static constexpr auto signature = const_str("(") + cast_in::arg_names + const_str(") -> ") + cast_out::name;
+        static constexpr auto signature = const_name("(") + cast_in::arg_names + const_name(") -> ") + cast_out::name;
         PYBIND11_DESCR_CONSTEXPR auto types = decltype(signature)::types();
 
         /* Register the function with Python from generic (non-templated) code */

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -435,7 +435,7 @@ inline void raise_from(error_already_set& err, PyObject *type, const char *messa
 
 #endif
 
-/** \defgroup python_builtins _
+/** \defgroup python_builtins const_str
     Unless stated otherwise, the following C++ functions behave the same
     as their Python counterparts.
  */

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -435,7 +435,7 @@ inline void raise_from(error_already_set& err, PyObject *type, const char *messa
 
 #endif
 
-/** \defgroup python_builtins const_str
+/** \defgroup python_builtins const_name
     Unless stated otherwise, the following C++ functions behave the same
     as their Python counterparts.
  */

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -78,7 +78,7 @@ template <typename Type, typename Key> struct set_caster {
         return s.release();
     }
 
-    PYBIND11_TYPE_CASTER(type, _("Set[") + key_conv::name + _("]"));
+    PYBIND11_TYPE_CASTER(type, const_str("Set[") + key_conv::name + const_str("]"));
 };
 
 template <typename Type, typename Key, typename Value> struct map_caster {
@@ -120,7 +120,7 @@ template <typename Type, typename Key, typename Value> struct map_caster {
         return d.release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, _("Dict[") + key_conv::name + _(", ") + value_conv::name + _("]"));
+    PYBIND11_TYPE_CASTER(Type, const_str("Dict[") + key_conv::name + const_str(", ") + value_conv::name + const_str("]"));
 };
 
 template <typename Type, typename Value> struct list_caster {
@@ -166,7 +166,7 @@ public:
         return l.release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, _("List[") + value_conv::name + _("]"));
+    PYBIND11_TYPE_CASTER(Type, const_str("List[") + value_conv::name + const_str("]"));
 };
 
 template <typename Type, typename Alloc> struct type_caster<std::vector<Type, Alloc>>
@@ -223,7 +223,7 @@ public:
         return l.release();
     }
 
-    PYBIND11_TYPE_CASTER(ArrayType, _("List[") + value_conv::name + _<Resizable>(_(""), _("[") + _<Size>() + _("]")) + _("]"));
+    PYBIND11_TYPE_CASTER(ArrayType, const_str("List[") + value_conv::name + const_str<Resizable>(const_str(""), const_str("[") + const_str<Size>() + const_str("]")) + const_str("]"));
 };
 
 template <typename Type, size_t Size> struct type_caster<std::array<Type, Size>>
@@ -273,7 +273,7 @@ template<typename Type, typename Value = typename Type::value_type> struct optio
         return true;
     }
 
-    PYBIND11_TYPE_CASTER(Type, _("Optional[") + value_conv::name + _("]"));
+    PYBIND11_TYPE_CASTER(Type, const_str("Optional[") + value_conv::name + const_str("]"));
 };
 
 #if defined(PYBIND11_HAS_OPTIONAL)
@@ -353,7 +353,7 @@ struct variant_caster<V<Ts...>> {
     }
 
     using Type = V<Ts...>;
-    PYBIND11_TYPE_CASTER(Type, _("Union[") + detail::concat(make_caster<Ts>::name...) + _("]"));
+    PYBIND11_TYPE_CASTER(Type, const_str("Union[") + detail::concat(make_caster<Ts>::name...) + const_str("]"));
 };
 
 #if defined(PYBIND11_HAS_VARIANT)

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -78,7 +78,7 @@ template <typename Type, typename Key> struct set_caster {
         return s.release();
     }
 
-    PYBIND11_TYPE_CASTER(type, const_str("Set[") + key_conv::name + const_str("]"));
+    PYBIND11_TYPE_CASTER(type, const_name("Set[") + key_conv::name + const_name("]"));
 };
 
 template <typename Type, typename Key, typename Value> struct map_caster {
@@ -120,7 +120,7 @@ template <typename Type, typename Key, typename Value> struct map_caster {
         return d.release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, const_str("Dict[") + key_conv::name + const_str(", ") + value_conv::name + const_str("]"));
+    PYBIND11_TYPE_CASTER(Type, const_name("Dict[") + key_conv::name + const_name(", ") + value_conv::name + const_name("]"));
 };
 
 template <typename Type, typename Value> struct list_caster {
@@ -166,7 +166,7 @@ public:
         return l.release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, const_str("List[") + value_conv::name + const_str("]"));
+    PYBIND11_TYPE_CASTER(Type, const_name("List[") + value_conv::name + const_name("]"));
 };
 
 template <typename Type, typename Alloc> struct type_caster<std::vector<Type, Alloc>>
@@ -223,7 +223,7 @@ public:
         return l.release();
     }
 
-    PYBIND11_TYPE_CASTER(ArrayType, const_str("List[") + value_conv::name + const_str<Resizable>(const_str(""), const_str("[") + const_str<Size>() + const_str("]")) + const_str("]"));
+    PYBIND11_TYPE_CASTER(ArrayType, const_name("List[") + value_conv::name + const_name<Resizable>(const_name(""), const_name("[") + const_name<Size>() + const_name("]")) + const_name("]"));
 };
 
 template <typename Type, size_t Size> struct type_caster<std::array<Type, Size>>
@@ -273,7 +273,7 @@ template<typename Type, typename Value = typename Type::value_type> struct optio
         return true;
     }
 
-    PYBIND11_TYPE_CASTER(Type, const_str("Optional[") + value_conv::name + const_str("]"));
+    PYBIND11_TYPE_CASTER(Type, const_name("Optional[") + value_conv::name + const_name("]"));
 };
 
 #if defined(PYBIND11_HAS_OPTIONAL)
@@ -353,7 +353,7 @@ struct variant_caster<V<Ts...>> {
     }
 
     using Type = V<Ts...>;
-    PYBIND11_TYPE_CASTER(Type, const_str("Union[") + detail::concat(make_caster<Ts>::name...) + const_str("]"));
+    PYBIND11_TYPE_CASTER(Type, const_name("Union[") + detail::concat(make_caster<Ts>::name...) + const_name("]"));
 };
 
 #if defined(PYBIND11_HAS_VARIANT)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -92,7 +92,7 @@ public:
         return true;
     }
 
-    PYBIND11_TYPE_CASTER(T, _("os.PathLike"));
+    PYBIND11_TYPE_CASTER(T, const_str("os.PathLike"));
 };
 
 template<> struct type_caster<std::filesystem::path>

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -92,7 +92,7 @@ public:
         return true;
     }
 
-    PYBIND11_TYPE_CASTER(T, const_str("os.PathLike"));
+    PYBIND11_TYPE_CASTER(T, const_name("os.PathLike"));
 };
 
 template<> struct type_caster<std::filesystem::path>

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -65,7 +65,7 @@ PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
 template<> class type_caster<RValueCaster> {
 public:
-    PYBIND11_TYPE_CASTER(RValueCaster, _("RValueCaster"));
+    PYBIND11_TYPE_CASTER(RValueCaster, const_str("RValueCaster"));
     static handle cast(RValueCaster &&, return_value_policy, handle) { return py::str("rvalue").release(); }
     static handle cast(const RValueCaster &, return_value_policy, handle) { return py::str("lvalue").release(); }
 };

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -65,7 +65,7 @@ PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
 template<> class type_caster<RValueCaster> {
 public:
-    PYBIND11_TYPE_CASTER(RValueCaster, const_str("RValueCaster"));
+    PYBIND11_TYPE_CASTER(RValueCaster, const_name("RValueCaster"));
     static handle cast(RValueCaster &&, return_value_policy, handle) { return py::str("rvalue").release(); }
     static handle cast(const RValueCaster &, return_value_policy, handle) { return py::str("lvalue").release(); }
 };

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -19,7 +19,7 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 template <>
 class type_caster<ConstRefCasted> {
  public:
-  static constexpr auto name = _<ConstRefCasted>();
+  static constexpr auto name = const_str<ConstRefCasted>();
 
   // Input is unimportant, a new value will always be constructed based on the
   // cast operator.

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -19,7 +19,7 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 template <>
 class type_caster<ConstRefCasted> {
  public:
-  static constexpr auto name = const_str<ConstRefCasted>();
+  static constexpr auto name = const_name<ConstRefCasted>();
 
   // Input is unimportant, a new value will always be constructed based on the
   // cast operator.

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -85,13 +85,13 @@ public:
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
 template <> struct type_caster<MoveOnlyInt> {
-    PYBIND11_TYPE_CASTER(MoveOnlyInt, _("MoveOnlyInt"));
+    PYBIND11_TYPE_CASTER(MoveOnlyInt, const_str("MoveOnlyInt"));
     bool load(handle src, bool) { value = MoveOnlyInt(src.cast<int>()); return true; }
     static handle cast(const MoveOnlyInt &m, return_value_policy r, handle p) { return pybind11::cast(m.value, r, p); }
 };
 
 template <> struct type_caster<MoveOrCopyInt> {
-    PYBIND11_TYPE_CASTER(MoveOrCopyInt, _("MoveOrCopyInt"));
+    PYBIND11_TYPE_CASTER(MoveOrCopyInt, const_str("MoveOrCopyInt"));
     bool load(handle src, bool) { value = MoveOrCopyInt(src.cast<int>()); return true; }
     static handle cast(const MoveOrCopyInt &m, return_value_policy r, handle p) { return pybind11::cast(m.value, r, p); }
 };
@@ -100,7 +100,7 @@ template <> struct type_caster<CopyOnlyInt> {
 protected:
     CopyOnlyInt value;
 public:
-    static constexpr auto name = _("CopyOnlyInt");
+    static constexpr auto name = const_str("CopyOnlyInt");
     bool load(handle src, bool) { value = CopyOnlyInt(src.cast<int>()); return true; }
     static handle cast(const CopyOnlyInt &m, return_value_policy r, handle p) { return pybind11::cast(m.value, r, p); }
     static handle cast(const CopyOnlyInt *src, return_value_policy policy, handle parent) {

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -85,13 +85,13 @@ public:
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
 template <> struct type_caster<MoveOnlyInt> {
-    PYBIND11_TYPE_CASTER(MoveOnlyInt, const_str("MoveOnlyInt"));
+    PYBIND11_TYPE_CASTER(MoveOnlyInt, const_name("MoveOnlyInt"));
     bool load(handle src, bool) { value = MoveOnlyInt(src.cast<int>()); return true; }
     static handle cast(const MoveOnlyInt &m, return_value_policy r, handle p) { return pybind11::cast(m.value, r, p); }
 };
 
 template <> struct type_caster<MoveOrCopyInt> {
-    PYBIND11_TYPE_CASTER(MoveOrCopyInt, const_str("MoveOrCopyInt"));
+    PYBIND11_TYPE_CASTER(MoveOrCopyInt, const_name("MoveOrCopyInt"));
     bool load(handle src, bool) { value = MoveOrCopyInt(src.cast<int>()); return true; }
     static handle cast(const MoveOrCopyInt &m, return_value_policy r, handle p) { return pybind11::cast(m.value, r, p); }
 };
@@ -100,7 +100,7 @@ template <> struct type_caster<CopyOnlyInt> {
 protected:
     CopyOnlyInt value;
 public:
-    static constexpr auto name = const_str("CopyOnlyInt");
+    static constexpr auto name = const_name("CopyOnlyInt");
     bool load(handle src, bool) { value = CopyOnlyInt(src.cast<int>()); return true; }
     static handle cast(const CopyOnlyInt &m, return_value_policy r, handle p) { return pybind11::cast(m.value, r, p); }
     static handle cast(const CopyOnlyInt *src, return_value_policy policy, handle parent) {

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -22,7 +22,7 @@ public:
 #ifndef _
     PYBIND11_TYPE_CASTER(ArgInspector1, _("ArgInspector1"));
 #else
-    PYBIND11_TYPE_CASTER(ArgInspector1, const_str("ArgInspector1"));
+    PYBIND11_TYPE_CASTER(ArgInspector1, const_name("ArgInspector1"));
 #endif
 
     bool load(handle src, bool convert) {
@@ -38,7 +38,7 @@ public:
 };
 template <> struct type_caster<ArgInspector2> {
 public:
-    PYBIND11_TYPE_CASTER(ArgInspector2, const_str("ArgInspector2"));
+    PYBIND11_TYPE_CASTER(ArgInspector2, const_name("ArgInspector2"));
 
     bool load(handle src, bool convert) {
         value.arg = "loading ArgInspector2 argument " +
@@ -53,7 +53,7 @@ public:
 };
 template <> struct type_caster<ArgAlwaysConverts> {
 public:
-    PYBIND11_TYPE_CASTER(ArgAlwaysConverts, const_str("ArgAlwaysConverts"));
+    PYBIND11_TYPE_CASTER(ArgAlwaysConverts, const_name("ArgAlwaysConverts"));
 
     bool load(handle, bool convert) {
         return convert;
@@ -81,7 +81,7 @@ public:
 };
 namespace pybind11 { namespace detail {
 template <> struct type_caster<DestructionTester> {
-    PYBIND11_TYPE_CASTER(DestructionTester, const_str("DestructionTester"));
+    PYBIND11_TYPE_CASTER(DestructionTester, const_name("DestructionTester"));
     bool load(handle, bool) { return true; }
 
     static handle cast(const DestructionTester &, return_value_policy, handle) {

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -18,7 +18,12 @@ class ArgAlwaysConverts { };
 namespace pybind11 { namespace detail {
 template <> struct type_caster<ArgInspector1> {
 public:
+    // Classic
+#ifndef _
+    PYBIND11_TYPE_CASTER(ArgInspector1, _("ArgInspector1"));
+#else
     PYBIND11_TYPE_CASTER(ArgInspector1, const_str("ArgInspector1"));
+#endif
 
     bool load(handle src, bool convert) {
         value.arg = "loading ArgInspector1 argument " +

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -18,7 +18,7 @@ class ArgAlwaysConverts { };
 namespace pybind11 { namespace detail {
 template <> struct type_caster<ArgInspector1> {
 public:
-    PYBIND11_TYPE_CASTER(ArgInspector1, _("ArgInspector1"));
+    PYBIND11_TYPE_CASTER(ArgInspector1, const_str("ArgInspector1"));
 
     bool load(handle src, bool convert) {
         value.arg = "loading ArgInspector1 argument " +
@@ -33,7 +33,7 @@ public:
 };
 template <> struct type_caster<ArgInspector2> {
 public:
-    PYBIND11_TYPE_CASTER(ArgInspector2, _("ArgInspector2"));
+    PYBIND11_TYPE_CASTER(ArgInspector2, const_str("ArgInspector2"));
 
     bool load(handle src, bool convert) {
         value.arg = "loading ArgInspector2 argument " +
@@ -48,7 +48,7 @@ public:
 };
 template <> struct type_caster<ArgAlwaysConverts> {
 public:
-    PYBIND11_TYPE_CASTER(ArgAlwaysConverts, _("ArgAlwaysConverts"));
+    PYBIND11_TYPE_CASTER(ArgAlwaysConverts, const_str("ArgAlwaysConverts"));
 
     bool load(handle, bool convert) {
         return convert;
@@ -76,7 +76,7 @@ public:
 };
 namespace pybind11 { namespace detail {
 template <> struct type_caster<DestructionTester> {
-    PYBIND11_TYPE_CASTER(DestructionTester, _("DestructionTester"));
+    PYBIND11_TYPE_CASTER(DestructionTester, const_str("DestructionTester"));
     bool load(handle, bool) { return true; }
 
     static handle cast(const DestructionTester &, return_value_policy, handle) {


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Closes #3401 by avoiding using a raw `_`.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Replace ``_`` with ``const_name`` in internals, avoid defining ``pybind::_`` if ``_`` defined as macro (common gettext usage).
```

<!-- If the upgrade guide needs updating, note that here too -->
