### PR TITLE
Updated bug in Object oriented examples

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -27,7 +27,7 @@ The binding code for ``Pet`` looks as follows:
 
     namespace py = pybind11;
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(Pet, m) {
         py::class_<Pet>(m, "Pet")
             .def(py::init<const std::string &>())
             .def("setName", &Pet::setName)


### PR DESCRIPTION
The pybind11 documentation still refers to example instead of the Pet module https://pybind11.readthedocs.io/en/stable/classes.html#creating-bindings-for-a-custom-type
I came across this issue, bug the documentation still has a bug in it.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
