### PR TITLE
Don't add -g0 to Pybind11Extension if $CFLAGS sets -g.

### DIFF
--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import contextlib
 import os
 import platform
+import shlex
 import shutil
 import sys
 import sysconfig
@@ -143,7 +144,12 @@ class Pybind11Extension(_Extension):
         if WIN:
             cflags += ["/EHsc", "/bigobj"]
         else:
-            cflags += ["-fvisibility=hidden", "-g0"]
+            cflags += ["-fvisibility=hidden"]
+            env_cflags = os.environ.get("CFLAGS", "")
+            env_cppflags = os.environ.get("CPPFLAGS", "")
+            c_cpp_flags = shlex.split(env_cflags) + shlex.split(env_cppflags)
+            if not any(opt.startswith("-g") for opt in c_cpp_flags):
+                cflags += ["-g0"]
             if MACOS:
                 cflags += ["-stdlib=libc++"]
                 ldflags += ["-stdlib=libc++"]


### PR DESCRIPTION
On Unix, setuptools prepends $CFLAGS and $CPPFLAGS to the compiler flags
(they always come before extra_compile_args and anything else; see
distutils.sysconfig.customize_compiler).  In practice, the environment
variables are useful e.g. to quickly generate a debug build (e.g. by
setting CFLAGS=-g), but Pybind11Extension currently unconditionally
overwrites this with -g0.

Instead, check the environment variables and only insert -g0 if not
overridden by them.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Flags starting with ``-g`` in ``$CFLAGS`` and ``$CPPFLAGS`` are no longer overridden by ``.Pybind11Extension``.
```

<!-- If the upgrade guide needs updating, note that here too -->
