### PR TITLE
fix: add missing std::forward calls

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -115,7 +115,7 @@ public:
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     // NOLINTNEXTLINE(google-explicit-constructor)
     cpp_function(Return (Class::*f)(Arg...)&, const Extra&... extra) {
-        initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(args...); },
+        initialize([f](Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
                    (Return (*) (Class *, Arg...)) nullptr, extra...);
     }
 
@@ -133,7 +133,7 @@ public:
     template <typename Return, typename Class, typename... Arg, typename... Extra>
     // NOLINTNEXTLINE(google-explicit-constructor)
     cpp_function(Return (Class::*f)(Arg...) const&, const Extra&... extra) {
-        initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(args...); },
+        initialize([f](const Class *c, Arg... args) -> Return { return (c->*f)(std::forward<Arg>(args)...); },
                    (Return (*)(const Class *, Arg ...)) nullptr, extra...);
     }
 

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -161,10 +161,10 @@ struct RefQualified {
 
 // Test rvalue ref param
 struct RValueRefParam {
-    int func1(std::string&& s) { return s.size(); }
-    int func2(std::string&& s) const { return s.size(); }
-    int func3(std::string&& s) & { return s.size(); }
-    int func4(std::string&& s) const & { return s.size(); }
+    std::size_t func1(std::string&& s) { return s.size(); }
+    std::size_t func2(std::string&& s) const { return s.size(); }
+    std::size_t func3(std::string&& s) & { return s.size(); }
+    std::size_t func4(std::string&& s) const & { return s.size(); }
 };
 
 TEST_SUBMODULE(methods_and_attributes, m) {

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -159,12 +159,12 @@ struct RefQualified {
     int constRefQualified(int other) const & { return value + other; }
 };
 
-// Test rvalue param
-struct RValueParam {
-    void func1(std::string&&) {}
-    void func2(std::string&&) const {}
-    void func3(std::string&&) & {}
-    void func4(std::string&&) const & {}
+// Test rvalue ref param
+struct RValueRefParam {
+    int func1(std::string&& s) { return s.size(); }
+    int func2(std::string&& s) const { return s.size(); }
+    int func3(std::string&& s) & { return s.size(); }
+    int func4(std::string&& s) const & { return s.size(); }
 };
 
 TEST_SUBMODULE(methods_and_attributes, m) {
@@ -418,10 +418,10 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         .def("refQualified", &RefQualified::refQualified)
         .def("constRefQualified", &RefQualified::constRefQualified);
 
-    py::class_<RValueParam>(m, "RValueParam")
+    py::class_<RValueRefParam>(m, "RValueRefParam")
         .def(py::init<>())
-        .def("func1", &RValueParam::func1)
-        .def("func2", &RValueParam::func2)
-        .def("func3", &RValueParam::func3)
-        .def("func4", &RValueParam::func4);
+        .def("func1", &RValueRefParam::func1)
+        .def("func2", &RValueRefParam::func2)
+        .def("func3", &RValueRefParam::func3)
+        .def("func4", &RValueRefParam::func4);
 }

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -159,6 +159,14 @@ struct RefQualified {
     int constRefQualified(int other) const & { return value + other; }
 };
 
+// Test rvalue param
+struct RValueParam {
+    void func1(std::string&&) {}
+    void func2(std::string&&) const {}
+    void func3(std::string&&) & {}
+    void func4(std::string&&) const & {}
+};
+
 TEST_SUBMODULE(methods_and_attributes, m) {
     // test_methods_and_attributes
     py::class_<ExampleMandA> emna(m, "ExampleMandA");
@@ -409,4 +417,11 @@ TEST_SUBMODULE(methods_and_attributes, m) {
         .def_readonly("value", &RefQualified::value)
         .def("refQualified", &RefQualified::refQualified)
         .def("constRefQualified", &RefQualified::constRefQualified);
+
+    py::class_<RValueParam>(m, "RValueParam")
+        .def(py::init<>())
+        .def("func1", &RValueParam::func1)
+        .def("func2", &RValueParam::func2)
+        .def("func3", &RValueParam::func3)
+        .def("func4", &RValueParam::func4);
 }

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -519,7 +519,7 @@ def test_overload_ordering():
 
 def test_rvalue_ref_param():
     r = m.RValueRefParam()
-    assert r.func1('123') == 3
-    assert r.func2('1234') == 4
-    assert r.func3('12345') == 5
-    assert r.func4('123456') == 6
+    assert r.func1("123") == 3
+    assert r.func2("1234") == 4
+    assert r.func3("12345") == 5
+    assert r.func4("123456") == 6

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -515,3 +515,11 @@ def test_overload_ordering():
     assert "2. (arg0: {}) -> int".format(uni_name) in str(err.value)
     assert "3. (arg0: {}) -> int".format(uni_name) in str(err.value)
     assert "4. (arg0: int) -> int" in str(err.value)
+
+
+def test_rvalue_ref_param():
+    r = m.RValueRefParam()
+    assert r.func1('123') == 3
+    assert r.func2('1234') == 4
+    assert r.func3('12345') == 5
+    assert r.func4('123456') == 6


### PR DESCRIPTION
Two of the four cpp_function overloads are missing std::forward calls, which seems like a simple oversight.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
