### PR TITLE
Removed duplicated word in docs/advanced/cast/eigen.rst

### DIFF
--- a/docs/advanced/cast/eigen.rst
+++ b/docs/advanced/cast/eigen.rst
@@ -52,7 +52,7 @@ can be mapped *and* if the numpy array is writeable (that is
 the passed variable will be transparently carried out directly on the
 ``numpy.ndarray``.
 
-This means you can can write code such as the following and have it work as
+This means you can write code such as the following and have it work as
 expected:
 
 .. code-block:: cpp


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Typo update in docs where a duplicated word was inserted in `docs/advanced/cast/eigen.rst`


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
- Typo update in docs where a duplicated word was inserted in `docs/advanced/cast/eigen.rst`
```

<!-- If the upgrade guide needs updating, note that here too -->
