### PR TITLE
[smart_holder] Wrong caching of overrides 

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2093,6 +2093,16 @@ inline std::pair<decltype(internals::registered_types_py)::iterator, bool> all_t
         // gets destroyed:
         weakref((PyObject *) type, cpp_function([type](handle wr) {
             get_internals().registered_types_py.erase(type);
+
+            // Actually just `std::erase_if`, but that's only available in C++20
+            auto &cache = get_internals().inactive_override_cache;
+            for (auto it = cache.begin(), last = cache.end(); it != last; ) {
+                if (it->first == reinterpret_cast<PyObject *>(type))
+                    it = cache.erase(it);
+                else
+                    ++it;
+            }
+
             wr.dec_ref();
         })).release();
     }

--- a/tests/test_class_sh_inheritance.py
+++ b/tests/test_class_sh_inheritance.py
@@ -61,3 +61,22 @@ def test_python_drvd2():
     assert i1 == 110 + 21
     i2 = m.pass_cptr_base2(d)
     assert i2 == 120 + 22
+
+
+def test_python_override():
+    def func():
+        class Test(m.test_derived):
+            def func(self):
+                return 42
+
+        return Test()
+
+    def func2():
+        class Test(m.test_derived):
+            pass
+
+        return Test()
+
+    for _ in range(1500):
+        assert m.test_override_cache(func()) == 42
+        assert m.test_override_cache(func2()) == 0

--- a/tests/test_embed/CMakeLists.txt
+++ b/tests/test_embed/CMakeLists.txt
@@ -25,7 +25,7 @@ pybind11_enable_warnings(test_embed)
 target_link_libraries(test_embed PRIVATE pybind11::embed Catch2::Catch2 Threads::Threads)
 
 if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
-  file(COPY test_interpreter.py DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+  file(COPY test_interpreter.py test_derived.py DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
 add_custom_target(

--- a/tests/test_embed/test_derived.py
+++ b/tests/test_embed/test_derived.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+import derived_module
+
+
+def func():
+    class Test(derived_module.test_derived):
+        def func(self):
+            return 42
+
+    return Test()
+
+
+def func2():
+    class Test(derived_module.test_derived):
+        pass
+
+    return Test()


### PR DESCRIPTION
## Description
There was a problem when the python type, which was stored in override
cache for C++ functions, was destroyed and the record wasn't removed from the
override cache. Therefor, dangling pointer was stored there. Then when the
memory was reused and new type was allocated at the given address and the
method with the same name (as previously stored in the cache) was actually
overridden in python, it would wrongly find it in the override cache for C++
functions and therefor override from python wouldn't be called.
The fix is to erase the type from the override cache when the type is destroyed.

Closes: #3369

## Suggested changelog entry:

```rst
Fix caching of the C++ overrides
```
