### PR TITLE
cmake: report version type in the version string

### DIFF
--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -13,7 +13,7 @@ This module sets the following variables in your project:
 ``pybind11_VERSION``
   pybind11 version in format Major.Minor.Release
 ``pybind11_VERSION_TYPE``
-  pybind11 version type (dev, release)
+  pybind11 version type (``dev*`` or empty for a release)
 ``pybind11_INCLUDE_DIRS``
   Directories where pybind11 and python headers are located.
 ``pybind11_INCLUDE_DIR``
@@ -228,6 +228,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/pybind11Common.cmake")
 if(NOT pybind11_FIND_QUIETLY)
   message(
     STATUS
-      "Found pybind11: ${pybind11_INCLUDE_DIR} (found version \"${pybind11_VERSION}\" ${pybind11_VERSION_TYPE})"
+      "Found pybind11: ${pybind11_INCLUDE_DIR} (found version \"${pybind11_VERSION}${pybind11_VERSION_TYPE}\")"
   )
 endif()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
The version type is now part of the version string which avoids an empty space in release versions of the library. The version string now resembles [PEP 440](https://www.python.org/dev/peps/pep-0440/) albeit without a dot (since it's a CMake version string). Also, updated the documentation wording which claims the version to be set to `release` in final (released) versions but is actually left empty.

Fixes #3471


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
cmake: report version type as part of the version string to avoid a spurious space in the package status message
```

<!-- If the upgrade guide needs updating, note that here too -->
