### PR TITLE
Removed duplicated word in docs/advanced/exceptions.rst

### DIFF
--- a/docs/advanced/exceptions.rst
+++ b/docs/advanced/exceptions.rst
@@ -64,7 +64,7 @@ at its exception handler.
 +--------------------------------------+--------------------------------------+
 
 Exception translation is not bidirectional. That is, *catching* the C++
-exceptions defined above above will not trap exceptions that originate from
+exceptions defined above will not trap exceptions that originate from
 Python. For that, catch :class:`pybind11::error_already_set`. See :ref:`below
 <handling_python_exceptions_cpp>` for further details.
 


### PR DESCRIPTION
## Description

Typo update in docs where a duplicated word was inserted in docs/advanced/exceptions.rst

## Suggested changelog entry:

```rst
- Typo update in docs where a duplicated word was inserted in `docs/advanced/exceptions.rst`
```

<!-- If the upgrade guide needs updating, note that here too -->
