### PR TITLE
Fix py::kw_only when used before the first arg of a method

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -414,15 +414,15 @@ inline void check_kw_only_arg(const arg &a, function_record *r) {
         pybind11_fail("arg(): cannot specify an unnamed argument after a kw_only() annotation or args() argument");
 }
 
-inline void check_have_self_arg(function_record *r) {
+inline void append_self_arg_if_needed(function_record *r) {
     if (r->is_method && r->args.empty())
-        r->args.emplace_back("self", nullptr, handle(), true /*convert*/, false /*none not allowed*/);
+        r->args.emplace_back("self", nullptr, handle(), /*convert=*/ true, /*none=*/ false);
 }
 
 /// Process a keyword argument attribute (*without* a default value)
 template <> struct process_attribute<arg> : process_attribute_default<arg> {
     static void init(const arg &a, function_record *r) {
-        check_have_self_arg(r);
+        append_self_arg_if_needed(r);
         r->args.emplace_back(a.name, nullptr, handle(), !a.flag_noconvert, a.flag_none);
 
         check_kw_only_arg(a, r);
@@ -433,7 +433,7 @@ template <> struct process_attribute<arg> : process_attribute_default<arg> {
 template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
     static void init(const arg_v &a, function_record *r) {
         if (r->is_method && r->args.empty())
-            r->args.emplace_back("self", nullptr /*descr*/, handle() /*parent*/, true /*convert*/, false /*none not allowed*/);
+            r->args.emplace_back("self", /*descr=*/ nullptr, /*parent=*/ handle(), /*convert=*/ true, /*none=*/ false);
 
         if (!a.value) {
 #if !defined(NDEBUG)
@@ -465,7 +465,7 @@ template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
 /// Process a keyword-only-arguments-follow pseudo argument
 template <> struct process_attribute<kw_only> : process_attribute_default<kw_only> {
     static void init(const kw_only &, function_record *r) {
-        check_have_self_arg(r);
+        append_self_arg_if_needed(r);
         if (r->has_args && r->nargs_pos != static_cast<std::uint16_t>(r->args.size()))
             pybind11_fail("Mismatched args() and kw_only(): they must occur at the same relative argument location (or omit kw_only() entirely)");
         r->nargs_pos = static_cast<std::uint16_t>(r->args.size());
@@ -475,7 +475,7 @@ template <> struct process_attribute<kw_only> : process_attribute_default<kw_onl
 /// Process a positional-only-argument maker
 template <> struct process_attribute<pos_only> : process_attribute_default<pos_only> {
     static void init(const pos_only &, function_record *r) {
-        check_have_self_arg(r);
+        append_self_arg_if_needed(r);
         r->nargs_pos_only = static_cast<std::uint16_t>(r->args.size());
         if (r->nargs_pos_only > r->nargs_pos)
             pybind11_fail("pos_only(): cannot follow a py::args() argument");

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -229,6 +229,19 @@ def test_keyword_only_args(msg):
     """
     )
 
+    # https://github.com/pybind/pybind11/pull/3402#issuecomment-963341987
+    x = m.first_arg_kw_only(i=1)
+    x.method()
+    x.method(i=1, j=2)
+    assert (
+        m.first_arg_kw_only.__init__.__doc__
+        == "__init__(self: pybind11_tests.kwargs_and_defaults.first_arg_kw_only, *, i: int = 0) -> None\n"  # noqa: E501 line too long
+    )
+    assert (
+        m.first_arg_kw_only.method.__doc__
+        == "method(self: pybind11_tests.kwargs_and_defaults.first_arg_kw_only, *, i: int = 1, j: int = 2) -> None\n"  # noqa: E501 line too long
+    )
+
 
 def test_positional_only_args(msg):
     assert m.pos_only_all(1, 2) == (1, 2)
@@ -308,6 +321,14 @@ def test_positional_only_args(msg):
         (),
         9,
         {"i": 5, "m": 8},
+    )
+
+    # pos_only at the beginning of the argument list was "broken" in how it was displayed (though
+    # this is fairly useless in practice).  Related to:
+    # https://github.com/pybind/pybind11/pull/3402#issuecomment-963341987
+    assert (
+        m.first_arg_kw_only.pos_only.__doc__
+        == "pos_only(self: pybind11_tests.kwargs_and_defaults.first_arg_kw_only, /, i: int, j: int) -> None\n"  # noqa: E501 line too long
     )
 
 


### PR DESCRIPTION
The implicit space for the `self` argument isn't added until we hit the first argument, but this wasn't being done for `kw_only` or `pos_only` that happen *before* the first argument, and so a `kw_only` before the first argument on methods/constructors would break.

This fixes it by properly checking whether we need to add the self arg in those places as well.

(The `pos_only` issue here was extremely mild -- you didn't get the `/` in the docstring, but AFAICT it has no other effect since there are no meaningful arguments before it anyway).

Closes #3789 (thanks to @rwgk for the minimal test case in that PR).