### PR TITLE
Fixing `stict` vs `strict` typo.

### DIFF
--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -38,7 +38,7 @@ def test_from_python():
 # https://foss.heptapod.net/pypy/pypy/-/issues/2444
 # TODO: fix on recent PyPy
 @pytest.mark.xfail(
-    env.PYPY, reason="PyPy 7.3.7 doesn't clear this anymore", stict=False
+    env.PYPY, reason="PyPy 7.3.7 doesn't clear this anymore", strict=False
 )
 def test_to_python():
     mat = m.Matrix(5, 4)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Interestingly, this caused a failure only when testing the smart_holder branch, and only with `py::smart_holder` as the default holder.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
