### PR TITLE
Replace usage of deprecated Eigen class MappedSparseMatrix.

### DIFF
--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -50,8 +50,12 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 
 #if EIGEN_VERSION_AT_LEAST(3,3,0)
 using EigenIndex = Eigen::Index;
+template<typename Scalar, int Flags, typename StorageIndex>
+using eigen_mapped_sparse_matrix = Eigen::Map<Eigen::SparseMatrix<Scalar, Flags, StorageIndex>>;
 #else
 using EigenIndex = EIGEN_DEFAULT_DENSE_INDEX_TYPE;
+template<typename Scalar, int Flags, typename StorageIndex>
+using eigen_mapped_sparse_matrix = Eigen::MappedSparseMatrix<Scalar, Flags, StorageIndex>;
 #endif
 
 // Matches Eigen::Map, Eigen::Ref, blocks, etc:
@@ -573,9 +577,9 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
         if (!values || !innerIndices || !outerIndices)
             return false;
 
-        value = Eigen::Map<Eigen::SparseMatrix<Scalar,
+        value = eigen_mapped_sparse_matrix<Scalar,
                                           Type::Flags & (Eigen::RowMajor | Eigen::ColMajor),
-                                          StorageIndex>>(
+                                          StorageIndex>(
             shape[0].cast<Index>(), shape[1].cast<Index>(), nnz,
             outerIndices.mutable_data(), innerIndices.mutable_data(), values.mutable_data());
 

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -51,11 +51,11 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 #if EIGEN_VERSION_AT_LEAST(3,3,0)
 using EigenIndex = Eigen::Index;
 template<typename Scalar, int Flags, typename StorageIndex>
-using eigen_mapped_sparse_matrix = Eigen::Map<Eigen::SparseMatrix<Scalar, Flags, StorageIndex>>;
+using EigenMapSparseMatrix = Eigen::Map<Eigen::SparseMatrix<Scalar, Flags, StorageIndex>>;
 #else
 using EigenIndex = EIGEN_DEFAULT_DENSE_INDEX_TYPE;
 template<typename Scalar, int Flags, typename StorageIndex>
-using eigen_mapped_sparse_matrix = Eigen::MappedSparseMatrix<Scalar, Flags, StorageIndex>;
+using EigenMapSparseMatrix = Eigen::MappedSparseMatrix<Scalar, Flags, StorageIndex>;
 #endif
 
 // Matches Eigen::Map, Eigen::Ref, blocks, etc:
@@ -577,9 +577,9 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
         if (!values || !innerIndices || !outerIndices)
             return false;
 
-        value = eigen_mapped_sparse_matrix<Scalar,
-                                          Type::Flags & (Eigen::RowMajor | Eigen::ColMajor),
-                                          StorageIndex>(
+        value = EigenMapSparseMatrix<Scalar,
+                                     Type::Flags & (Eigen::RowMajor | Eigen::ColMajor),
+                                     StorageIndex>(
             shape[0].cast<Index>(), shape[1].cast<Index>(), nnz,
             outerIndices.mutable_data(), innerIndices.mutable_data(), values.mutable_data());
 


### PR DESCRIPTION
Replace usage of deprecated Eigen class MappedSparseMatrix.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
`Eigen::MappedSparseMatrix` has been deprecated since Eigen 3.3 from 2016. Use the equivalent modern syntax `Eigen::Map<Eigen::SparseMatrix<...>>`.

The deprecated class was removed on the Eigen master branch in:

https://gitlab.com/libeigen/eigen/-/commit/7e586635ba85ba926ba3148f8d14beca3535f970

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

```rst
Replace usage of deprecated ``Eigen::MappedSparseMatrix`` with ``Eigen::Map<Eigen::SparseMatrix<...>>`` for Eigen 3.3+.
```
