### PR TITLE
Expand std::string_view support to str, bytes, memoryview

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -27,23 +27,6 @@
 #include <utility>
 #include <vector>
 
-#if defined(PYBIND11_CPP17)
-#  if defined(__has_include)
-#    if __has_include(<string_view>)
-#      define PYBIND11_HAS_STRING_VIEW
-#    endif
-#  elif defined(_MSC_VER)
-#    define PYBIND11_HAS_STRING_VIEW
-#  endif
-#endif
-#ifdef PYBIND11_HAS_STRING_VIEW
-#include <string_view>
-#endif
-
-#if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
-#  define PYBIND11_HAS_U8STRING
-#endif
-
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -244,9 +244,6 @@
 #    include <version>
 #  endif
 #endif
-#ifdef PYBIND11_HAS_STRING_VIEW
-#  include <string_view>
-#endif
 
 // #define PYBIND11_STR_LEGACY_PERMISSIVE
 // If DEFINED, pybind11::str can hold PyUnicodeObject or PyBytesObject

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -183,6 +183,21 @@
 #  define PYBIND11_HAS_VARIANT 1
 #endif
 
+#if defined(PYBIND11_CPP17)
+#  if defined(__has_include)
+#    if __has_include(<string_view>)
+#      define PYBIND11_HAS_STRING_VIEW
+#    endif
+#  elif defined(_MSC_VER)
+#    define PYBIND11_HAS_STRING_VIEW
+#  endif
+#endif
+
+#if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
+#  define PYBIND11_HAS_U8STRING
+#endif
+
+
 #include <Python.h>
 #include <frameobject.h>
 #include <pythread.h>
@@ -228,6 +243,9 @@
 #  if __has_include(<version>)
 #    include <version>
 #  endif
+#endif
+#ifdef PYBIND11_HAS_STRING_VIEW
+#  include <string_view>
 #endif
 
 // #define PYBIND11_STR_LEGACY_PERMISSIVE

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1090,8 +1090,10 @@ public:
     str(const std::string &s) : str(s.data(), s.size()) { }
 
 #ifdef PYBIND11_HAS_STRING_VIEW
+    // enable_if is needed to avoid "ambiguous conversion" errors (see PR #3521).
+    template <typename T, detail::enable_if_t<std::is_same<T, std::string_view>::value, int> = 0>
     // NOLINTNEXTLINE(google-explicit-constructor)
-    str(std::string_view s) : str(s.data(), s.size()) { }
+    str(T s) : str(s.data(), s.size()) { }
 
 # ifdef PYBIND11_HAS_U8STRING
     // reinterpret_cast here is safe (C++20 guarantees char8_t has the same size/alignment as char)

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -18,6 +18,10 @@
 #  include <optional>
 #endif
 
+#ifdef PYBIND11_HAS_STRING_VIEW
+#  include <string_view>
+#endif
+
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 /* A few forward declarations */

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1186,8 +1186,8 @@ public:
 
 #ifdef PYBIND11_HAS_STRING_VIEW
     // enable_if is needed to avoid "ambiguous conversion" errors (see PR #3521).
-    // NOLINTNEXTLINE(google-explicit-constructor)
     template <typename T, detail::enable_if_t<std::is_same<T, std::string_view>::value, int> = 0>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     bytes(T s) : bytes(s.data(), s.size()) { }
 
     // Obtain a string view that views the current `bytes` buffer value.  Note that this is only

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1185,8 +1185,10 @@ public:
     }
 
 #ifdef PYBIND11_HAS_STRING_VIEW
+    // enable_if is needed to avoid "ambiguous conversion" errors (see PR #3521).
     // NOLINTNEXTLINE(google-explicit-constructor)
-    bytes(std::string_view s) : bytes(s.data(), s.size()) { }
+    template <typename T, detail::enable_if_t<std::is_same<T, std::string_view>::value, int> = 0>
+    bytes(T s) : bytes(s.data(), s.size()) { }
 
     // Obtain a string view that views the current `bytes` buffer value.  Note that this is only
     // valid so long as the `bytes` instance remains alive and so generally should not outlive the

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1085,6 +1085,18 @@ public:
     // NOLINTNEXTLINE(google-explicit-constructor)
     str(const std::string &s) : str(s.data(), s.size()) { }
 
+#ifdef PYBIND11_HAS_STRING_VIEW
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    str(std::string_view s) : str(s.data(), s.size()) { }
+
+# ifdef PYBIND11_HAS_U8STRING
+    // reinterpret_cast here is safe (C++20 guarantees char8_t has the same size/alignment as char)
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    str(std::u8string_view s) : str(reinterpret_cast<const char*>(s.data()), s.size()) { }
+# endif
+
+#endif
+
     explicit str(const bytes &b);
 
     /** \rst
@@ -1167,6 +1179,24 @@ public:
             pybind11_fail("Unable to extract bytes contents!");
         return std::string(buffer, (size_t) length);
     }
+
+#ifdef PYBIND11_HAS_STRING_VIEW
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    bytes(std::string_view s) : bytes(s.data(), s.size()) { }
+
+    // Obtain a string view that views the current `bytes` buffer value.  Note that this is only
+    // valid so long as the `bytes` instance remains alive and so generally should not outlive the
+    // lifetime of the `bytes` instance.
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    operator std::string_view() const {
+        char *buffer = nullptr;
+        ssize_t length = 0;
+        if (PYBIND11_BYTES_AS_STRING_AND_SIZE(m_ptr, &buffer, &length))
+            pybind11_fail("Unable to extract bytes contents!");
+        return {buffer, static_cast<size_t>(length)};
+    }
+#endif
+
 };
 // Note: breathe >= 4.17.0 will fail to build docs if the below two constructors
 // are included in the doxygen group; close here and reopen after as a workaround
@@ -1714,6 +1744,13 @@ public:
     static memoryview from_memory(const void *mem, ssize_t size) {
         return memoryview::from_memory(const_cast<void*>(mem), size, true);
     }
+
+#ifdef PYBIND11_HAS_STRING_VIEW
+    static memoryview from_memory(std::string_view mem) {
+        return from_memory(const_cast<char*>(mem.data()), static_cast<ssize_t>(mem.size()), true);
+    }
+#endif
+
 #endif
 };
 

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -160,7 +160,9 @@ TEST_SUBMODULE(builtin_casters, m) {
 #   endif
 
     struct TypeWithBothOperatorStringAndStringView {
+        // NOLINTNEXTLINE(google-explicit-constructor)
         operator std::string() const { return "success"; }
+        // NOLINTNEXTLINE(google-explicit-constructor)
         operator std::string_view() const { return "failure"; }
     };
     m.def("bytes_from_type_with_both_operator_string_and_string_view",

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -167,6 +167,8 @@ TEST_SUBMODULE(builtin_casters, m) {
     };
     m.def("bytes_from_type_with_both_operator_string_and_string_view",
           []() { return py::bytes(TypeWithBothOperatorStringAndStringView()); });
+    m.def("str_from_type_with_both_operator_string_and_string_view",
+          []() { return py::str(TypeWithBothOperatorStringAndStringView()); });
 #endif
 
     // test_integer_casting

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -158,6 +158,13 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("string_view8_return", []() { return std::u8string_view(u8"utf8 secret \U0001f382"); });
     m.def("string_view8_str",    []() { return py::str{std::u8string_view{u8"abc ‽ def"}}; });
 #   endif
+
+    struct TypeWithBothOperatorStringAndStringView {
+        operator std::string() const { return "success"; }
+        operator std::string_view() const { return "failure"; }
+    };
+    m.def("bytes_from_type_with_both_operator_string_and_string_view",
+          []() { return py::bytes(TypeWithBothOperatorStringAndStringView()); });
 #endif
 
     // test_integer_casting

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -215,6 +215,7 @@ def test_string_view(capture):
         assert m.string_view_memoryview() == "Have some 🎂".encode()
 
     assert m.bytes_from_type_with_both_operator_string_and_string_view() == b"success"
+    assert m.str_from_type_with_both_operator_string_and_string_view() == "success"
 
 
 def test_integer_casting():

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -214,6 +214,8 @@ def test_string_view(capture):
     if not env.PY2:
         assert m.string_view_memoryview() == "Have some 🎂".encode()
 
+    assert m.bytes_from_type_with_both_operator_string_and_string_view() == b"success"
+
 
 def test_integer_casting():
     """Issue #929 - out-of-range integer values shouldn't be accepted"""

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -206,6 +206,14 @@ def test_string_view(capture):
         """
         )
 
+    assert m.string_view_bytes() == b"abc \x80\x80 def"
+    assert m.string_view_str() == u"abc ‽ def"
+    assert m.string_view_from_bytes(u"abc ‽ def".encode("utf-8")) == u"abc ‽ def"
+    if hasattr(m, "has_u8string"):
+        assert m.string_view8_str() == u"abc ‽ def"
+    if not env.PY2:
+        assert m.string_view_memoryview() == "Have some 🎂".encode()
+
 
 def test_integer_casting():
     """Issue #929 - out-of-range integer values shouldn't be accepted"""


### PR DESCRIPTION
## Description

1. Allows constructing a str or bytes implicitly from a string_view; this is essentially a small shortcut allowing a caller to write `py::bytes{sv}` rather than `py::bytes{sv.data(), sv.size()}`.

    For `py::str` this also allows `std::u8string_view`, but not for `py::bytes` because that didn't seem entirely appropriate to me.

2. Allows implicit conversion *to* `std::string_view` from `py::bytes`—this plugs a current hole where there's no simple way to get such a view of the bytes without copying it (or resorting to Python API calls).

   (This is not done for `str` because when the str contains unicode we have to allocate to a temporary and so there might not be some string data we can properly view without owning.)

3. Allows `memoryview::from_memory` to accept a string_view.  As with the other from_memory calls, it's entirely your responsibility to keep it alive.

This also required moving the string_view availability detection into detail/common.h because this PR needs it in pytypes.h, which is higher up the include chain than cast.h where it was being detected currently.

## Suggested changelog entry:

```rst
* Make str/bytes/memoryview more interoperable with ``std::string_view``.
```