### PR TITLE
ICC Latest C++17 (for reporting errors to Intel).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,37 +555,37 @@ jobs:
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake --build build-11 --target test_cmake_build
 
-    - name: Configure C++20
+    - name: Configure C++14
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake -S . -B build-20     \
+        cmake -S . -B build-14     \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
-        -DCMAKE_CXX_STANDARD=20             \
+        -DCMAKE_CXX_STANDARD=14             \
         -DCMAKE_CXX_COMPILER=$(which icpc)  \
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
-    - name: Build C++20
+    - name: Build C++14
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-20 -j 2 -v
+        cmake --build build-14 -j 2 -v
 
-    - name: Python tests C++20
+    - name: Python tests C++14
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         sudo service apport stop
-        cmake --build build-20 --target check
+        cmake --build build-14 --target check
 
-    - name: C++ tests C++20
+    - name: C++ tests C++14
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-20 --target cpptest
+        cmake --build build-14 --target cpptest
 
-    - name: Interface test C++20
+    - name: Interface test C++14
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-20 --target test_cmake_build
+        cmake --build build-14 --target test_cmake_build
 
 
   # Testing on CentOS (manylinux uses a centos base, and this is an easy way

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,37 +555,37 @@ jobs:
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake --build build-11 --target test_cmake_build
 
-    - name: Configure C++17
+    - name: Configure C++14
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake -S . -B build-17     \
+        cmake -S . -B build-14     \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
-        -DCMAKE_CXX_STANDARD=17             \
+        -DCMAKE_CXX_STANDARD=14             \
         -DCMAKE_CXX_COMPILER=$(which icpc)  \
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
-    - name: Build C++17
+    - name: Build C++14
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-17 -j 2 -v
+        cmake --build build-14 -j 2 -v
 
-    - name: Python tests C++17
+    - name: Python tests C++14
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         sudo service apport stop
-        cmake --build build-17 --target check
+        cmake --build build-14 --target check
 
-    - name: C++ tests C++17
+    - name: C++ tests C++14
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-17 --target cpptest
+        cmake --build build-14 --target cpptest
 
-    - name: Interface test C++17
+    - name: Interface test C++14
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-17 --target test_cmake_build
+        cmake --build build-14 --target test_cmake_build
 
 
   # Testing on CentOS (manylinux uses a centos base, and this is an easy way

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,37 +555,37 @@ jobs:
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake --build build-11 --target test_cmake_build
 
-    - name: Configure C++14
+    - name: Configure C++20
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake -S . -B build-14     \
+        cmake -S . -B build-20     \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
-        -DCMAKE_CXX_STANDARD=14             \
+        -DCMAKE_CXX_STANDARD=20             \
         -DCMAKE_CXX_COMPILER=$(which icpc)  \
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
-    - name: Build C++14
+    - name: Build C++20
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-14 -j 2 -v
+        cmake --build build-20 -j 2 -v
 
-    - name: Python tests C++14
+    - name: Python tests C++20
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         sudo service apport stop
-        cmake --build build-14 --target check
+        cmake --build build-20 --target check
 
-    - name: C++ tests C++14
+    - name: C++ tests C++20
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-14 --target cpptest
+        cmake --build build-20 --target cpptest
 
-    - name: Interface test C++14
+    - name: Interface test C++20
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-14 --target test_cmake_build
+        cmake --build build-20 --target test_cmake_build
 
 
   # Testing on CentOS (manylinux uses a centos base, and this is an easy way

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,37 +555,37 @@ jobs:
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake --build build-11 --target test_cmake_build
 
-    - name: Configure C++14
+    - name: Configure C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake -S . -B build-14     \
+        cmake -S . -B build-17     \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
-        -DCMAKE_CXX_STANDARD=14             \
+        -DCMAKE_CXX_STANDARD=17             \
         -DCMAKE_CXX_COMPILER=$(which icpc)  \
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
-    - name: Build C++14
+    - name: Build C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-14 -j 2 -v
+        cmake --build build-17 -j 2 -v
 
-    - name: Python tests C++14
+    - name: Python tests C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         sudo service apport stop
-        cmake --build build-14 --target check
+        cmake --build build-17 --target check
 
-    - name: C++ tests C++14
+    - name: C++ tests C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-14 --target cpptest
+        cmake --build build-17 --target cpptest
 
-    - name: Interface test C++14
+    - name: Interface test C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-14 --target test_cmake_build
+        cmake --build build-17 --target test_cmake_build
 
 
   # Testing on CentOS (manylinux uses a centos base, and this is an easy way

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. figure:: https://github.com/pybind/pybind11/raw/master/docs/pybind11-logo.png
    :alt: pybind11 logo
 
-**pybind11 — Seamless operability between C++11 and Python**
+**pybind11 — Seamless operability between C++ and Python**
 
 |Latest Documentation Status| |Stable Documentation Status| |Gitter chat| |GitHub Discussions| |CI| |Build status|
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Work in progress.

The C++17 build was working with

* Intel 2021.4.0.20210910 (/opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64/icpc)

but started failing with

* Intel 2021.5.0.20211109 (/opt/intel/oneapi/compiler/2022.0.0/linux/bin/intel64/icpc)

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
