### PR TITLE
Replacing ICC C++14 with C++17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,37 +559,37 @@ jobs:
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake --build build-11 --target test_cmake_build
 
-    - name: Configure C++14
+    - name: Configure C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake -S . -B build-14     \
+        cmake -S . -B build-17     \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
-        -DCMAKE_CXX_STANDARD=14             \
+        -DCMAKE_CXX_STANDARD=17             \
         -DCMAKE_CXX_COMPILER=$(which icpc)  \
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
-    - name: Build C++14
+    - name: Build C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-14 -j 2 -v
+        cmake --build build-17 -j 2 -v
 
-    - name: Python tests C++14
+    - name: Python tests C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         sudo service apport stop
-        cmake --build build-14 --target check
+        cmake --build build-17 --target check
 
-    - name: C++ tests C++14
+    - name: C++ tests C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-14 --target cpptest
+        cmake --build build-17 --target cpptest
 
-    - name: Interface test C++14
+    - name: Interface test C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        cmake --build build-14 --target test_cmake_build
+        cmake --build build-17 --target test_cmake_build
 
 
   # Testing on CentOS (manylinux uses a centos base, and this is an easy way

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,7 +562,6 @@ jobs:
     - name: Configure C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        # export CXXFLAGS="-diag-disable:conversion" # Did not work.
         cmake -S . -B build-17     \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,6 +562,7 @@ jobs:
     - name: Configure C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        export CXXFLAGS="-diag-disable:conversion"
         cmake -S . -B build-17     \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,9 +562,9 @@ jobs:
     - name: Configure C++17
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
-        export CXXFLAGS="-diag-disable:conversion"
+        # export CXXFLAGS="-diag-disable:conversion" # Did not work.
         cmake -S . -B build-17     \
-        -DPYBIND11_WERROR=ON    \
+        -DPYBIND11_WERROR=OFF   \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
         -DCMAKE_CXX_STANDARD=17             \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,7 +564,7 @@ jobs:
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         # export CXXFLAGS="-diag-disable:conversion" # Did not work.
         cmake -S . -B build-17     \
-        -DPYBIND11_WERROR=OFF   \
+        -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
         -DCMAKE_CXX_STANDARD=17             \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -330,7 +330,7 @@ function(pybind11_enable_warnings target_name)
       target_compile_options(
         ${target_name}
         PRIVATE
-          -Werror-all
+          -Werror-all -Wno-conversion
           # "Inlining inhibited by limit max-size", "Inlining inhibited by limit max-total-size"
           -diag-disable 11074,11076)
     endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -327,10 +327,13 @@ function(pybind11_enable_warnings target_name)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang|IntelLLVM)")
       target_compile_options(${target_name} PRIVATE -Werror)
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+      if(CMAKE_CXX_STANDARD EQUAL 17) # See PR #3570
+        target_compile_options(${target_name} PRIVATE -Wno-conversion)
+      endif()
       target_compile_options(
         ${target_name}
         PRIVATE
-          -Werror-all -Wno-conversion
+          -Werror-all
           # "Inlining inhibited by limit max-size", "Inlining inhibited by limit max-total-size"
           -diag-disable 11074,11076)
     endif()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

This PR reverts most of PR #3551. To work around the issue that started with Intel 2021.5.0.20211109, `-Wno-conversion` is added specifically for C++17 (as recommended here: https://github.com/pybind/pybind11/pull/3570#issuecomment-1006553543).

Quality assurance: https://github.com/pybind/pybind11/pull/3570#issuecomment-1009456381

Original PR description
-----------------------
For reporting to Intel.

The C++17 build was working with

* Intel 2021.4.0.20210910 (/opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64/icpc)

but started failing with

* Intel 2021.5.0.20211109 (/opt/intel/oneapi/compiler/2022.0.0/linux/bin/intel64/icpc)

See also: PR #3551

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
- Fix: the latest release warned in ``#include <variant>``, which failed ``-DPYBIND11_WERROR=ON``
```

<!-- If the upgrade guide needs updating, note that here too -->
