### PR TITLE
fix(setup): support overriding CMake args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,8 @@ with remove_output("pybind11/include", "pybind11/share"):
             "-DBUILD_TESTING=OFF",
             "-DPYBIND11_NOPYTHON=ON",
         ]
+        if "CMAKE_ARGS" in os.environ:
+            cmd += os.environ["CMAKE_ARGS"].split()
         cmake_opts = dict(cwd=DIR, stdout=sys.stdout, stderr=sys.stderr)
         subprocess.check_call(cmd, **cmake_opts)
         subprocess.check_call(["cmake", "--install", tmpdir], **cmake_opts)

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,11 @@ with remove_output("pybind11/include", "pybind11/share"):
             "-DPYBIND11_NOPYTHON=ON",
         ]
         if "CMAKE_ARGS" in os.environ:
-            fcommand = [c for c in os.environ["CMAKE_ARGS"].split() if "DCMAKE_INSTALL_PREFIX" not in c]
+            fcommand = [
+                c
+                for c in os.environ["CMAKE_ARGS"].split()
+                if "DCMAKE_INSTALL_PREFIX" not in c
+            ]
             cmd += fcommand
         cmake_opts = dict(cwd=DIR, stdout=sys.stdout, stderr=sys.stderr)
         subprocess.check_call(cmd, **cmake_opts)

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,8 @@ with remove_output("pybind11/include", "pybind11/share"):
             "-DPYBIND11_NOPYTHON=ON",
         ]
         if "CMAKE_ARGS" in os.environ:
-            cmd += os.environ["CMAKE_ARGS"].split()
+            fcommand = [c for c in os.environ["CMAKE_ARGS"].split() if "DCMAKE_INSTALL_PREFIX" not in c]
+            cmd += fcommand
         cmake_opts = dict(cwd=DIR, stdout=sys.stdout, stderr=sys.stderr)
         subprocess.check_call(cmd, **cmake_opts)
         subprocess.check_call(["cmake", "--install", tmpdir], **cmake_opts)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Supports setting CMAKE_ARGS to control the CMake file generation. Needed for conda-forge, which does not find the compiler otherwise.

See https://github.com/conda-forge/pybind11-feedstock/pull/74.

## Suggested changelog entry:

```rst
* Allow CMAKE_ARGS to override CMake args in pybind11's own setup.py.
```
