### PR TITLE
[smart_holder] fix: names of types held by smart holder should be the actual type

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -703,7 +703,7 @@ struct smart_holder_type_caster : smart_holder_type_caster_load<T>,
 template <typename T>
 struct smart_holder_type_caster<std::shared_ptr<T>> : smart_holder_type_caster_load<T>,
                                                       smart_holder_type_caster_class_hooks {
-    static constexpr auto name = const_name<std::shared_ptr<T>>();
+    static constexpr auto name = const_name<T>();
 
     static handle cast(const std::shared_ptr<T> &src, return_value_policy policy, handle parent) {
         switch (policy) {
@@ -760,7 +760,7 @@ struct smart_holder_type_caster<std::shared_ptr<T>> : smart_holder_type_caster_l
 template <typename T>
 struct smart_holder_type_caster<std::shared_ptr<T const>> : smart_holder_type_caster_load<T>,
                                                             smart_holder_type_caster_class_hooks {
-    static constexpr auto name = const_name<std::shared_ptr<T const>>();
+    static constexpr auto name = const_name<T>();
 
     static handle
     cast(const std::shared_ptr<T const> &src, return_value_policy policy, handle parent) {
@@ -780,7 +780,7 @@ struct smart_holder_type_caster<std::shared_ptr<T const>> : smart_holder_type_ca
 template <typename T, typename D>
 struct smart_holder_type_caster<std::unique_ptr<T, D>> : smart_holder_type_caster_load<T>,
                                                          smart_holder_type_caster_class_hooks {
-    static constexpr auto name = const_name<std::unique_ptr<T, D>>();
+    static constexpr auto name = const_name<T>();
 
     static handle cast(std::unique_ptr<T, D> &&src, return_value_policy policy, handle parent) {
         if (policy != return_value_policy::automatic
@@ -857,7 +857,7 @@ struct smart_holder_type_caster<std::unique_ptr<T, D>> : smart_holder_type_caste
 template <typename T, typename D>
 struct smart_holder_type_caster<std::unique_ptr<T const, D>>
     : smart_holder_type_caster_load<T>, smart_holder_type_caster_class_hooks {
-    static constexpr auto name = const_name<std::unique_ptr<T const, D>>();
+    static constexpr auto name = const_name<T>();
 
     static handle
     cast(std::unique_ptr<T const, D> &&src, return_value_policy policy, handle parent) {

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -154,6 +154,12 @@ TEST_SUBMODULE(class_sh_basic, m) {
     m.def("py_type_handle_of_atyp", []() {
         return py::type::handle_of<atyp>(); // Exercises static_cast in this function.
     });
+
+    // Checks for type names used as arguments
+    m.def("args_shared_ptr", [](std::shared_ptr<atyp> p) { return p; });
+    m.def("args_shared_ptr_const", [](std::shared_ptr<atyp const> p) { return p; });
+    m.def("args_unique_ptr", [](std::unique_ptr<atyp> p) { return p; });
+    m.def("args_unique_ptr_const", [](std::unique_ptr<atyp const> p) { return p; });
 }
 
 } // namespace class_sh_basic

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -163,3 +163,22 @@ def test_unique_ptr_consumer_roundtrip(pass_f, rtrn_f, moved_out, moved_in):
 def test_py_type_handle_of_atyp():
     obj = m.py_type_handle_of_atyp()
     assert obj.__class__.__name__ == "pybind11_type"
+
+
+def test_function_signatures(doc):
+    assert (
+        doc(m.args_shared_ptr)
+        == "args_shared_ptr(arg0: m.class_sh_basic.atyp) -> m.class_sh_basic.atyp"
+    )
+    assert (
+        doc(m.args_shared_ptr_const)
+        == "args_shared_ptr_const(arg0: m.class_sh_basic.atyp) -> m.class_sh_basic.atyp"
+    )
+    assert (
+        doc(m.args_unique_ptr)
+        == "args_unique_ptr(arg0: m.class_sh_basic.atyp) -> m.class_sh_basic.atyp"
+    )
+    assert (
+        doc(m.args_unique_ptr_const)
+        == "args_unique_ptr_const(arg0: m.class_sh_basic.atyp) -> m.class_sh_basic.atyp"
+    )


### PR DESCRIPTION
Required for pybind11-stubgen to work properly