### PR TITLE
A way to register additional test targets and support .py only tests.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -159,8 +159,9 @@ tests with these targets:
 * `test_cmake_build`: Install / subdirectory tests
 
 If you want to build just a subset of tests, use
-`-DPYBIND11_TEST_OVERRIDE="test_callbacks.cpp;test_pickling.cpp"`. If this is
-empty, all tests will be built.
+`-DPYBIND11_TEST_OVERRIDE="test_callbacks;test_pickling"`. If this is
+empty, all tests will be built. Tests are specified without an extension if they need both a .py and
+.cpp file.
 
 You may also pass flags to the `pytest` target by editing `tests/pytest.ini` or
 by using the `PYTEST_ADDOPTS` environment variable

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,7 +36,8 @@ macro(pybind11_filter_tests LISTNAME)
     list(FIND LIST_WITHOUT_EXTENSIONS ${filename_no_ext} _FILE_FOUND)
     if(_FILE_FOUND GREATER -1)
       list(REMOVE_AT ${LISTNAME} ${_FILE_FOUND}) # And remove from the list with extensions.
-      list(REMOVE_AT LIST_WITHOUT_EXTENSIONS ${_FILE_FOUND}) # And our search list, to ensure it is in sync.
+      list(REMOVE_AT LIST_WITHOUT_EXTENSIONS ${_FILE_FOUND}
+      )# And our search list, to ensure it is in sync.
       set(PYBIND11_FILTER_TESTS_FOUND ON)
     endif()
   endforeach()
@@ -166,7 +167,8 @@ if(PYBIND11_TEST_OVERRIDE)
   string(REGEX REPLACE "\\.[^.]*;" ";" TEST_FILES_NO_EXT "${PYBIND11_TEST_FILES};")
   # This allows the override to be done with extensions, preserving backwards compatibility.
   foreach(test_name ${TEST_FILES_NO_EXT})
-    if(NOT ${test_name} IN_LIST TEST_OVERRIDE_NO_EXT) # If not in the whitelist, add to be filtered out.
+    if(NOT ${test_name} IN_LIST TEST_OVERRIDE_NO_EXT
+    )# If not in the whitelist, add to be filtered out.
       list(APPEND PYBIND11_TEST_FILTER ${test_name})
     endif()
   endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,18 @@ macro(possibly_uninitialized)
   endforeach()
 endmacro()
 
+# Function to add additional targets if any of the provided tests are found.
+# Needles; Specifies the test names to look for.
+# Additions; Specifies the additional test targets to add when any of the needles are found.
+macro(tests_extra_targets needles additions)
+  # Add the index for this relation to the index extra targets map.
+  list(LENGTH PYBIND11_TEST_EXTRA_TARGETS PYBIND11_TEST_EXTRA_TARGETS_LEN)
+  list(APPEND PYBIND11_TEST_EXTRA_TARGETS ${PYBIND11_TEST_EXTRA_TARGETS_LEN})
+  # Add the test names to look for, and the associated test target additions.
+  set(PYBIND11_TEST_EXTRA_TARGETS_NEEDLES_${PYBIND11_TEST_EXTRA_TARGETS_LEN} ${needles})
+  set(PYBIND11_TEST_EXTRA_TARGETS_ADDITION_${PYBIND11_TEST_EXTRA_TARGETS_LEN} ${additions})
+endmacro()
+
 # New Python support
 if(DEFINED Python_EXECUTABLE)
   set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
@@ -167,10 +179,11 @@ string(REPLACE ".cpp" ".py" PYBIND11_PYTEST_FILES "${PYBIND11_TEST_FILES}")
 # Contains the set of test files that require pybind11_cross_module_tests to be
 # built; if none of these are built (i.e. because TEST_OVERRIDE is used and
 # doesn't include them) the second module doesn't get built.
-set(PYBIND11_CROSS_MODULE_TESTS test_exceptions.py test_local_bindings.py test_stl.py
-                                test_stl_binders.py)
+tests_extra_targets("test_exceptions.py;test_local_bindings.py;test_stl.py;test_stl_binders.py"
+                    "pybind11_cross_module_tests")
 
-set(PYBIND11_CROSS_MODULE_GIL_TESTS test_gil_scoped.py)
+# And add additional targets for other tests.
+tests_extra_targets("test_gil_scoped.py" "cross_module_gil_utils")
 
 set(PYBIND11_EIGEN_REPO
     "https://gitlab.com/libeigen/eigen.git"
@@ -353,21 +366,17 @@ endfunction()
 
 set(test_targets pybind11_tests)
 
-# Build pybind11_cross_module_tests if any test_whatever.py are being built that require it
-foreach(t ${PYBIND11_CROSS_MODULE_TESTS})
-  list(FIND PYBIND11_PYTEST_FILES ${t} i)
-  if(i GREATER -1)
-    list(APPEND test_targets pybind11_cross_module_tests)
-    break()
-  endif()
-endforeach()
-
-foreach(t ${PYBIND11_CROSS_MODULE_GIL_TESTS})
-  list(FIND PYBIND11_PYTEST_FILES ${t} i)
-  if(i GREATER -1)
-    list(APPEND test_targets cross_module_gil_utils)
-    break()
-  endif()
+# Check if any tests need extra targets by iterating through the mappings registered.
+foreach(i ${PYBIND11_TEST_EXTRA_TARGETS})
+  foreach(needle ${PYBIND11_TEST_EXTRA_TARGETS_NEEDLES_${i}})
+    if(${needle} IN_LIST PYBIND11_PYTEST_FILES)
+      # Add all the additional targets to the test list. List join in newer cmake.
+      foreach(extra_target ${PYBIND11_TEST_EXTRA_TARGETS_ADDITION_${i}})
+        list(APPEND test_targets ${extra_target})
+      endforeach()
+      break() # Breaks out of the needle search, continues with the next mapping.
+    endif()
+  endforeach()
 endforeach()
 
 # Support CUDA testing by forcing the target file to compile with NVCC

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ macro(pybind11_filter_tests LISTNAME)
   set(PYBIND11_FILTER_TESTS_FOUND OFF)
   # Make a list of the test without any extensions, for easier filtering.
   set(_TMP_ACTUAL_LIST "${${LISTNAME}};") # enforce ';' at the end to allow matching last item.
-  string(REGEX REPLACE "\\.[^.]*;" ";" LIST_WITHOUT_EXTENSIONS "${_TMP_ACTUAL_LIST}")
+  string(REGEX REPLACE "\\.[^.;]*;" ";" LIST_WITHOUT_EXTENSIONS "${_TMP_ACTUAL_LIST}")
   foreach(filename IN LISTS ARG_UNPARSED_ARGUMENTS)
     string(REGEX REPLACE "\\.[^.]*$" "" filename_no_ext ${filename})
     # Search in the list without extensions.
@@ -163,8 +163,8 @@ set(PYBIND11_TEST_FILES
 if(PYBIND11_TEST_OVERRIDE)
   # Instead of doing a direct override here, we iterate over the overrides without extension and
   # match them against entries from the PYBIND11_TEST_FILES, anything that not matches goes into the filter list.
-  string(REGEX REPLACE "\\.[^.]*;" ";" TEST_OVERRIDE_NO_EXT "${PYBIND11_TEST_OVERRIDE};")
-  string(REGEX REPLACE "\\.[^.]*;" ";" TEST_FILES_NO_EXT "${PYBIND11_TEST_FILES};")
+  string(REGEX REPLACE "\\.[^.;]*;" ";" TEST_OVERRIDE_NO_EXT "${PYBIND11_TEST_OVERRIDE};")
+  string(REGEX REPLACE "\\.[^.;]*;" ";" TEST_FILES_NO_EXT "${PYBIND11_TEST_FILES};")
   # This allows the override to be done with extensions, preserving backwards compatibility.
   foreach(test_name ${TEST_FILES_NO_EXT})
     if(NOT ${test_name} IN_LIST TEST_OVERRIDE_NO_EXT

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ macro(pybind11_filter_tests LISTNAME)
     list(FIND LIST_WITHOUT_EXTENSIONS ${filename_no_ext} _FILE_FOUND)
     if(_FILE_FOUND GREATER -1)
       list(REMOVE_AT ${LISTNAME} ${_FILE_FOUND}) # And remove from the list with extensions.
+      list(REMOVE_AT LIST_WITHOUT_EXTENSIONS ${_FILE_FOUND}) # And our search list, to ensure it is in sync.
       set(PYBIND11_FILTER_TESTS_FOUND ON)
     endif()
   endforeach()
@@ -120,20 +121,6 @@ set(PYBIND11_TEST_FILES
     test_callbacks
     test_chrono
     test_class
-    test_class_sh_basic
-    test_class_sh_disowning
-    test_class_sh_disowning_mi
-    test_class_sh_factory_constructors
-    test_class_sh_inheritance
-    test_class_sh_shared_ptr_copy_move
-    test_class_sh_trampoline_basic
-    test_class_sh_trampoline_self_life_support
-    test_class_sh_trampoline_shared_from_this
-    test_class_sh_trampoline_shared_ptr_cpp_arg
-    test_class_sh_trampoline_unique_ptr
-    test_class_sh_unique_ptr_member
-    test_class_sh_virtual_py_cpp_mix
-    test_classh_mock
     test_const_name
     test_constants_and_functions
     test_copy_move
@@ -173,7 +160,16 @@ set(PYBIND11_TEST_FILES
 # lets you override the tests that get compiled and run.  You can restore to all tests with:
 #     cmake -DPYBIND11_TEST_OVERRIDE= ..
 if(PYBIND11_TEST_OVERRIDE)
-  set(PYBIND11_TEST_FILES ${PYBIND11_TEST_OVERRIDE})
+  # Instead of doing a direct override here, we iterate over the overrides without extension and
+  # match them against entries from the PYBIND11_TEST_FILES, anything that not matches goes into the filter list.
+  string(REGEX REPLACE "\\.[^.]*;" ";" TEST_OVERRIDE_NO_EXT "${PYBIND11_TEST_OVERRIDE};")
+  string(REGEX REPLACE "\\.[^.]*;" ";" TEST_FILES_NO_EXT "${PYBIND11_TEST_FILES};")
+  # This allows the override to be done with extensions, preserving backwards compatibility.
+  foreach(test_name ${TEST_FILES_NO_EXT})
+    if(NOT ${test_name} IN_LIST TEST_OVERRIDE_NO_EXT) # If not in the whitelist, add to be filtered out.
+      list(APPEND PYBIND11_TEST_FILTER ${test_name})
+    endif()
+  endforeach()
 endif()
 
 # You can also filter tests:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 # Only needed for CMake < 3.5 support
 include(CMakeParseArguments)
 
-# Filter out items; print an optional message if any items filtered
+# Filter out items; print an optional message if any items filtered. This ignores extensions.
 #
 # Usage:
 #   pybind11_filter_tests(LISTNAME file1.cpp file2.cpp ... MESSAGE "")
@@ -27,10 +27,15 @@ include(CMakeParseArguments)
 macro(pybind11_filter_tests LISTNAME)
   cmake_parse_arguments(ARG "" "MESSAGE" "" ${ARGN})
   set(PYBIND11_FILTER_TESTS_FOUND OFF)
+  # Make a list of the test without any extensions, for easier filtering.
+  set(_TMP_ACTUAL_LIST "${${LISTNAME}};") # enforce ';' at the end to allow matching last item.
+  string(REGEX REPLACE "\\.[^.]*;" ";" LIST_WITHOUT_EXTENSIONS "${_TMP_ACTUAL_LIST}")
   foreach(filename IN LISTS ARG_UNPARSED_ARGUMENTS)
-    list(FIND ${LISTNAME} ${filename} _FILE_FOUND)
+    string(REGEX REPLACE "\\.[^.]*$" "" filename_no_ext ${filename})
+    # Search in the list without extensions.
+    list(FIND LIST_WITHOUT_EXTENSIONS ${filename_no_ext} _FILE_FOUND)
     if(_FILE_FOUND GREATER -1)
-      list(REMOVE_AT ${LISTNAME} ${_FILE_FOUND})
+      list(REMOVE_AT ${LISTNAME} ${_FILE_FOUND}) # And remove from the list with extensions.
       set(PYBIND11_FILTER_TESTS_FOUND ON)
     endif()
   endforeach()
@@ -104,48 +109,64 @@ if(PYBIND11_CUDA_TESTS)
   set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 endif()
 
-# Full set of test files (you can override these; see below)
+# Full set of test files (you can override these; see below, overrides ignore extension)
+# Any test that has no extension is both .py and .cpp, so 'foo' will add 'foo.cpp' and 'foo.py'.
+# Any test that has an extension is exclusively that and handled as such.
 set(PYBIND11_TEST_FILES
-    test_async.cpp
-    test_buffers.cpp
-    test_builtin_casters.cpp
-    test_call_policies.cpp
-    test_callbacks.cpp
-    test_chrono.cpp
-    test_class.cpp
-    test_const_name.cpp
-    test_constants_and_functions.cpp
-    test_copy_move.cpp
-    test_custom_type_casters.cpp
-    test_custom_type_setup.cpp
-    test_docstring_options.cpp
-    test_eigen.cpp
-    test_enum.cpp
-    test_eval.cpp
-    test_exceptions.cpp
-    test_factory_constructors.cpp
-    test_gil_scoped.cpp
-    test_iostream.cpp
-    test_kwargs_and_defaults.cpp
-    test_local_bindings.cpp
-    test_methods_and_attributes.cpp
-    test_modules.cpp
-    test_multiple_inheritance.cpp
-    test_numpy_array.cpp
-    test_numpy_dtypes.cpp
-    test_numpy_vectorize.cpp
-    test_opaque_types.cpp
-    test_operator_overloading.cpp
-    test_pickling.cpp
-    test_pytypes.cpp
-    test_sequences_and_iterators.cpp
-    test_smart_ptr.cpp
-    test_stl.cpp
-    test_stl_binders.cpp
-    test_tagbased_polymorphic.cpp
-    test_thread.cpp
-    test_union.cpp
-    test_virtual_functions.cpp)
+    test_async
+    test_buffers
+    test_builtin_casters
+    test_call_policies
+    test_callbacks
+    test_chrono
+    test_class
+    test_class_sh_basic
+    test_class_sh_disowning
+    test_class_sh_disowning_mi
+    test_class_sh_factory_constructors
+    test_class_sh_inheritance
+    test_class_sh_shared_ptr_copy_move
+    test_class_sh_trampoline_basic
+    test_class_sh_trampoline_self_life_support
+    test_class_sh_trampoline_shared_from_this
+    test_class_sh_trampoline_shared_ptr_cpp_arg
+    test_class_sh_trampoline_unique_ptr
+    test_class_sh_unique_ptr_member
+    test_class_sh_virtual_py_cpp_mix
+    test_classh_mock
+    test_const_name
+    test_constants_and_functions
+    test_copy_move
+    test_custom_type_casters
+    test_custom_type_setup
+    test_docstring_options
+    test_eigen
+    test_enum
+    test_eval
+    test_exceptions
+    test_factory_constructors
+    test_gil_scoped
+    test_iostream
+    test_kwargs_and_defaults
+    test_local_bindings
+    test_methods_and_attributes
+    test_modules
+    test_multiple_inheritance
+    test_numpy_array
+    test_numpy_dtypes
+    test_numpy_vectorize
+    test_opaque_types
+    test_operator_overloading
+    test_pickling
+    test_pytypes
+    test_sequences_and_iterators
+    test_smart_ptr
+    test_stl
+    test_stl_binders
+    test_tagbased_polymorphic
+    test_thread
+    test_union
+    test_virtual_functions)
 
 # Invoking cmake with something like:
 #     cmake -DPYBIND11_TEST_OVERRIDE="test_callbacks.cpp;test_pickling.cpp" ..
@@ -174,7 +195,25 @@ if(PYBIND11_CUDA_TESTS)
     "Skipping test_constants_and_functions due to incompatible exception specifications")
 endif()
 
-string(REPLACE ".cpp" ".py" PYBIND11_PYTEST_FILES "${PYBIND11_TEST_FILES}")
+# Now that the test filtering is complete, we need to split the list into the test for PYTEST
+# and the list for the cpp targets.
+set(PYBIND11_CPPTEST_FILES "")
+set(PYBIND11_PYTEST_FILES "")
+
+foreach(test_name ${PYBIND11_TEST_FILES})
+  if(test_name MATCHES "\\.py$") # Ends in .py, purely python test.
+    list(APPEND PYBIND11_PYTEST_FILES ${test_name})
+  elseif(test_name MATCHES "\\.cpp$") # Ends in .cpp, purely cpp test.
+    list(APPEND PYBIND11_CPPTEST_FILES ${test_name})
+  elseif(NOT test_name MATCHES "\\.") # No extension specified, assume both, add extension.
+    list(APPEND PYBIND11_PYTEST_FILES ${test_name}.py)
+    list(APPEND PYBIND11_CPPTEST_FILES ${test_name}.cpp)
+  else()
+    message(WARNING "Unhanded test extension in test: ${test_name}")
+  endif()
+endforeach()
+set(PYBIND11_TEST_FILES ${PYBIND11_CPPTEST_FILES})
+list(SORT PYBIND11_PYTEST_FILES)
 
 # Contains the set of test files that require pybind11_cross_module_tests to be
 # built; if none of these are built (i.e. because TEST_OVERRIDE is used and
@@ -369,7 +408,7 @@ set(test_targets pybind11_tests)
 # Check if any tests need extra targets by iterating through the mappings registered.
 foreach(i ${PYBIND11_TEST_EXTRA_TARGETS})
   foreach(needle ${PYBIND11_TEST_EXTRA_TARGETS_NEEDLES_${i}})
-    if(${needle} IN_LIST PYBIND11_PYTEST_FILES)
+    if(needle IN_LIST PYBIND11_PYTEST_FILES)
       # Add all the additional targets to the test list. List join in newer cmake.
       foreach(extra_target ${PYBIND11_TEST_EXTRA_TARGETS_ADDITION_${i}})
         list(APPEND test_targets ${extra_target})


### PR DESCRIPTION
## Description

@rwgk asked for help on the CMake bullet point in [this comment](https://github.com/pybind/pybind11/pull/2839#issuecomment-1004202218). I proposed some changes in the [comment](https://github.com/pybind/pybind11/pull/2839#issuecomment-1004465857) after that, moving it to a PR for easier discussion.

Changes in this PR are two-fold:
- Make it easier to register additional targets necessary to run a test.
- Support tests where a python file does not map to a single cpp file.

The first commit, solves the first problem. So before, there was special handling for `PYBIND11_CROSS_MODULE_TESTS`, `PYBIND11_CROSS_MODULE_GIL_TESTS` and `PYBIND11_CLASS_SH_MODULE_LOCAL_TESTS` in the new test @rwgk  added in the `smart_holder` branch. I thought that that [block](https://github.com/pybind/pybind11/blob/73197b392a1a1a2c3d89a8c9119162ccda6e285f/tests/CMakeLists.txt#L371-L396), I initially thought the desire was to make that handling uniform. So what I made to handle that using common logic is a lookup where we can register additional targets if a particular test is present. Registering extra targets is done through the new `tests_extra_targets` macro.  The first argument it takes (needles), are test that will be looked for in the PYTEST lists, if any of the needles is found, the additional targets specified in the second argument (additions) will be added. The registered mappings are stored in an [emulated map](https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/VariablesListsStrings#emulating-maps) called `PYBIND11_TEST_EXTRA_TARGETS`.

So, registration is done through `tests_extra_targets`, then, after all the filtering is performed on the tests, we iterate through the registered `test->targets` mapping (`PYBIND11_TEST_EXTRA_TARGETS`), check if any of the needles are found in the tests, if so we add the additional targets that are stored as values in the map.

The second commit addresses the actual concern @rwgk had with the new test addition not behaving nicely with the override and test filtering. So, the original CMakeLists file assumed that for each cpp file in `PYBIND11_TEST_FILES`, there would be a single .py file with the same name. This didn't play nicely with the new test being added, which has just a single python file, this broke the assumption that the big lists of tests is a list of cpp files for which a .py file exists. So, change made here is to have the big list of files use no extension when both a `.py` file AND a `.cpp` file is present. If an extension is specified this test is assumed to be stand alone, without a .py or .cpp counterpart of the same name. After filtering, the test list it split with python files going into the already existing PYTEST list and the `PYBIND11_TEST_FILES` variable is overwritten with the .cpp files.

To preserve backwards compatibility on the test filter, we made the filter function ignore any extensions. After all, the big lists of tests now contains either no extension, or .cpp or .py, but we don't want to break anyone's already existing filters. Then, this still broke the test override, so we fixed (third commit) that by instead of directly overriding `PYBIND11_TEST_FILES` with the override, we now instead match the override list against the test list (ignoring extensions again), and filter out anything that is NOT present in the override. This ensures that overrides specified with a `.cpp` file, but in the test list without an extension will still be respected as without an extension. This should make it fully backwards compatible, both for the filter flag and the override flag.

It adds a bit of code, but it's fully backwards compatible and should allow for more uniform handling of tests made up of .py, .cpp or both.

## Suggested changelog entry:

```rst
* More uniform handling of test targets.
```

