### PR TITLE
Workaround for CUDA 11 breakage.

### DIFF
--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -56,7 +56,11 @@ int f1(int x) noexcept(true) { return x+1; }
 int f1(int x) noexcept { return x+1; }
 #endif
 int f2(int x) noexcept(true) { return x+2; }
+#if defined(__CUDACC__)
+int f3(int x) { return x+3; } // noexcept(false) stopped working 2022-01-07
+#else
 int f3(int x) noexcept(false) { return x+3; }
+#endif
 #if defined(__GNUG__) && !defined(__INTEL_COMPILER)
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wdeprecated"


### PR DESCRIPTION
```
tests/test_constants_and_functions.cpp(140): error: incompatible exception specifications
```

Breakage observed with:
```
-- The CXX compiler identification is GNU 9.3.0
-- The CUDA compiler identification is NVIDIA 11.0.221
```

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
