### PR TITLE
Add additional info to TypeError when C++->Python casting fails

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -996,6 +996,13 @@ protected:
                               "Python type! The signature was\n\t";
             msg += it->signature;
             append_note_if_missing_header_is_suspected(msg);
+#if PY_VERSION_HEX >= 0x03030000
+            // Attach additional error info to the exception if supported
+            if (PyErr_Occurred()) {
+                raise_from(PyExc_TypeError, msg.c_str());
+                return nullptr;
+            }
+#endif
             PyErr_SetString(PyExc_TypeError, msg.c_str());
             return nullptr;
         }

--- a/tests/test_operator_overloading.cpp
+++ b/tests/test_operator_overloading.cpp
@@ -7,10 +7,11 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11_tests.h"
 #include "constructor_stats.h"
-#include <pybind11/operators.h>
+#include "pybind11_tests.h"
 #include <functional>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
 
 class Vector2 {
 public:
@@ -71,6 +72,12 @@ int operator+(const C2 &, const C2 &) { return 22; }
 int operator+(const C2 &, const C1 &) { return 21; }
 int operator+(const C1 &, const C2 &) { return 12; }
 
+struct HashMe {
+    std::string member;
+};
+
+bool operator==(const HashMe &lhs, const HashMe &rhs) { return lhs.member == rhs.member; }
+
 // Note: Specializing explicit within `namespace std { ... }` is done due to a
 // bug in GCC<7. If you are supporting compilers later than this, consider
 // specializing `using template<> struct std::hash<...>` in the global
@@ -81,6 +88,13 @@ namespace std {
     struct hash<Vector2> {
         // Not a good hash function, but easy to test
         size_t operator()(const Vector2 &) { return 4; }
+    };
+
+    template <>
+    struct hash<HashMe> {
+        std::size_t operator()(const HashMe &selector) const {
+            return std::hash<std::string>()(selector.member);
+        }
     };
 } // namespace std
 
@@ -228,8 +242,12 @@ TEST_SUBMODULE(operators, m) {
         .def("__hash__", &Hashable::hash)
         .def(py::init<int>())
         .def(py::self == py::self);
-}
 
+    // define __eq__ but not __hash__
+    py::class_<HashMe>(m, "Hashable3").def(py::self == py::self);
+
+    m.def("get_unhashable_HashMe_set", []() { return std::unordered_set<HashMe>{{"one"}}; });
+}
 #if !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
   #pragma GCC diagnostic pop
 #endif

--- a/tests/test_operator_overloading.cpp
+++ b/tests/test_operator_overloading.cpp
@@ -90,6 +90,7 @@ namespace std {
         size_t operator()(const Vector2 &) { return 4; }
     };
 
+    // HashMe has a hash function in C++ but no `__hash__` for Python.
     template <>
     struct hash<HashMe> {
         std::size_t operator()(const HashMe &selector) const {

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -136,8 +136,9 @@ def test_overriding_eq_reset_hash():
     assert m.Comparable(15) is not m.Comparable(15)
     assert m.Comparable(15) == m.Comparable(15)
 
-    with pytest.raises(TypeError):
-        hash(m.Comparable(15))  # TypeError: unhashable type: 'm.Comparable'
+    with pytest.raises(TypeError) as excinfo:
+        hash(m.Comparable(15))
+    assert str(excinfo.value).startswith("unhashable type:")
 
     for hashable in (m.Hashable, m.Hashable2):
         assert hashable(15) is not hashable(15)

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+import env
 from pybind11_tests import ConstructorStats
 from pybind11_tests import operators as m
 
@@ -144,3 +145,10 @@ def test_overriding_eq_reset_hash():
 
         assert hash(hashable(15)) == 15
         assert hash(hashable(15)) == hash(hashable(15))
+
+
+def test_return_set_of_unhashable():
+    with pytest.raises(TypeError) as excinfo:
+        m.get_unhashable_HashMe_set()
+    if not env.PY2:
+        assert str(excinfo.value.__cause__).startswith("unhashable type:")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Adds additional information when raising a type error during function return. Inspired by the unexpected behavior from #3600 .
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* If possible, attach Python exception with ``py::raise_from`` to TypeError when casting from C++ to Python. This will give additional info if Python exceptions occur in the caster. Adds a test case of trying to convert a set from C++ to Python when the hash function is not defined in Python. 
```

As a meta note, this is an issue because we are a bit inconsistent in how we handle Python exceptions with ``py::set``, ``py::dict``, etc...). We currently not raising an exception from Python to C++ when interacting with them, maybe we should consider doing that.

<!-- If the upgrade guide needs updating, note that here too -->
