### PR TITLE
Add support for nested C++11 exceptions

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -36,6 +36,9 @@
 #    define PYBIND11_CPP14
 #    if __cplusplus >= 201703L
 #      define PYBIND11_CPP17
+#      if __cplusplus >= 202002L
+#        define PYBIND11_CPP20
+#      endif
 #    endif
 #  endif
 #elif defined(_MSC_VER) && __cplusplus == 199711L
@@ -45,6 +48,9 @@
 #    define PYBIND11_CPP14
 #    if _MSVC_LANG > 201402L && _MSC_VER >= 1910
 #      define PYBIND11_CPP17
+#      if _MSVC_LANG > 202002L
+#        define PYBIND11_CPP20
+#      endif
 #    endif
 #  endif
 #endif
@@ -610,6 +616,18 @@ template <bool B, typename T = void> using enable_if_t = typename std::enable_if
 template <bool B, typename T, typename F> using conditional_t = typename std::conditional<B, T, F>::type;
 template <typename T> using remove_cv_t = typename std::remove_cv<T>::type;
 template <typename T> using remove_reference_t = typename std::remove_reference<T>::type;
+#endif
+
+#if defined(PYBIND11_CPP20)
+using std::remove_cvref;
+using std::remove_cvref_t;
+#else
+template <class T>
+struct remove_cvref {
+    using type = remove_cv_t<remove_reference_t<T>>;
+};
+template <class T>
+using remove_cvref_t = typename remove_cvref<T>::type;
 #endif
 
 /// Index sequences

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -48,7 +48,7 @@
 #    define PYBIND11_CPP14
 #    if _MSVC_LANG > 201402L && _MSC_VER >= 1910
 #      define PYBIND11_CPP17
-#      if _MSVC_LANG > 202002L
+#      if _MSVC_LANG >= 202002L
 #        define PYBIND11_CPP20
 #      endif
 #    endif

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -327,7 +327,7 @@ void handle_nested_exception(T, std::exception_ptr) {
 
 inline bool raise_err(PyObject *exc_type, const char *msg) {
     PyErr_SetString(exc_type, msg);
-    return false
+    return false;
 }
 #endif
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "../pytypes.h"
-#include <__threading_support>
 #include <exception>
 #include <type_traits>
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -382,7 +382,7 @@ inline void translate_exception(std::exception_ptr p) {
         raise_err(PyExc_RuntimeError, e.what());
         return;
     } catch (const std::nested_exception &e) {
-        handle_nested_exception(e, p);.
+        handle_nested_exception(e, p);
         raise_err(PyExc_RuntimeError, "Caught an unknown nested exception!");
     } catch (...) {
         raise_err(PyExc_RuntimeError, "Caught an unknown exception!");

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -283,7 +283,7 @@ inline internals **&get_internals_pp() {
 
 #if PY_VERSION_HEX >= 0x03030000
 inline bool raise_err(PyObject *exc_type, const char *msg) {
-    bool err_occurred = PyErr_Occurred();
+    bool err_occurred = PyErr_Occurred() != nullptr;
     if (err_occurred) {
         raise_from(exc_type, msg);
     } else {

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -321,7 +321,7 @@ bool handle_nested_exception(const T &exc, const std::exception_ptr &p) {
 }
 #else
 template <class T>
-void handle_nested_exception(T, std::exception_ptr p) {
+void handle_nested_exception(T, std::exception_ptr) {
     return;
 }
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -384,6 +384,7 @@ inline void translate_exception(std::exception_ptr p) {
     } catch (const std::nested_exception &e) {
         handle_nested_exception(e, p);
         raise_err(PyExc_RuntimeError, "Caught an unknown nested exception!");
+        return;
     } catch (...) {
         raise_err(PyExc_RuntimeError, "Caught an unknown exception!");
         return;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -282,15 +282,6 @@ inline internals **&get_internals_pp() {
 }
 
 #if PY_VERSION_HEX >= 0x03030000
-inline bool raise_err(PyObject *exc_type, const char *msg) {
-    if (PyErr_Occurred()) {
-        raise_from(exc_type, msg);
-        return true;
-    }
-    PyErr_SetString(exc_type, msg);
-    return false;
-};
-
 // forward decl
 inline void translate_exception(std::exception_ptr);
 
@@ -315,16 +306,23 @@ bool handle_nested_exception(const T &exc, const std::exception_ptr &p) {
 }
 
 #else
-inline bool raise_err(PyObject *exc_type, const char *msg) {
-    PyErr_SetString(exc_type, msg);
-    return false;
-}
 
 template <class T>
-bool handle_nested_exception(const T &, std::exception_ptr) {
+bool handle_nested_exception(const T &, std::exception_ptr &) {
     return false;
 }
 #endif
+
+inline bool raise_err(PyObject *exc_type, const char *msg) {
+#if PY_VERSION_HEX >= 0x03030000
+    if (PyErr_Occurred()) {
+        raise_from(exc_type, msg);
+        return true;
+    }
+#endif
+    PyErr_SetString(exc_type, msg);
+    return false;
+};
 
 inline void translate_exception(std::exception_ptr p) {
     if (!p) {

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -321,8 +321,8 @@ bool handle_nested_exception(const T &exc, const std::exception_ptr &p) {
 }
 #else
 template <class T>
-void handle_nested_exception(T, std::exception_ptr) {
-    return;
+bool handle_nested_exception(T, std::exception_ptr) {
+    return false;
 }
 
 inline bool raise_err(PyObject *exc_type, const char *msg) {

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -10,6 +10,9 @@
 #pragma once
 
 #include "../pytypes.h"
+#include <__threading_support>
+#include <exception>
+#include <type_traits>
 
 /// Tracks the `internals` and `type_info` ABI version independent of the main library version.
 ///
@@ -280,21 +283,91 @@ inline internals **&get_internals_pp() {
     return internals_pp;
 }
 
+#if PY_VERSION_HEX >= 0x03030000
+/*
+// For nested_exception support (todo not working)
+template <class T>
+std::exception_ptr get_nested_exception_ptr_impl(const T &e, std::true_type) {
+    if (auto nep = dynamic_cast<const std::nested_exception *>(std::addressof(e))) {
+        return nep->nested_ptr();
+        ;
+    }
+    return nullptr;
+}
+
+template <class T>
+std::exception_ptr get_nested_exception_ptr_impl(const T &, std::false_type) {
+    return nullptr;
+}
+
+template <class T>
+std::exception_ptr get_nested_exception_ptr(const T &e) {
+    return get_nested_exception_ptr_impl(e, is_accessible_base_of<T, std::nested_exception>());
+}
+#endif
+*/
 inline void translate_exception(std::exception_ptr p) {
+    if (!p) {
+        return;
+    }
+    auto raise_err = PyErr_SetString;
+#if PY_VERSION_HEX >= 0x03030000
+    // handles nested C++ exceptions if supported
     try {
-        if (p) std::rethrow_exception(p);
-    } catch (error_already_set &e)           { e.restore();                                    return;
-    } catch (const builtin_exception &e)     { e.set_error();                                  return;
-    } catch (const std::bad_alloc &e)        { PyErr_SetString(PyExc_MemoryError,   e.what()); return;
-    } catch (const std::domain_error &e)     { PyErr_SetString(PyExc_ValueError,    e.what()); return;
-    } catch (const std::invalid_argument &e) { PyErr_SetString(PyExc_ValueError,    e.what()); return;
-    } catch (const std::length_error &e)     { PyErr_SetString(PyExc_ValueError,    e.what()); return;
-    } catch (const std::out_of_range &e)     { PyErr_SetString(PyExc_IndexError,    e.what()); return;
-    } catch (const std::range_error &e)      { PyErr_SetString(PyExc_ValueError,    e.what()); return;
-    } catch (const std::overflow_error &e)   { PyErr_SetString(PyExc_OverflowError, e.what()); return;
-    } catch (const std::exception &e)        { PyErr_SetString(PyExc_RuntimeError,  e.what()); return;
+        // std::rethrow_if_nested cannot take exception_ptr
+        // the only non-UB way to deference it is to throw it
+        try {
+            std::rethrow_exception(p);
+        } catch (const std::exception &e) {
+            // Future performance optimization
+            // This throw can be removed with our own template
+            // that gets the nested exception_ptr directly.
+            std::rethrow_if_nested(e);
+        }
     } catch (...) {
-        PyErr_SetString(PyExc_RuntimeError, "Caught an unknown exception!");
+        std::exception_ptr nested = std::current_exception();
+        if (nested != p) {
+            translate_exception(nested);
+            if (PyErr_Occurred()) {
+                raise_err = raise_from;
+            }
+        }
+    }
+#endif
+    try {
+        std::rethrow_exception(p);
+    } catch (error_already_set &e) {
+        e.restore();
+        return;
+    } catch (const builtin_exception &e) {
+        e.set_error();
+        return;
+    } catch (const std::bad_alloc &e) {
+        raise_err(PyExc_MemoryError, e.what());
+        return;
+    } catch (const std::domain_error &e) {
+        raise_err(PyExc_ValueError, e.what());
+        return;
+    } catch (const std::invalid_argument &e) {
+        raise_err(PyExc_ValueError, e.what());
+        return;
+    } catch (const std::length_error &e) {
+        raise_err(PyExc_ValueError, e.what());
+        return;
+    } catch (const std::out_of_range &e) {
+        raise_err(PyExc_IndexError, e.what());
+        return;
+    } catch (const std::range_error &e) {
+        raise_err(PyExc_ValueError, e.what());
+        return;
+    } catch (const std::overflow_error &e) {
+        raise_err(PyExc_OverflowError, e.what());
+        return;
+    } catch (const std::exception &e) {
+        raise_err(PyExc_RuntimeError, e.what());
+        return;
+    } catch (...) {
+        raise_err(PyExc_RuntimeError, "Caught an unknown exception!");
         return;
     }
 }

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -291,7 +291,7 @@ inline void translate_exception(std::exception_ptr p) {
 #if PY_VERSION_HEX >= 0x03030000
         // handles nested C++ exceptions if supported
         try {
-            // Deference the exception_ptr by rethrowing it.
+            // Rethrow the exception_ptr to recove type info.
             // Dereferencing an exception_ptr is UB otherwise.
             std::rethrow_exception(p);
         } catch (const std::exception &e) {

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -321,7 +321,7 @@ bool handle_nested_exception(const T &exc, const std::exception_ptr &p) {
 }
 #else
 template <class T>
-void handle_nested_exception(T) {
+void handle_nested_exception(T, std::exception_ptr p) {
     return;
 }
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -314,7 +314,7 @@ template <
     enable_if_t<!std::is_same<std::nested_exception, remove_cv_t<remove_reference_t<T>>>::value,
                 int> = 0>
 bool handle_nested_exception(const T &exc, const std::exception_ptr &p) {
-    if (auto nep = dynamic_cast<const std::nested_exception *>(std::addressof(exc))) {
+    if (auto *nep = dynamic_cast<const std::nested_exception *>(std::addressof(exc))) {
         return handle_nested_exception(*nep, p);
     }
     return false;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -282,8 +282,8 @@ inline internals **&get_internals_pp() {
     return internals_pp;
 }
 
-#if PY_VERSION_HEX >= 0x03030000
 /*
+#if PY_VERSION_HEX >= 0x03030000
 // For nested_exception support (todo not working)
 template <class T>
 std::exception_ptr get_nested_exception_ptr_impl(const T &e, std::true_type) {

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -283,13 +283,12 @@ inline internals **&get_internals_pp() {
 
 #if PY_VERSION_HEX >= 0x03030000
 inline bool raise_err(PyObject *exc_type, const char *msg) {
-    bool err_occurred = PyErr_Occurred() != nullptr;
-    if (err_occurred) {
+    if (PyErr_Occurred()) {
         raise_from(exc_type, msg);
-    } else {
-        PyErr_SetString(exc_type, msg);
+        return true;
     }
-    return err_occurred;
+    PyErr_SetString(exc_type, msg);
+    return false;
 };
 
 // forward decl
@@ -298,8 +297,7 @@ inline void translate_exception(std::exception_ptr);
 template <class T,
           enable_if_t<std::is_same<std::nested_exception, remove_cvref_t<T>>::value, int> = 0>
 bool handle_nested_exception(const T &exc, const std::exception_ptr &p) {
-    std::exception_ptr nested = nullptr;
-    nested = exc.nested_ptr();
+    std::exception_ptr nested = exc.nested_ptr();
     if (nested != nullptr && nested != p) {
         translate_exception(nested);
         return true;
@@ -323,7 +321,7 @@ inline bool raise_err(PyObject *exc_type, const char *msg) {
 }
 
 template <class T>
-bool handle_nested_exception(const T&, std::exception_ptr) {
+bool handle_nested_exception(const T &, std::exception_ptr) {
     return false;
 }
 #endif

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -11,6 +11,8 @@
 #include "local_bindings.h"
 
 #include "pybind11_tests.h"
+#include <exception>
+#include <stdexcept>
 #include <utility>
 
 // A type that should be raised as an exception in Python
@@ -104,7 +106,6 @@ struct PythonAlreadySetInDestructor {
 
     py::str s;
 };
-
 
 TEST_SUBMODULE(exceptions, m) {
     m.def("throw_std_exception", []() {
@@ -281,5 +282,12 @@ TEST_SUBMODULE(exceptions, m) {
         }
     });
 
+    m.def("throw_nested_exception", []() {
+        try {
+            throw std::runtime_error("Inner Exception");
+        } catch (const std::runtime_error &) {
+            std::throw_with_nested(std::runtime_error("Outer Exception"));
+        }
+    });
 #endif
 }

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -239,11 +239,11 @@ def test_nested_throws(capture):
     assert str(excinfo.value) == "this is a helper-defined translated exception"
 
 
+@pytest.mark.skipif("env.PY2")
 def test_throw_nested_exception():
     with pytest.raises(RuntimeError) as excinfo:
         m.throw_nested_exception()
-    if not env.PY2:
-        assert str(excinfo.value.__cause__) == "Inner Exception"
+    assert str(excinfo.value.__cause__) == "Inner Exception"
 
 
 # This can often happen if you wrap a pybind11 class in a Python wrapper

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -243,6 +243,7 @@ def test_nested_throws(capture):
 def test_throw_nested_exception():
     with pytest.raises(RuntimeError) as excinfo:
         m.throw_nested_exception()
+    assert str(excinfo.value) == "Outer Exception"
     assert str(excinfo.value.__cause__) == "Inner Exception"
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -239,6 +239,13 @@ def test_nested_throws(capture):
     assert str(excinfo.value) == "this is a helper-defined translated exception"
 
 
+def test_throw_nested_exception():
+    with pytest.raises(RuntimeError) as excinfo:
+        m.throw_nested_exception()
+    if not env.PY2:
+        assert str(excinfo.value.__cause__) == "Inner Exception"
+
+
 # This can often happen if you wrap a pybind11 class in a Python wrapper
 def test_invalid_repr():
     class MyRepr(object):


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* This PR closes #1913 and maps C++11 nested exception to their Python equivalent in Python 3.3 and greater using the newly introduced raise_from utility.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Adds a mapping of C++11 nested exceptions to their Python exception equivalent using ``py::raise_from``. This attaches the nested exceptions in Python using the ``__cause__`` field.
```

<!-- If the upgrade guide needs updating, note that here too -->
