### PR TITLE
Render `py::bool_` and `py::float_` without `_` in docstrings

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -765,6 +765,7 @@ template <typename base, typename deleter> struct is_holder_type<base, std::uniq
     std::true_type {};
 
 template <typename T> struct handle_type_name { static constexpr auto name = const_name<T>(); };
+template <> struct handle_type_name<bool_> { static constexpr auto name = const_name("bool"); };
 template <> struct handle_type_name<bytes> { static constexpr auto name = const_name(PYBIND11_BYTES_NAME); };
 template <> struct handle_type_name<int_> { static constexpr auto name = const_name("int"); };
 template <> struct handle_type_name<iterable> { static constexpr auto name = const_name("Iterable"); };

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -770,6 +770,7 @@ template <> struct handle_type_name<bytes> { static constexpr auto name = const_
 template <> struct handle_type_name<int_> { static constexpr auto name = const_name("int"); };
 template <> struct handle_type_name<iterable> { static constexpr auto name = const_name("Iterable"); };
 template <> struct handle_type_name<iterator> { static constexpr auto name = const_name("Iterator"); };
+template <> struct handle_type_name<float_> { static constexpr auto name = const_name("float"); };
 template <> struct handle_type_name<none> { static constexpr auto name = const_name("None"); };
 template <> struct handle_type_name<args> { static constexpr auto name = const_name("*args"); };
 template <> struct handle_type_name<kwargs> { static constexpr auto name = const_name("**kwargs"); };

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -21,6 +21,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("get_iterator", []{return py::iterator();});
     // test_iterable
     m.def("get_iterable", []{return py::iterable();});
+    // test_float
+    m.def("get_float", []{return py::float_(0.0f);});
     // test_list
     m.def("list_no_args", []() { return py::list{}; });
     m.def("list_ssize_t", []() { return py::list{(py::ssize_t) 0}; });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -13,6 +13,8 @@
 
 
 TEST_SUBMODULE(pytypes, m) {
+    // test_bool
+    m.def("get_bool", []{return py::bool_(false);});
     // test_int
     m.def("get_int", []{return py::int_(0);});
     // test_iterator

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -10,6 +10,10 @@ from pybind11_tests import debug_enabled
 from pybind11_tests import pytypes as m
 
 
+def test_bool(doc):
+    assert doc(m.get_bool) == "get_bool() -> bool"
+
+
 def test_int(doc):
     assert doc(m.get_int) == "get_int() -> int"
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -26,6 +26,10 @@ def test_iterable(doc):
     assert doc(m.get_iterable) == "get_iterable() -> Iterable"
 
 
+def test_float(doc):
+    assert doc(m.get_float) == "get_float() -> float"
+
+
 def test_list(capture, doc):
     assert m.list_no_args() == []
     assert m.list_ssize_t() == []


### PR DESCRIPTION
## Description

`py::bool_`/`py::float_` used to be rendered as `bool_`/`float_` in docstrings

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
 - Render `py::bool_` and `py::float_` as `bool` and `float` respectively
```