### PR TITLE
[Smart holder] Support void pointer capsules

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -122,7 +122,8 @@ public:
         // Convert `a::b::c` to `a_b_c`
         replace_all(type_name, "::", '_');
 
-        std::string as_void_ptr_function_name = "as_" + type_name;
+        std::string as_void_ptr_function_name("as_");
+        as_void_ptr_function_name += type_name;
         if (hasattr(src, as_void_ptr_function_name.c_str())) {
           auto as_void_ptr_function = function(
               src.attr(as_void_ptr_function_name.c_str()));

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -113,21 +113,18 @@ public:
         // Convert `a::b::c` to `a_b_c`
         size_t pos = type_name.find("::");
         while (pos != std::string::npos) {
-            type_name.replace(pos, 2, "_");
+            type_name.replace(pos, 2, 1, '_');
             pos = type_name.find("::", pos);
         }
 
         std::string as_void_ptr_function_name = "as_" + type_name;
         if (hasattr(src, as_void_ptr_function_name.c_str())) {
-          auto void_ptr_capsule = reinterpret_borrow<object>(
-              PyObject_CallMethod(src.ptr(),
-                  const_cast<char *>(as_void_ptr_function_name.c_str()),
-                  nullptr));
+          auto as_void_ptr_function = function(
+              src.attr(as_void_ptr_function_name.c_str()));
+          auto void_ptr_capsule = as_void_ptr_function();
           if (isinstance<capsule>(void_ptr_capsule)) {
-            unowned_void_ptr_from_void_ptr_capsule = static_cast<void *>(
-                PyCapsule_GetPointer(
-                    void_ptr_capsule.ptr(),
-                    PyCapsule_GetName(void_ptr_capsule.ptr())));
+            unowned_void_ptr_from_void_ptr_capsule = reinterpret_borrow<capsule>(
+                void_ptr_capsule).get_pointer();
             return true;
           }
         }

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -548,9 +548,10 @@ private:
         std::string function_name = "as_" + std::regex_replace(
             type_name, std::regex("::"), "_");
         if (hasattr(src, function_name.c_str())) {
-          capsule c = reinterpret_borrow<capsule>(PyObject_CallMethod(
+          object obj = reinterpret_borrow<object>(PyObject_CallMethod(
               src.ptr(), function_name.c_str(), nullptr));
-          if (c.check()) {
+          if (isinstance<capsule>(obj)) {
+            capsule c(obj);
             return c.get_pointer<T>();
           }
         }

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -110,8 +110,15 @@ public:
     bool try_as_void_ptr_capsule(handle src) {
         std::string type_name = cpptype->name();
         detail::clean_type_id(type_name);
-        std::string as_void_ptr_function_name = "as_" + std::regex_replace(
-            type_name, std::regex("::"), "_");
+
+        // Convert `a::b::c` to `a_b_c`
+        size_t pos = type_name.find("::");
+        while (pos != std::string::npos) {
+            type_name.replace(pos, 2, "_");
+            pos = type_name.find("::", pos);
+        }
+
+        std::string as_void_ptr_function_name = "as_" + type_name;
         if (hasattr(src, as_void_ptr_function_name.c_str())) {
           auto void_ptr_capsule = reinterpret_borrow<object>(
               PyObject_CallMethod(src.ptr(),

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -38,7 +38,7 @@ inline void register_instance(instance *self, void *valptr, const type_info *tin
 inline bool deregister_instance(instance *self, void *valptr, const type_info *tinfo);
 
 // Replace all occurrences of a character in string.
-inline void replace_all(std::string& str, std::string from, char to) {
+inline void replace_all(std::string& str, const std::string& from, char to) {
     size_t pos = str.find(from);
     while (pos != std::string::npos) {
         str.replace(pos, from.length(), 1, to);

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -19,7 +19,6 @@
 #include <cstddef>
 #include <memory>
 #include <new>
-#include <regex>
 #include <string>
 #include <type_traits>
 #include <typeinfo>

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -37,7 +37,6 @@ struct NoCapsuleReturned: public CapsuleBase {
     int get() const { return 103; }
 
     PyObject* as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned() {
-      void* vptr = static_cast<void*>(this);
       capsule_generated = true;
       Py_XINCREF(Py_None);
       return Py_None;

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -7,19 +7,30 @@
 namespace pybind11_tests {
 namespace class_sh_void_ptr_capsule {
 
-struct CapsuleBase {
-    CapsuleBase() = default;
-    virtual ~CapsuleBase() = default;
+// Without the helper we will run into a type_caster::load recursion.
+// This is because whenever the type_caster::load is called, it checks
+// whether the object defines an `as_` method that returns the void pointer
+// capsule. If yes, it calls the method. But in the following testcases, those
+// `as_` methods are defined with pybind11, which implicitly takes the object
+// itself as the first parameter. Therefore calling those methods causes loading
+// the object again, which causes infinite recursion.
+// This test is unusual in the sense that the void pointer capsules are meant to
+// be provided by objects wrapped with systems other than pybind11
+// (i.e. having to avoid the recursion is an artificial problem, not the norm).
+// Conveniently, the helper also serves to keep track of `capsule_generated`.
+struct HelperBase {
+    HelperBase() = default;
+    virtual ~HelperBase() = default;
 
     bool capsule_generated = false;
     virtual int get() const { return 100; }
 };
 
-struct Valid: public CapsuleBase {
+struct Valid: public HelperBase {
     int get() const override { return 101; }
 
     PyObject* as_pybind11_tests_class_sh_void_ptr_capsule_Valid() {
-      void* vptr = static_cast<void*>(this);
+      void* vptr = dynamic_cast<void*>(this);
       capsule_generated = true;
       // We assume vptr out lives the capsule, so we use nullptr for the
       // destructor.
@@ -29,11 +40,11 @@ struct Valid: public CapsuleBase {
     }
 };
 
-struct NoConversion: public CapsuleBase {
+struct NoConversion: public HelperBase {
     int get() const override { return 102; }
 };
 
-struct NoCapsuleReturned: public CapsuleBase {
+struct NoCapsuleReturned: public HelperBase {
     int get() const { return 103; }
 
     PyObject* as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned() {
@@ -43,11 +54,11 @@ struct NoCapsuleReturned: public CapsuleBase {
     }
 };
 
-struct AsAnotherObject: public CapsuleBase {
+struct AsAnotherObject: public HelperBase {
     int get() const override { return 104; }
 
     PyObject* as_pybind11_tests_class_sh_void_ptr_capsule_Valid() {
-      void* vptr = static_cast<void*>(this);
+      void* vptr = dynamic_cast<void*>(this);
       capsule_generated = true;
       // We assume vptr out lives the capsule, so we use nullptr for the
       // destructor.
@@ -80,7 +91,7 @@ int get_from_no_capsule_returned(const NoCapsuleReturned* c) {
 } // namespace class_sh_void_ptr_capsule
 } // namespace pybind11_tests
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::CapsuleBase)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::HelperBase)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Valid)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::NoConversion)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::NoCapsuleReturned)
@@ -89,38 +100,38 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::As
 TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     using namespace pybind11_tests::class_sh_void_ptr_capsule;
 
-    py::classh<CapsuleBase>(m, "CapsuleBase")
+    py::classh<HelperBase>(m, "HelperBase")
         .def(py::init<>())
-        .def("get", &CapsuleBase::get)
-        .def_readonly("capsule_generated", &CapsuleBase::capsule_generated);
+        .def("get", &HelperBase::get)
+        .def_readonly("capsule_generated", &HelperBase::capsule_generated);
 
-    py::classh<Valid, CapsuleBase>(m, "Valid")
+    py::classh<Valid, HelperBase>(m, "Valid")
         .def(py::init<>())
         .def("as_pybind11_tests_class_sh_void_ptr_capsule_Valid",
-             [](CapsuleBase* self) {
+             [](HelperBase* self) {
           Valid *obj = dynamic_cast<Valid *>(self);
           assert(obj != nullptr);
           PyObject* capsule = obj->as_pybind11_tests_class_sh_void_ptr_capsule_Valid();
           return pybind11::reinterpret_steal<py::capsule>(capsule);
         });
 
-    py::classh<NoConversion, CapsuleBase>(m, "NoConversion")
+    py::classh<NoConversion, HelperBase>(m, "NoConversion")
         .def(py::init<>());
 
-    py::classh<NoCapsuleReturned, CapsuleBase>(m, "NoCapsuleReturned")
+    py::classh<NoCapsuleReturned, HelperBase>(m, "NoCapsuleReturned")
         .def(py::init<>())
         .def("as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned",
-             [](CapsuleBase* self) {
+             [](HelperBase* self) {
           NoCapsuleReturned *obj = dynamic_cast<NoCapsuleReturned *>(self);
           assert(obj != nullptr);
           PyObject* capsule = obj->as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned();
           return pybind11::reinterpret_steal<py::capsule>(capsule);
         });
 
-    py::classh<AsAnotherObject, CapsuleBase>(m, "AsAnotherObject")
+    py::classh<AsAnotherObject, HelperBase>(m, "AsAnotherObject")
         .def(py::init<>())
         .def("as_pybind11_tests_class_sh_void_ptr_capsule_Valid",
-             [](CapsuleBase* self) {
+             [](HelperBase* self) {
           AsAnotherObject *obj = dynamic_cast<AsAnotherObject *>(self);
           assert(obj != nullptr);
           PyObject* capsule = obj->as_pybind11_tests_class_sh_void_ptr_capsule_Valid();

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -23,6 +23,8 @@ struct Valid: public CapsuleBase {
     PyObject* as_pybind11_tests_class_sh_void_ptr_capsule_Valid() {
       void* vptr = static_cast<void*>(this);
       capsule_generated = true;
+      // We assume vptr out lives the capsule, so we use nullptr for the
+      // destructor.
       return PyCapsule_New(
           vptr, "::pybind11_tests::class_sh_void_ptr_capsule::Valid",
           nullptr);
@@ -49,6 +51,8 @@ struct AsAnotherObject: public CapsuleBase {
     PyObject* as_pybind11_tests_class_sh_void_ptr_capsule_Valid() {
       void* vptr = static_cast<void*>(this);
       capsule_generated = true;
+      // We assume vptr out lives the capsule, so we use nullptr for the
+      // destructor.
       return PyCapsule_New(
           vptr, "::pybind11_tests::class_sh_void_ptr_capsule::Valid",
           nullptr);

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -1,7 +1,5 @@
 #include "pybind11_tests.h"
 
-#include <Python.h>
-
 #include <pybind11/smart_holder.h>
 
 #include <memory>
@@ -101,6 +99,7 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
         .def("as_pybind11_tests_class_sh_void_ptr_capsule_Valid",
              [](CapsuleBase* self) {
           Valid *obj = dynamic_cast<Valid *>(self);
+          assert(obj != nullptr);
           PyObject* capsule = obj->as_pybind11_tests_class_sh_void_ptr_capsule_Valid();
           return pybind11::reinterpret_steal<py::capsule>(capsule);
         });
@@ -113,6 +112,7 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
         .def("as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned",
              [](CapsuleBase* self) {
           NoCapsuleReturned *obj = dynamic_cast<NoCapsuleReturned *>(self);
+          assert(obj != nullptr);
           PyObject* capsule = obj->as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned();
           return pybind11::reinterpret_steal<py::capsule>(capsule);
         });
@@ -122,6 +122,7 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
         .def("as_pybind11_tests_class_sh_void_ptr_capsule_Valid",
              [](CapsuleBase* self) {
           AsAnotherObject *obj = dynamic_cast<AsAnotherObject *>(self);
+          assert(obj != nullptr);
           PyObject* capsule = obj->as_pybind11_tests_class_sh_void_ptr_capsule_Valid();
           return pybind11::reinterpret_steal<py::capsule>(capsule);
         });

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -1,0 +1,131 @@
+#include "pybind11_tests.h"
+
+#include <Python.h>
+
+#include <pybind11/smart_holder.h>
+
+#include <memory>
+
+namespace pybind11_tests {
+namespace class_sh_void_ptr_capsule {
+
+struct CapsuleBase {
+    CapsuleBase() = default;
+    virtual ~CapsuleBase() = default;
+
+    bool capsule_generated = false;
+    virtual int get() const { return 100; }
+};
+
+struct Valid: public CapsuleBase {
+    int get() const override { return 101; }
+
+    PyObject* as_pybind11_tests_class_sh_void_ptr_capsule_Valid() {
+      void* vptr = static_cast<void*>(this);
+      capsule_generated = true;
+      return PyCapsule_New(
+          vptr, "::pybind11_tests::class_sh_void_ptr_capsule::Valid",
+          nullptr);
+    }
+};
+
+struct NoConversion: public CapsuleBase {
+    int get() const override { return 102; }
+};
+
+struct NoCapsuleReturned: public CapsuleBase {
+    int get() const { return 103; }
+
+    PyObject* as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned() {
+      void* vptr = static_cast<void*>(this);
+      capsule_generated = true;
+      Py_XINCREF(Py_None);
+      return Py_None;
+    }
+};
+
+struct AsAnotherObject: public CapsuleBase {
+    int get() const override { return 104; }
+
+    PyObject* as_pybind11_tests_class_sh_void_ptr_capsule_Valid() {
+      void* vptr = static_cast<void*>(this);
+      capsule_generated = true;
+      return PyCapsule_New(
+          vptr, "::pybind11_tests::class_sh_void_ptr_capsule::Valid",
+          nullptr);
+    }
+};
+
+int get_from_valid_capsule(const Valid* c) {
+  return c->get();
+}
+
+int get_from_shared_ptr_valid_capsule(std::shared_ptr<Valid> c) {
+  return c->get();
+}
+
+int get_from_unique_ptr_valid_capsule(std::unique_ptr<Valid> c) {
+  return c->get();
+}
+
+int get_from_no_conversion_capsule(const NoConversion* c) {
+  return c->get();
+}
+
+int get_from_no_capsule_returned(const NoCapsuleReturned* c) {
+  return c->get();
+}
+
+} // namespace class_sh_void_ptr_capsule
+} // namespace pybind11_tests
+
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::CapsuleBase)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Valid)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::NoConversion)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::NoCapsuleReturned)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::AsAnotherObject)
+
+TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
+    using namespace pybind11_tests::class_sh_void_ptr_capsule;
+
+    py::classh<CapsuleBase>(m, "CapsuleBase")
+        .def(py::init<>())
+        .def("get", &CapsuleBase::get)
+        .def_readonly("capsule_generated", &CapsuleBase::capsule_generated);
+
+    py::classh<Valid, CapsuleBase>(m, "Valid")
+        .def(py::init<>())
+        .def("as_pybind11_tests_class_sh_void_ptr_capsule_Valid",
+             [](CapsuleBase* self) {
+          Valid *obj = dynamic_cast<Valid *>(self);
+          PyObject* capsule = obj->as_pybind11_tests_class_sh_void_ptr_capsule_Valid();
+          return pybind11::reinterpret_steal<py::capsule>(capsule);
+        });
+
+    py::classh<NoConversion, CapsuleBase>(m, "NoConversion")
+        .def(py::init<>());
+
+    py::classh<NoCapsuleReturned, CapsuleBase>(m, "NoCapsuleReturned")
+        .def(py::init<>())
+        .def("as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned",
+             [](CapsuleBase* self) {
+          NoCapsuleReturned *obj = dynamic_cast<NoCapsuleReturned *>(self);
+          PyObject* capsule = obj->as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned();
+          return pybind11::reinterpret_steal<py::capsule>(capsule);
+        });
+
+    py::classh<AsAnotherObject, CapsuleBase>(m, "AsAnotherObject")
+        .def(py::init<>())
+        .def("as_pybind11_tests_class_sh_void_ptr_capsule_Valid",
+             [](CapsuleBase* self) {
+          AsAnotherObject *obj = dynamic_cast<AsAnotherObject *>(self);
+          PyObject* capsule = obj->as_pybind11_tests_class_sh_void_ptr_capsule_Valid();
+          return pybind11::reinterpret_steal<py::capsule>(capsule);
+        });
+
+    m.def("get_from_valid_capsule", &get_from_valid_capsule);
+    m.def("get_from_shared_ptr_valid_capsule", &get_from_shared_ptr_valid_capsule);
+    m.def("get_from_unique_ptr_valid_capsule", &get_from_unique_ptr_valid_capsule);
+    m.def("get_from_no_conversion_capsule", &get_from_no_conversion_capsule);
+    m.def("get_from_no_capsule_returned", &get_from_no_capsule_returned);
+}

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -10,7 +10,7 @@ from pybind11_tests import class_sh_void_ptr_capsule as m
         (m.Valid, m.get_from_valid_capsule, 101, True),
         (m.NoConversion, m.get_from_no_conversion_capsule, 102, False),
         (m.NoCapsuleReturned, m.get_from_no_capsule_returned, 103, True),
-        (m.AsAnotherObject, m.get_from_valid_capsule, 104, True),
+        (m.AsAnotherObject, m.get_from_valid_capsule, 104, True)
     ],
 )
 def test_as_void_ptr_capsule(ctor, caller, expected, capsule_generated):

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from pybind11_tests import class_sh_void_ptr_capsule as m
+
+
+@pytest.mark.parametrize(
+    "ctor, caller, expected, capsule_generated",
+    [
+        (m.Valid, m.get_from_valid_capsule, 101, True),
+        (m.NoConversion, m.get_from_no_conversion_capsule, 102, False),
+        (m.NoCapsuleReturned, m.get_from_no_capsule_returned, 103, True),
+        (m.AsAnotherObject, m.get_from_valid_capsule, 104, True)
+    ],
+)
+def test_as_void_ptr_capsule(ctor, caller, expected, capsule_generated):
+    obj = ctor()
+    assert caller(obj) == expected
+    assert obj.capsule_generated == capsule_generated
+
+
+@pytest.mark.parametrize(
+    "ctor, caller, pointer_type, capsule_generated",
+    [
+        (m.AsAnotherObject, m.get_from_shared_ptr_valid_capsule, "shared_ptr", True),
+        (m.AsAnotherObject, m.get_from_unique_ptr_valid_capsule, "unique_ptr", True),
+    ],
+)
+def test_as_void_ptr_capsule_unsupported(ctor, caller, pointer_type, capsule_generated):
+    obj = ctor()
+    with pytest.raises(RuntimeError) as excinfo:
+        caller(obj)
+    assert pointer_type in str(excinfo.value)
+    assert obj.capsule_generated == capsule_generated

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -10,7 +10,7 @@ from pybind11_tests import class_sh_void_ptr_capsule as m
         (m.Valid, m.get_from_valid_capsule, 101, True),
         (m.NoConversion, m.get_from_no_conversion_capsule, 102, False),
         (m.NoCapsuleReturned, m.get_from_no_capsule_returned, 103, True),
-        (m.AsAnotherObject, m.get_from_valid_capsule, 104, True)
+        (m.AsAnotherObject, m.get_from_valid_capsule, 104, True),
     ],
 )
 def test_as_void_ptr_capsule(ctor, caller, expected, capsule_generated):


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Make smart holder type casters support void pointer capsules.

The original motivation for this is to support passing SWIG objects to pybind11 wrapped functions. This is achieved by checking whether the object has a particular method defined. Suppose we have the following C++ code:
```
namespace pybind11_tests {
namespace void_ptr_capsule {
class Obj { };

void func(const Obj* obj) { }
}
}
```

Then if an object has the method `as_pybind11_tests_void_ptr_capsule_Obj` defined, and the method returns a capsule with name `pybind11_tests::void_ptr_capsule::Obj`, then we think this object can be converted to `pybind11_tests::void_ptr_capsule::Obj`, so we accept the object as a parameter.