### PR TITLE
Function pybind11_select_caster uses ADL to select the caster.

### DIFF
--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -101,12 +101,12 @@ There are two ways to do this:
       in every compilation unit of the Python extension module. Otherwise,
       undefined behavior can ensue.
 
-* The preferred method is to *declare* a function named `pybind11_declare_caster`,
+* The preferred method is to *declare* a function named `pybind11_select_caster`,
   its only purpose is to associate the C++ type with its caster class:
 
   .. code-block:: cpp
 
-      inty_type_caster pybind11_declare_caster(inty*);
+      inty_type_caster pybind11_select_caster(inty*);
 
   The argument is a *pointer* to the C++ type, the return type is the
   `caster_type`. This function has no implementation!

--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -31,63 +31,82 @@ The following Python snippet demonstrates the intended usage from the Python sid
 
     print(A())
 
-To register the necessary conversion routines, it is necessary to add an
-instantiation of the ``pybind11::detail::type_caster<T>`` template.
-Although this is an implementation detail, adding an instantiation of this
-type is explicitly allowed.
+To register the necessary conversion routines, it is necessary to define a
+`type_caster` class, and register it with the other pybind11 casters:
 
 .. code-block:: cpp
 
-    namespace pybind11 { namespace detail {
-        template <> struct type_caster<inty> {
-        public:
-            /**
-             * This macro establishes the name 'inty' in
-             * function signatures and declares a local variable
-             * 'value' of type inty
-             */
-            PYBIND11_TYPE_CASTER(inty, const_name("inty"));
+    struct inty_type_caster {
+    public:
+        /**
+         * This macro establishes the name 'inty' in
+         * function signatures and declares a local variable
+         * 'value' of type inty
+         */
+        PYBIND11_TYPE_CASTER(inty, const_name("inty"));
 
-            /**
-             * Conversion part 1 (Python->C++): convert a PyObject into a inty
-             * instance or return false upon failure. The second argument
-             * indicates whether implicit conversions should be applied.
-             */
-            bool load(handle src, bool) {
-                /* Extract PyObject from handle */
-                PyObject *source = src.ptr();
-                /* Try converting into a Python integer value */
-                PyObject *tmp = PyNumber_Long(source);
-                if (!tmp)
-                    return false;
-                /* Now try to convert into a C++ int */
-                value.long_value = PyLong_AsLong(tmp);
-                Py_DECREF(tmp);
-                /* Ensure return code was OK (to avoid out-of-range errors etc) */
-                return !(value.long_value == -1 && !PyErr_Occurred());
-            }
+        /**
+         * Conversion part 1 (Python->C++): convert a PyObject into a inty
+         * instance or return false upon failure. The second argument
+         * indicates whether implicit conversions should be applied.
+         */
+        bool load(handle src, bool) {
+            /* Extract PyObject from handle */
+            PyObject *source = src.ptr();
+            /* Try converting into a Python integer value */
+            PyObject *tmp = PyNumber_Long(source);
+            if (!tmp)
+                return false;
+            /* Now try to convert into a C++ int */
+            value.long_value = PyLong_AsLong(tmp);
+            Py_DECREF(tmp);
+            /* Ensure return code was OK (to avoid out-of-range errors etc) */
+            return !(value.long_value == -1 && !PyErr_Occurred());
+        }
 
-            /**
-             * Conversion part 2 (C++ -> Python): convert an inty instance into
-             * a Python object. The second and third arguments are used to
-             * indicate the return value policy and parent object (for
-             * ``return_value_policy::reference_internal``) and are generally
-             * ignored by implicit casters.
-             */
-            static handle cast(inty src, return_value_policy /* policy */, handle /* parent */) {
-                return PyLong_FromLong(src.long_value);
-            }
-        };
-    }} // namespace pybind11::detail
+        /**
+         * Conversion part 2 (C++ -> Python): convert an inty instance into
+         * a Python object. The second and third arguments are used to
+         * indicate the return value policy and parent object (for
+         * ``return_value_policy::reference_internal``) and are generally
+         * ignored by implicit casters.
+         */
+        static handle cast(inty src, return_value_policy /* policy */, handle /* parent */) {
+            return PyLong_FromLong(src.long_value);
+        }
+    };
 
 .. note::
 
-    A ``type_caster<T>`` defined with ``PYBIND11_TYPE_CASTER(T, ...)`` requires
+    A `type_caster` defined with ``PYBIND11_TYPE_CASTER(T, ...)`` requires
     that ``T`` is default-constructible (``value`` is first default constructed
     and then ``load()`` assigns to it).
 
-.. warning::
+The `type_caster` defined above must be registered with pybind11.
+There are two ways to do this:
 
-    When using custom type casters, it's important to declare them consistently
-    in every compilation unit of the Python extension module. Otherwise,
-    undefined behavior can ensue.
+* As an instantiation of the ``pybind11::detail::type_caster<T>`` template.
+  Although this is an implementation detail, adding an instantiation of this
+  type is explicitly allowed:
+
+  .. code-block:: cpp
+
+      namespace pybind11 { namespace detail {
+          template <> struct type_caster<inty> : inty_type_caster {};
+      }} // namespace pybind11::detail
+
+  .. warning::
+
+      When using this method, it's important to declare them consistently
+      in every compilation unit of the Python extension module. Otherwise,
+      undefined behavior can ensue.
+
+* The preferred method is to *declare* a function named `pybind11_declare_caster`,
+  its only purpose is to associate the C++ type with its caster class:
+
+  .. code-block:: cpp
+
+      inty_type_caster pybind11_declare_caster(inty*);
+
+  The argument is a *pointer* to the C++ type, the return type is the
+  `caster_type`. This function has no implementation!

--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -32,7 +32,7 @@ The following Python snippet demonstrates the intended usage from the Python sid
     print(A())
 
 To register the necessary conversion routines, it is necessary to define a
-`type_caster` class, and register it with the other pybind11 casters:
+caster class, and register it with the other pybind11 casters:
 
 .. code-block:: cpp
 
@@ -78,12 +78,12 @@ To register the necessary conversion routines, it is necessary to define a
 
 .. note::
 
-    A `type_caster` defined with ``PYBIND11_TYPE_CASTER(T, ...)`` requires
+    A caster class defined with ``PYBIND11_TYPE_CASTER(T, ...)`` requires
     that ``T`` is default-constructible (``value`` is first default constructed
     and then ``load()`` assigns to it).
 
-The `type_caster` defined above must be registered with pybind11.
-There are two ways to do this:
+The caster defined above must be registered with pybind11.
+There are two ways to do it:
 
 * As an instantiation of the ``pybind11::detail::type_caster<T>`` template.
   Although this is an implementation detail, adding an instantiation of this
@@ -101,12 +101,13 @@ There are two ways to do this:
       in every compilation unit of the Python extension module. Otherwise,
       undefined behavior can ensue.
 
-* The preferred method is to *declare* a function named `pybind11_select_caster`,
-  its only purpose is to associate the C++ type with its caster class:
+* The preferred method is to *declare* a function named
+  ``pybind11_select_caster``, its only purpose is to associate the C++ type
+  with its caster class:
 
   .. code-block:: cpp
 
       inty_type_caster pybind11_select_caster(inty*);
 
   The argument is a *pointer* to the C++ type, the return type is the
-  `caster_type`. This function has no implementation!
+  caster type. This function has no implementation!

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -999,15 +999,15 @@ template <typename T> enable_if_t<!cast_is_temporary_value_reference<T>::value, 
 // though if it's in dead code, so we provide a "trampoline" to pybind11::cast that only does anything in
 // cases where pybind11::cast is valid.
 template <typename T>
-enable_if_t<!std::is_same<void, intrinsic_t<T>> &&
+enable_if_t<!std::is_same<void, intrinsic_t<T>>::value &&
             !cast_is_temporary_value_reference<T>::value, T>
 cast_safe(object &&o) { return pybind11::cast<T>(std::move(o)); }
 template <typename T>
 enable_if_t<cast_is_temporary_value_reference<T>::value, T>
 cast_safe(object &&) {  pybind11_fail("Internal error: cast_safe fallback invoked"); }
 template <typename T>
-enable_if_t<std::is_same<void, intrinsic_t<T>>, void>
-cast_safe<void>(object &&) {}
+enable_if_t<std::is_same<void, intrinsic_t<T>>::value, void>
+cast_safe(object &&) {}
 
 PYBIND11_NAMESPACE_END(detail)
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -998,11 +998,16 @@ template <typename T> enable_if_t<!cast_is_temporary_value_reference<T>::value, 
 // Trampoline use: Having a pybind11::cast with an invalid reference type is going to static_assert, even
 // though if it's in dead code, so we provide a "trampoline" to pybind11::cast that only does anything in
 // cases where pybind11::cast is valid.
-template <typename T> enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&o) {
-    return pybind11::cast<T>(std::move(o)); }
-template <typename T> enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&) {
-    pybind11_fail("Internal error: cast_safe fallback invoked"); }
-template <> inline void cast_safe<void>(object &&) {}
+template <typename T>
+enable_if_t<!std::is_same<void, intrinsic_t<T>> &&
+            !cast_is_temporary_value_reference<T>::value, T>
+cast_safe(object &&o) { return pybind11::cast<T>(std::move(o)); }
+template <typename T>
+enable_if_t<cast_is_temporary_value_reference<T>::value, T>
+cast_safe(object &&) {  pybind11_fail("Internal error: cast_safe fallback invoked"); }
+template <typename T>
+enable_if_t<std::is_same<void, intrinsic_t<T>>, void>
+cast_safe<void>(object &&) {}
 
 PYBIND11_NAMESPACE_END(detail)
 


### PR DESCRIPTION
## Description

Instead of the `type_caster` template specialization, it is possible to register the conversions with a function *declaration*, which will be found with [ADL](https://en.cppreference.com/w/cpp/language/adl).

```c++
namespace std {
string_caster pybind11_select_caster(std::string*);
}
```

The parameter is a pointer to the C++ (intrinsic) type. The returned type is the caster class. This function should have no implementation!

- There is no ODR violation when different translation units define different conversions: distinct modules might choose different behavior. This is the main motivation of this change.
- The declarations need to be defined in the original namespace of the converted C++ type.
- The default behavior did not change: `type_caster<T>` will be used as a fallback.
- Because `type_caster<T>` not always used, I had to update some places with `make_caster<T>`.

So far I do not propose to convert the existing casters. I updated the one for `std::string` just to prove the concept, and check that it works on all compilers.
