### PR TITLE
WIP Fixing MINGW CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -904,6 +904,7 @@ jobs:
           - { sys: mingw64, env: x86_64 }
           - { sys: mingw32, env: i686 }
     steps:
+    # https://github.com/pybind/pybind11/pull/3643#issuecomment-1021381760
     # Force version because of https://github.com/msys2/setup-msys2/issues/167
     - uses: msys2/setup-msys2@v2.4.2
       with:


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
@henryiii Do we finally need to update MSYS2? (question originally asked by @Skylion007)

* Last successful: [Sat, 22 Jan 2022 07:34:24 GMT] https://github.com/pybind/pybind11/actions/runs/1732355974
* First failing: [Mon, 24 Jan 2022 21:24:12 GMT] https://github.com/pybind/pybind11/actions/runs/1742241885

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
