### PR TITLE
fix msys ci python issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -904,8 +904,7 @@ jobs:
           - { sys: mingw64, env: x86_64 }
           - { sys: mingw32, env: i686 }
     steps:
-    # Force version because of https://github.com/msys2/setup-msys2/issues/167
-    - uses: msys2/setup-msys2@v2.4.2
+    - uses: msys2/setup-msys2@v2
       with:
         msystem: ${{matrix.sys}}
         install: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -934,10 +934,10 @@ jobs:
       run: cmake --build build --target pytest -j 2
 
     - name: C++11 tests
-      run: cmake --build build --target cpptest -j 2
+      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build --target cpptest -j 2
 
     - name: Interface test C++11
-      run: cmake --build build --target test_cmake_build
+      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build --target test_cmake_build
 
     - name: Clean directory
       run: git clean -fdx
@@ -952,10 +952,10 @@ jobs:
       run: cmake --build build2 --target pytest -j 2
 
     - name: C++14 tests
-      run: cmake --build build2 --target cpptest -j 2
+      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build2 --target cpptest -j 2
 
     - name: Interface test C++14
-      run: cmake --build build2 --target test_cmake_build
+      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build2 --target test_cmake_build
 
     - name: Clean directory
       run: git clean -fdx
@@ -970,7 +970,7 @@ jobs:
       run: cmake --build build3 --target pytest -j 2
 
     - name: C++17 tests
-      run: cmake --build build3 --target cpptest -j 2
+      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build3 --target cpptest -j 2
 
     - name: Interface test C++17
-      run: cmake --build build3 --target test_cmake_build
+      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build3 --target test_cmake_build


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

* msys ci: un-pin setup-msys2 action version
* msys ci: explicitly set PYTHONHOME and PYTHONPATH for c++ and interface tests (to workaround https://github.com/msys2/setup-msys2/issues/167)
* see #3646

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
