### PR TITLE
Fix caster optimization regression introduced in #3650

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -201,7 +201,8 @@ struct type_info {
     void *(*module_local_load)(PyObject *, const type_info *) = nullptr;
     /* A simple type never occurs as a (direct or indirect) parent
      * of a class that makes use of multiple inheritance.
-     * The child remains simple unless it becomes a parent of a pybind type. */
+     * A type can be simple even if it has non-simple ancestors as long as it has no descendants.
+     */
     bool simple_type : 1;
     /* True if there is no multiple inheritance in this type's inheritance tree */
     bool simple_ancestors : 1;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -200,7 +200,8 @@ struct type_info {
     void *get_buffer_data = nullptr;
     void *(*module_local_load)(PyObject *, const type_info *) = nullptr;
     /* A simple type never occurs as a (direct or indirect) parent
-     * of a class that makes use of multiple inheritance */
+     * of a class that makes use of multiple inheritance.
+     * The child remains simple unless it becomes a parent of a pybind type. */
     bool simple_type : 1;
     /* True if there is no multiple inheritance in this type's inheritance tree */
     bool simple_ancestors : 1;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1206,13 +1206,14 @@ protected:
         if (rec.bases.size() > 1 || rec.multiple_inheritance) {
             mark_parents_nonsimple(tinfo->type);
             tinfo->simple_ancestors = false;
-            tinfo->simple_type = false;
         }
         else if (rec.bases.size() == 1) {
-            auto parent_tinfo = get_type_info((PyTypeObject *) rec.bases[0].ptr());
-            tinfo->simple_ancestors = parent_tinfo->simple_ancestors;
-            // a child of a non-simple type can never be a simple type
-            tinfo->simple_type = parent_tinfo->simple_type;
+            auto *parent_tinfo = get_type_info((PyTypeObject *) rec.bases[0].ptr());
+            assert(parent_tinfo != nullptr);
+            bool parent_simple_ancestors = parent_tinfo->simple_ancestors;
+            tinfo->simple_ancestors = parent_simple_ancestors;
+            // The parent can no longer be a simple type if it has MI and has descendants
+            parent_tinfo->simple_type = parent_tinfo->simple_type && parent_simple_ancestors;
         }
 
         if (rec.module_local) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1212,7 +1212,7 @@ protected:
             assert(parent_tinfo != nullptr);
             bool parent_simple_ancestors = parent_tinfo->simple_ancestors;
             tinfo->simple_ancestors = parent_simple_ancestors;
-            // The parent can no longer be a simple type if it has MI and has descendants
+            // The parent can no longer be a simple type if it has MI and has a child
             parent_tinfo->simple_type = parent_tinfo->simple_type && parent_simple_ancestors;
         }
 

--- a/tests/test_multiple_inheritance.cpp
+++ b/tests/test_multiple_inheritance.cpp
@@ -235,7 +235,7 @@ TEST_SUBMODULE(multiple_inheritance, m) {
     // - functions are get_{base}_{var}, return {var}
     struct MVB {
         MVB() = default;
-        MVB(const MVB&) = default;
+        MVB(const MVB &) = default;
         virtual ~MVB() = default;
 
         int b = 1;

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -472,3 +472,23 @@ def test_pr3635_diamond_f():
     assert o.get_f_e() == 5
 
     assert o.get_f_f() == 6
+
+
+def test_python_inherit_from_mi():
+    class PYMVF(m.MVF):
+        g = 7
+
+        def get_g_g(self):
+            return self.g
+
+    o = PYMVF()
+
+    assert o.b == 1
+    assert o.c == 2
+    assert o.d0 == 3
+    assert o.d1 == 4
+    assert o.e == 5
+    assert o.f == 6
+    assert o.g == 7
+
+    assert o.get_g_g() == 7

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -475,13 +475,15 @@ def test_pr3635_diamond_f():
 
 
 def test_python_inherit_from_mi():
-    class PYMVF(m.MVF):
+    """Tests extending a Python class from a single inheritor of an MI class"""
+
+    class PyMVF(m.MVF):
         g = 7
 
         def get_g_g(self):
             return self.g
 
-    o = PYMVF()
+    o = PyMVF()
 
     assert o.b == 1
     assert o.c == 2

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -475,7 +475,7 @@ def test_pr3635_diamond_f():
 
 
 def test_python_inherit_from_mi():
-    """Tests extending a Python class from a single inheritor of an MI class"""
+    """Tests extending a Python class from a single inheritor of a MI class"""
 
     class PyMVF(m.MVF):
         g = 7


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
So I thought about this some more, and I realized the difference between simple type and simple ancestors in the caster. A non-simple type is any ancestor who has any descendants who have multi-inheritance from C++ classes. The descendant itself is a simple type though, unless it also has descendants. This PR fixes a mistake made in #3650 where the descendants themselves can remain simple types until they are extended. Marking a type as non-simple adds some additional pointer checks in the casters and while this is an edge case, we should be careful not to undo the optimization here.

Ping @virtuald 
TLDR: Figured out what the difference is between simple_type and simple_ancestors. 
1. A type can be simple if it has MI, but has no descendants. 
2. As soon as it gets PyBind11 descendants, it ceases to be simple. 
In otherwise, `!simple_ancestors => !simple_type` only if it has PyBind11 descendants. 
I figured this out by thinking about why the rec.multiple_inheritance pathway didn't cause issues before as long multiple_inheritance was specified. The difference being that the single base pathway failed to update the type of the parent to non-simple.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fix previous PR.
```
(just a reminder to include both PR numbers)

<!-- If the upgrade guide needs updating, note that here too -->
