### PR TITLE
Remove extra semicolon

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -322,7 +322,7 @@ inline bool raise_err(PyObject *exc_type, const char *msg) {
 #endif
     PyErr_SetString(exc_type, msg);
     return false;
-};
+}
 
 inline void translate_exception(std::exception_ptr p) {
     if (!p) {


### PR DESCRIPTION
Just a stray semicolon triggering a warning, it was causing issues with `-Werror` for me.
