### PR TITLE
fix: update catch to 2.13.5 to fix glibc 2.34 failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -932,7 +932,7 @@ jobs:
       run: git clean -fdx
 
     - name: Configure C++14
-      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=14 -S . -B build2
+      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=14 -DDOWNLOAD_CATCH=ON -S . -B build2
 
     - name: Build C++14
       run: cmake --build build2 -j 2
@@ -950,7 +950,7 @@ jobs:
       run: git clean -fdx
 
     - name: Configure C++17
-      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=17 -S . -B build3
+      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=17 -DDOWNLOAD_CATCH=ON -S . -B build3
 
     - name: Build C++17
       run: cmake --build build3 -j 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             python: '3.6'
             args: >
               -DPYBIND11_FINDPYTHON=ON
-              -DPYBIND11_DEFINE_UNDERSCORE=ON
+              -DCMAKE_CXX_FLAGS="-D_=1"
           - runs-on: windows-latest
             python: '3.6'
             args: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -914,7 +914,7 @@ jobs:
     - name: Configure C++11
       # LTO leads to many undefined reference like
       # `pybind11::detail::function_call::function_call(pybind11::detail::function_call&&)
-      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=11 -S . -B build
+      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=11 -DDOWNLOAD_CATCH=ON -S . -B build
 
     - name: Build C++11
       run: cmake --build build -j 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             python: '3.6'
             args: >
               -DPYBIND11_FINDPYTHON=ON
-              -DCMAKE_CXX_FLAGS="-D_=1"
+              -DPYBIND11_DEFINE_UNDERSCORE=ON
           - runs-on: windows-latest
             python: '3.6'
             args: >

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../tools")
 option(PYBIND11_WERROR "Report all warnings as errors" OFF)
 option(DOWNLOAD_EIGEN "Download EIGEN (requires CMake 3.11+)" OFF)
 option(PYBIND11_CUDA_TESTS "Enable building CUDA tests (requires CMake 3.12+)" OFF)
+option(PYBIND11_DEFINE_UNDERSCORE "Define the underscore to make sure it is safe" OFF)
+
 set(PYBIND11_TEST_OVERRIDE
     ""
     CACHE STRING "Tests from ;-separated list of *.cpp files will be built instead of all tests")
@@ -435,6 +437,9 @@ foreach(target ${test_targets})
   # Create the binding library
   pybind11_add_module(${target} THIN_LTO ${target}.cpp ${test_files} ${PYBIND11_HEADERS})
   pybind11_enable_warnings(${target})
+  if(PYBIND11_DEFINE_UNDERSCORE)
+    target_compile_definitions(${target} PUBLIC -D_=1)
+  endif()
 
   if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
     get_property(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,8 +81,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../tools")
 option(PYBIND11_WERROR "Report all warnings as errors" OFF)
 option(DOWNLOAD_EIGEN "Download EIGEN (requires CMake 3.11+)" OFF)
 option(PYBIND11_CUDA_TESTS "Enable building CUDA tests (requires CMake 3.12+)" OFF)
-option(PYBIND11_DEFINE_UNDERSCORE "Define the underscore to make sure it is safe" OFF)
-
 set(PYBIND11_TEST_OVERRIDE
     ""
     CACHE STRING "Tests from ;-separated list of *.cpp files will be built instead of all tests")
@@ -437,9 +435,6 @@ foreach(target ${test_targets})
   # Create the binding library
   pybind11_add_module(${target} THIN_LTO ${target}.cpp ${test_files} ${PYBIND11_HEADERS})
   pybind11_enable_warnings(${target})
-  if(PYBIND11_DEFINE_UNDERSCORE)
-    target_compile_definitions(${target} PUBLIC -D_=1)
-  endif()
 
   if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
     get_property(

--- a/tests/test_embed/CMakeLists.txt
+++ b/tests/test_embed/CMakeLists.txt
@@ -7,7 +7,7 @@ if("${PYTHON_MODULE_EXTENSION}" MATCHES "pypy" OR "${Python_INTERPRETER_ID}" STR
   return()
 endif()
 
-find_package(Catch 2.13.2)
+find_package(Catch 2.13.5)
 
 if(CATCH_FOUND)
   message(STATUS "Building interpreter tests using Catch v${CATCH_VERSION}")

--- a/tests/test_embed/catch.cpp
+++ b/tests/test_embed/catch.cpp
@@ -9,6 +9,11 @@
 #  pragma warning(disable: 4996)
 #endif
 
+// Catch uses _ internally, which breaks gettext style defines
+#ifdef _
+#undef _
+#endif
+
 #define CATCH_CONFIG_RUNNER
 #include <catch.hpp>
 


### PR DESCRIPTION
## Description

Update the downloaded Catch version to 2.13.8, in order to fix build
failure on glibc 2.34:

```
In file included from /usr/include/signal.h:328,
                 from /tmp/pybind11/.nox/tests-3-9/tmp/tests/catch/catch.hpp:8030,
                 from /tmp/pybind11/tests/test_embed/catch.cpp:13:
/tmp/pybind11/.nox/tests-3-9/tmp/tests/catch/catch.hpp:10818:58: error: call to non-‘constexpr’ function ‘long int sysconf(int)’
10818 |     static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
      |                                                          ^~~~~~~~~~~
In file included from /usr/include/python3.9/Python.h:36,
                 from /tmp/pybind11/include/pybind11/detail/common.h:215,
                 from /tmp/pybind11/include/pybind11/pytypes.h:12,
                 from /tmp/pybind11/include/pybind11/cast.h:13,
                 from /tmp/pybind11/include/pybind11/attr.h:13,
                 from /tmp/pybind11/include/pybind11/pybind11.h:13,
                 from /tmp/pybind11/include/pybind11/embed.h:12,
                 from /tmp/pybind11/tests/test_embed/catch.cpp:4:
/usr/include/unistd.h:640:17: note: ‘long int sysconf(int)’ declared here
  640 | extern long int sysconf (int __name) __THROW;
      |                 ^~~~~~~
In file included from /tmp/pybind11/tests/test_embed/catch.cpp:13:
/tmp/pybind11/.nox/tests-3-9/tmp/tests/catch/catch.hpp:10877:45: error: size of array ‘altStackMem’ is not an integral constant-expression
10877 |     char FatalConditionHandler::altStackMem[sigStackSize] = {};
      |                                             ^~~~~~~~~~~~
```