### PR TITLE
docs: fix imported target name

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -475,7 +475,7 @@ available in all modes. The targets provided are:
      Everything for extension modules - ``pybind11::pybind11`` + ``Python::Module`` (FindPython CMake 3.15+) or ``pybind11::python_link_helper``
 
    ``pybind11::embed``
-     Everything for embedding the Python interpreter - ``pybind11::pybind11`` + ``Python::Embed`` (FindPython) or Python libs
+     Everything for embedding the Python interpreter - ``pybind11::pybind11`` + ``Python::Python`` (FindPython) or Python libs
 
    ``pybind11::lto`` / ``pybind11::thin_lto``
      An alternative to `INTERPROCEDURAL_OPTIMIZATION` for adding link-time optimization.


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

The docs mention a non-existent target ``Python::Embed`` from FindPython. Correct is ``Python::Python`` which is also used in the code, https://github.com/pybind/pybind11/blob/36813cfa1228f9414aac669d239a0d3255fc25c3/tools/pybind11NewTools.cmake#L174

<!-- Include relevant issues or PRs here, describe what changed and why -->


