### PR TITLE
Manually applying two clang-format changes that need fix-ups for clang-tidy.

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1516,8 +1516,8 @@ public:
         }
     }
 
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    template <typename T> operator T *() const {
+    template <typename T>
+    operator T *() const { // NOLINT(google-explicit-constructor)
         return get_pointer<T>();
     }
 

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -400,10 +400,11 @@ TEST_SUBMODULE(stl, m) {
     m.def("half_or_none_refsensitive", [](int x) -> refsensitive_opt_int {
         return x != 0 ? refsensitive_opt_int(x / 2) : refsensitive_opt_int();
     });
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    m.def("test_nullopt_refsensitive", [](refsensitive_opt_int x) {
-        return x ? x.value() : 42;
-    }, py::arg_v("x", refsensitive_opt_int(), "None"));
+    m.def(
+        "test_nullopt_refsensitive",
+        // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        [](refsensitive_opt_int x) { return x ? x.value() : 42; },
+        py::arg_v("x", refsensitive_opt_int(), "None"));
     m.def("test_no_assign_refsensitive", [](const refsensitive_opt_no_assign &x) {
         return x ? x->value : 42;
     }, py::arg_v("x", refsensitive_opt_no_assign(), "None"));


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Preparation for full `clang-format`ing, informed by work under PRs https://github.com/pybind/pybind11/pull/3683 and https://github.com/pybind/pybind11/pull/3703.

With these manual "forward ports" of clang-format changes + manual fix-ups for clang-tidy compatibility, a full clang-format run builds out of the box.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
