### PR TITLE
(clang-tidy): Enable static downcast check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ FormatStyle: file
 Checks: '
 *bugprone*,
 cppcoreguidelines-init-variables,
+cppcoreguidelines-pro-type-static-cast-downcast,
 cppcoreguidelines-slicing,
 clang-analyzer-optin.cplusplus.VirtualCall,
 google-explicit-constructor,


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Enable a clang-tidy check to ensure we don't do static_cast for downcasting and always use dynamic_cast. This is safer, more likely to be correct, and most compilers will optimize them to be the same speed anyway if valid. There are no other changes to the codebase currently since we do it properly, but this check ensures the regression doesn't get introduced in a  PR.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Enable cppcoreguidelines-pro-type-static-cast-downcast in clang-tidy.
```

<!-- If the upgrade guide needs updating, note that here too -->
