### PR TITLE
chore(clang-tidy): Add missing clang-tidy fixes

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -445,13 +445,16 @@ template <> struct process_attribute<arg_v> : process_attribute_default<arg_v> {
         if (!a.value) {
 #if !defined(NDEBUG)
             std::string descr("'");
-            if (a.name) descr += std::string(a.name) + ": ";
+            if (a.name) {
+                descr += std::string(a.name) + ": ";
+            }
             descr += a.type + "'";
             if (r->is_method) {
-                if (r->name)
+                if (r->name) {
                     descr += " in method '" + (std::string) str(r->scope) + "." + (std::string) r->name + "'";
-                else
+                } else {
                     descr += " in method of '" + (std::string) str(r->scope) + "'";
+                }
             } else if (r->name) {
                 descr += " in function '" + (std::string) r->name + "'";
             }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -628,9 +628,11 @@ protected:
             return false;
         }
 #else
-        for (bool r : {std::get<Is>(subcasters).load(seq[Is], convert)...})
-            if (!r)
+        for (bool r : {std::get<Is>(subcasters).load(seq[Is], convert)...}) {
+            if (!r) {
                 return false;
+            }
+        }
 #endif
         return true;
     }

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -118,8 +118,9 @@ struct type_hash {
     size_t operator()(const std::type_index &t) const {
         size_t hash = 5381;
         const char *ptr = t.name();
-        while (auto c = static_cast<unsigned char>(*ptr++))
+        while (auto c = static_cast<unsigned char>(*ptr++)) {
             hash = (hash * 33) ^ c;
+        }
         return hash;
     }
 };
@@ -388,7 +389,9 @@ inline void translate_exception(std::exception_ptr p) {
 #if !defined(__GLIBCXX__)
 inline void translate_local_exception(std::exception_ptr p) {
     try {
-        if (p) std::rethrow_exception(p);
+        if (p) {
+            std::rethrow_exception(p);
+        }
     } catch (error_already_set &e)       { e.restore();   return;
     } catch (const builtin_exception &e) { e.set_error(); return;
     }

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -65,9 +65,10 @@ public:
         if (!tstate) {
             tstate = PyThreadState_New(internals.istate);
             #if !defined(NDEBUG)
-                if (!tstate)
-                    pybind11_fail("scoped_acquire: could not create thread state!");
-            #endif
+            if (!tstate) {
+                pybind11_fail("scoped_acquire: could not create thread state!");
+            }
+#endif
             tstate->gilstate_counter = 0;
             PYBIND11_TLS_REPLACE_VALUE(internals.tstate, tstate);
         } else {
@@ -88,16 +89,19 @@ public:
     PYBIND11_NOINLINE void dec_ref() {
         --tstate->gilstate_counter;
         #if !defined(NDEBUG)
-            if (detail::get_thread_state_unchecked() != tstate)
-                pybind11_fail("scoped_acquire::dec_ref(): thread state must be current!");
-            if (tstate->gilstate_counter < 0)
-                pybind11_fail("scoped_acquire::dec_ref(): reference count underflow!");
-        #endif
+        if (detail::get_thread_state_unchecked() != tstate) {
+            pybind11_fail("scoped_acquire::dec_ref(): thread state must be current!");
+        }
+        if (tstate->gilstate_counter < 0) {
+            pybind11_fail("scoped_acquire::dec_ref(): reference count underflow!");
+        }
+#endif
         if (tstate->gilstate_counter == 0) {
             #if !defined(NDEBUG)
-                if (!release)
-                    pybind11_fail("scoped_acquire::dec_ref(): internal error!");
-            #endif
+            if (!release) {
+                pybind11_fail("scoped_acquire::dec_ref(): internal error!");
+            }
+#endif
             PyThreadState_Clear(tstate);
             if (active) {
                 PyThreadState_DeleteCurrent();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -873,9 +873,10 @@ protected:
                 // 5. Put everything in a vector.  Not technically step 5, we've been building it
                 // in `call.args` all along.
                 #if !defined(NDEBUG)
-                if (call.args.size() != func.nargs || call.args_convert.size() != func.nargs)
+                if (call.args.size() != func.nargs || call.args_convert.size() != func.nargs) {
                     pybind11_fail("Internal error: function call dispatcher inserted wrong number of arguments!");
-                #endif
+                }
+#endif
 
                 std::vector<bool> second_pass_convert;
                 if (overloaded) {
@@ -2527,8 +2528,9 @@ inline function get_type_override(const void *this_ptr, const type_info *this_ty
         PyFrame_FastToLocals(frame);
         PyObject *self_caller = dict_getitem(
             frame->f_locals, PyTuple_GET_ITEM(frame->f_code->co_varnames, 0));
-        if (self_caller == self.ptr())
+        if (self_caller == self.ptr()) {
             return function();
+        }
     }
 #endif
 

--- a/tests/test_cmake_build/embed.cpp
+++ b/tests/test_cmake_build/embed.cpp
@@ -6,15 +6,17 @@ PYBIND11_EMBEDDED_MODULE(test_cmake_build, m) {
 }
 
 int main(int argc, char *argv[]) {
-    if (argc != 2)
+    if (argc != 2) {
         throw std::runtime_error("Expected test.py file as the first argument");
-    auto test_py_file = argv[1];
+    }
+    auto *test_py_file = argv[1];
 
     py::scoped_interpreter guard{};
 
     auto m = py::module_::import("test_cmake_build");
-    if (m.attr("add")(1, 2).cast<int>() != 3)
+    if (m.attr("add")(1, 2).cast<int>() != 3) {
         throw std::runtime_error("embed.cpp failed");
+    }
 
     py::module_::import("sys").attr("argv") = py::make_tuple("test.py", "embed.cpp");
     py::eval_file(test_py_file, py::globals());


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* The recent clang-tidy fixes did not have full coverage because of various ifdefs. I ran clang-tidy on my local machine and found lots of errors. Adding the fixes in this PR. We may want to use cmake to run clang-tidy on every CI to catch this or at least have the clang-tidy config use the debug config.
<!-- Include relevant issues or PRs here, describe what changed and why -->
