### PR TITLE
chore(clang-tidy): Add clang-tidy rules: prefer-member-initializer and optin.performance.Padding

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ FormatStyle: file
 Checks: '
 *bugprone*,
 cppcoreguidelines-init-variables,
+cppcoreguidelines-prefer-member-initializer,
 cppcoreguidelines-pro-type-static-cast-downcast,
 cppcoreguidelines-slicing,
 clang-analyzer-optin.performance.Padding,
@@ -66,6 +67,6 @@ CheckOptions:
 - key:             readability-implicit-bool-conversion.AllowPointerConditions
   value:           true
 
-HeaderFilterRegex: '(^(include/pybind11/.*h | tests/*.h))'
+HeaderFilterRegex: 'pybind11/.*h'
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: '
 cppcoreguidelines-init-variables,
 cppcoreguidelines-pro-type-static-cast-downcast,
 cppcoreguidelines-slicing,
+clang-analyzer-optin.performance.Padding,
 clang-analyzer-optin.cplusplus.VirtualCall,
 google-explicit-constructor,
 llvm-namespace-comment,
@@ -65,6 +66,6 @@ CheckOptions:
 - key:             readability-implicit-bool-conversion.AllowPointerConditions
   value:           true
 
-HeaderFilterRegex: 'pybind11/.*h'
+HeaderFilterRegex: '(^(include/pybind11/.*h | tests/*.h))'
 
 WarningsAsErrors: '*'

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -89,7 +89,9 @@ struct buffer_info {
             ? std::vector<ssize_t>(view->strides, view->strides + view->ndim)
             : detail::c_strides({view->shape, view->shape + view->ndim}, view->itemsize),
             (view->readonly != 0)) {
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         this->m_view = view;
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         this->ownview = ownview;
     }
 

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -135,6 +135,7 @@ public:
         // `internals.tstate` for subsequent `gil_scoped_acquire` calls. Otherwise, an
         // initialization race could occur as multiple threads try `gil_scoped_acquire`.
         auto &internals = detail::get_internals();
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         tstate = PyEval_SaveThread();
         if (disassoc) {
             // Python >= 3.7 can remove this, it's an int before 3.7

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -17,12 +17,14 @@ TEST_SUBMODULE(buffers, m) {
     public:
         Matrix(py::ssize_t rows, py::ssize_t cols) : m_rows(rows), m_cols(cols) {
             print_created(this, std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
-            m_data = new float[(size_t) (rows*cols)];
+            // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+            m_data = new float[(size_t) (rows * cols)];
             memset(m_data, 0, sizeof(float) * (size_t) (rows * cols));
         }
 
         Matrix(const Matrix &s) : m_rows(s.m_rows), m_cols(s.m_cols) {
             print_copy_created(this, std::to_string(m_rows) + "x" + std::to_string(m_cols) + " matrix");
+            // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
             m_data = new float[(size_t) (m_rows * m_cols)];
             memcpy(m_data, s.m_data, sizeof(float) * (size_t) (m_rows * m_cols));
         }

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -66,7 +66,11 @@ public:
         std::swap(value, m.value);
         return *this;
     }
-    MoveOrCopyInt(const MoveOrCopyInt &c) { print_copy_created(this, c.value); value = c.value; }
+    MoveOrCopyInt(const MoveOrCopyInt &c) {
+        print_copy_created(this, c.value);
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+        value = c.value;
+    }
     MoveOrCopyInt &operator=(const MoveOrCopyInt &c) { print_copy_assigned(this, c.value); value = c.value; return *this; }
     ~MoveOrCopyInt() { print_destroyed(this); }
 
@@ -76,7 +80,11 @@ class CopyOnlyInt {
 public:
     CopyOnlyInt() { print_default_created(this); }
     explicit CopyOnlyInt(int v) : value{v} { print_created(this, value); }
-    CopyOnlyInt(const CopyOnlyInt &c) { print_copy_created(this, c.value); value = c.value; }
+    CopyOnlyInt(const CopyOnlyInt &c) {
+        print_copy_created(this, c.value);
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+        value = c.value;
+    }
     CopyOnlyInt &operator=(const CopyOnlyInt &c) { print_copy_assigned(this, c.value); value = c.value; return *this; }
     ~CopyOnlyInt() { print_destroyed(this); }
 

--- a/tests/test_factory_constructors.cpp
+++ b/tests/test_factory_constructors.cpp
@@ -38,8 +38,7 @@ class TestFactory2 {
     explicit TestFactory2(std::string v) : value(std::move(v)) { print_created(this, value); }
 
 public:
-    TestFactory2(TestFactory2 &&m) noexcept {
-        value = std::move(m.value);
+    TestFactory2(TestFactory2 &&m) noexcept : value{std::move(m.value)} {
         print_move_created(this);
     }
     TestFactory2 &operator=(TestFactory2 &&m) noexcept {
@@ -59,8 +58,7 @@ protected:
 
 public:
     explicit TestFactory3(std::string v) : value(std::move(v)) { print_created(this, value); }
-    TestFactory3(TestFactory3 &&m) noexcept {
-        value = std::move(m.value);
+    TestFactory3(TestFactory3 &&m) noexcept : value{std::move(m.value)} {
         print_move_created(this);
     }
     TestFactory3 &operator=(TestFactory3 &&m) noexcept {
@@ -93,10 +91,18 @@ public:
     explicit TestFactory6(int i) : value{i} { print_created(this, i); }
     TestFactory6(TestFactory6 &&f) noexcept {
         print_move_created(this);
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         value = f.value;
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         alias = f.alias;
     }
-    TestFactory6(const TestFactory6 &f) { print_copy_created(this); value = f.value; alias = f.alias; }
+    TestFactory6(const TestFactory6 &f) {
+        print_copy_created(this);
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+        value = f.value;
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+        alias = f.alias;
+    }
     virtual ~TestFactory6() { print_destroyed(this); }
     virtual int get() { return value; }
     bool has_alias() const { return alias; }
@@ -131,10 +137,18 @@ public:
     explicit TestFactory7(int i) : value{i} { print_created(this, i); }
     TestFactory7(TestFactory7 &&f) noexcept {
         print_move_created(this);
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         value = f.value;
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         alias = f.alias;
     }
-    TestFactory7(const TestFactory7 &f) { print_copy_created(this); value = f.value; alias = f.alias; }
+    TestFactory7(const TestFactory7 &f) {
+        print_copy_created(this);
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+        value = f.value;
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+        alias = f.alias;
+    }
     virtual ~TestFactory7() { print_destroyed(this); }
     virtual int get() { return value; }
     bool has_alias() const { return alias; }
@@ -142,6 +156,7 @@ public:
 class PyTF7 : public TestFactory7 {
 public:
     explicit PyTF7(int i) : TestFactory7(i) {
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         alias = true;
         print_created(this, i);
     }

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -152,23 +152,26 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
     public:
         explicit Sequence(size_t size) : m_size(size) {
             print_created(this, "of size", m_size);
+            // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
             m_data = new float[size];
             memset(m_data, 0, sizeof(float) * size);
         }
         explicit Sequence(const std::vector<float> &value) : m_size(value.size()) {
             print_created(this, "of size", m_size, "from std::vector");
+            // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
             m_data = new float[m_size];
             memcpy(m_data, &value[0], sizeof(float) * m_size);
         }
         Sequence(const Sequence &s) : m_size(s.m_size) {
             print_copy_created(this);
+            // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
             m_data = new float[m_size];
             memcpy(m_data, s.m_data, sizeof(float)*m_size);
         }
         Sequence(Sequence &&s) noexcept : m_size(s.m_size), m_data(s.m_data) {
             print_move_created(this);
+            // NOTLINENEXTLINE(cppcoreguidelines-prefer-member-initializer)
             s.m_size = 0;
-            s.m_data = nullptr;
         }
 
         ~Sequence() { print_destroyed(this); delete[] m_data; }
@@ -236,7 +239,7 @@ TEST_SUBMODULE(sequences_and_iterators, m) {
 
     private:
         size_t m_size;
-        float *m_data;
+        float *m_data = nullptr;
     };
     py::class_<Sequence>(m, "Sequence")
         .def(py::init<size_t>())

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -131,8 +131,7 @@ class MyObject4a;
 std::unordered_set<MyObject4a *> myobject4a_instances;
 class MyObject4a {
 public:
-    explicit MyObject4a(int i) {
-        value = i;
+    explicit MyObject4a(int i) : value{i} {
         print_created(this);
         myobject4a_instances.insert(this);
     };

--- a/tests/test_virtual_functions.cpp
+++ b/tests/test_virtual_functions.cpp
@@ -103,10 +103,7 @@ public:
 class NonCopyable {
 public:
     NonCopyable(int a, int b) : value{new int(a*b)} { print_created(this, a, b); }
-    NonCopyable(NonCopyable &&o) noexcept {
-        value = std::move(o.value);
-        print_move_created(this);
-    }
+    NonCopyable(NonCopyable &&o) noexcept : value{std::move(o.value)} { print_move_created(this); }
     NonCopyable(const NonCopyable &) = delete;
     NonCopyable() = delete;
     void operator=(const NonCopyable &) = delete;
@@ -128,11 +125,8 @@ private:
 class Movable {
 public:
     Movable(int a, int b) : value{a+b} { print_created(this, a, b); }
-    Movable(const Movable &m) { value = m.value; print_copy_created(this); }
-    Movable(Movable &&m) noexcept {
-        value = m.value;
-        print_move_created(this);
-    }
+    Movable(const Movable &m) : value{m.value} { print_copy_created(this); }
+    Movable(Movable &&m) noexcept : value{m.value} { print_move_created(this); }
     std::string get_value() const { return std::to_string(value); }
     ~Movable() { print_destroyed(this); }
 private:


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Adds rule and proper suppression for clang-tidy prefer-member-initializer
* Adds optin analyzer rule to ensure we do not introduce any poorly padded structs.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Enable cppcoreguidelines-prefer-member-initializer and clang-analyzer-optin.performance.Padding clang-tidy checks
```

<!-- If the upgrade guide needs updating, note that here too -->
