### PR TITLE
fix: minor CMake warning fix for unused variable

### DIFF
--- a/tools/FindCatch.cmake
+++ b/tools/FindCatch.cmake
@@ -9,6 +9,8 @@
 #  CATCH_INCLUDE_DIR      - path to catch.hpp
 #  CATCH_VERSION          - version number
 
+option(DOWNLOAD_CATCH "Download catch2 if not found")
+
 if(NOT Catch_FIND_VERSION)
   message(FATAL_ERROR "A version number must be specified.")
 elseif(Catch_FIND_REQUIRED)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

Too small, just hides a warning when actively passing `-DDOWNLOAD_CATCH=ON`.

<!-- If the upgrade guide needs updating, note that here too -->
