### PR TITLE
tests: use 'build' in tests instead of running setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "cmake>=3.18", "ninja"]
+requires = ["setuptools>=42", "cmake>=3.18", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [tool.check-manifest]

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -108,19 +108,19 @@ def test_build_sdist(monkeypatch, tmpdir):
     out = subprocess.check_output(
         [
             sys.executable,
-            "setup.py",
-            "sdist",
-            "--formats=tar",
-            "--dist-dir",
+            "-m",
+            "build",
+            "--sdist",
+            "--outdir",
             str(tmpdir),
         ]
     )
     if hasattr(out, "decode"):
         out = out.decode()
 
-    (sdist,) = tmpdir.visit("*.tar")
+    (sdist,) = tmpdir.visit("*.tar.gz")
 
-    with tarfile.open(str(sdist)) as tar:
+    with tarfile.open(str(sdist), "r:gz") as tar:
         start = tar.getnames()[0] + "/"
         version = start[9:-1]
         simpler = {n.split("/", 1)[-1] for n in tar.getnames()[1:]}
@@ -169,23 +169,23 @@ def test_build_global_dist(monkeypatch, tmpdir):
 
     monkeypatch.chdir(MAIN_DIR)
     monkeypatch.setenv("PYBIND11_GLOBAL_SDIST", "1")
-
     out = subprocess.check_output(
         [
             sys.executable,
-            "setup.py",
-            "sdist",
-            "--formats=tar",
-            "--dist-dir",
+            "-m",
+            "build",
+            "--sdist",
+            "--outdir",
             str(tmpdir),
         ]
     )
+
     if hasattr(out, "decode"):
         out = out.decode()
 
-    (sdist,) = tmpdir.visit("*.tar")
+    (sdist,) = tmpdir.visit("*.tar.gz")
 
-    with tarfile.open(str(sdist)) as tar:
+    with tarfile.open(str(sdist), "r:gz") as tar:
         start = tar.getnames()[0] + "/"
         version = start[16:-1]
         simpler = {n.split("/", 1)[-1] for n in tar.getnames()[1:]}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+build==0.7.0
 numpy==1.21.5; platform_python_implementation=="PyPy" and sys_platform=="linux" and python_version=="3.7"
 numpy==1.19.3; platform_python_implementation!="PyPy" and python_version=="3.6"
 numpy==1.21.5; platform_python_implementation!="PyPy" and python_version>="3.7" and python_version<"3.10"


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Use build instead of direct setup.py commands in our tests. Mostly by @abravalheri, pulled from #3711.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Avoid ``setup.py <command>`` usage in internal tests.
```

<!-- If the upgrade guide needs updating, note that here too -->
