### PR TITLE
Removing `// clang-format off` - `on` directives from test_pickling.cpp

### DIFF
--- a/tests/test_pickling.cpp
+++ b/tests/test_pickling.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /*
     tests/test_pickling.cpp -- pickle support
 
@@ -10,8 +9,6 @@
 */
 
 #include "pybind11_tests.h"
-
-// clang-format on
 
 #include <memory>
 #include <stdexcept>
@@ -63,19 +60,18 @@ void wrap(py::module m) {
 
 } // namespace exercise_trampoline
 
-// clang-format off
-
 TEST_SUBMODULE(pickling, m) {
     // test_roundtrip
     class Pickleable {
     public:
-        explicit Pickleable(const std::string &value) : m_value(value) { }
+        explicit Pickleable(const std::string &value) : m_value(value) {}
         const std::string &value() const { return m_value; }
 
         void setExtra1(int extra1) { m_extra1 = extra1; }
         void setExtra2(int extra2) { m_extra2 = extra2; }
         int extra1() const { return m_extra1; }
         int extra2() const { return m_extra2; }
+
     private:
         std::string m_value;
         int m_extra1 = 0;
@@ -88,8 +84,7 @@ TEST_SUBMODULE(pickling, m) {
     };
 
     py::class_<Pickleable> pyPickleable(m, "Pickleable");
-    pyPickleable
-        .def(py::init<std::string>())
+    pyPickleable.def(py::init<std::string>())
         .def("value", &Pickleable::value)
         .def("extra1", &Pickleable::extra1)
         .def("extra2", &Pickleable::extra2)
@@ -105,7 +100,7 @@ TEST_SUBMODULE(pickling, m) {
         pyPickleable.def("__setstate__", [](Pickleable &p, const py::tuple &t) {
             if (t.size() != 3) {
                 throw std::runtime_error("Invalid state!");
-}
+            }
             /* Invoke the constructor (need to use in-place version) */
             new (&p) Pickleable(t[0].cast<std::string>());
 
@@ -124,7 +119,7 @@ TEST_SUBMODULE(pickling, m) {
             [](const py::tuple &t) {
                 if (t.size() != 3) {
                     throw std::runtime_error("Invalid state!");
-}
+                }
                 auto p = PickleableNew(t[0].cast<std::string>());
 
                 p.setExtra1(t[1].cast<int>());
@@ -136,7 +131,7 @@ TEST_SUBMODULE(pickling, m) {
     // test_roundtrip_with_dict
     class PickleableWithDict {
     public:
-        explicit PickleableWithDict(const std::string &value) : value(value) { }
+        explicit PickleableWithDict(const std::string &value) : value(value) {}
 
         std::string value;
         int extra;
@@ -147,7 +142,8 @@ TEST_SUBMODULE(pickling, m) {
         using PickleableWithDict::PickleableWithDict;
     };
 
-    py::class_<PickleableWithDict> pyPickleableWithDict(m, "PickleableWithDict", py::dynamic_attr());
+    py::class_<PickleableWithDict> pyPickleableWithDict(
+        m, "PickleableWithDict", py::dynamic_attr());
     pyPickleableWithDict.def(py::init<std::string>())
         .def_readwrite("value", &PickleableWithDict::value)
         .def_readwrite("extra", &PickleableWithDict::extra)
@@ -159,7 +155,7 @@ TEST_SUBMODULE(pickling, m) {
         pyPickleableWithDict.def("__setstate__", [](const py::object &self, const py::tuple &t) {
             if (t.size() != 3) {
                 throw std::runtime_error("Invalid state!");
-}
+            }
             /* Cast and construct */
             auto &p = self.cast<PickleableWithDict &>();
             new (&p) PickleableWithDict(t[0].cast<std::string>());
@@ -176,12 +172,13 @@ TEST_SUBMODULE(pickling, m) {
         .def(py::init<std::string>())
         .def(py::pickle(
             [](const py::object &self) {
-                return py::make_tuple(self.attr("value"), self.attr("extra"), self.attr("__dict__"));
+                return py::make_tuple(
+                    self.attr("value"), self.attr("extra"), self.attr("__dict__"));
             },
             [](const py::tuple &t) {
                 if (t.size() != 3) {
                     throw std::runtime_error("Invalid state!");
-}
+                }
 
                 auto cpp_state = PickleableWithDictNew(t[0].cast<std::string>());
                 cpp_state.extra = t[1].cast<int>();


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Sorry I forgot to remove these while working on PR #3712.

The clang-format directives were introduced in my PR #2972. At that time, the idea was to have the newly added code clang-format'ed, but not the existing code.

The only manual changes in this PR are the removal of the clang-format directives (3 lines). The other changes are the result of running pre-commit.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
