### PR TITLE
Fix exception handling when pybind11::weakref() fails.

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -936,9 +936,11 @@ PYBIND11_RUNTIME_EXCEPTION(cast_error, PyExc_RuntimeError) /// Thrown when pybin
 PYBIND11_RUNTIME_EXCEPTION(reference_cast_error, PyExc_RuntimeError) /// Used internally
 
 [[noreturn]] PYBIND11_NOINLINE void pybind11_fail(const char *reason) {
+    assert(!PyErr_Occurred());
     throw std::runtime_error(reason);
 }
 [[noreturn]] PYBIND11_NOINLINE void pybind11_fail(const std::string &reason) {
+    assert(!PyErr_Occurred());
     throw std::runtime_error(reason);
 }
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1509,6 +1509,7 @@ public:
     explicit weakref(handle obj, handle callback = {})
         : object(PyWeakref_NewRef(obj.ptr(), callback.ptr()), stolen_t{}) {
         if (!m_ptr) {
+            PyErr_Clear();
             pybind11_fail("Could not allocate weak reference!");
         }
     }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1511,9 +1511,8 @@ public:
         if (!m_ptr) {
             if (PyErr_Occurred()) {
                 throw error_already_set();
-            } else {
-                pybind11_fail("Could not allocate weak reference!");
             }
+            throw type_error("Could not allocate weak reference!");
         }
     }
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1512,7 +1512,7 @@ public:
             if (PyErr_Occurred()) {
                 throw error_already_set();
             }
-            throw type_error("Could not allocate weak reference!");
+            pybind11_fail("Could not allocate weak reference!");
         }
     }
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1509,8 +1509,11 @@ public:
     explicit weakref(handle obj, handle callback = {})
         : object(PyWeakref_NewRef(obj.ptr(), callback.ptr()), stolen_t{}) {
         if (!m_ptr) {
-            PyErr_Clear();
-            pybind11_fail("Could not allocate weak reference!");
+            if (PyErr_Occurred()) {
+                throw error_already_set();
+            } else {
+                pybind11_fail("Could not allocate weak reference!");
+            }
         }
     }
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -594,8 +594,6 @@ def test_weakref(create_weakref, create_weakref_with_callback):
     ],
 )
 def test_weakref_err(create_weakref, has_callback):
-    from weakref import getweakrefcount
-
     class C:
         __slots__ = []
 
@@ -603,7 +601,6 @@ def test_weakref_err(create_weakref, has_callback):
         pass
 
     ob = C()
-    assert getweakrefcount(ob) == 0
     # Should raise TypeError on CPython
     with pytest.raises(TypeError) if not env.PYPY else contextlib.nullcontext():
         if has_callback:

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -584,15 +584,27 @@ def test_weakref(create_weakref, create_weakref_with_callback):
 
 
 @pytest.mark.parametrize(
-    "create_weakref", (m.weakref_from_handle, m.weakref_from_object)
+    "create_weakref, has_callback",
+    [
+        (m.weakref_from_handle, False),
+        (m.weakref_from_object, False),
+        (m.weakref_from_handle_and_function, True),
+        (m.weakref_from_object_and_function, True),
+    ],
 )
-def test_weakref_err(create_weakref):
+def test_weakref_err(create_weakref, has_callback):
     class C:
         __slots__ = []
 
+    def callback(_):
+        pass
+
     ob = C()
-    with pytest.raises(RuntimeError):
-        create_weakref(ob)
+    with pytest.raises(TypeError):
+        if has_callback:
+            _ = create_weakref(ob, callback)
+        else:
+            _ = create_weakref(ob)
 
 
 def test_cpp_iterators():

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -583,6 +583,18 @@ def test_weakref(create_weakref, create_weakref_with_callback):
     assert callback_called
 
 
+@pytest.mark.parametrize(
+    "create_weakref", (m.weakref_from_handle, m.weakref_from_object)
+)
+def test_weakref_err(create_weakref):
+    class C:
+        __slots__ = []
+
+    ob = C()
+    with pytest.raises(RuntimeError):
+        create_weakref(ob)
+
+
 def test_cpp_iterators():
     assert m.tuple_iterator() == 12
     assert m.dict_iterator() == 305 + 711

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1,8 +1,9 @@
+import contextlib
 import sys
 
 import pytest
 
-import env  # noqa: F401
+import env
 from pybind11_tests import debug_enabled
 from pybind11_tests import pytypes as m
 
@@ -593,6 +594,8 @@ def test_weakref(create_weakref, create_weakref_with_callback):
     ],
 )
 def test_weakref_err(create_weakref, has_callback):
+    from weakref import getweakrefcount
+
     class C:
         __slots__ = []
 
@@ -600,7 +603,9 @@ def test_weakref_err(create_weakref, has_callback):
         pass
 
     ob = C()
-    with pytest.raises(TypeError):
+    assert getweakrefcount(ob) == 0
+    # Should raise TypeError on CPython
+    with pytest.raises(TypeError) if not env.PYPY else contextlib.nullcontext():
         if has_callback:
             _ = create_weakref(ob, callback)
         else:


### PR DESCRIPTION
The `weakref()` constructor calls `pybind11_fail()` without clearing any
Python interpreter error state. If a client catches the C++ exception
thrown by `pybind11_fail()`, the Python interpreter will be left in an
error state.

I found this problem while fixing code that called `pybind11::weakref(obj)` where `obj` is not weak-referenceable. In that case, I wanted to fallback to another code path by catching the exception raised by `pybind11_fail`, e.g.,

```
try {
  x = py::weakref(obj);
} catch (std::runtime_error& e) {
 ... do something else
}
```

However, if you do this, then the Python error flag is left set in the catch case and not cleared. This causes later calls into the Python interpreter to fail.

It is possible that this PR should be more aggressive: all calls to `pybind11_fail()` should clear the error flag. If we are going to throw a C++ exception, then presumably that is replacing any Python error state.
