### PR TITLE
Disable ipo by property

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -328,11 +328,12 @@ function(_pybind11_generate_lto target prefer_thin_lto)
     # CONFIG takes multiple values in CMake 3.19+, until then we have to use OR
     set(is_debug "$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>")
     set(not_debug "$<NOT:${is_debug}>")
+    set(not_optout "$<NOT:$<BOOL:$<TARGET_PROPERTY:PYBIND11_NO_IPO>>>")
     set(cxx_lang "$<COMPILE_LANGUAGE:CXX>")
     if(MSVC AND CMAKE_VERSION VERSION_LESS 3.11)
-      set(genex "${not_debug}")
+      set(genex "$<AND:${not_debug},${not_optout}>")
     else()
-      set(genex "$<AND:${not_debug},${cxx_lang}>")
+      set(genex "$<AND:${not_debug},${cxx_lang},${not_optout}>")
     endif()
     set_property(
       TARGET ${target}

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -353,12 +353,12 @@ function(_pybind11_generate_lto target prefer_thin_lto)
       set_property(
         TARGET ${target}
         APPEND
-        PROPERTY INTERFACE_LINK_LIBRARIES "$<${not_debug}:${PYBIND11_LTO_LINKER_FLAGS}>")
+        PROPERTY INTERFACE_LINK_LIBRARIES "$<${genex}:${PYBIND11_LTO_LINKER_FLAGS}>")
     else()
       set_property(
         TARGET ${target}
         APPEND
-        PROPERTY INTERFACE_LINK_OPTIONS "$<${not_debug}:${PYBIND11_LTO_LINKER_FLAGS}>")
+        PROPERTY INTERFACE_LINK_OPTIONS "$<${genex}:${PYBIND11_LTO_LINKER_FLAGS}>")
     endif()
   endif()
 endfunction()


### PR DESCRIPTION
## Description

IPO is expensive and it can cause out-of-memory in CI. It would be nice to be able to disable IPO in these cases.

## Suggested changelog entry:

```rst
* Targets may now set the `PYBIND11_NO_IPO` target property to `1` to opt-out of IPO for PyBind11 targets.
```