### PR TITLE
MSVC C++20 test_eigen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,7 +712,7 @@ jobs:
 
         include:
           - python: 3.9
-            args: -DCMAKE_CXX_STANDARD=20 -DDOWNLOAD_EIGEN=ON -DPYBIND11_WERROR=OFF
+            args: -DCMAKE_CXX_STANDARD=20
           - python: 3.8
             args: -DCMAKE_CXX_STANDARD=17
 
@@ -837,7 +837,6 @@ jobs:
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
         -DCMAKE_CXX_STANDARD=20
-        -DPYBIND11_WERROR=OFF
 
     - name: Build C++20
       run: cmake --build build -j 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -835,7 +835,7 @@ jobs:
         cmake -S . -B build
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
-        -DDOWNLOAD_EIGEN=OFF
+        -DDOWNLOAD_EIGEN=ON
         -DCMAKE_CXX_STANDARD=20
 
     - name: Build C++20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,7 +712,7 @@ jobs:
 
         include:
           - python: 3.9
-            args: -DCMAKE_CXX_STANDARD=20 -DDOWNLOAD_EIGEN=ON
+            args: -DCMAKE_CXX_STANDARD=20 -DDOWNLOAD_EIGEN=ON -DPYBIND11_WERROR=OFF
           - python: 3.8
             args: -DCMAKE_CXX_STANDARD=17
 
@@ -837,6 +837,7 @@ jobs:
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
         -DCMAKE_CXX_STANDARD=20
+        -DPYBIND11_WERROR=OFF
 
     - name: Build C++20
       run: cmake --build build -j 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,7 +712,7 @@ jobs:
 
         include:
           - python: 3.9
-            args: -DCMAKE_CXX_STANDARD=20 -DDOWNLOAD_EIGEN=OFF
+            args: -DCMAKE_CXX_STANDARD=20 -DDOWNLOAD_EIGEN=ON
           - python: 3.8
             args: -DCMAKE_CXX_STANDARD=17
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -822,7 +822,7 @@ struct is_template_base_of_impl {
 /// Check if a template is the base of a type. For example:
 /// `is_template_base_of<Base, T>` is true if `struct T : Base<U> {}` where U can be anything
 template <template <typename...> class Base, typename T>
-#if !defined(_MSC_VER) // Sadly, all MSVC versions incl. 2022 need this.
+#if defined(PYBIND11_CPP20) || !defined(_MSC_VER) // Sadly, all MSVC versions incl. 2022 need this.
 using is_template_base_of
     = decltype(is_template_base_of_impl<Base>::check((intrinsic_t<T> *) nullptr));
 #else

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -822,7 +822,7 @@ struct is_template_base_of_impl {
 /// Check if a template is the base of a type. For example:
 /// `is_template_base_of<Base, T>` is true if `struct T : Base<U> {}` where U can be anything
 template <template <typename...> class Base, typename T>
-#if defined(PYBIND11_CPP20) || !defined(_MSC_VER) // Sadly, all MSVC versions incl. 2022 need this.
+#if !defined(_MSC_VER) // Sadly, all MSVC versions incl. 2022 need this.
 using is_template_base_of
     = decltype(is_template_base_of_impl<Base>::check((intrinsic_t<T> *) nullptr));
 #else

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -822,7 +822,9 @@ struct is_template_base_of_impl {
 /// Check if a template is the base of a type. For example:
 /// `is_template_base_of<Base, T>` is true if `struct T : Base<U> {}` where U can be anything
 template <template <typename...> class Base, typename T>
-#if defined(PYBIND11_CPP20) || !defined(_MSC_VER) // Sadly, all MSVC versions incl. 2022 need this.
+// Sadly, all MSVC versions incl. 2022 need the workaround, even in C++20 mode.
+// See also: https://github.com/pybind/pybind11/pull/3741
+#if !defined(_MSC_VER)
 using is_template_base_of
     = decltype(is_template_base_of_impl<Base>::check((intrinsic_t<T> *) nullptr));
 #else

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -21,10 +21,12 @@
 // make it version specific, or even remove it later, but considering that
 // 1. C4127 is generally far more distracting than useful for modern template code, and
 // 2. we definitely want to ignore any MSVC warnings originating from Eigen code,
-// it is probably best to keep this around indefinitely.
+//    it is probably best to keep this around indefinitely.
 #if defined(_MSC_VER)
 #    pragma warning(push)
 #    pragma warning(disable : 4127) // C4127: conditional expression is constant
+#    pragma warning(disable : 5054) // https://github.com/pybind/pybind11/pull/3741
+//       C5054: operator '&': deprecated between enumerations of different types
 #endif
 
 #include <Eigen/Core>


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This PR enables test_eigen for MSVC 2019 & 2022 C++20.

With the combination of

* re-enabling the age-old MSVC workaround even for MSVC C++20 (533e5ad4b8e9a3712ba648559003a7db4dfe99a9)
* adding a warning suppression to eigen.h (cbb29c0b51d8976ba6e0b5f867c85bbaaaa56393)

test_eigen runs successfully with MSVC 2019 & 2022 C++20.

See also: https://github.com/pybind/pybind11/pull/3722#discussion_r805877201 (the entire discussion thread there)

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Testing eigen.h is now also enabled for MSVC 2019 & 2022 in C++20 mode.
```

<!-- If the upgrade guide needs updating, note that here too -->
