### PR TITLE
ci: test pypy upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         - '3.10'
         - 'pypy-3.7'
         - 'pypy-3.8'
+        - 'pypy-3.9'
 
         # Items in here will either be added to the build matrix (if not
         # present), or add new keys to an existing matrix element if all the

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -16,7 +16,7 @@ jobs:
   standard:
     name: "🐍 3.11 dev • ubuntu-latest • x64"
     runs-on: ubuntu-latest
-    if: "contains(github.event.pull_request.labels.*.name, 'python dev')"
+    if: "contains(github.event.pull_request.labels.*.name, 'python dev') || github.event_name == 'workflow_dispatch'"
 
     steps:
     - uses: actions/checkout@v2
@@ -110,3 +110,23 @@ jobs:
     # setuptools
     - name: Setuptools helpers test
       run: pytest tests/extra_setuptools
+
+  pypy:
+    name: "🐍 PyPy ${{ matrix.pypy-version }} dev • ${{ matrix.runs-on }} • x64"
+    runs-on: ${{ matrix.runs-on }}
+    if: "contains(github.event.pull_request.labels.*.name, 'python dev') || github.event_name == 'workflow_dispatch'"
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest]
+        pypy-version: ["3.7", "3.8", "3.9"]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Boost (Linux)
+      if: runner.os == 'Linux'
+      run: sudo apt-get install libboost-dev
+
+    - name: Build and test
+      run: pipx run nox -s 'pypy_upstream(${{ matrix.pypy-version }})'

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -95,7 +95,11 @@ def ignore_pytest_unraisable_warning(f):
 
 
 # TODO: find out why this fails on PyPy, https://foss.heptapod.net/pypy/pypy/-/issues/3583
-@pytest.mark.xfail(env.PYPY, reason="Failure on PyPy 3.8 (7.3.7)", strict=False)
+@pytest.mark.xfail(
+    env.PYPY and sys.version_info >= (3, 8),
+    reason="Failure on PyPy 3.8 (7.3.7)",
+    strict=False,
+)
 @ignore_pytest_unraisable_warning
 def test_python_alreadyset_in_destructor(monkeypatch, capsys):
     hooked = False


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Adding a nox test for PyPy upstream before their next release. I think this works on 3.7 and 3.8, though we should see if we still need our workarounds, and fails on PyPy 3.9, but haven't really looked into it more than just adding the tests. One test was regularly xpassing for me. CC @mattip.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Support testing development versions of PyPy (UNIX only) via nox
```

<!-- If the upgrade guide needs updating, note that here too -->
