### PR TITLE
fix: clear local internals after finalizing interpreter #2101

### DIFF
--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -198,7 +198,7 @@ inline void finalize_interpreter() {
     if (builtins.contains(id) && isinstance<capsule>(builtins[id])) {
         internals_ptr_ptr = capsule(builtins[id]);
     }
-
+    // Local internals contains data managed by the current interpreter, so we must clear them to avoid undefined behaviors when initializing another interpreter
     detail::get_local_internals().registered_types_cpp.clear();
     detail::get_local_internals().registered_exception_translators.clear();
 

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -199,6 +199,9 @@ inline void finalize_interpreter() {
         internals_ptr_ptr = capsule(builtins[id]);
     }
 
+    detail::get_local_internals().registered_types_cpp.clear();
+    detail::get_local_internals().registered_exception_translators.clear();
+
     Py_Finalize();
 
     if (internals_ptr_ptr) {

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -198,7 +198,8 @@ inline void finalize_interpreter() {
     if (builtins.contains(id) && isinstance<capsule>(builtins[id])) {
         internals_ptr_ptr = capsule(builtins[id]);
     }
-    // Local internals contains data managed by the current interpreter, so we must clear them to avoid undefined behaviors when initializing another interpreter
+    // Local internals contains data managed by the current interpreter, so we must clear them to
+    // avoid undefined behaviors when initializing another interpreter
     detail::get_local_internals().registered_types_cpp.clear();
     detail::get_local_internals().registered_exception_translators.clear();
 

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -377,6 +377,7 @@ TEST_CASE("sys.argv gets initialized properly") {
 }
 
 TEST_CASE("make_iterator can be called before then after finalizing an interpreter") {
+    // Reproduction of issue #2101 (https://github.com/pybind/pybind11/issues/2101)
     py::finalize_interpreter();
 
     std::vector<int> container;

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -375,3 +375,20 @@ TEST_CASE("sys.argv gets initialized properly") {
     }
     py::initialize_interpreter();
 }
+
+TEST_CASE("make_iterator can be called before then after finalizing an interpreter") {
+    py::finalize_interpreter();
+
+    std::vector<int> container;
+    {
+        pybind11::scoped_interpreter g;
+        auto iter = pybind11::make_iterator(container.begin(), container.end());
+    }
+
+    REQUIRE_NOTHROW([&]() {
+        pybind11::scoped_interpreter g;
+        auto iter = pybind11::make_iterator(container.begin(), container.end());
+    }());
+
+    py::initialize_interpreter();
+}


### PR DESCRIPTION
## Description

The author of #2101 proposed to clear the local internals after finalizing an interpreter. It seems that when registering a type as local, some of the data is managed by the current interpreter through pointers, which are then dangling when the interpreter is finalized. I implemented the solution suggested by the author, as it does not seem that keeping the local internals between two consecutive interpreters is the expected behavior.