### PR TITLE
Adding "make_alias" to use a different `__name__` as shared-object

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1245,6 +1245,28 @@ public:
         //       For Python 2, reinterpret_borrow was correct.
         return reinterpret_borrow<module_>(m);
     }
+
+    struct strip_leading_underscore_from_name;
+
+    static module_ make_alias(const char *name) {
+        module_ ret = *this;
+        ret.attr("__name__") = this.attr(name);
+        return ret;
+    }
+
+    static module_ make_alias(strip_leading_underscore_from_name) {
+        const char *name = PyModule_GetName(*this);
+        size_t n = strlen(name);
+        if (n == 0) {
+            return this->make_alias(name);
+        }
+        if (name[0] != "_") {
+            return this->make_alias(name);
+        }
+        char alias[n - 1];
+        std::copy(&name[1], &name[n - 1], &alias[0]);
+        return this->make_alias(alias);
+    }
 };
 
 // When inside a namespace (or anywhere as long as it's not the first item on a line),

--- a/tests/test_make_alias.cpp
+++ b/tests/test_make_alias.cpp
@@ -1,0 +1,22 @@
+/*
+    tests/make_alias -- make alias
+
+    Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#include <pybind11/pybind11.h>
+
+#include "constructor_stats.h"
+#include "pybind11_tests.h"
+
+#if defined(_MSC_VER)
+#    pragma warning(disable : 4996) // C4996: std::unary_negation is deprecated
+#endif
+
+TEST_SUBMODULE(_make_alias, m) {
+    ma = m.make_alias(pybind11::module::strip_leading_underscore_from_name);
+    ma.def("foo", []() -> { });
+}

--- a/tests/test_make_alias.py
+++ b/tests/test_make_alias.py
@@ -1,0 +1,8 @@
+import pytest
+
+from pybind11_tests import ConstructorStats
+
+m = pytest.importorskip("pybind11_tests.make_alias")
+
+def assert_name(mat):
+    assert m.__name__ == "make_alias"


### PR DESCRIPTION
## Description

I have a set of functions written in C++ that I compile in a module `_foo`.
My python module simply imports all functions from it. I.e. `foo/__init__.py` reads
```python
from _foo import *
```
This was giving issues with my documentation, and did not give nice error messages. This PR fixes this.
See https://github.com/pybind/pybind11/discussions/3748


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Adding "make_alias" to use a different `__name__` as shared-object
```

<!-- If the upgrade guide needs updating, note that here too -->
