### PR TITLE
FIX: support python311

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -213,6 +213,9 @@
 #    error "PYTHON < 3.6 IS UNSUPPORTED. pybind11 v2.9 was the last to support Python 2 and 3.5."
 #endif
 #include <frameobject.h>
+#if PY_VERSION_HEX >= 0x030b00A5
+#include "internal/pycore_frame.h"
+#endif
 #include <pythread.h>
 
 /* Python #defines overrides on all sorts of core functions, which

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -214,7 +214,7 @@
 #endif
 #include <frameobject.h>
 #if PY_VERSION_HEX >= 0x030b00A5
-#include "internal/pycore_frame.h"
+#    include "internal/pycore_frame.h"
 #endif
 #include <pythread.h>
 


### PR DESCRIPTION
In 18b5dd68c6b616257ae243c0b6bb965ffc885a23 / python/cpython#31530 / https://bugs.python.org/issue46836 the _frame struct was moved to an internal header, however the public API is primarily read-only.

I am not sure that this is the correct fix, but it gets scipy to compile again!

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
FIX: include internal CPython hearders
```

<!-- If the upgrade guide needs updating, note that here too -->
