### PR TITLE
Use sysconfig in Python >= 3.10

### DIFF
--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -112,11 +112,20 @@ endif()
 # VERSION. VERSION will typically be like "2.7" on unix, and "27" on windows.
 execute_process(
   COMMAND
-    "${PYTHON_EXECUTABLE}" "-c" "from distutils import sysconfig as s;import sys;import struct;
+    "${PYTHON_EXECUTABLE}" "-c" "
+import sys;import struct;
+import sysconfig as s
+USE_SYSCONFIG = sys.version_info >= (3, 10)
+if not USE_SYSCONFIG:
+    from distutils import sysconfig as ds
 print('.'.join(str(v) for v in sys.version_info));
 print(sys.prefix);
-print(s.get_python_inc(plat_specific=True));
-print(s.get_python_lib(plat_specific=True));
+if USE_SYSCONFIG:
+    print(s.get_path('platinclude'))
+    print(s.get_path('platlib'))
+else:
+    print(ds.get_python_inc(plat_specific=True));
+    print(ds.get_python_lib(plat_specific=True));
 print(s.get_config_var('EXT_SUFFIX') or s.get_config_var('SO'));
 print(hasattr(sys, 'gettotalrefcount')+0);
 print(struct.calcsize('@P'));

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -121,7 +121,11 @@ if not USE_SYSCONFIG:
 print('.'.join(str(v) for v in sys.version_info));
 print(sys.prefix);
 if USE_SYSCONFIG:
-    print(s.get_path('platinclude'))
+    scheme = s.get_default_scheme()
+    if scheme == 'posix_local':
+        # Debian's default scheme installs to /usr/local/ but we want to find headers in /usr/
+        scheme = 'posix_prefix'
+    print(s.get_path('platinclude', scheme))
     print(s.get_path('platlib'))
 else:
     print(ds.get_python_inc(plat_specific=True));


### PR DESCRIPTION
## Description

Rely on sysconfig for installation paths for Python >= 3.10. distutils has been deprecated and will be removed.

Fixes: #3677

## Suggested changelog entry:

```rst
* Uses ``sysconfig`` module to determine installation locations on Python >= 3.10, instead of ``distutils`` which has been deprecated.
```