### PR TITLE
fix: Fix potential memory leak pypy

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2694,9 +2694,9 @@ get_type_override(const void *this_ptr, const type_info *this_type, const char *
                        d.ptr());
     if (result == nullptr)
         throw error_already_set();
+    Py_DECREF(result);
     if (d["self"].is_none())
         return function();
-    Py_DECREF(result);
 #endif
 
     return override;


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* This would potentially leak if the early return occurred for PyPy based on where `d[self].is_none()`. We should call PY_DECREF before this line since the value of result is not used in the if clause. We do not have any valgrind testing on PyPy builds so our testing suite likely missed this bug.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fixed a potential memleak in PyPy in `get_type_override`.
```

<!-- If the upgrade guide needs updating, note that here too -->
