### PR TITLE
fix: add missing moves in eval.h

### DIFF
--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -82,7 +82,7 @@ template <eval_mode mode = eval_expr, size_t N>
 object eval(const char (&s)[N], object global = globals(), object local = object()) {
     /* Support raw string literals by removing common leading whitespace */
     auto expr = (s[0] == '\n') ? str(module_::import("textwrap").attr("dedent")(s)) : str(s);
-    return eval<mode>(expr, global, local);
+    return eval<mode>(expr, std::move(global), std::move(local));
 }
 
 inline void exec(const str &expr, object global = globals(), object local = object()) {
@@ -91,7 +91,7 @@ inline void exec(const str &expr, object global = globals(), object local = obje
 
 template <size_t N>
 void exec(const char (&s)[N], object global = globals(), object local = object()) {
-    eval<eval_statements>(s, global, local);
+    eval<eval_statements>(s, std::move(global), std::move(local));
 }
 
 #if defined(PYPY_VERSION)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
I was reading through the source code and noticed a couple of useful std::move were missing in eval.h. Seems clang-tidy didn't have the confidence to suggest them since they were in template functions. Now the behavior just matches the non-template version of the same function.

<!-- If the upgrade guide needs updating, note that here too -->
