### PR TITLE
Docs: No Strip in Debug

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -509,7 +509,10 @@ You can use these targets to build complex applications. For example, the
     target_link_libraries(example PRIVATE pybind11::module pybind11::lto pybind11::windows_extras)
 
     pybind11_extension(example)
-    pybind11_strip(example)
+    if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
+        # Strip unnecessary sections of the binary on Linux/macOS
+        pybind11_strip(example)
+    endif()
 
     set_target_properties(example PROPERTIES CXX_VISIBILITY_PRESET "hidden"
                                              CUDA_VISIBILITY_PRESET "hidden")


### PR DESCRIPTION
## Description

The docs were not 100% the same as we advertise and do with our high-level tooling function: most users do not want to strip symbols in Debug builds.


## Suggested changelog entry:

```rst
* compilation documentation: guard ``pybind11_strip`` to keep symbols in debug builds
```

<!-- If the upgrade guide needs updating, note that here too -->
