### PR TITLE
PYBIND11_OBJECT_CVT should use namespace for error_already_set()

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1038,12 +1038,12 @@ public:                                                                         
     Name(const object &o)                                                                         \
         : Parent(check_(o) ? o.inc_ref().ptr() : ConvertFun(o.ptr()), stolen_t{}) {               \
         if (!m_ptr)                                                                               \
-            throw error_already_set();                                                            \
+            throw ::pybind11::error_already_set();                                                \
     }                                                                                             \
     /* NOLINTNEXTLINE(google-explicit-constructor) */                                             \
     Name(object &&o) : Parent(check_(o) ? o.release().ptr() : ConvertFun(o.ptr()), stolen_t{}) {  \
         if (!m_ptr)                                                                               \
-            throw error_already_set();                                                            \
+            throw ::pybind11::error_already_set();                                                \
     }
 
 #define PYBIND11_OBJECT_CVT_DEFAULT(Name, Parent, CheckFun, ConvertFun)                           \

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -35,12 +35,12 @@ namespace external {
 	}
     }
     class float_ : public py::object {
-	PYBIND11_OBJECT_CVT(float_, py::object, ::detail::check, ::detail::conv)
+	PYBIND11_OBJECT_CVT(float_, py::object, external::detail::check, external::detail::conv)
 
-	float_() : py::object(::detail::default_constructed(), borrowed_t{}) {}
+	float_() : py::object(external::detail::default_constructed(), borrowed_t{}) {}
 
 	double get_value() const { return PyFloat_AsDouble(this->ptr()); }
-    }
+    };
 }
 
 TEST_SUBMODULE(pytypes, m) {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -33,7 +33,7 @@ PyObject *default_constructed() { return PyFloat_FromDouble(0.0); }
 class float_ : public py::object {
     PYBIND11_OBJECT_CVT(float_, py::object, external::detail::check, external::detail::conv)
 
-    float_() : py::object(external::detail::default_constructed(), borrowed_t{}) {}
+    float_() : py::object(external::detail::default_constructed(), stolen_t{}) {}
 
     double get_value() const { return PyFloat_AsDouble(this->ptr()); }
 };

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -16,16 +16,16 @@ namespace detail {
 bool check(PyObject *o) { return PyFloat_Check(o) != 0; }
 
 PyObject *conv(PyObject *o) {
+    PyObject *ret = nullptr;
     if (PyLong_Check(o)) {
         double v = PyLong_AsDouble(o);
-        if (v == -1.0 && PyErr_Occurred()) {
-            return nullptr;
-        }
-        return PyFloat_FromDouble(v);
+        if (!(v == -1.0 && PyErr_Occurred())) {
+            ret = PyFloat_FromDouble(v);
+	}
     } else {
         PyErr_SetString(PyExc_TypeError, "Unexpected type");
-        return nullptr;
     }
+    return ret;
 }
 
 PyObject *default_constructed() { return PyFloat_FromDouble(0.0); }
@@ -574,7 +574,7 @@ TEST_SUBMODULE(pytypes, m) {
         return o;
     });
 
-    m.def("square_float_", [](external::float_ x) -> double {
+    m.def("square_float_", [](const external::float_ &x) -> double {
         double v = x.get_value();
         return v * v;
     });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -21,7 +21,7 @@ PyObject *conv(PyObject *o) {
         double v = PyLong_AsDouble(o);
         if (!(v == -1.0 && PyErr_Occurred())) {
             ret = PyFloat_FromDouble(v);
-	}
+        }
     } else {
         PyErr_SetString(PyExc_TypeError, "Unexpected type");
     }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -11,37 +11,33 @@
 
 #include <utility>
 
-
-
 namespace external {
-    namespace detail {
-	bool check(PyObject *o) { return PyFloat_Check(o) != 0; }
+namespace detail {
+bool check(PyObject *o) { return PyFloat_Check(o) != 0; }
 
-	PyObject *conv(PyObject *o) {
-	    if (PyLong_Check(o)) {
-		double v = PyLong_AsDouble(o);
-		if (v == -1.0 && PyErr_Occurred()) {
-		    return nullptr;
-		}
-		return PyFloat_FromDouble(v);
-	    } else {
-		PyErr_SetString(PyExc_TypeError, "Unexpected type");
-		return nullptr;
-	    }
-	}
-
-	PyObject *default_constructed() {
-	    return PyFloat_FromDouble(0.0);
-	}
+PyObject *conv(PyObject *o) {
+    if (PyLong_Check(o)) {
+        double v = PyLong_AsDouble(o);
+        if (v == -1.0 && PyErr_Occurred()) {
+            return nullptr;
+        }
+        return PyFloat_FromDouble(v);
+    } else {
+        PyErr_SetString(PyExc_TypeError, "Unexpected type");
+        return nullptr;
     }
-    class float_ : public py::object {
-	PYBIND11_OBJECT_CVT(float_, py::object, external::detail::check, external::detail::conv)
-
-	float_() : py::object(external::detail::default_constructed(), borrowed_t{}) {}
-
-	double get_value() const { return PyFloat_AsDouble(this->ptr()); }
-    };
 }
+
+PyObject *default_constructed() { return PyFloat_FromDouble(0.0); }
+} // namespace detail
+class float_ : public py::object {
+    PYBIND11_OBJECT_CVT(float_, py::object, external::detail::check, external::detail::conv)
+
+    float_() : py::object(external::detail::default_constructed(), borrowed_t{}) {}
+
+    double get_value() const { return PyFloat_AsDouble(this->ptr()); }
+};
+} // namespace external
 
 TEST_SUBMODULE(pytypes, m) {
     // test_bool
@@ -578,5 +574,8 @@ TEST_SUBMODULE(pytypes, m) {
         return o;
     });
 
-    m.def("square_float_", [](external::float_ x) -> double { double v = x.get_value(); return v*v; });
+    m.def("square_float_", [](external::float_ x) -> double {
+        double v = x.get_value();
+        return v * v;
+    });
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -634,3 +634,10 @@ def test_implementation_details():
     assert m.tuple_item_set_ssize_t() == ("emely", "edmond")
     assert m.tuple_item_get_size_t(tup) == 93
     assert m.tuple_item_set_size_t() == ("candy", "cat")
+
+
+def test_external_float_():
+    r1 = m.square_float_(2.0)
+    assert r1 == 4.0
+    r2 = m.square_float_(4)
+    assert r2 == 16.0

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -639,5 +639,3 @@ def test_implementation_details():
 def test_external_float_():
     r1 = m.square_float_(2.0)
     assert r1 == 4.0
-    r2 = m.square_float_(4)
-    assert r2 == 16.0


### PR DESCRIPTION
This change makes the macro usable outside of pybind11 namespace.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Change to `PYBIND11_OBJECT_CVT` macro to fully qualify `error_already_set` used in constructors. This change allows macro to be used outside of `pybind11` namespace.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
PYBIND11_OBJECT_CVT and PYBIND11_OBJECT_CVT_DEFAULT macro can be used to define classes in namespaces other than pybind11.
```

<!-- If the upgrade guide needs updating, note that here too -->
