### PR TITLE
fix: Make non-embedded module clear their locals before deallocation

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -510,9 +510,17 @@ struct local_internals {
 };
 
 /// Works like `get_internals`, but for things which are locally registered.
+/// There is one variable storing the local internals for each module, but every embedded module
+/// shares the same locals.
 inline local_internals &get_local_internals() {
     static local_internals locals;
     return locals;
+}
+
+/// Clears the locally registered types and exception translators.
+inline void clear_local_internals() {
+    detail::get_local_internals().registered_types_cpp.clear();
+    detail::get_local_internals().registered_exception_translators.clear();
 }
 
 /// Constructs a std::string with the given arguments, stores it in `internals`, and returns its

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -42,7 +42,7 @@
     static ::pybind11::module_::module_def PYBIND11_CONCAT(pybind11_module_def_, name);           \
     static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);                     \
     static PyObject PYBIND11_CONCAT(*pybind11_init_wrapper_, name)() {                            \
-        auto m = ::pybind11::module_::create_extension_module(                                    \
+        auto m = ::pybind11::module_::create_embedded_extension_module(                           \
             PYBIND11_TOSTRING(name), nullptr, &PYBIND11_CONCAT(pybind11_module_def_, name));      \
         try {                                                                                     \
             PYBIND11_CONCAT(pybind11_init_, name)(m);                                             \
@@ -200,8 +200,7 @@ inline void finalize_interpreter() {
     }
     // Local internals contains data managed by the current interpreter, so we must clear them to
     // avoid undefined behaviors when initializing another interpreter
-    detail::get_local_internals().registered_types_cpp.clear();
-    detail::get_local_internals().registered_exception_translators.clear();
+    detail::clear_local_internals();
 
     Py_Finalize();
 

--- a/tests/test_embed/external_module.cpp
+++ b/tests/test_embed/external_module.cpp
@@ -13,7 +13,10 @@ PYBIND11_MODULE(external_module, m) {
         int v;
     };
 
+    class B {};
+
     py::class_<A>(m, "A").def(py::init<int>()).def_readwrite("value", &A::v);
+    py::class_<B>(m, "B", py::module_local());
 
     m.def("internals_at",
           []() { return reinterpret_cast<uintptr_t>(&py::detail::get_internals()); });


### PR DESCRIPTION
## Description
This fix aims to solve the issue #3776. The problem was that every non-embedded module had their own locals, which could only be accessed through the `get_local_internals` function of the shared library they were in. So when these modules were deallocated, their locals were not cleared, and if the modules were initialized again, C++ types could not be registered in the locals.
I used the [PyModuleDef::m_free](https://docs.python.org/3/c-api/module.html#c.PyModuleDef.m_free) field to register a cleanup callback which clears the locals on non-embedded module deallocation. I added another function for creating embedded module, so that embedded modules do not clear the locals on deallocation.
I also registered a local class in the [external_module](https://github.com/pybind/pybind11/blob/master/tests/test_embed/external_module.cpp) used for testing. This new line was making the ["Restart the interpreter"](https://github.com/pybind/pybind11/blob/91a6e129d9274a0b10943044e5aeae08471e00fe/tests/test_embed/test_interpreter.cpp#L174) test case fail.