### PR TITLE
Fixes issue #3801

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -292,9 +292,11 @@ public:
             loaded_v_h = value_and_holder();
             return true;
         }
-        const auto &bases = all_type_info(srctype);
-        if (convert && cpptype && bases.empty() && try_as_void_ptr_capsule(src)) {
-            return true;
+        if (convert && cpptype) {
+            const auto &bases = all_type_info(srctype);
+            if (bases.empty() && try_as_void_ptr_capsule(src)) {
+                return true;
+            }
         }
         return false;
     }

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -292,7 +292,8 @@ public:
             loaded_v_h = value_and_holder();
             return true;
         }
-        if (convert && cpptype && try_as_void_ptr_capsule(src)) {
+        const auto &bases = all_type_info(srctype);
+        if (convert && cpptype && bases.empty() && try_as_void_ptr_capsule(src)) {
             return true;
         }
         return false;

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -94,7 +94,8 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     py::classh<Base12, Base1, Base2>(m, "Base12")
         .def(py::init<>())
         .def("foo", &Base12::foo)
-        .def("__getattr__", [](Base12 &, const std::string &key) { return "Base GetAttr: " + key; });
+        .def("__getattr__",
+             [](Base12 &, const std::string &key) { return "Base GetAttr: " + key; });
 
     py::classh<Derived1, Base12>(m, "Derived1").def(py::init<>()).def("bar", &Derived1::bar);
 

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -25,7 +25,7 @@ py::object create_void_ptr_capsule(py::object obj, const std::string &class_name
 
 int get_from_valid_capsule(const Valid *) { return 1; }
 
-int get_from_shared_ptr_valid_capsule(std::shared_ptr<Valid>) { return 2; }
+int get_from_shared_ptr_valid_capsule(const std::shared_ptr<Valid> &) { return 2; }
 
 int get_from_unique_ptr_valid_capsule(std::unique_ptr<Valid>) { return 3; }
 
@@ -94,7 +94,7 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     py::classh<Base12, Base1, Base2>(m, "Base12")
         .def(py::init<>())
         .def("foo", &Base12::foo)
-        .def("__getattr__", [](Base12 &, std::string key) { return "Base GetAttr: " + key; });
+        .def("__getattr__", [](Base12 &, const std::string &key) { return "Base GetAttr: " + key; });
 
     py::classh<Derived1, Base12>(m, "Derived1").def(py::init<>()).def("bar", &Derived1::bar);
 

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -7,53 +7,31 @@
 namespace pybind11_tests {
 namespace class_sh_void_ptr_capsule {
 
-// Conveniently, the helper serves to keep track of `capsule_generated`.
-struct HelperBase {
-    HelperBase() = default;
-    HelperBase(const HelperBase &) = delete;
-    virtual ~HelperBase() = default;
+struct Valid { };
 
-    bool capsule_generated = false;
-    virtual int get() const { return 100; }
-};
+struct NoConversion { };
 
-struct Valid : public HelperBase {
-    int get() const override { return 101; }
+struct NoCapsuleReturned { };
 
-    PyObject *as_pybind11_tests_class_sh_void_ptr_capsule_Valid() {
-        void *vptr = dynamic_cast<void *>(this);
-        capsule_generated = true;
-        // We assume vptr out lives the capsule, so we use nullptr for the
-        // destructor.
-        return PyCapsule_New(vptr, "::pybind11_tests::class_sh_void_ptr_capsule::Valid", nullptr);
-    }
-};
+struct AsAnotherObject { };
 
-struct NoConversion : public HelperBase {
-    int get() const override { return 102; }
-};
+py::object create_void_ptr_capsule(py::object obj, std::string class_name) {
+    void *vptr = static_cast<void *>(obj.ptr());
+    // We assume vptr out lives the capsule, so we use nullptr for the
+    // destructor.
+    return pybind11::reinterpret_steal<py::capsule>(
+        PyCapsule_New(vptr, class_name.c_str(), nullptr));
+}
 
-struct NoCapsuleReturned : public HelperBase {
-    int get() const override { return 103; }
+int get_from_valid_capsule(const Valid *c) { return 1; }
 
-    PyObject *as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned() {
-        capsule_generated = true;
-        Py_XINCREF(Py_None);
-        return Py_None;
-    }
-};
+int get_from_shared_ptr_valid_capsule(const std::shared_ptr<Valid> &c) { return 2; }
 
-struct AsAnotherObject : public HelperBase {
-    int get() const override { return 104; }
+int get_from_unique_ptr_valid_capsule(std::unique_ptr<Valid> c) { return 3; }
 
-    PyObject *as_pybind11_tests_class_sh_void_ptr_capsule_Valid() {
-        void *vptr = dynamic_cast<void *>(this);
-        capsule_generated = true;
-        // We assume vptr out lives the capsule, so we use nullptr for the
-        // destructor.
-        return PyCapsule_New(vptr, "::pybind11_tests::class_sh_void_ptr_capsule::Valid", nullptr);
-    }
-};
+int get_from_no_conversion_capsule(const NoConversion *c) { return 4; }
+
+int get_from_no_capsule_returned(const NoCapsuleReturned *c) { return 5; }
 
 // https://github.com/pybind/pybind11/issues/3788
 struct TypeWithGetattr {
@@ -61,68 +39,67 @@ struct TypeWithGetattr {
     int get_42() const { return 42; }
 };
 
-int get_from_valid_capsule(const Valid *c) { return c->get(); }
+// https://github.com/pybind/pybind11/issues/3804
+struct Base1 {int a1{};};
+struct Base2 {int a2{};};
 
-int get_from_shared_ptr_valid_capsule(const std::shared_ptr<Valid> &c) { return c->get(); }
+struct Base12 : Base1, Base2 {
+    virtual ~Base12() = default;
+    int foo() const { return 0; }
+};
 
-int get_from_unique_ptr_valid_capsule(std::unique_ptr<Valid> c) { return c->get(); }
+struct Derived1 : Base12 {
+    int bar() const { return 1; }
+};
 
-int get_from_no_conversion_capsule(const NoConversion *c) { return c->get(); }
-
-int get_from_no_capsule_returned(const NoCapsuleReturned *c) { return c->get(); }
+struct Derived2 : Base12 {
+    int bar() const { return 2; }
+};
 
 } // namespace class_sh_void_ptr_capsule
 } // namespace pybind11_tests
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::HelperBase)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Valid)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::NoConversion)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::NoCapsuleReturned)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::AsAnotherObject)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::TypeWithGetattr)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Base1)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Base2)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Base12)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Derived1)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Derived2)
 
 TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     using namespace pybind11_tests::class_sh_void_ptr_capsule;
 
-    py::classh<HelperBase>(m, "HelperBase")
-        .def(py::init<>())
-        .def("get", &HelperBase::get)
-        .def_readonly("capsule_generated", &HelperBase::capsule_generated);
-
-    py::classh<Valid, HelperBase>(m, "Valid")
-        .def(py::init<>())
-        .def("as_pybind11_tests_class_sh_void_ptr_capsule_Valid", [](Valid &self) {
-            PyObject *capsule = self.as_pybind11_tests_class_sh_void_ptr_capsule_Valid();
-            return pybind11::reinterpret_steal<py::capsule>(capsule);
-        });
-
-    py::classh<NoConversion, HelperBase>(m, "NoConversion").def(py::init<>());
-
-    py::classh<NoCapsuleReturned, HelperBase>(m, "NoCapsuleReturned")
-        .def(py::init<>())
-        .def("as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned",
-             [](NoCapsuleReturned &self) {
-                 PyObject *capsule
-                     = self.as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned();
-                 return pybind11::reinterpret_steal<py::capsule>(capsule);
-             });
-
-    py::classh<AsAnotherObject, HelperBase>(m, "AsAnotherObject")
-        .def(py::init<>())
-        .def("as_pybind11_tests_class_sh_void_ptr_capsule_Valid", [](AsAnotherObject &self) {
-            PyObject *capsule = self.as_pybind11_tests_class_sh_void_ptr_capsule_Valid();
-            return pybind11::reinterpret_steal<py::capsule>(capsule);
-        });
+    py::classh<Valid>(m, "Valid");
 
     m.def("get_from_valid_capsule", &get_from_valid_capsule);
     m.def("get_from_shared_ptr_valid_capsule", &get_from_shared_ptr_valid_capsule);
     m.def("get_from_unique_ptr_valid_capsule", &get_from_unique_ptr_valid_capsule);
     m.def("get_from_no_conversion_capsule", &get_from_no_conversion_capsule);
     m.def("get_from_no_capsule_returned", &get_from_no_capsule_returned);
+    m.def("create_void_ptr_capsule", &create_void_ptr_capsule);
 
     py::classh<TypeWithGetattr>(m, "TypeWithGetattr")
         .def(py::init<>())
         .def("get_42", &TypeWithGetattr::get_42)
         .def("__getattr__",
              [](TypeWithGetattr &, const std::string &key) { return "GetAttr: " + key; });
+
+    py::classh<Base1>(m, "Base1");
+    py::classh<Base2>(m, "Base2");
+
+    py::classh<Base12, Base1, Base2>(m, "Base12")
+        .def(py::init<>())
+        .def("foo", &Base12::foo)
+        .def("__getattr__", [](Base12&, std::string key) {
+             return "Base GetAttr: " + key;
+         });
+
+    py::classh<Derived1, Base12>(m, "Derived1")
+        .def(py::init<>())
+        .def("bar", &Derived1::bar);
+
+    py::classh<Derived2, Base12>(m, "Derived2")
+        .def(py::init<>())
+        .def("bar", &Derived2::bar);
 }

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -17,9 +17,7 @@ struct AsAnotherObject {};
 
 // Create a void pointer capsule for test. The encapsulated object does not
 // matter for this test case.
-py::handle create_test_void_ptr_capsule() {
-    return pybind11::capsule((void *) 12345, "int").release();
-}
+PyObject *create_test_void_ptr_capsule() { return PyCapsule_New((void *) 12345, "int", nullptr); }
 
 int get_from_valid_capsule(const Valid *) { return 1; }
 
@@ -78,7 +76,10 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     m.def("get_from_unique_ptr_valid_capsule", &get_from_unique_ptr_valid_capsule);
     m.def("get_from_no_conversion_capsule", &get_from_no_conversion_capsule);
     m.def("get_from_no_capsule_returned", &get_from_no_capsule_returned);
-    m.def("create_test_void_ptr_capsule", &create_test_void_ptr_capsule);
+    m.def("create_test_void_ptr_capsule", []() {
+        PyObject *capsule = create_test_void_ptr_capsule();
+        return pybind11::reinterpret_steal<py::capsule>(capsule);
+    });
 
     py::classh<TypeWithGetattr>(m, "TypeWithGetattr")
         .def(py::init<>())

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -17,11 +17,9 @@ struct AsAnotherObject {};
 
 // Create a void pointer capsule for test. The encapsulated object does not
 // matter for this test case.
-PyObject* create_test_void_ptr_capsule() {
+PyObject *create_test_void_ptr_capsule() {
     static int just_to_have_something_to_point_to = 0;
-    return PyCapsule_New(
-        static_cast<void *>(&just_to_have_something_to_point_to), "int",
-        nullptr);
+    return PyCapsule_New(static_cast<void *>(&just_to_have_something_to_point_to), "int", nullptr);
 }
 
 int get_from_valid_capsule(const Valid *) { return 1; }
@@ -82,8 +80,8 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     m.def("get_from_no_conversion_capsule", &get_from_no_conversion_capsule);
     m.def("get_from_no_capsule_returned", &get_from_no_capsule_returned);
     m.def("create_test_void_ptr_capsule", []() {
-      PyObject *capsule = create_test_void_ptr_capsule();
-      return pybind11::reinterpret_steal<py::capsule>(capsule);
+        PyObject *capsule = create_test_void_ptr_capsule();
+        return pybind11::reinterpret_steal<py::capsule>(capsule);
     });
 
     py::classh<TypeWithGetattr>(m, "TypeWithGetattr")

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -15,7 +15,7 @@ struct NoCapsuleReturned {};
 
 struct AsAnotherObject {};
 
-py::object create_void_ptr_capsule(py::object obj, std::string class_name) {
+py::object create_void_ptr_capsule(py::object obj, const std::string& class_name) {
     void *vptr = static_cast<void *>(obj.ptr());
     // We assume vptr out lives the capsule, so we use nullptr for the
     // destructor.
@@ -48,7 +48,6 @@ struct Base2 {
 };
 
 struct Base12 : Base1, Base2 {
-    virtual ~Base12() = default;
     int foo() const { return 0; }
 };
 

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -15,12 +15,8 @@ struct NoCapsuleReturned {};
 
 struct AsAnotherObject {};
 
-py::object create_void_ptr_capsule(py::object obj, const std::string &class_name) {
-    void *vptr = static_cast<void *>(obj.ptr());
-    // We assume vptr out lives the capsule, so we use nullptr for the
-    // destructor.
-    return pybind11::reinterpret_steal<py::capsule>(
-        PyCapsule_New(vptr, class_name.c_str(), nullptr));
+py::handle create_test_void_ptr_capsule() {
+    return pybind11::capsule((void *) 12345, "int").release();
 }
 
 int get_from_valid_capsule(const Valid *) { return 1; }
@@ -80,7 +76,7 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     m.def("get_from_unique_ptr_valid_capsule", &get_from_unique_ptr_valid_capsule);
     m.def("get_from_no_conversion_capsule", &get_from_no_conversion_capsule);
     m.def("get_from_no_capsule_returned", &get_from_no_capsule_returned);
-    m.def("create_void_ptr_capsule", &create_void_ptr_capsule);
+    m.def("create_test_void_ptr_capsule", &create_test_void_ptr_capsule);
 
     py::classh<TypeWithGetattr>(m, "TypeWithGetattr")
         .def(py::init<>())

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -15,7 +15,7 @@ struct NoCapsuleReturned {};
 
 struct AsAnotherObject {};
 
-py::object create_void_ptr_capsule(py::object obj, const std::string& class_name) {
+py::object create_void_ptr_capsule(py::object obj, const std::string &class_name) {
     void *vptr = static_cast<void *>(obj.ptr());
     // We assume vptr out lives the capsule, so we use nullptr for the
     // destructor.

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -23,15 +23,15 @@ py::object create_void_ptr_capsule(py::object obj, std::string class_name) {
         PyCapsule_New(vptr, class_name.c_str(), nullptr));
 }
 
-int get_from_valid_capsule(const Valid *c) { return 1; }
+int get_from_valid_capsule(const Valid *) { return 1; }
 
-int get_from_shared_ptr_valid_capsule(const std::shared_ptr<Valid> &c) { return 2; }
+int get_from_shared_ptr_valid_capsule(std::shared_ptr<Valid>) { return 2; }
 
-int get_from_unique_ptr_valid_capsule(std::unique_ptr<Valid> c) { return 3; }
+int get_from_unique_ptr_valid_capsule(std::unique_ptr<Valid>) { return 3; }
 
-int get_from_no_conversion_capsule(const NoConversion *c) { return 4; }
+int get_from_no_conversion_capsule(const NoConversion *) { return 4; }
 
-int get_from_no_capsule_returned(const NoCapsuleReturned *c) { return 5; }
+int get_from_no_capsule_returned(const NoCapsuleReturned *) { return 5; }
 
 // https://github.com/pybind/pybind11/issues/3788
 struct TypeWithGetattr {

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -15,6 +15,8 @@ struct NoCapsuleReturned {};
 
 struct AsAnotherObject {};
 
+// Create a void pointer capsule for test. The encapsulated object does not
+// matter for this test case.
 py::handle create_test_void_ptr_capsule() {
     return pybind11::capsule((void *) 12345, "int").release();
 }

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -17,7 +17,12 @@ struct AsAnotherObject {};
 
 // Create a void pointer capsule for test. The encapsulated object does not
 // matter for this test case.
-PyObject *create_test_void_ptr_capsule() { return PyCapsule_New((void *) 12345, "int", nullptr); }
+PyObject* create_test_void_ptr_capsule() {
+    static int just_to_have_something_to_point_to = 0;
+    return PyCapsule_New(
+        static_cast<void *>(&just_to_have_something_to_point_to), "int",
+        nullptr);
+}
 
 int get_from_valid_capsule(const Valid *) { return 1; }
 
@@ -77,8 +82,8 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     m.def("get_from_no_conversion_capsule", &get_from_no_conversion_capsule);
     m.def("get_from_no_capsule_returned", &get_from_no_capsule_returned);
     m.def("create_test_void_ptr_capsule", []() {
-        PyObject *capsule = create_test_void_ptr_capsule();
-        return pybind11::reinterpret_steal<py::capsule>(capsule);
+      PyObject *capsule = create_test_void_ptr_capsule();
+      return pybind11::reinterpret_steal<py::capsule>(capsule);
     });
 
     py::classh<TypeWithGetattr>(m, "TypeWithGetattr")

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -7,13 +7,13 @@
 namespace pybind11_tests {
 namespace class_sh_void_ptr_capsule {
 
-struct Valid { };
+struct Valid {};
 
-struct NoConversion { };
+struct NoConversion {};
 
-struct NoCapsuleReturned { };
+struct NoCapsuleReturned {};
 
-struct AsAnotherObject { };
+struct AsAnotherObject {};
 
 py::object create_void_ptr_capsule(py::object obj, std::string class_name) {
     void *vptr = static_cast<void *>(obj.ptr());
@@ -40,8 +40,12 @@ struct TypeWithGetattr {
 };
 
 // https://github.com/pybind/pybind11/issues/3804
-struct Base1 {int a1{};};
-struct Base2 {int a2{};};
+struct Base1 {
+    int a1{};
+};
+struct Base2 {
+    int a2{};
+};
 
 struct Base12 : Base1, Base2 {
     virtual ~Base12() = default;
@@ -91,15 +95,9 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     py::classh<Base12, Base1, Base2>(m, "Base12")
         .def(py::init<>())
         .def("foo", &Base12::foo)
-        .def("__getattr__", [](Base12&, std::string key) {
-             return "Base GetAttr: " + key;
-         });
+        .def("__getattr__", [](Base12 &, std::string key) { return "Base GetAttr: " + key; });
 
-    py::classh<Derived1, Base12>(m, "Derived1")
-        .def(py::init<>())
-        .def("bar", &Derived1::bar);
+    py::classh<Derived1, Base12>(m, "Derived1").def(py::init<>()).def("bar", &Derived1::bar);
 
-    py::classh<Derived2, Base12>(m, "Derived2")
-        .def(py::init<>())
-        .def("bar", &Derived2::bar);
+    py::classh<Derived2, Base12>(m, "Derived2").def(py::init<>()).def("bar", &Derived2::bar);
 }

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -7,7 +7,7 @@ class Valid:
 
     capsule_generated = False
 
-    def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):
+    def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):  # noqa: N802
         self.capsule_generated = True
         return m.create_void_ptr_capsule(
             self, "::pybind11_tests::class_sh_void_ptr_capsule::Valid"
@@ -23,7 +23,7 @@ class NoCapsuleReturned:
 
     capsule_generated = False
 
-    def as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned(self):
+    def as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned(self):  # noqa: N802
         return
 
 
@@ -31,7 +31,7 @@ class AsAnotherObject:
 
     capsule_generated = False
 
-    def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):
+    def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):  # noqa: N802
         self.capsule_generated = True
         return m.create_void_ptr_capsule(
             self, "::pybind11_tests::class_sh_void_ptr_capsule::Valid"
@@ -45,7 +45,7 @@ class AsAnotherObject:
         (AsAnotherObject, m.get_from_valid_capsule, 1, True),
     ],
 )
-def test_valid_as_void_ptr_capsule_function(ctor, caller, expected, capsule_generated):
+def test_valid_as_void_ptr_capsule_function(ctor, caller, expected, capsule_generated):  # noqa: N802
     obj = ctor()
     assert caller(obj) == expected
     assert obj.capsule_generated == capsule_generated
@@ -62,7 +62,7 @@ def test_invalid_as_void_ptr_capsule_function(
     ctor, caller, expected, capsule_generated
 ):
     obj = ctor()
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(TypeError):
         caller(obj)
     assert obj.capsule_generated == capsule_generated
 

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -23,7 +23,7 @@ class NoCapsuleReturned:
 
     capsule_generated = False
 
-    def as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned(
+    def as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned(  # noqa: N802
         self,
     ):
         return

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -5,35 +5,37 @@ from pybind11_tests import class_sh_void_ptr_capsule as m
 
 class Valid:
 
-  capsule_generated = False
+    capsule_generated = False
 
-  def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):
-    self.capsule_generated = True
-    return m.create_void_ptr_capsule(
-        self, "::pybind11_tests::class_sh_void_ptr_capsule::Valid")
+    def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):
+        self.capsule_generated = True
+        return m.create_void_ptr_capsule(
+            self, "::pybind11_tests::class_sh_void_ptr_capsule::Valid"
+        )
 
 
 class NoConversion:
 
-  capsule_generated = False
+    capsule_generated = False
 
 
 class NoCapsuleReturned:
 
-  capsule_generated = False
+    capsule_generated = False
 
-  def as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned(self):
-    return
+    def as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned(self):
+        return
 
 
 class AsAnotherObject:
 
-  capsule_generated = False
+    capsule_generated = False
 
-  def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):
-    self.capsule_generated = True
-    return m.create_void_ptr_capsule(
-        self, "::pybind11_tests::class_sh_void_ptr_capsule::Valid")
+    def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):
+        self.capsule_generated = True
+        return m.create_void_ptr_capsule(
+            self, "::pybind11_tests::class_sh_void_ptr_capsule::Valid"
+        )
 
 
 @pytest.mark.parametrize(
@@ -56,7 +58,9 @@ def test_valid_as_void_ptr_capsule_function(ctor, caller, expected, capsule_gene
         (NoCapsuleReturned, m.get_from_no_capsule_returned, 3, False),
     ],
 )
-def test_invalid_as_void_ptr_capsule_function(ctor, caller, expected, capsule_generated):
+def test_invalid_as_void_ptr_capsule_function(
+    ctor, caller, expected, capsule_generated
+):
     obj = ctor()
     with pytest.raises(TypeError) as excinfo:
         caller(obj)
@@ -88,9 +92,9 @@ def test_multiple_inheritance_getattr():
     d1 = m.Derived1()
     assert d1.foo() == 0
     assert d1.bar() == 1
-    assert d1.prop1 == 'Base GetAttr: prop1'
+    assert d1.prop1 == "Base GetAttr: prop1"
 
     d2 = m.Derived2()
     assert d2.foo() == 0
     assert d2.bar() == 2
-    assert d2.prop2 == 'Base GetAttr: prop2'
+    assert d2.prop2 == "Base GetAttr: prop2"

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -5,7 +5,8 @@ from pybind11_tests import class_sh_void_ptr_capsule as m
 
 class Valid:
 
-    capsule_generated = False
+    def __init__(self):
+        self.capsule_generated = False
 
     def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):  # noqa: N802
         self.capsule_generated = True
@@ -16,12 +17,14 @@ class Valid:
 
 class NoConversion:
 
-    capsule_generated = False
+    def __init__(self):
+        self.capsule_generated = False
 
 
 class NoCapsuleReturned:
 
-    capsule_generated = False
+    def __init__(self):
+        self.capsule_generated = False
 
     def as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned(  # noqa: N802
         self,
@@ -31,7 +34,8 @@ class NoCapsuleReturned:
 
 class AsAnotherObject:
 
-    capsule_generated = False
+    def __init__(self):
+        self.capsule_generated = False
 
     def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):  # noqa: N802
         self.capsule_generated = True

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -9,9 +9,7 @@ class Valid:
 
     def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):  # noqa: N802
         self.capsule_generated = True
-        return m.create_void_ptr_capsule(
-            self, "::pybind11_tests::class_sh_void_ptr_capsule::Valid"
-        )
+        return m.create_test_void_ptr_capsule()
 
 
 class NoConversion:
@@ -35,9 +33,7 @@ class AsAnotherObject:
 
     def as_pybind11_tests_class_sh_void_ptr_capsule_Valid(self):  # noqa: N802
         self.capsule_generated = True
-        return m.create_void_ptr_capsule(
-            self, "::pybind11_tests::class_sh_void_ptr_capsule::Valid"
-        )
+        return m.create_test_void_ptr_capsule()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -4,7 +4,6 @@ from pybind11_tests import class_sh_void_ptr_capsule as m
 
 
 class Valid:
-
     def __init__(self):
         self.capsule_generated = False
 
@@ -16,13 +15,11 @@ class Valid:
 
 
 class NoConversion:
-
     def __init__(self):
         self.capsule_generated = False
 
 
 class NoCapsuleReturned:
-
     def __init__(self):
         self.capsule_generated = False
 
@@ -33,7 +30,6 @@ class NoCapsuleReturned:
 
 
 class AsAnotherObject:
-
     def __init__(self):
         self.capsule_generated = False
 

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -24,7 +24,7 @@ class NoCapsuleReturned:
     def as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned(  # noqa: N802
         self,
     ):
-        return
+        pass
 
 
 class AsAnotherObject:

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -23,7 +23,9 @@ class NoCapsuleReturned:
 
     capsule_generated = False
 
-    def as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned(self):  # noqa: N802
+    def as_pybind11_tests_class_sh_void_ptr_capsule_NoCapsuleReturned(
+        self,
+    ):
         return
 
 
@@ -45,7 +47,9 @@ class AsAnotherObject:
         (AsAnotherObject, m.get_from_valid_capsule, 1, True),
     ],
 )
-def test_valid_as_void_ptr_capsule_function(ctor, caller, expected, capsule_generated):  # noqa: N802
+def test_valid_as_void_ptr_capsule_function(
+    ctor, caller, expected, capsule_generated
+):
     obj = ctor()
     assert caller(obj) == expected
     assert obj.capsule_generated == capsule_generated

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -47,9 +47,7 @@ class AsAnotherObject:
         (AsAnotherObject, m.get_from_valid_capsule, 1, True),
     ],
 )
-def test_valid_as_void_ptr_capsule_function(
-    ctor, caller, expected, capsule_generated
-):
+def test_valid_as_void_ptr_capsule_function(ctor, caller, expected, capsule_generated):
     obj = ctor()
     assert caller(obj) == expected
     assert obj.capsule_generated == capsule_generated


### PR DESCRIPTION
## Description

Fixes https://github.com/pybind/pybind11/issues/3801 by only calling `try_as_void_ptr_capsule` when the Python object is not wrapped with pybind11.

Also modified the test cases to make them work with the new implementation.