### PR TITLE
Use rvalue reference for std::variant cast_op<T>

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -372,7 +372,7 @@ struct variant_caster<V<Ts...>> {
     bool load_alternative(handle src, bool convert, type_list<U, Us...>) {
         auto caster = make_caster<U>();
         if (caster.load(src, convert)) {
-            value = cast_op<U>(caster);
+            value = cast_op<U>(std::move(caster));
             return true;
         }
         return load_alternative(src, convert, type_list<Us...>{});


### PR DESCRIPTION
Nearly every call site of `cast_op<T>` uses an r-value reference.

Except in stl.h `variant_caster::load_alternative` which handles `std::variant`.

Fix that.

