### PR TITLE
Add type_caster<std::monostate>

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -406,6 +406,9 @@ struct variant_caster<V<Ts...>> {
 #if defined(PYBIND11_HAS_VARIANT)
 template <typename... Ts>
 struct type_caster<std::variant<Ts...>> : variant_caster<std::variant<Ts...>> {};
+
+template <>
+struct type_caster<std::monostate> : public void_caster<std::monostate> {};
 #endif
 
 PYBIND11_NAMESPACE_END(detail)

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -436,9 +436,9 @@ TEST_SUBMODULE(stl, m) {
         result_type operator()(const std::string &) { return "std::string"; }
         result_type operator()(double) { return "double"; }
         result_type operator()(std::nullptr_t) { return "std::nullptr_t"; }
-#if defined(PYBIND11_HAS_VARIANT)
+#    if defined(PYBIND11_HAS_VARIANT)
         result_type operator()(std::monostate) { return "std::monostate"; }
-#endif
+#    endif
     };
 
     // test_variant
@@ -453,16 +453,17 @@ TEST_SUBMODULE(stl, m) {
         return py::make_tuple(V(5), V("Hello"));
     });
 
-#if defined(PYBIND11_HAS_VARIANT)
+#    if defined(PYBIND11_HAS_VARIANT)
     // std::monostate tests.
-    m.def("load_monostate_variant", [](const variant<std::monostate, int, std::string> &v) -> const char *{
-        return py::detail::visit_helper<variant>::call(visitor(), v);
-    });
+    m.def("load_monostate_variant",
+          [](const variant<std::monostate, int, std::string> &v) -> const char * {
+              return py::detail::visit_helper<variant>::call(visitor(), v);
+          });
     m.def("cast_monostate_variant", []() {
         using V = variant<std::monostate, int, std::string>;
         return py::make_tuple(V{}, V(5), V("Hello"));
     });
-#endif   
+#    endif
 #endif
 
     // #528: templated constructor

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -267,13 +267,11 @@ def test_variant(doc):
     assert m.load_monostate_variant(None) == "std::monostate"
     assert m.load_monostate_variant(1) == "int"
     assert m.load_monostate_variant("1") == "std::string"
-    assert m.load_monostate_variant(1.0) == "double"
-    assert m.load_monostate_variant(None) == "std::nullptr_t"
 
     assert m.cast_monostate_variant() == (None, 5, "Hello")
 
     assert (
-        doc(m.load_variant) == "load_monostate_variant(arg0: Union[int, str, float, None]) -> str"
+        doc(m.load_variant) == "load_monostate_variant(arg0: Union[None, int, str]) -> str"
     )
 
 

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -262,7 +262,10 @@ def test_variant(doc):
         doc(m.load_variant) == "load_variant(arg0: Union[int, str, float, None]) -> str"
     )
 
-@pytest.mark.skipif(not hasattr(m, "load_monostate_variant"), reason="no std::monostate")
+
+@pytest.mark.skipif(
+    not hasattr(m, "load_monostate_variant"), reason="no std::monostate"
+)
 def test_variant(doc):
     assert m.load_monostate_variant(None) == "std::monostate"
     assert m.load_monostate_variant(1) == "int"
@@ -271,7 +274,8 @@ def test_variant(doc):
     assert m.cast_monostate_variant() == (None, 5, "Hello")
 
     assert (
-        doc(m.load_variant) == "load_monostate_variant(arg0: Union[None, int, str]) -> str"
+        doc(m.load_variant)
+        == "load_monostate_variant(arg0: Union[None, int, str]) -> str"
     )
 
 

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -262,6 +262,20 @@ def test_variant(doc):
         doc(m.load_variant) == "load_variant(arg0: Union[int, str, float, None]) -> str"
     )
 
+@pytest.mark.skipif(not hasattr(m, "load_monostate_variant"), reason="no std::monostate")
+def test_variant(doc):
+    assert m.load_monostate_variant(None) == "std::monostate"
+    assert m.load_monostate_variant(1) == "int"
+    assert m.load_monostate_variant("1") == "std::string"
+    assert m.load_monostate_variant(1.0) == "double"
+    assert m.load_monostate_variant(None) == "std::nullptr_t"
+
+    assert m.cast_monostate_variant() == (None, 5, "Hello")
+
+    assert (
+        doc(m.load_variant) == "load_monostate_variant(arg0: Union[int, str, float, None]) -> str"
+    )
+
 
 def test_vec_of_reference_wrapper():
     """#171: Can't return reference wrappers (or STL structures containing them)"""

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -266,7 +266,7 @@ def test_variant(doc):
 @pytest.mark.skipif(
     not hasattr(m, "load_monostate_variant"), reason="no std::monostate"
 )
-def test_variant(doc):
+def test_variant_monostate(doc):
     assert m.load_monostate_variant(None) == "std::monostate"
     assert m.load_monostate_variant(1) == "int"
     assert m.load_monostate_variant("1") == "std::string"

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -274,7 +274,7 @@ def test_variant_monostate(doc):
     assert m.cast_monostate_variant() == (None, 5, "Hello")
 
     assert (
-        doc(m.load_variant)
+        doc(m.load_monostate_variant)
         == "load_monostate_variant(arg0: Union[None, int, str]) -> str"
     )
 


### PR DESCRIPTION
## Description

`std::monostate` is a tag type that allows std::variant to act as an optional, or allows default construction of a std::variant holding a non-default constructible type.

Here a type_caster<std::monostate> is added that specialized void_caster<>, as well as tests for the same.

