### PR TITLE
fix: improve str exceptions and consistency with python

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -278,6 +278,7 @@
 #define PYBIND11_BYTES_CHECK PyBytes_Check
 #define PYBIND11_BYTES_FROM_STRING PyBytes_FromString
 #define PYBIND11_BYTES_FROM_STRING_AND_SIZE PyBytes_FromStringAndSize
+#define PYBIND11_BYTES_AS_STRING_AND_SIZE PyBytes_AsStringAndSize
 #define PYBIND11_BYTES_AS_STRING PyBytes_AsString
 #define PYBIND11_BYTES_SIZE PyBytes_Size
 #define PYBIND11_LONG_CHECK(o) PyLong_Check(o)

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -278,7 +278,6 @@
 #define PYBIND11_BYTES_CHECK PyBytes_Check
 #define PYBIND11_BYTES_FROM_STRING PyBytes_FromString
 #define PYBIND11_BYTES_FROM_STRING_AND_SIZE PyBytes_FromStringAndSize
-#define PYBIND11_BYTES_AS_STRING_AND_SIZE PyBytes_AsStringAndSize
 #define PYBIND11_BYTES_AS_STRING PyBytes_AsString
 #define PYBIND11_BYTES_SIZE PyBytes_Size
 #define PYBIND11_LONG_CHECK(o) PyLong_Check(o)

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1243,8 +1243,8 @@ public:
         }
         char *buffer = nullptr;
         ssize_t length = 0;
-        if (PYBIND11_BYTES_AS_STRING_AND_SIZE(temp.ptr(), &buffer, &length)) {
-            pybind11_fail("Unable to extract string contents! (invalid type)");
+        if (PyBytes_AsStringAndSize(temp.ptr(), &buffer, &length)) {
+            throw error_already_set();
         }
         return std::string(buffer, (size_t) length);
     }
@@ -1302,8 +1302,8 @@ public:
     operator std::string() const {
         char *buffer = nullptr;
         ssize_t length = 0;
-        if (PYBIND11_BYTES_AS_STRING_AND_SIZE(m_ptr, &buffer, &length)) {
-            pybind11_fail("Unable to extract bytes contents!");
+        if (PyBytes_AsStringAndSize(m_ptr, &buffer, &length)) {
+            throw error_already_set();
         }
         return std::string(buffer, (size_t) length);
     }
@@ -1321,8 +1321,8 @@ public:
     operator std::string_view() const {
         char *buffer = nullptr;
         ssize_t length = 0;
-        if (PYBIND11_BYTES_AS_STRING_AND_SIZE(m_ptr, &buffer, &length)) {
-            pybind11_fail("Unable to extract bytes contents!");
+        if (PyBytes_AsStringAndSize(m_ptr, &buffer, &length)) {
+            throw error_already_set();
         }
         return {buffer, static_cast<size_t>(length)};
     }
@@ -1337,13 +1337,13 @@ inline bytes::bytes(const pybind11::str &s) {
     if (PyUnicode_Check(s.ptr())) {
         temp = reinterpret_steal<object>(PyUnicode_AsUTF8String(s.ptr()));
         if (!temp) {
-            pybind11_fail("Unable to extract string contents! (encoding issue)");
+            throw error_already_set();
         }
     }
     char *buffer = nullptr;
     ssize_t length = 0;
-    if (PYBIND11_BYTES_AS_STRING_AND_SIZE(temp.ptr(), &buffer, &length)) {
-        pybind11_fail("Unable to extract string contents! (invalid type)");
+    if (PyBytes_AsStringAndSize(temp.ptr(), &buffer, &length)) {
+        throw error_already_set();
     }
     auto obj = reinterpret_steal<object>(PYBIND11_BYTES_FROM_STRING_AND_SIZE(buffer, length));
     if (!obj) {
@@ -1355,8 +1355,8 @@ inline bytes::bytes(const pybind11::str &s) {
 inline str::str(const bytes &b) {
     char *buffer = nullptr;
     ssize_t length = 0;
-    if (PYBIND11_BYTES_AS_STRING_AND_SIZE(b.ptr(), &buffer, &length)) {
-        pybind11_fail("Unable to extract bytes contents!");
+    if (PyBytes_AsStringAndSize(b.ptr(), &buffer, &length)) {
+        throw error_already_set();
     }
     auto obj = reinterpret_steal<object>(PyUnicode_FromStringAndSize(buffer, length));
     if (!obj) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1243,7 +1243,7 @@ public:
         }
         char *buffer = nullptr;
         ssize_t length = 0;
-        if (PyBytes_AsStringAndSize(temp.ptr(), &buffer, &length)) {
+        if (PyBytes_AsStringAndSize(temp.ptr(), &buffer, &length) != 0) {
             throw error_already_set();
         }
         return std::string(buffer, (size_t) length);
@@ -1302,7 +1302,7 @@ public:
     operator std::string() const {
         char *buffer = nullptr;
         ssize_t length = 0;
-        if (PyBytes_AsStringAndSize(m_ptr, &buffer, &length)) {
+        if (PyBytes_AsStringAndSize(m_ptr, &buffer, &length) != 0) {
             throw error_already_set();
         }
         return std::string(buffer, (size_t) length);
@@ -1342,7 +1342,7 @@ inline bytes::bytes(const pybind11::str &s) {
     }
     char *buffer = nullptr;
     ssize_t length = 0;
-    if (PyBytes_AsStringAndSize(temp.ptr(), &buffer, &length)) {
+    if (PyBytes_AsStringAndSize(temp.ptr(), &buffer, &length) != 0) {
         throw error_already_set();
     }
     auto obj = reinterpret_steal<object>(PYBIND11_BYTES_FROM_STRING_AND_SIZE(buffer, length));
@@ -1355,7 +1355,7 @@ inline bytes::bytes(const pybind11::str &s) {
 inline str::str(const bytes &b) {
     char *buffer = nullptr;
     ssize_t length = 0;
-    if (PyBytes_AsStringAndSize(b.ptr(), &buffer, &length)) {
+    if (PyBytes_AsStringAndSize(b.ptr(), &buffer, &length) != 0) {
         throw error_already_set();
     }
     auto obj = reinterpret_steal<object>(PyUnicode_FromStringAndSize(buffer, length));

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1321,7 +1321,7 @@ public:
     operator std::string_view() const {
         char *buffer = nullptr;
         ssize_t length = 0;
-        if (PyBytes_AsStringAndSize(m_ptr, &buffer, &length)) {
+        if (PyBytes_AsStringAndSize(m_ptr, &buffer, &length) != 0) {
             throw error_already_set();
         }
         return {buffer, static_cast<size_t>(length)};

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1299,14 +1299,7 @@ public:
     explicit bytes(const pybind11::str &s);
 
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator std::string() const {
-        char *buffer = nullptr;
-        ssize_t length = 0;
-        if (PyBytes_AsStringAndSize(m_ptr, &buffer, &length) != 0) {
-            throw error_already_set();
-        }
-        return std::string(buffer, (size_t) length);
-    }
+    operator std::string() const { return string_op<std::string>(); }
 
 #ifdef PYBIND11_HAS_STRING_VIEW
     // enable_if is needed to avoid "ambiguous conversion" errors (see PR #3521).
@@ -1318,7 +1311,11 @@ public:
     // valid so long as the `bytes` instance remains alive and so generally should not outlive the
     // lifetime of the `bytes` instance.
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator std::string_view() const {
+    operator std::string_view() const { return string_op<std::string_view>(); }
+#endif
+private:
+    template <typename T>
+    T string_op() const {
         char *buffer = nullptr;
         ssize_t length = 0;
         if (PyBytes_AsStringAndSize(m_ptr, &buffer, &length) != 0) {
@@ -1326,7 +1323,6 @@ public:
         }
         return {buffer, static_cast<size_t>(length)};
     }
-#endif
 };
 // Note: breathe >= 4.17.0 will fail to build docs if the below two constructors
 // are included in the doxygen group; close here and reopen after as a workaround


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Use error_already_set() to provide more informative exceptions and better alignment with CPython exception strings
* Replaces the related compatibility macro. 
* Raise CodecError instead of TypeError in the byte constructor to be consistent with the fix in #2903 
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Improve exception handling in python str bindings
```

<!-- If the upgrade guide needs updating, note that here too -->
