### PR TITLE
Revert "ci: test pypy 3.9"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         - '3.10'
         - 'pypy-3.7'
         - 'pypy-3.8'
+        - 'pypy-3.9'
 
         # Items in here will either be added to the build matrix (if not
         # present), or add new keys to an existing matrix element if all the
@@ -45,6 +46,10 @@ jobs:
             args: >
               -DPYBIND11_FINDPYTHON=ON
               -DCMAKE_CXX_FLAGS="-D_=1"
+          - runs-on: ubuntu-latest
+            python: 'pypy-3.8'
+            args: >
+              -DPYBIND11_FINDPYTHON=ON
           - runs-on: windows-2019
             python: '3.6'
             args: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
         - '3.10'
         - 'pypy-3.7'
         - 'pypy-3.8'
-        - 'pypy-3.9'
 
         # Items in here will either be added to the build matrix (if not
         # present), or add new keys to an existing matrix element if all the
@@ -46,10 +45,6 @@ jobs:
             args: >
               -DPYBIND11_FINDPYTHON=ON
               -DCMAKE_CXX_FLAGS="-D_=1"
-          - runs-on: ubuntu-latest
-            python: 'pypy-3.9'
-            args: >
-              -DPYBIND11_FINDPYTHON=ON
           - runs-on: windows-2019
             python: '3.6'
             args: >


### PR DESCRIPTION
Reverts pybind/pybind11#3789

PyPy 3.9 discovery for FindPython does seem to be broken. (or all, I only added a test for that one).

Actually, let's see if 3.8 has the same problem.