### PR TITLE
[smart_holder] Add a new return value policy `return_as_bytes`

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -447,15 +447,14 @@ struct string_caster {
         return true;
     }
 
-    static handle
-    cast(const StringType &src, return_value_policy policy, handle /* parent */) {
+    static handle cast(const StringType &src, return_value_policy policy, handle /* parent */) {
         const char *buffer = reinterpret_cast<const char *>(src.data());
         auto nbytes = ssize_t(src.size() * sizeof(CharT));
         handle s;
         if (policy == return_value_policy::return_as_bytes) {
-          s = PYBIND11_BYTES_FROM_STRING_AND_SIZE(buffer, nbytes);
+            s = PYBIND11_BYTES_FROM_STRING_AND_SIZE(buffer, nbytes);
         } else {
-          s = decode_utfN(buffer, nbytes);
+            s = decode_utfN(buffer, nbytes);
         }
         if (!s) {
             throw error_already_set();

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -452,7 +452,7 @@ struct string_caster {
         auto nbytes = ssize_t(src.size() * sizeof(CharT));
         handle s;
         if (policy == return_value_policy::return_as_bytes) {
-            s = PYBIND11_BYTES_FROM_STRING_AND_SIZE(buffer, nbytes);
+            s = PyBytes_FromStringAndSize(buffer, nbytes);
         } else {
             s = decode_utfN(buffer, nbytes);
         }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -448,10 +448,15 @@ struct string_caster {
     }
 
     static handle
-    cast(const StringType &src, return_value_policy /* policy */, handle /* parent */) {
+    cast(const StringType &src, return_value_policy policy, handle /* parent */) {
         const char *buffer = reinterpret_cast<const char *>(src.data());
         auto nbytes = ssize_t(src.size() * sizeof(CharT));
-        handle s = decode_utfN(buffer, nbytes);
+        handle s;
+        if (policy == return_value_policy::return_as_bytes) {
+          s = PYBIND11_BYTES_FROM_STRING_AND_SIZE(buffer, nbytes);
+        } else {
+          s = decode_utfN(buffer, nbytes);
+        }
         if (!s) {
             throw error_already_set();
         }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -451,7 +451,7 @@ struct string_caster {
         const char *buffer = reinterpret_cast<const char *>(src.data());
         auto nbytes = ssize_t(src.size() * sizeof(CharT));
         handle s;
-        if (policy == return_value_policy::return_as_bytes) {
+        if (policy == return_value_policy::_return_as_bytes) {
             s = PyBytes_FromStringAndSize(buffer, nbytes);
         } else {
             s = decode_utfN(buffer, nbytes);

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -461,8 +461,7 @@ enum class return_value_policy : uint8_t {
         return_value_policy::reference and the keep_alive call policy */
     reference_internal,
 
-    /** This policy is experimental and likely to change in the future. With
-        this policy, C++ string types are converted to Python bytes,
+    /** With this policy, C++ string types are converted to Python bytes,
         instead of str. This is most useful when a C++ function returns a
         container-like type with nested C++ string types, and py::bytes cannot
         be applied easily. Dictionary like types might not work, for example,
@@ -470,7 +469,8 @@ enum class return_value_policy : uint8_t {
         to be converted to bytes. Note that this return_value_policy is not
         concerned with lifetime/ownership semantics, like the other policies,
         but the purpose of return_as_bytes is certain to be orthogonal, because
-        C++ strings are always copied to Python bytes or str. */
+        C++ strings are always copied to Python `bytes` or `str`.
+        NOTE: This policy is NOT available on master. */
     return_as_bytes
 };
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -463,15 +463,15 @@ enum class return_value_policy : uint8_t {
 
     /** With this policy, C++ string types are converted to Python bytes,
         instead of str. This is most useful when a C++ function returns a
-        container-like type with nested C++ string types, and py::bytes cannot
+        container-like type with nested C++ string types, and `py::bytes` cannot
         be applied easily. Dictionary like types might not work, for example,
         `Dict[str, bytes]`, because this policy forces all string return values
         to be converted to bytes. Note that this return_value_policy is not
         concerned with lifetime/ownership semantics, like the other policies,
-        but the purpose of return_as_bytes is certain to be orthogonal, because
+        but the purpose of _return_as_bytes is certain to be orthogonal, because
         C++ strings are always copied to Python `bytes` or `str`.
         NOTE: This policy is NOT available on master. */
-    return_as_bytes
+    _return_as_bytes
 };
 
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -461,13 +461,16 @@ enum class return_value_policy : uint8_t {
         return_value_policy::reference and the keep_alive call policy */
     reference_internal,
 
-    /** With this policy, C++ string types are converted to Python bytes,
+    /** This policy is experimental and likely to change in the future. With
+        this policy, C++ string types are converted to Python bytes,
         instead of str. This is most useful when a C++ function returns a
         container-like type with nested C++ string types, and py::bytes cannot
-        be applied easily. Note that this return_value_policy is not concerned
-        with lifetime/ownership semantics, like the other policies, but the
-        purpose of return_as_bytes is certain to be orthogonal, because C++
-        strings are always copied to Python bytes or str. */
+        be applied easily. Dictionary like types might not work, for example,
+        `Dict[str, bytes]`, because this policy forces all string return values
+        to be converted to bytes. Note that this return_value_policy is not
+        concerned with lifetime/ownership semantics, like the other policies,
+        but the purpose of return_as_bytes is certain to be orthogonal, because
+        C++ strings are always copied to Python bytes or str. */
     return_as_bytes
 };
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -461,11 +461,13 @@ enum class return_value_policy : uint8_t {
         return_value_policy::reference and the keep_alive call policy */
     reference_internal,
 
-    /** Use this policy to make C++ functions return bytes to Python instead of
-        str. This is useful when C++ function returns nested type of string,
-        where we cannot apply `py::bytes` easily. Note that when C++ function
-        returns string, we don't have to deal ownership for sure, because we
-        are always copying the C++ string to a new Python str/bytes object.*/
+    /** With this policy, C++ string types are converted to Python bytes,
+        instead of str. This is most useful when a C++ function returns a
+        container-like type with nested C++ string types, and py::bytes cannot
+        be applied easily. Note that this return_value_policy is not concerned
+        with lifetime/ownership semantics, like the other policies, but the
+        purpose of return_as_bytes is certain to be orthogonal, because C++
+        strings are always copied to Python bytes or str. */
     return_as_bytes
 };
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -459,7 +459,14 @@ enum class return_value_policy : uint8_t {
         collected while Python is still using the child. More advanced
         variations of this scheme are also possible using combinations of
         return_value_policy::reference and the keep_alive call policy */
-    reference_internal
+    reference_internal,
+
+    /** Use this policy to make C++ functions return bytes to Python instead of
+        str. This is useful when C++ function returns nested type of string,
+        where we cannot apply `py::bytes` easily. Note that when C++ function
+        returns string, we don't have to deal ownership for sure, because we
+        are always copying the C++ string to a new Python str/bytes object.*/
+    return_as_bytes
 };
 
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -790,6 +790,8 @@ struct smart_holder_type_caster<std::shared_ptr<T>> : smart_holder_type_caster_l
                 throw cast_error("Invalid return_value_policy for shared_ptr (reference).");
             case return_value_policy::reference_internal:
                 break;
+            case return_value_policy::return_as_bytes:
+                break;
         }
         if (!src) {
             return none().release();

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -783,13 +783,14 @@ struct smart_holder_type_caster<std::shared_ptr<T>> : smart_holder_type_caster_l
                 break;
             case return_value_policy::take_ownership:
                 throw cast_error("Invalid return_value_policy for shared_ptr (take_ownership).");
+                break;
             case return_value_policy::copy:
             case return_value_policy::move:
                 break;
             case return_value_policy::reference:
                 throw cast_error("Invalid return_value_policy for shared_ptr (reference).");
-            case return_value_policy::reference_internal:
                 break;
+            case return_value_policy::reference_internal:
             case return_value_policy::return_as_bytes:
                 break;
         }

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -791,7 +791,7 @@ struct smart_holder_type_caster<std::shared_ptr<T>> : smart_holder_type_caster_l
                 throw cast_error("Invalid return_value_policy for shared_ptr (reference).");
                 break;
             case return_value_policy::reference_internal:
-            case return_value_policy::return_as_bytes:
+            case return_value_policy::_return_as_bytes:
                 break;
         }
         if (!src) {

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -651,8 +651,8 @@ public:
                 keep_alive_impl(inst, parent);
                 break;
 
-            case return_value_policy::return_as_bytes:
-                pybind11_fail("return_value_policy::return_as_bytes does not apply.");
+            case return_value_policy::_return_as_bytes:
+                pybind11_fail("return_value_policy::_return_as_bytes does not apply.");
                 break;
 
             default:

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -651,6 +651,9 @@ public:
                 keep_alive_impl(inst, parent);
                 break;
 
+            case return_value_policy::return_as_bytes:
+                pybind11_fail("return_value_policy::return_as_bytes does not apply.");
+
             default:
                 throw cast_error("unhandled return_value_policy: should not happen!");
         }

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -653,6 +653,7 @@ public:
 
             case return_value_policy::return_as_bytes:
                 pybind11_fail("return_value_policy::return_as_bytes does not apply.");
+                break;
 
             default:
                 throw cast_error("unhandled return_value_policy: should not happen!");

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -349,8 +349,8 @@ private:
                 return eigen_ref_array<props>(*src);
             case return_value_policy::reference_internal:
                 return eigen_ref_array<props>(*src, parent);
-            case return_value_policy::return_as_bytes:
-                pybind11_fail("return_value_policy::return_as_bytes does not apply.");
+            case return_value_policy::_return_as_bytes:
+                pybind11_fail("return_value_policy::_return_as_bytes does not apply.");
                 break;
             default:
                 throw cast_error("unhandled return_value_policy: should not happen!");

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -349,6 +349,8 @@ private:
                 return eigen_ref_array<props>(*src);
             case return_value_policy::reference_internal:
                 return eigen_ref_array<props>(*src, parent);
+            case return_value_policy::return_as_bytes:
+                pybind11_fail("return_value_policy::return_as_bytes does not apply.");
             default:
                 throw cast_error("unhandled return_value_policy: should not happen!");
         };

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -351,6 +351,7 @@ private:
                 return eigen_ref_array<props>(*src, parent);
             case return_value_policy::return_as_bytes:
                 pybind11_fail("return_value_policy::return_as_bytes does not apply.");
+                break;
             default:
                 throw cast_error("unhandled return_value_policy: should not happen!");
         };

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -386,27 +386,27 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("takes_const_ref_wrap",
           [](std::reference_wrapper<const ConstRefCasted> x) { return x.get().tag; });
 
-    // test return_value_policy::return_as_bytes
+    // test return_value_policy::_return_as_bytes
     m.def(
         "invalid_utf8_string_as_bytes",
         []() { return std::string("\xba\xd0\xba\xd0"); },
-        py::return_value_policy::return_as_bytes);
+        py::return_value_policy::_return_as_bytes);
     m.def("invalid_utf8_string_as_str", []() { return std::string("\xba\xd0\xba\xd0"); });
     m.def(
         "invalid_utf8_char_array_as_bytes",
         []() { return "\xba\xd0\xba\xd0"; },
-        py::return_value_policy::return_as_bytes);
+        py::return_value_policy::_return_as_bytes);
     py::class_<StringAttr>(m, "StringAttr")
         .def(py::init<std::string>())
         .def_property(
             "value",
             py::cpp_function([](StringAttr &self) { return self.value; },
-                             py::return_value_policy::return_as_bytes),
+                             py::return_value_policy::_return_as_bytes),
             py::cpp_function([](StringAttr &self, std::string v) { self.value = std::move(v); }));
 #ifdef PYBIND11_HAS_STRING_VIEW
     m.def(
         "invalid_utf8_string_view_as_bytes",
         []() { return std::string_view("\xba\xd0\xba\xd0"); },
-        py::return_value_policy::return_as_bytes);
+        py::return_value_policy::_return_as_bytes);
 #endif
 }

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -380,18 +380,19 @@ TEST_SUBMODULE(builtin_casters, m) {
           [](std::reference_wrapper<const ConstRefCasted> x) { return x.get().tag; });
 
     // test return_value_policy::return_as_bytes
-    m.def("invalid_utf8_string_as_bytes", []() {
-        return std::string("\xba\xd0\xba\xd0");
-    }, py::return_value_policy::return_as_bytes);
-    m.def("invalid_utf8_string_as_str", []() {
-        return std::string("\xba\xd0\xba\xd0");
-    });
-    m.def("invalid_utf8_char_array_as_bytes", []() {
-        return "\xba\xd0\xba\xd0";
-    }, py::return_value_policy::return_as_bytes);
+    m.def(
+        "invalid_utf8_string_as_bytes",
+        []() { return std::string("\xba\xd0\xba\xd0"); },
+        py::return_value_policy::return_as_bytes);
+    m.def("invalid_utf8_string_as_str", []() { return std::string("\xba\xd0\xba\xd0"); });
+    m.def(
+        "invalid_utf8_char_array_as_bytes",
+        []() { return "\xba\xd0\xba\xd0"; },
+        py::return_value_policy::return_as_bytes);
 #ifdef PYBIND11_HAS_STRING_VIEW
-    m.def("invalid_utf8_string_view_as_bytes", []() {
-        return std::string_view("\xba\xd0\xba\xd0");
-    }, py::return_value_policy::return_as_bytes);
+    m.def(
+        "invalid_utf8_string_view_as_bytes",
+        []() { return std::string_view("\xba\xd0\xba\xd0"); },
+        py::return_value_policy::return_as_bytes);
 #endif
 }

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -378,4 +378,20 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("takes_const_ref", [](const ConstRefCasted &x) { return x.tag; });
     m.def("takes_const_ref_wrap",
           [](std::reference_wrapper<const ConstRefCasted> x) { return x.get().tag; });
+
+    // test return_value_policy::return_as_bytes
+    m.def("invalid_utf8_string_as_bytes", []() {
+        return std::string("\xba\xd0\xba\xd0");
+    }, py::return_value_policy::return_as_bytes);
+    m.def("invalid_utf8_string_as_str", []() {
+        return std::string("\xba\xd0\xba\xd0");
+    });
+    m.def("invalid_utf8_char_array_as_bytes", []() {
+        return "\xba\xd0\xba\xd0";
+    }, py::return_value_policy::return_as_bytes);
+#ifdef PYBIND11_HAS_STRING_VIEW
+    m.def("invalid_utf8_string_view_as_bytes", []() {
+        return std::string_view("\xba\xd0\xba\xd0");
+    }, py::return_value_policy::return_as_bytes);
+#endif
 }

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -11,12 +11,14 @@
 
 #include "pybind11_tests.h"
 
+#include <utility>
+
 struct ConstRefCasted {
     int tag;
 };
 
 struct StringAttr {
-    StringAttr(std::string v) : value(v) {}
+    explicit StringAttr(std::string v) : value(std::move(v)) {}
     std::string value;
 };
 
@@ -396,10 +398,11 @@ TEST_SUBMODULE(builtin_casters, m) {
         py::return_value_policy::return_as_bytes);
     py::class_<StringAttr>(m, "StringAttr")
         .def(py::init<std::string>())
-        .def_property("value",
-                      py::cpp_function([](StringAttr &self) { return self.value; },
-                                       py::return_value_policy::return_as_bytes),
-                      py::cpp_function([](StringAttr &self, std::string v) { self.value = v; }));
+        .def_property(
+            "value",
+            py::cpp_function([](StringAttr &self) { return self.value; },
+                             py::return_value_policy::return_as_bytes),
+            py::cpp_function([](StringAttr &self, std::string v) { self.value = std::move(v); }));
 #ifdef PYBIND11_HAS_STRING_VIEW
     m.def(
         "invalid_utf8_string_view_as_bytes",

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -15,6 +15,11 @@ struct ConstRefCasted {
     int tag;
 };
 
+struct StringAttr {
+    StringAttr(std::string v) : value(v) {}
+    std::string value;
+};
+
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
 template <>
@@ -389,6 +394,12 @@ TEST_SUBMODULE(builtin_casters, m) {
         "invalid_utf8_char_array_as_bytes",
         []() { return "\xba\xd0\xba\xd0"; },
         py::return_value_policy::return_as_bytes);
+    py::class_<StringAttr>(m, "StringAttr")
+        .def(py::init<std::string>())
+        .def_property("value",
+                      py::cpp_function([](StringAttr &self) { return self.value; },
+                                       py::return_value_policy::return_as_bytes),
+                      py::cpp_function([](StringAttr &self, std::string v) { self.value = v; }));
 #ifdef PYBIND11_HAS_STRING_VIEW
     m.def(
         "invalid_utf8_string_view_as_bytes",

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -524,3 +524,13 @@ def test_const_ref_caster():
     assert m.takes_const_ptr(x) == 5
     assert m.takes_const_ref(x) == 4
     assert m.takes_const_ref_wrap(x) == 4
+
+
+def test_return_as_bytes_policy():
+    expected_return_value = b"\xba\xd0\xba\xd0"
+    assert m.invalid_utf8_string_as_bytes() == expected_return_value
+    with pytest.raises(UnicodeDecodeError):
+        m.invalid_utf8_string_as_str()
+    assert m.invalid_utf8_char_array_as_bytes() == expected_return_value
+    if hasattr(m, "has_string_view"):
+        assert m.invalid_utf8_string_view_as_bytes() == expected_return_value

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -532,5 +532,9 @@ def test_return_as_bytes_policy():
     with pytest.raises(UnicodeDecodeError):
         m.invalid_utf8_string_as_str()
     assert m.invalid_utf8_char_array_as_bytes() == expected_return_value
+    obj = m.StringAttr(expected_return_value)
+    assert obj.value == expected_return_value
+    obj.value = "123"
+    assert obj.value == b"123"
     if hasattr(m, "has_string_view"):
         assert m.invalid_utf8_string_view_as_bytes() == expected_return_value

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -559,7 +559,7 @@ TEST_SUBMODULE(stl, m) {
 #ifdef PYBIND11_TEST_VARIANT
     m.def(
         "invalid_utf8_variant_string_as_bytes",
-        []() { return std::variant<std::string, std::monostate>{"\xba\xd0\xba\xd0"}; },
+        []() { return variant<std::string, int>{"\xba\xd0\xba\xd0"}; },
         py::return_value_policy::return_as_bytes);
 #endif
 }

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -545,10 +545,10 @@ TEST_SUBMODULE(stl, m) {
     // test return_value_policy::return_as_bytes
     m.def(
         "invalid_utf8_string_array_as_bytes",
-        []() { return std::array<std::string, 1>{"\xba\xd0\xba\xd0"}; },
+        []() { return std::array<std::string, 1>{{"\xba\xd0\xba\xd0"}} },
         py::return_value_policy::return_as_bytes);
     m.def("invalid_utf8_string_array_as_str",
-          []() { return std::array<std::string, 1>{std::string("\xba\xd0\xba\xd0")}; });
+          []() { return std::array<std::string, 1>{{"\xba\xd0\xba\xd0"}}; });
 #ifdef PYBIND11_HAS_OPTIONAL
     m.def(
         "invalid_utf8_optional_string_as_bytes",

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -545,7 +545,11 @@ TEST_SUBMODULE(stl, m) {
     // test return_value_policy::return_as_bytes
     m.def(
         "invalid_utf8_string_array_as_bytes",
-        []() { return std::array<std::string, 1>{{"\xba\xd0\xba\xd0"}} },
+        []() {
+            return std::array<std::string, 1> {
+                { "\xba\xd0\xba\xd0" }
+            }
+        },
         py::return_value_policy::return_as_bytes);
     m.def("invalid_utf8_string_array_as_str",
           []() { return std::array<std::string, 1>{{"\xba\xd0\xba\xd0"}}; });

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -541,4 +541,23 @@ TEST_SUBMODULE(stl, m) {
         []() { return new std::vector<bool>(4513); },
         // Without explicitly specifying `take_ownership`, this function leaks.
         py::return_value_policy::take_ownership);
+
+    // test return_value_policy::return_as_bytes
+    m.def("invalid_utf8_string_array_as_bytes", []() {
+        return std::array<std::string, 1>{"\xba\xd0\xba\xd0"};
+    }, py::return_value_policy::return_as_bytes);
+    m.def("invalid_utf8_string_array_as_str", []() {
+        return std::array<std::string, 1>{std::string("\xba\xd0\xba\xd0")};
+    });
+#ifdef PYBIND11_HAS_OPTIONAL
+    m.def("invalid_utf8_optional_string_as_bytes", []() {
+        return std::optional<std::string>{"\xba\xd0\xba\xd0"};
+    }, py::return_value_policy::return_as_bytes);
+#endif
+
+#ifdef PYBIND11_TEST_VARIANT
+    m.def("invalid_utf8_variant_string_as_bytes", []() {
+        return std::variant<std::string, std::monostate>{"\xba\xd0\xba\xd0"};
+    }, py::return_value_policy::return_as_bytes);
+#endif
 }

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -542,24 +542,24 @@ TEST_SUBMODULE(stl, m) {
         // Without explicitly specifying `take_ownership`, this function leaks.
         py::return_value_policy::take_ownership);
 
-    // test return_value_policy::return_as_bytes
+    // test return_value_policy::_return_as_bytes
     m.def(
         "invalid_utf8_string_array_as_bytes",
         []() { return std::array<std::string, 1>{{"\xba\xd0\xba\xd0"}}; },
-        py::return_value_policy::return_as_bytes);
+        py::return_value_policy::_return_as_bytes);
     m.def("invalid_utf8_string_array_as_str",
           []() { return std::array<std::string, 1>{{"\xba\xd0\xba\xd0"}}; });
 #ifdef PYBIND11_HAS_OPTIONAL
     m.def(
         "invalid_utf8_optional_string_as_bytes",
         []() { return std::optional<std::string>{"\xba\xd0\xba\xd0"}; },
-        py::return_value_policy::return_as_bytes);
+        py::return_value_policy::_return_as_bytes);
 #endif
 
 #ifdef PYBIND11_TEST_VARIANT
     m.def(
         "invalid_utf8_variant_string_as_bytes",
         []() { return variant<std::string, int>{"\xba\xd0\xba\xd0"}; },
-        py::return_value_policy::return_as_bytes);
+        py::return_value_policy::_return_as_bytes);
 #endif
 }

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -545,11 +545,7 @@ TEST_SUBMODULE(stl, m) {
     // test return_value_policy::return_as_bytes
     m.def(
         "invalid_utf8_string_array_as_bytes",
-        []() {
-            return std::array<std::string, 1> {
-                { "\xba\xd0\xba\xd0" }
-            }
-        },
+        []() { return std::array<std::string, 1>{{"\xba\xd0\xba\xd0"}}; },
         py::return_value_policy::return_as_bytes);
     m.def("invalid_utf8_string_array_as_str",
           []() { return std::array<std::string, 1>{{"\xba\xd0\xba\xd0"}}; });

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -543,21 +543,23 @@ TEST_SUBMODULE(stl, m) {
         py::return_value_policy::take_ownership);
 
     // test return_value_policy::return_as_bytes
-    m.def("invalid_utf8_string_array_as_bytes", []() {
-        return std::array<std::string, 1>{"\xba\xd0\xba\xd0"};
-    }, py::return_value_policy::return_as_bytes);
-    m.def("invalid_utf8_string_array_as_str", []() {
-        return std::array<std::string, 1>{std::string("\xba\xd0\xba\xd0")};
-    });
+    m.def(
+        "invalid_utf8_string_array_as_bytes",
+        []() { return std::array<std::string, 1>{"\xba\xd0\xba\xd0"}; },
+        py::return_value_policy::return_as_bytes);
+    m.def("invalid_utf8_string_array_as_str",
+          []() { return std::array<std::string, 1>{std::string("\xba\xd0\xba\xd0")}; });
 #ifdef PYBIND11_HAS_OPTIONAL
-    m.def("invalid_utf8_optional_string_as_bytes", []() {
-        return std::optional<std::string>{"\xba\xd0\xba\xd0"};
-    }, py::return_value_policy::return_as_bytes);
+    m.def(
+        "invalid_utf8_optional_string_as_bytes",
+        []() { return std::optional<std::string>{"\xba\xd0\xba\xd0"}; },
+        py::return_value_policy::return_as_bytes);
 #endif
 
 #ifdef PYBIND11_TEST_VARIANT
-    m.def("invalid_utf8_variant_string_as_bytes", []() {
-        return std::variant<std::string, std::monostate>{"\xba\xd0\xba\xd0"};
-    }, py::return_value_policy::return_as_bytes);
+    m.def(
+        "invalid_utf8_variant_string_as_bytes",
+        []() { return std::variant<std::string, std::monostate>{"\xba\xd0\xba\xd0"}; },
+        py::return_value_policy::return_as_bytes);
 #endif
 }

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -371,3 +371,15 @@ def test_return_vector_bool_raw_ptr():
     v = m.return_vector_bool_raw_ptr()
     assert isinstance(v, list)
     assert len(v) == 4513
+
+
+def test_return_as_bytes_policy():
+    expected_return_value = b"\xba\xd0\xba\xd0"
+    assert m.invalid_utf8_string_array_as_bytes() == [expected_return_value]
+    with pytest.raises(UnicodeDecodeError):
+        m.invalid_utf8_string_array_as_str()
+    if hasattr(m, "has_optional"):
+        assert m.invalid_utf8_optional_string_as_bytes() == expected_return_value
+    if hasattr(m, "load_variant"):
+        assert m.invalid_utf8_variant_string_as_bytes() == expected_return_value
+

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -382,4 +382,3 @@ def test_return_as_bytes_policy():
         assert m.invalid_utf8_optional_string_as_bytes() == expected_return_value
     if hasattr(m, "load_variant"):
         assert m.invalid_utf8_variant_string_as_bytes() == expected_return_value
-


### PR DESCRIPTION
## Description
Add a new return value policy `return_as_bytes` to make C++ functions return `bytes` to Python instead of `str`.

We can convert return values to `bytes` by applying `py::bytes`, but this might be hard when dealing with nested types.
