### PR TITLE
feature: support compilers that use std::experimental::filesystem 

### DIFF
--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -104,7 +104,8 @@ public:
 };
 
 template <>
-struct type_caster<pybind11_filesystem_alias::path> : public path_caster<pybind11_filesystem_alias::path> {};
+struct type_caster<pybind11_filesystem_alias::path>
+    : public path_caster<pybind11_filesystem_alias::path> {};
 #endif // PYBIND11_HAS_FILESYSTEM
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -18,11 +18,9 @@
           PY_VERSION_HEX >= 0x03060000
 #            include <filesystem>
 #            define PYBIND11_HAS_FILESYSTEM 1
-namespace pybind11::filesystem_alias = std::filesystem;
 #        elif __has_include(<experimental/filesystem>)
 #            include <experimental/filesystem>
 #            define PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM 1
-namespace pybind11::filesystem_alias = std::experimental::filesystem;
 #        endif
 #    endif
 #endif
@@ -103,10 +101,17 @@ public:
     PYBIND11_TYPE_CASTER(T, const_name("os.PathLike"));
 };
 
+#endif // PYBIND11_HAS_FILESYSTEM || defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)
+
+#if defined(PYBIND11_HAS_FILESYSTEM)
 template <>
-struct type_caster<pybind11::filesystem_alias::path>
-    : public path_caster<pybind11::filesystem_alias::path> {};
-#endif // PYBIND11_HAS_FILESYSTEM
+struct type_caster<std::filesystem::path>
+    : public path_caster<std::filesystem::path> {};
+#elif defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)
+template <>
+struct type_caster<std::experimental::filesystem::path>
+    : public path_caster<std::experimental::filesystem::path> {};
+#endif
 
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -105,8 +105,7 @@ public:
 
 #if defined(PYBIND11_HAS_FILESYSTEM)
 template <>
-struct type_caster<std::filesystem::path>
-    : public path_caster<std::filesystem::path> {};
+struct type_caster<std::filesystem::path> : public path_caster<std::filesystem::path> {};
 #elif defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)
 template <>
 struct type_caster<std::experimental::filesystem::path>

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -18,11 +18,11 @@
           PY_VERSION_HEX >= 0x03060000
 #            include <filesystem>
 #            define PYBIND11_HAS_FILESYSTEM 1
-namespace pybind11_filesystem_alias = std::filesystem;
+namespace pybind11::filesystem_alias = std::filesystem;
 #        elif __has_include(<experimental/filesystem>)
 #            include <experimental/filesystem>
 #            define PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM 1
-namespace pybind11_filesystem_alias = std::experimental::filesystem;
+namespace pybind11::filesystem_alias = std::experimental::filesystem;
 #        endif
 #    endif
 #endif
@@ -104,8 +104,8 @@ public:
 };
 
 template <>
-struct type_caster<pybind11_filesystem_alias::path>
-    : public path_caster<pybind11_filesystem_alias::path> {};
+struct type_caster<pybind11::filesystem_alias::path>
+    : public path_caster<pybind11::filesystem_alias::path> {};
 #endif // PYBIND11_HAS_FILESYSTEM
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -13,21 +13,23 @@
 #include <string>
 
 #ifdef __has_include
-#    if defined(PYBIND11_CPP17) && __has_include(<filesystem>) && \
-      PY_VERSION_HEX >= 0x03060000
-#        include <filesystem>
-#        define PYBIND11_HAS_FILESYSTEM 1
-         namespace fs = std::filesystem;
-#    elif __has_include(<experimental/filesystem>)
-#        include <experimental/filesystem>    
-#        define PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM
-         namespace fs = std::experimental::filesystem;
+#    if defined(PYBIND11_CPP17)
+#       if __has_include(<filesystem>) && \
+          PY_VERSION_HEX >= 0x03060000
+#            include <filesystem>
+#            define PYBIND11_HAS_FILESYSTEM 1
+             namespace fs = std::filesystem;
+#        elif __has_include(<experimental/filesystem>)
+#            include <experimental/filesystem>    
+#            define PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM
+             namespace fs = std::experimental::filesystem;
+#        endif
 #    endif
 #endif
 
-#if !defined(PYBIND11_HAS_FILESYSTEM) && !defined(PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL) && !defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)
+#if !defined(PYBIND11_HAS_FILESYSTEM) && !defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM) && !defined(PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL)
 #    error                                                                                        \
-        "#include <filesystem> is not available. (Use -DPYBIND11_HAS_FILESYSTEM_IS_OPTIONAL to ignore.)"
+        "Neither #include <filesystem> nor #include <experimental/filesystem is available. (Use -DPYBIND11_HAS_FILESYSTEM_IS_OPTIONAL to ignore.)"
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -13,13 +13,19 @@
 #include <string>
 
 #ifdef __has_include
-#    if defined(PYBIND11_CPP17) && __has_include(<filesystem>)
+#    if defined(PYBIND11_CPP17) && __has_include(<filesystem>) && \
+      PY_VERSION_HEX >= 0x03060000
 #        include <filesystem>
 #        define PYBIND11_HAS_FILESYSTEM 1
+         namespace fs = std::filesystem;
+#    elif __has_include(<experimental/filesystem>)
+#        include <experimental/filesystem>    
+#        define PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM
+         namespace fs = std::experimental::filesystem;
 #    endif
 #endif
 
-#if !defined(PYBIND11_HAS_FILESYSTEM) && !defined(PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL)
+#if !defined(PYBIND11_HAS_FILESYSTEM) && !defined(PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL) && !defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)
 #    error                                                                                        \
         "#include <filesystem> is not available. (Use -DPYBIND11_HAS_FILESYSTEM_IS_OPTIONAL to ignore.)"
 #endif
@@ -27,7 +33,7 @@
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-#if defined(PYBIND11_HAS_FILESYSTEM)
+#if defined(PYBIND11_HAS_FILESYSTEM) || defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)
 template <typename T>
 struct path_caster {
 
@@ -95,7 +101,7 @@ public:
 };
 
 template <>
-struct type_caster<std::filesystem::path> : public path_caster<std::filesystem::path> {};
+struct type_caster<fs::path> : public path_caster<fs::path> {};
 #endif // PYBIND11_HAS_FILESYSTEM
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -14,20 +14,21 @@
 
 #ifdef __has_include
 #    if defined(PYBIND11_CPP17)
-#       if __has_include(<filesystem>) && \
+#        if __has_include(<filesystem>) && \
           PY_VERSION_HEX >= 0x03060000
 #            include <filesystem>
 #            define PYBIND11_HAS_FILESYSTEM 1
-             namespace fs = std::filesystem;
+namespace fs = std::filesystem;
 #        elif __has_include(<experimental/filesystem>)
-#            include <experimental/filesystem>    
+#            include <experimental/filesystem>
 #            define PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM
-             namespace fs = std::experimental::filesystem;
+namespace fs = std::experimental::filesystem;
 #        endif
 #    endif
 #endif
 
-#if !defined(PYBIND11_HAS_FILESYSTEM) && !defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM) && !defined(PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL)
+#if !defined(PYBIND11_HAS_FILESYSTEM) && !defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)           \
+    && !defined(PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL)
 #    error                                                                                        \
         "Neither #include <filesystem> nor #include <experimental/filesystem is available. (Use -DPYBIND11_HAS_FILESYSTEM_IS_OPTIONAL to ignore.)"
 #endif

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -18,11 +18,11 @@
           PY_VERSION_HEX >= 0x03060000
 #            include <filesystem>
 #            define PYBIND11_HAS_FILESYSTEM 1
-namespace fs = std::filesystem;
+namespace pybind11_filesystem_alias = std::filesystem;
 #        elif __has_include(<experimental/filesystem>)
 #            include <experimental/filesystem>
-#            define PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM
-namespace fs = std::experimental::filesystem;
+#            define PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM 1
+namespace pybind11_filesystem_alias = std::experimental::filesystem;
 #        endif
 #    endif
 #endif
@@ -104,7 +104,7 @@ public:
 };
 
 template <>
-struct type_caster<fs::path> : public path_caster<fs::path> {};
+struct type_caster<pybind11_filesystem_alias::path> : public path_caster<pybind11_filesystem_alias::path> {};
 #endif // PYBIND11_HAS_FILESYSTEM
 
 PYBIND11_NAMESPACE_END(detail)


### PR DESCRIPTION
feature: support compilers that use std::experimental::filesystem such as gcc7

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Minor changes to support older C++ compilers where filesystem is not yet part of the standard library and is instead included in std::experimental::filesystem. 
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Minor changes to support older C++ compilers where filesystem is not yet part of the standard library and is instead included in std::experimental::filesystem. 
```

<!-- If the upgrade guide needs updating, note that here too -->
