### PR TITLE
Make slice constructor consistent

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1491,7 +1491,7 @@ private:
                                                         type_id<T>());
 #endif
         }
-        args_list.append(o);
+        args_list.append(std::move(o));
     }
 
     void process(list &args_list, detail::args_proxy ap) {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -640,9 +640,9 @@ private:
 
         list names, formats, offsets;
         for (auto &descr : field_descriptors) {
-            names.append(descr.name);
-            formats.append(descr.format);
-            offsets.append(descr.offset);
+            names.append(std::move(descr.name));
+            formats.append(std::move(descr.format));
+            offsets.append(std::move(descr.offset));
         }
         return dtype(std::move(names), std::move(formats), std::move(offsets), itemsize);
     }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1519,8 +1519,8 @@ private:
 class slice : public object {
 public:
     PYBIND11_OBJECT_DEFAULT(slice, object, PySlice_Check)
-    slice(handle start, handle stop, handle step) {
-        m_ptr = PySlice_New(start.ptr(), stop.ptr(), step.ptr());
+    slice(handle start, handle stop, handle step)
+        : object(PySlice_New(start.ptr(), stop.ptr(), step.ptr()), stolen_t{}) {
         if (!m_ptr) {
             pybind11_fail("Could not allocate slice object!");
         }

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -79,7 +79,7 @@ struct set_caster {
         for (auto &&value : src) {
             auto value_ = reinterpret_steal<object>(
                 key_conv::cast(forward_like<T>(value), policy, parent));
-            if (!value_ || !s.add(value_)) {
+            if (!value_ || !s.add(std::move(value_))) {
                 return handle();
             }
         }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Looking through the pytypes code and realized that Slice didn't call it's parent constructor which is undesirable. This changes the constructor to be more consistent.
* I realized the list C++ bindings take rvalues allowing me to ensure that any objects that append or add to them within the our library can be reference stolen
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Made slice constructor more consistent
* Improve performance of some casters by allowing reference stealing.
```

<!-- If the upgrade guide needs updating, note that here too -->
