### PR TITLE
chore: Make stl_bind take slice as const_ref

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1817,7 +1817,8 @@ private:
         if (holder_ptr) {
             init_holder_from_existing(v_h, holder_ptr, std::is_copy_constructible<holder_type>());
             v_h.set_holder_constructed();
-        } else if (detail::always_construct_holder<holder_type>::value || inst->owned) {
+        } else if (PYBIND11_SILENCE_MSVC_C4127(detail::always_construct_holder<holder_type>::value)
+                   || inst->owned) {
             new (std::addressof(v_h.holder<holder_type>())) holder_type(v_h.value_ptr<type>());
             v_h.set_holder_constructed();
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1817,7 +1817,7 @@ private:
         if (holder_ptr) {
             init_holder_from_existing(v_h, holder_ptr, std::is_copy_constructible<holder_type>());
             v_h.set_holder_constructed();
-        } else if (inst->owned || detail::always_construct_holder<holder_type>::value) {
+        } else if (detail::always_construct_holder<holder_type>::value || inst->owned) {
             new (std::addressof(v_h.holder<holder_type>())) holder_type(v_h.value_ptr<type>());
             v_h.set_holder_constructed();
         }

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -232,7 +232,7 @@ void vector_modifiers(
     /// Slicing protocol
     cl.def(
         "__getitem__",
-        [](const Vector &v, slice slice) -> Vector * {
+        [](const Vector &v, const slice &slice) -> Vector * {
             size_t start = 0, stop = 0, step = 0, slicelength = 0;
 
             if (!slice.compute(v.size(), &start, &stop, &step, &slicelength)) {
@@ -253,7 +253,7 @@ void vector_modifiers(
 
     cl.def(
         "__setitem__",
-        [](Vector &v, slice slice, const Vector &value) {
+        [](Vector &v, const slice &slice, const Vector &value) {
             size_t start = 0, stop = 0, step = 0, slicelength = 0;
             if (!slice.compute(v.size(), &start, &stop, &step, &slicelength)) {
                 throw error_already_set();
@@ -281,7 +281,7 @@ void vector_modifiers(
 
     cl.def(
         "__delitem__",
-        [](Vector &v, slice slice) {
+        [](Vector &v, const slice &slice) {
             size_t start = 0, stop = 0, step = 0, slicelength = 0;
 
             if (!slice.compute(v.size(), &start, &stop, &step, &slicelength)) {


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* I noticed that the slice arg was being copied in stl-bind when we really only need to take it by const-ref within the lambdas. This should remove some unnecessary copies and their corresponding reference counts.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* stil_bind.h bindings now take slice args as a const-ref.
```

<!-- If the upgrade guide needs updating, note that here too -->
