### PR TITLE
ci: drop win2016

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,55 +814,6 @@ jobs:
     - name: Python tests
       run: cmake --build build --config Debug -t pytest
 
-  win32-msvc2017:
-    name: "🐍 ${{ matrix.python }} • MSVC 2017 • x64"
-    runs-on: windows-2016
-    strategy:
-      fail-fast: false
-      matrix:
-        python:
-          - 3.6
-          - 3.7
-        std:
-          - 14
-
-        include:
-          - python: 3.7
-            std: 17
-            args: >
-              -DCMAKE_CXX_FLAGS="/permissive- /EHsc /GR"
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Setup 🐍 ${{ matrix.python }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-
-    - name: Update CMake
-      uses: jwlawson/actions-setup-cmake@v1.12
-
-    - name: Prepare env
-      run: |
-        python -m pip install -r tests/requirements.txt
-
-    # First build - C++11 mode and inplace
-    - name: Configure
-      run: >
-        cmake -S . -B build
-        -G "Visual Studio 15 2017" -A x64
-        -DPYBIND11_WERROR=ON
-        -DDOWNLOAD_CATCH=ON
-        -DDOWNLOAD_EIGEN=ON
-        -DCMAKE_CXX_STANDARD=${{ matrix.std }}
-        ${{ matrix.args }}
-
-    - name: Build ${{ matrix.std }}
-      run: cmake --build build -j 2
-
-    - name: Run all checks
-      run: cmake --build build -t check
 
   windows-2022:
     strategy:

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
         arch: [x64]
-        cmake: ["3.21"]
+        cmake: ["3.23"]
 
         include:
         - runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
           arch: x64
           cmake: 3.7
 
-        - runs-on: windows-latest
+        - runs-on: windows-2019
           arch: x86
           cmake: 3.18
 

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -30,7 +30,7 @@ jobs:
           cmake: 3.7
 
         - runs-on: windows-2019
-          arch: x86
+          arch: x64 # x86 compilers seem to be missing on 2019 image
           cmake: 3.18
 
     name: 🐍 3.7 • CMake ${{ matrix.cmake }} • ${{ matrix.runs-on }}

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -29,11 +29,7 @@ jobs:
           arch: x64
           cmake: 3.7
 
-        - runs-on: windows-2016
-          arch: x86
-          cmake: 3.8
-
-        - runs-on: windows-2016
+        - runs-on: windows-latest
           arch: x86
           cmake: 3.18
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,6 @@ repos:
   rev: "v1.2.5"
   hooks:
   - id: pycln
-    additional_dependencies: [click<8.1]  # Unpin when typer updates
     stages: [manual]
 
 # Checking for common mistakes
@@ -127,7 +126,7 @@ repos:
   rev: "v0.942"
   hooks:
   - id: mypy
-    args: [--show-error-codes]
+    args: []
     exclude: ^(tests|docs)/
     additional_dependencies: [nox, rich]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,10 @@ profile = "black"
 [tool.mypy]
 files = ["pybind11"]
 python_version = "3.6"
-warn_unused_configs = true
 strict = true
+show_error_codes = true
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+warn_unreachable = true
 
 [[tool.mypy.overrides]]
 module = ["ghapi.*", "setuptools.*"]


### PR DESCRIPTION
- ci: drop dead windows CI jobs
- chore: touch up pre-commit

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Long removed from GHA. Currently we have MSVC 2017 coverage only through Appveyor.
