### PR TITLE
cast: Add is_generic_type<T>

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -36,6 +36,15 @@ class type_caster : public type_caster_base<type> {};
 template <typename type>
 using make_caster = type_caster<intrinsic_t<type>>;
 
+template <typename T>
+struct is_generic_type<T, enable_if_t<std::is_base_of<type_caster_generic, make_caster<T>>::value>>
+    : public std::true_type {};
+
+template <typename T>
+struct is_generic_type<T,
+                       enable_if_t<!std::is_base_of<type_caster_generic, make_caster<T>>::value>>
+    : public std::false_type {};
+
 // Shortcut for calling a caster's `cast_op_type` cast operator for casting a type_caster to a T
 template <typename T>
 typename make_caster<T>::template cast_op_type<T> cast_op(make_caster<T> &caster) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -38,6 +38,11 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 class args_proxy;
 bool isinstance_generic(handle obj, const std::type_info &tp);
 
+// Indicates that type is generic and and does not have a specialized
+// `type_caster<>` specialization. Defined in `cast.h`.
+template <typename T, typename SFINAE = void>
+struct is_generic_type;
+
 // Accessor forward declarations
 template <typename Policy>
 class accessor;
@@ -476,7 +481,7 @@ inline void raise_from(error_already_set &err, PyObject *type, const char *messa
 /** \ingroup python_builtins
     \rst
     Return true if ``obj`` is an instance of ``T``. Type ``T`` must be a subclass of
-    `object` or a class which was exposed to Python as ``py::class_<T>``.
+    `object` or a class which was exposed to Python as ``py::class_<T>`` (generic).
 \endrst */
 template <typename T, detail::enable_if_t<std::is_base_of<object, T>::value, int> = 0>
 bool isinstance(handle obj) {
@@ -485,6 +490,8 @@ bool isinstance(handle obj) {
 
 template <typename T, detail::enable_if_t<!std::is_base_of<object, T>::value, int> = 0>
 bool isinstance(handle obj) {
+    static_assert(detail::is_generic_type<T>::value,
+                  "isisntance<T>() requires specialization for this type");
     return detail::isinstance_generic(obj, typeid(T));
 }
 


### PR DESCRIPTION
## Description

Adds explicit way to denote a `is_generic_type<>`, which is effectively bullet point (1) from the docs:
https://pybind11.readthedocs.io/en/stable/advanced/cast/index.html

Permits distinction from bullet points (2) and (3)

## Suggested changelog entry:

```rst
Adds is_generic_type<> trait
```