### PR TITLE
Prefer make_caster<T> to type_caster<T>

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -514,7 +514,7 @@ struct type_caster<std::basic_string_view<CharT, Traits>,
 template <typename CharT>
 struct type_caster<CharT, enable_if_t<is_std_char_type<CharT>::value>> {
     using StringType = std::basic_string<CharT>;
-    using StringCaster = type_caster<StringType>;
+    using StringCaster = make_caster<StringType>;
     StringCaster str_caster;
     bool none = false;
     CharT one_char = 0;


### PR DESCRIPTION

Minor cleanup: Use make_caster<T> instead of type_caster<T> in the string type_caster specialization.

Extracted from #3674 
