### PR TITLE
Cleanup cast_safe<void> specialization

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1155,18 +1155,18 @@ enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_ref(object &&,
 // static_assert, even though if it's in dead code, so we provide a "trampoline" to pybind11::cast
 // that only does anything in cases where pybind11::cast is valid.
 template <typename T>
-enable_if_t<detail::none_of<std::is_same<void, intrinsic_t<T>>,
-                            cast_is_temporary_value_reference<T>>::value,
-            T>
-cast_safe(object &&o) {
-    return pybind11::cast<T>(std::move(o));
-}
-template <typename T>
 enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&) {
     pybind11_fail("Internal error: cast_safe fallback invoked");
 }
 template <typename T>
 enable_if_t<std::is_same<void, intrinsic_t<T>>::value, void> cast_safe(object &&) {}
+template <typename T>
+enable_if_t<detail::none_of<cast_is_temporary_value_reference<T>,
+                            std::is_same<void, intrinsic_t<T>>>::value,
+            T>
+cast_safe(object &&o) {
+    return pybind11::cast<T>(std::move(o));
+}
 
 PYBIND11_NAMESPACE_END(detail)
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1155,8 +1155,8 @@ enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_ref(object &&,
 // static_assert, even though if it's in dead code, so we provide a "trampoline" to pybind11::cast
 // that only does anything in cases where pybind11::cast is valid.
 template <typename T>
-enable_if_t<!std::is_same<void, intrinsic_t<T>>::value
-                && !cast_is_temporary_value_reference<T>::value,
+enable_if_t<detail::none_of<std::is_same<void, intrinsic_t<T>>, 
+                            cast_is_temporary_value_reference<T>>::value,
             T>
 cast_safe(object &&o) {
     return pybind11::cast<T>(std::move(o));

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1155,15 +1155,19 @@ enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_ref(object &&,
 // static_assert, even though if it's in dead code, so we provide a "trampoline" to pybind11::cast
 // that only does anything in cases where pybind11::cast is valid.
 template <typename T>
-enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&o) {
+enable_if_t<!std::is_same<void, intrinsic_t<T>>::value &&
+            !cast_is_temporary_value_reference<T>::value, T>
+cast_safe(object &&o) {
     return pybind11::cast<T>(std::move(o));
 }
 template <typename T>
-enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&) {
+enable_if_t<cast_is_temporary_value_reference<T>::value, T>
+cast_safe(object &&) {
     pybind11_fail("Internal error: cast_safe fallback invoked");
 }
-template <>
-inline void cast_safe<void>(object &&) {}
+template <typename T>
+enable_if_t<std::is_same<void, intrinsic_t<T>>::value, void>
+cast_safe(object &&) {}
 
 PYBIND11_NAMESPACE_END(detail)
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1155,7 +1155,7 @@ enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_ref(object &&,
 // static_assert, even though if it's in dead code, so we provide a "trampoline" to pybind11::cast
 // that only does anything in cases where pybind11::cast is valid.
 template <typename T>
-enable_if_t<detail::none_of<std::is_same<void, intrinsic_t<T>>, 
+enable_if_t<detail::none_of<std::is_same<void, intrinsic_t<T>>,
                             cast_is_temporary_value_reference<T>>::value,
             T>
 cast_safe(object &&o) {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1155,19 +1155,18 @@ enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_ref(object &&,
 // static_assert, even though if it's in dead code, so we provide a "trampoline" to pybind11::cast
 // that only does anything in cases where pybind11::cast is valid.
 template <typename T>
-enable_if_t<!std::is_same<void, intrinsic_t<T>>::value &&
-            !cast_is_temporary_value_reference<T>::value, T>
+enable_if_t<!std::is_same<void, intrinsic_t<T>>::value
+                && !cast_is_temporary_value_reference<T>::value,
+            T>
 cast_safe(object &&o) {
     return pybind11::cast<T>(std::move(o));
 }
 template <typename T>
-enable_if_t<cast_is_temporary_value_reference<T>::value, T>
-cast_safe(object &&) {
+enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&) {
     pybind11_fail("Internal error: cast_safe fallback invoked");
 }
 template <typename T>
-enable_if_t<std::is_same<void, intrinsic_t<T>>::value, void>
-cast_safe(object &&) {}
+enable_if_t<std::is_same<void, intrinsic_t<T>>::value, void> cast_safe(object &&) {}
 
 PYBIND11_NAMESPACE_END(detail)
 


### PR DESCRIPTION
Replace explicit specialization of cast_safe<void> with SFINAE.
It's better for SFINAE cases to cover all type-sets rather than mixing SFINAE and explicit specialization.

Extracted from #3674

