### PR TITLE
Adds set_name method of pybind11::capsule class

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1639,9 +1639,7 @@ public:
         }
     }
 
-    const char *name() const {
-        return get_name_or_throw(m_ptr);
-    }
+    const char *name() const { return get_name_or_throw(m_ptr); }
 
     /// Replaces a capsule's name *without* calling the destructor on the existing one.
     void set_name(const char *new_name) {
@@ -1649,13 +1647,14 @@ public:
             throw error_already_set();
         }
     }
+
 private:
-    static const char * get_name_or_throw(PyObject *o) {
+    static const char *get_name_or_throw(PyObject *o) {
         const char *name = PyCapsule_GetName(o);
         if (name == nullptr && PyErr_Occurred()) {
-	    throw error_already_set();
+            throw error_already_set();
         }
-	return name;
+        return name;
     }
 };
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1588,7 +1588,7 @@ public:
                 }
                 pybind11_fail("Unable to get capsule context");
             }
-            const char *name = get_name_no_throw(o);
+            const char *name = get_name_in_error_scope(o);
             void *ptr = PyCapsule_GetPointer(o, name);
             if (ptr == nullptr) {
                 throw error_already_set();
@@ -1603,7 +1603,7 @@ public:
 
     explicit capsule(void (*destructor)()) {
         m_ptr = PyCapsule_New(reinterpret_cast<void *>(destructor), nullptr, [](PyObject *o) {
-            const char *name = get_name_no_throw(o);
+            const char *name = get_name_in_error_scope(o);
             auto destructor = reinterpret_cast<void (*)()>(PyCapsule_GetPointer(o, name));
             if (destructor == nullptr) {
                 throw error_already_set();
@@ -1655,7 +1655,7 @@ public:
     }
 
 private:
-    static const char *get_name_no_throw(PyObject *o) {
+    static const char *get_name_in_error_scope(PyObject *o) {
         error_scope error_guard;
 
         const char *name = PyCapsule_GetName(o);

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1649,7 +1649,7 @@ public:
     }
 
 private:
-    static const char * get_name_or_throw(PyObject *o) {
+    static const char *get_name_or_throw(PyObject *o) {
         /* an exception may be in-flight, we must save it in case we create another one */
         PyObject *type, *value, *traceback;
         PyErr_Fetch(&type, &value, &traceback);

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1651,7 +1651,7 @@ public:
 private:
     static const char *get_name_or_throw(PyObject *o) {
         /* an exception may be in-flight, we must save it in case we create another one */
-        PyObject *type, *value, *traceback;
+        PyObject *type = nullptr, *value = nullptr, *traceback = nullptr;
         PyErr_Fetch(&type, &value, &traceback);
 
         const char *name = PyCapsule_GetName(o);

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1644,7 +1644,7 @@ public:
         if ((name == nullptr) && PyErr_Occurred()) {
             throw error_already_set();
         }
-	return name;
+        return name;
     }
 
     /// Replaces a capsule's name *without* calling the destructor on the existing one.

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1649,11 +1649,17 @@ public:
     }
 
 private:
-    static const char *get_name_or_throw(PyObject *o) {
+    static const char * get_name_or_throw(PyObject *o) {
+        /* an exception may be in-flight, we must save it in case we create another one */
+        PyObject *type, *value, *traceback;
+        PyErr_Fetch(&type, &value, &traceback);
+
         const char *name = PyCapsule_GetName(o);
-        if (name == nullptr && PyErr_Occurred()) {
+        if ((name == nullptr) && PyErr_Occurred()) {
             throw error_already_set();
         }
+
+        PyErr_Restore(type, value, traceback);
         return name;
     }
 };

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1656,9 +1656,7 @@ public:
 
 private:
     static const char *get_name_no_throw(PyObject *o) {
-        /* an exception may be in-flight, we must save it in case we create another one */
-        PyObject *type = nullptr, *value = nullptr, *traceback = nullptr;
-        PyErr_Fetch(&type, &value, &traceback);
+        error_scope error_guard;
 
         const char *name = PyCapsule_GetName(o);
         if ((name == nullptr) && PyErr_Occurred()) {
@@ -1666,7 +1664,6 @@ private:
             PyErr_WriteUnraisable(o);
         }
 
-        PyErr_Restore(type, value, traceback);
         return name;
     }
 };

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -159,11 +159,31 @@ TEST_SUBMODULE(pytypes, m) {
         return py::capsule([]() { py::print("destructing capsule"); });
     });
 
+    m.def("return_renamed_capsule_with_destructor", []() {
+        py::print("creating capsule");
+        auto cap = py::capsule([]() { py::print("destructing capsule"); });
+	static const char *capsule_name = "test_name1";
+        py::print("renaming capsule");
+	cap.set_name(capsule_name);
+	return cap;
+    });
+
     m.def("return_capsule_with_destructor_2", []() {
         py::print("creating capsule");
         return py::capsule((void *) 1234, [](void *ptr) {
             py::print("destructing capsule: {}"_s.format((size_t) ptr));
         });
+    });
+
+    m.def("return_renamed_capsule_with_destructor_2", []() {
+        py::print("creating capsule");
+        auto cap = py::capsule((void *) 1234, [](void *ptr) {
+            py::print("destructing capsule: {}"_s.format((size_t) ptr));
+        });
+	static const char *capsule_name = "test_name2";
+	py::print("renaming capsule");
+	cap.set_name(capsule_name);
+	return cap;
     });
 
     m.def("return_capsule_with_name_and_destructor", []() {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -162,10 +162,10 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("return_renamed_capsule_with_destructor", []() {
         py::print("creating capsule");
         auto cap = py::capsule([]() { py::print("destructing capsule"); });
-	static const char *capsule_name = "test_name1";
+        static const char *capsule_name = "test_name1";
         py::print("renaming capsule");
-	cap.set_name(capsule_name);
-	return cap;
+        cap.set_name(capsule_name);
+        return cap;
     });
 
     m.def("return_capsule_with_destructor_2", []() {
@@ -180,10 +180,10 @@ TEST_SUBMODULE(pytypes, m) {
         auto cap = py::capsule((void *) 1234, [](void *ptr) {
             py::print("destructing capsule: {}"_s.format((size_t) ptr));
         });
-	static const char *capsule_name = "test_name2";
-	py::print("renaming capsule");
-	cap.set_name(capsule_name);
-	return cap;
+        static const char *capsule_name = "test_name2";
+        py::print("renaming capsule");
+        cap.set_name(capsule_name);
+        return cap;
     });
 
     m.def("return_capsule_with_name_and_destructor", []() {

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -196,6 +196,19 @@ def test_capsule(capture):
     )
 
     with capture:
+        a = m.return_renamed_capsule_with_destructor()
+        del a
+        pytest.gc_collect()
+    assert (
+        capture.unordered
+        == """
+        creating capsule
+        renaming capsule
+        destructing capsule
+    """
+    )
+
+    with capture:
         a = m.return_capsule_with_destructor_2()
         del a
         pytest.gc_collect()
@@ -203,6 +216,19 @@ def test_capsule(capture):
         capture.unordered
         == """
         creating capsule
+        destructing capsule: 1234
+    """
+    )
+
+    with capture:
+        a = m.return_renamed_capsule_with_destructor_2()
+        del a
+        pytest.gc_collect()
+    assert (
+        capture.unordered
+        == """
+        creating capsule
+        renaming capsule
         destructing capsule: 1234
     """
     )


### PR DESCRIPTION
This calls `PyCapsule_SetName` on the underlying Python object.

## Description

Definition of `pybind11::capsule` class was missing `set_name` method.

This is useful if using pybind11 to implement DLPack protocol which [requires](https://dmlc.github.io/dlpack/latest/python_spec.html#implementation) to rename consumed capsule.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
pybind11::capsule::set_name added to mutate the name of the capsule instance.
```

<!-- If the upgrade guide needs updating, note that here too -->
