### PR TITLE
Expand dtype accessors

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -562,6 +562,14 @@ public:
         m_ptr = from_args(std::move(args)).release().ptr();
     }
 
+    explicit dtype(int typenum) {
+        if (auto *ptr = detail::npy_api::get().PyArray_DescrFromType_(typenum)) {
+            m_ptr = ptr;
+        } else {
+            throw error_already_set();
+        }
+    }
+
     /// This is essentially the same as calling numpy.dtype(args) in Python.
     static dtype from_args(object args) {
         PyObject *ptr = nullptr;
@@ -595,6 +603,23 @@ public:
         // C API (``PyArray_Descr::type``).
         return detail::array_descriptor_proxy(m_ptr)->type;
     }
+
+    /// type number of dtype.
+    ssize_t num() const {
+        // Note: The signature, `dtype::num` follows the naming of NumPy's public
+        // Python API (i.e., ``dtype.num``), rather than its internal
+        // C API (``PyArray_Descr::type_num``).
+        return detail::array_descriptor_proxy(m_ptr)->type_num;
+    }
+
+    /// Single character for byteorder
+    char byteorder() const { return detail::array_descriptor_proxy(m_ptr)->byteorder; }
+
+    /// Single character for byteorder
+    int alignment() const { return detail::array_descriptor_proxy(m_ptr)->alignment; }
+
+    /// Flags for the array descriptor
+    char flags() const { return detail::array_descriptor_proxy(m_ptr)->flags; }
 
 private:
     static object _dtype_from_pep3118() {

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -291,6 +291,7 @@ py::list test_dtype_ctors() {
     list.append(py::dtype(names, formats, offsets, 20));
     list.append(py::dtype(py::buffer_info((void *) 0, sizeof(unsigned int), "I", 1)));
     list.append(py::dtype(py::buffer_info((void *) 0, 0, "T{i:a:f:b:}", 1)));
+    list.append(py::dtype(py::detail::npy_api::NPY_DOUBLE_));
     return list;
 }
 
@@ -437,6 +438,34 @@ TEST_SUBMODULE(numpy_dtypes, m) {
         py::list list;
         for (const auto &dt_name : dtype_names) {
             list.append(py::dtype(dt_name).char_());
+        }
+        return list;
+    });
+    m.def("test_dtype_num", [dtype_names]() {
+        py::list list;
+        for (const auto &dt_name : dtype_names) {
+            list.append(py::dtype(dt_name).num());
+        }
+        return list;
+    });
+    m.def("test_dtype_byteorder", [dtype_names]() {
+        py::list list;
+        for (const auto &dt_name : dtype_names) {
+            list.append(py::dtype(dt_name).byteorder());
+        }
+        return list;
+    });
+    m.def("test_dtype_alignment", [dtype_names]() {
+        py::list list;
+        for (const auto &dt_name : dtype_names) {
+            list.append(py::dtype(dt_name).alignment());
+        }
+        return list;
+    });
+    m.def("test_dtype_flags", [dtype_names]() {
+        py::list list;
+        for (const auto &dt_name : dtype_names) {
+            list.append(py::dtype(dt_name).flags());
         }
         return list;
     });

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -160,6 +160,7 @@ def test_dtype(simple_dtype):
         d1,
         np.dtype("uint32"),
         d2,
+        np.dtype("d"),
     ]
 
     assert m.test_dtype_methods() == [
@@ -175,8 +176,18 @@ def test_dtype(simple_dtype):
         np.zeros(1, m.trailing_padding_dtype())
     )
 
+    expected_chars = "bhilqBHILQefdgFDG?MmO"
     assert m.test_dtype_kind() == list("iiiiiuuuuuffffcccbMmO")
-    assert m.test_dtype_char_() == list("bhilqBHILQefdgFDG?MmO")
+    assert m.test_dtype_char_() == list(expected_chars)
+    assert m.test_dtype_num() == [np.dtype(ch).num for ch in expected_chars]
+    assert m.test_dtype_byteorder() == [
+        np.dtype(ch).byteorder for ch in expected_chars
+    ]
+    assert m.test_dtype_alignment() == [
+        np.dtype(ch).alignment for ch in expected_chars
+    ]
+    assert m.test_dtype_flags() == [
+        chr(np.dtype(ch).flags) for ch in expected_chars]
 
 
 def test_recarray(simple_dtype, packed_dtype):


### PR DESCRIPTION
## Description

Added explicit constructor for `py::dtype` from type number. Also added accessor to retrieve the `type_num` field of the struct.

While at it, added other accessors. 

Added tests.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
dtype constructor from type number added, accessors corresponding to Python API `dtype.num`, `dtype.byteorder`, `dtype.flags` and `dtype.alignment` added.
```

<!-- If the upgrade guide needs updating, note that here too -->
