### PR TITLE
chore: simplify numpy dtype ctor

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -540,7 +540,7 @@ public:
     PYBIND11_OBJECT_DEFAULT(dtype, object, detail::npy_api::get().PyArrayDescr_Check_);
 
     explicit dtype(const buffer_info &info) {
-        dtype descr(_dtype_from_pep3118()(PYBIND11_STR_TYPE(info.format)));
+        dtype descr(_dtype_from_pep3118()(pybind11::str(info.format)));
         // If info.itemsize == 0, use the value calculated from the format string
         m_ptr = descr.strip_padding(info.itemsize != 0 ? info.itemsize : descr.itemsize())
                     .release()
@@ -636,7 +636,7 @@ private:
         }
 
         struct field_descr {
-            PYBIND11_STR_TYPE name;
+            pybind11::str name;
             object format;
             pybind11::int_ offset;
         };
@@ -651,7 +651,7 @@ private:
                 continue;
             }
             field_descriptors.push_back(
-                {(PYBIND11_STR_TYPE) name, format.strip_padding(format.itemsize()), offset});
+                {(pybind11::str) name, format.strip_padding(format.itemsize()), offset});
         }
 
         std::sort(field_descriptors.begin(),
@@ -1357,7 +1357,7 @@ PYBIND11_NOINLINE void register_structured_dtype(any_container<field_descriptor>
             pybind11_fail(std::string("NumPy: unsupported field dtype: `") + field.name + "` @ "
                           + tinfo.name());
         }
-        names.append(PYBIND11_STR_TYPE(field.name));
+        names.append(pybind11::str(field.name));
         formats.append(field.descr);
         offsets.append(pybind11::int_(field.offset));
     }

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -549,7 +549,7 @@ public:
 
     explicit dtype(const std::string &format) : dtype(from_args(pybind11::str(format))) {}
 
-    explicit dtype(const char *format) : dtype(std::string(format)) {}
+    explicit dtype(const char *format) : dtype(from_args(pybind11::str(format))) {}
 
     dtype(list names, list formats, list offsets, ssize_t itemsize) {
         dict args;

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -547,9 +547,7 @@ public:
                     .ptr();
     }
 
-    explicit dtype(const std::string &format) {
-        m_ptr = from_args(pybind11::str(format)).release().ptr();
-    }
+    explicit dtype(const std::string &format) : dtype(from_args(pybind11::str(format))) {}
 
     explicit dtype(const char *format) : dtype(std::string(format)) {}
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
When reviewing another PR #3868, I noticed one of the ctors could be simplified using ctor delegation so I went ahead an added a tiny PR to do that.
Also removed a few python 2 compat macros in numpy.h
<!-- Include relevant issues or PRs here, describe what changed and why -->