### PR TITLE
Added deleted copy constructor for error_scope to comply with rule of 3.

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -992,7 +992,7 @@ constexpr const char
 struct error_scope {
     PyObject *type, *value, *trace;
     error_scope() { PyErr_Fetch(&type, &value, &trace); }
-    error_scope(const error_scope&) = delete;
+    error_scope(const error_scope &) = delete;
     ~error_scope() { PyErr_Restore(type, value, trace); }
 };
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -992,6 +992,7 @@ constexpr const char
 struct error_scope {
     PyObject *type, *value, *trace;
     error_scope() { PyErr_Fetch(&type, &value, &trace); }
+    error_scope(const error_scope&) = delete;
     ~error_scope() { PyErr_Restore(type, value, trace); }
 };
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

As noted by @rwgk in #3866 the implementation of `error_scope` did not define the copy constructor.

This adds a deleted copy constructor to comply with the rule of 3.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

This is a technical debt change and may not warrant a change log entry.

<!-- If the upgrade guide needs updating, note that here too -->
