### PR TITLE
Use py::module instead of py::module_ in example code.

### DIFF
--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -108,11 +108,11 @@ The two approaches can also be combined:
 Importing modules
 =================
 
-Python modules can be imported using ``module_::import()``:
+Python modules can be imported using ``module::import()``:
 
 .. code-block:: cpp
 
-    py::module_ sys = py::module_::import("sys");
+    py::module sys = py::module::import("sys");
     py::print(sys.attr("path"));
 
 For convenience, the current working directory is included in ``sys.path`` when
@@ -129,12 +129,12 @@ embedding the interpreter. This makes it easy to import local Python files:
 
 .. code-block:: cpp
 
-    py::module_ calc = py::module_::import("calc");
+    py::module calc = py::module::import("calc");
     py::object result = calc.attr("add")(1, 2);
     int n = result.cast<int>();
     assert(n == 3);
 
-Modules can be reloaded using ``module_::reload()`` if the source is modified e.g.
+Modules can be reloaded using ``module::reload()`` if the source is modified e.g.
 by an external process. This can be useful in scenarios where the application
 imports a user defined data processing script which needs to be updated after
 changes by the user. Note that this function does not reload modules recursively.
@@ -154,7 +154,7 @@ like any other module.
     namespace py = pybind11;
 
     PYBIND11_EMBEDDED_MODULE(fast_calc, m) {
-        // `m` is a `py::module_` which is used to bind functions and classes
+        // `m` is a `py::module` which is used to bind functions and classes
         m.def("add", [](int i, int j) {
             return i + j;
         });
@@ -163,7 +163,7 @@ like any other module.
     int main() {
         py::scoped_interpreter guard{};
 
-        auto fast_calc = py::module_::import("fast_calc");
+        auto fast_calc = py::module::import("fast_calc");
         auto result = fast_calc.attr("add")(1, 2).cast<int>();
         assert(result == 3);
     }
@@ -197,7 +197,7 @@ naturally:
     int main() {
         py::scoped_interpreter guard{};
 
-        auto py_module = py::module_::import("py_module");
+        auto py_module = py::module::import("py_module");
 
         auto locals = py::dict("fmt"_a="{} + {} = {}", **py_module.attr("__dict__"));
         assert(locals["a"].cast<int>() == 1);


### PR DESCRIPTION
The changelog for v2.6 explains the reasons for py::module_, but also states "qualified usage is unaffected." User code should probably make use of py::module, since it is (1) uncluttered by the underscore, and (2) backwards compatible with pre-v2.6 builds.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Example code uses py::module_, which is neither backwards compatible, nor necessary. The underscore is an internal collision that needn't leak out.

## Suggested changelog entry:

```rst
Use py::module instead of py::module_ in example code.
```

