### PR TITLE
chore: Change numpy dtype from_args call sig to const ref

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -547,11 +547,11 @@ public:
                     .ptr();
     }
 
+    explicit dtype(const pybind11::str &s) : dtype(from_args(s)) {}
+
     explicit dtype(const std::string &format) : dtype(pybind11::str(format)) {}
 
     explicit dtype(const char *format) : dtype(pybind11::str(format)) {}
-
-    explicit dtype(const pybind11::str &s) : dtype(from_args(s)) {}
 
     dtype(list names, list formats, list offsets, ssize_t itemsize) {
         dict args;

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -547,9 +547,11 @@ public:
                     .ptr();
     }
 
-    explicit dtype(const std::string &format) : dtype(from_args(pybind11::str(format))) {}
+    explicit dtype(const std::string &format) : dtype(pybind11::str(format)) {}
 
-    explicit dtype(const char *format) : dtype(from_args(pybind11::str(format))) {}
+    explicit dtype(const char *format) : dtype(pybind11::str(format)) {}
+
+    explicit dtype(const pybind11::str &s) : dtype(from_args(s)) {}
 
     dtype(list names, list formats, list offsets, ssize_t itemsize) {
         dict args;
@@ -557,7 +559,7 @@ public:
         args["formats"] = std::move(formats);
         args["offsets"] = std::move(offsets);
         args["itemsize"] = pybind11::int_(itemsize);
-        m_ptr = from_args(std::move(args)).release().ptr();
+        m_ptr = from_args(args).release().ptr();
     }
 
     explicit dtype(int typenum)
@@ -568,7 +570,7 @@ public:
     }
 
     /// This is essentially the same as calling numpy.dtype(args) in Python.
-    static dtype from_args(object args) {
+    static dtype from_args(const object &args) {
         PyObject *ptr = nullptr;
         if ((detail::npy_api::get().PyArray_DescrConverter_(args.ptr(), &ptr) == 0) || !ptr) {
             throw error_already_set();

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -547,7 +547,7 @@ public:
                     .ptr();
     }
 
-    explicit dtype(const pybind11::str &s) : dtype(from_args(s)) {}
+    explicit dtype(const pybind11::str &format) : dtype(from_args(format)) {}
 
     explicit dtype(const std::string &format) : dtype(pybind11::str(format)) {}
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1914,8 +1914,8 @@ public:
         return memoryview::from_buffer(reinterpret_cast<void *>(ptr),
                                        sizeof(T),
                                        format_descriptor<T>::value,
-                                       shape,
-                                       strides,
+                                       std::move(shape),
+                                       std::move(strides),
                                        readonly);
     }
 
@@ -1923,7 +1923,8 @@ public:
     static memoryview from_buffer(const T *ptr,
                                   detail::any_container<ssize_t> shape,
                                   detail::any_container<ssize_t> strides) {
-        return memoryview::from_buffer(const_cast<T *>(ptr), shape, strides, true);
+        return memoryview::from_buffer(
+            const_cast<T *>(ptr), std::move(shape), std::move(strides), true);
     }
 
     /** \rst

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -610,5 +610,5 @@ TEST_SUBMODULE(numpy_dtypes, m) {
           []() { PYBIND11_NUMPY_DTYPE(SimpleStruct, bool_, uint_, float_, ldbl_); });
 
     // test_str_leak
-    m.def("dtype_wrapper", [](py::object d) { return py::dtype::from_args(std::move(d)); });
+    m.def("dtype_wrapper", [](py::object d) { return py::dtype::from_args(d); });
 }

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -610,5 +610,5 @@ TEST_SUBMODULE(numpy_dtypes, m) {
           []() { PYBIND11_NUMPY_DTYPE(SimpleStruct, bool_, uint_, float_, ldbl_); });
 
     // test_str_leak
-    m.def("dtype_wrapper", [](py::object d) { return py::dtype::from_args(d); });
+    m.def("dtype_wrapper", [](const py::object &d) { return py::dtype::from_args(d); });
 }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Adds a explicit pybind11::str ctor to dtype and delegates other ctors through it
* Changes dtype from_args method to use const ref avoiding copies
* Fixes a few missing std::moves in memory_view pytype.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Change numpy dtype from_args method to use const ref
```

<!-- If the upgrade guide needs updating, note that here too -->
