### PR TITLE
Support frozenset, tuple as dict keys

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -79,6 +79,9 @@ public:
     explicit operator std::reference_wrapper<type>() { return cast_op<type &>(subcaster); }
 };
 
+template <typename type>
+class type_caster<const type> : public type_caster<type> {};
+
 #define PYBIND11_TYPE_CASTER(type, py_name)                                                       \
 protected:                                                                                        \
     type value;                                                                                   \

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1784,14 +1784,11 @@ class kwargs : public dict {
     PYBIND11_OBJECT_DEFAULT(kwargs, dict, PyDict_Check)
 };
 
-class set : public object {
+class set_base : public object {
+protected:
+    PYBIND11_OBJECT(set_base, object, PyAnySet_Check)
+
 public:
-    PYBIND11_OBJECT_CVT(set, object, PySet_Check, PySet_New)
-    set() : object(PySet_New(nullptr), stolen_t{}) {
-        if (!m_ptr) {
-            pybind11_fail("Could not allocate set object!");
-        }
-    }
     size_t size() const { return (size_t) PySet_Size(m_ptr); }
     bool empty() const { return size() == 0; }
     template <typename T>
@@ -1802,6 +1799,26 @@ public:
     template <typename T>
     bool contains(T &&val) const {
         return PySet_Contains(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 1;
+    }
+};
+
+class set : public set_base {
+public:
+    PYBIND11_OBJECT_CVT(set, set_base, PySet_Check, PySet_New)
+    set() : set_base(PySet_New(nullptr), stolen_t{}) {
+        if (!m_ptr) {
+            pybind11_fail("Could not allocate set object!");
+        }
+    }
+};
+
+class frozenset : public set_base {
+public:
+    PYBIND11_OBJECT_CVT(frozenset, set_base, PyFrozenSet_Check, PyFrozenSet_New)
+    frozenset() : set_base(PyFrozenSet_New(nullptr), stolen_t{}) {
+        if (!m_ptr) {
+            pybind11_fail("Could not allocate frozenset object!");
+        }
     }
 };
 

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -248,6 +248,20 @@ TEST_SUBMODULE(stl, m) {
         return v;
     });
 
+    // test_frozen_key
+    m.def("cast_set_map", []() { return std::map<std::set<std::string>, std::string>{{{"key1", "key2"}, "value"}}; });
+    m.def("load_set_map", [](const std::map<std::set<std::string>, std::string> &map) {
+        return map.at({"key1", "key2"}) == "value" && map.at({"key3"}) == "value2";
+    });
+    m.def("cast_set_set", []() { return std::set<std::set<std::string>>{{"key1", "key2"}}; });
+    m.def("load_set_set", [](const std::set<std::set<std::string>> &set) {
+        return (set.count({"key1", "key2"}) != 0u) && (set.count({"key3"}) != 0u);
+    });
+    m.def("cast_vector_set", []() { return std::set<std::vector<int>>{{1, 2}}; });
+    m.def("load_vector_set", [](const std::set<std::vector<int>> &set) {
+        return (set.count({1, 2}) != 0u) && (set.count({3}) != 0u);
+    });
+
     pybind11::enum_<EnumType>(m, "EnumType")
         .value("kSet", EnumType::kSet)
         .value("kUnset", EnumType::kUnset);


### PR DESCRIPTION

## Description

https://github.com/pybind/pybind11/discussions/3836

Add frozenset as a pybind11 type.
Allow type_caster<const T> to be (explicitly) selected and specialized, defaulting to (inherit from) type_caster<T>.
Use type_caster<const K> for std::set, std::map etc. key converter.
Specialize type_caster<const C> for std::set, std::vector etc.
Add tests.

## Suggested changelog entry:

```rst
`std::map<std::set<int>, int>` now converts to/from `Dict[FrozenSet[int], int]`; likewise `std::set<std::vector<int>>` to/from `Set[Tuple[int, ...]]`.
```

<!-- If the upgrade guide needs updating, note that here too -->
