### PR TITLE
Support frozenset, tuple as dict keys (alternative approach)

### DIFF
--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -248,6 +248,22 @@ TEST_SUBMODULE(stl, m) {
         return v;
     });
 
+    // test_frozen_key
+    m.def("cast_set_map", []() {
+        return std::map<std::set<std::string>, std::string>{{{"key1", "key2"}, "value"}};
+    });
+    m.def("load_set_map", [](const std::map<std::set<std::string>, std::string> &map) {
+        return map.at({"key1", "key2"}) == "value" && map.at({"key3"}) == "value2";
+    });
+    m.def("cast_set_set", []() { return std::set<std::set<std::string>>{{"key1", "key2"}}; });
+    m.def("load_set_set", [](const std::set<std::set<std::string>> &set) {
+        return (set.count({"key1", "key2"}) != 0u) && (set.count({"key3"}) != 0u);
+    });
+    m.def("cast_vector_set", []() { return std::set<std::vector<int>>{{1, 2}}; });
+    m.def("load_vector_set", [](const std::set<std::vector<int>> &set) {
+        return (set.count({1, 2}) != 0u) && (set.count({3}) != 0u);
+    });
+
     pybind11::enum_<EnumType>(m, "EnumType")
         .value("kSet", EnumType::kSet)
         .value("kUnset", EnumType::kUnset);

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -94,6 +94,38 @@ def test_recursive_casting():
     assert z[0].value == 7 and z[1].value == 42
 
 
+def test_frozen_key(doc):
+    """Test that we special-case C++ key types to Python immutable containers, e.g.:
+    std::map<std::set<K>, V> <-> dict[frozenset[K], V]
+    std::set<std::set<T>> <-> set[frozenset[T]]
+    std::set<std::vector<T>> <-> set[tuple[T, ...]]
+    """
+    s = m.cast_set_map()
+    assert s == {frozenset({"key1", "key2"}): "value"}
+    s[frozenset({"key3"})] = "value2"
+    assert m.load_set_map(s)
+    assert doc(m.cast_set_map) == "cast_set_map() -> Dict[FrozenSet[str], str]"
+    assert (
+        doc(m.load_set_map) == "load_set_map(arg0: Dict[FrozenSet[str], str]) -> bool"
+    )
+
+    s = m.cast_set_set()
+    assert s == {frozenset({"key1", "key2"})}
+    s.add(frozenset({"key3"}))
+    assert m.load_set_set(s)
+    assert doc(m.cast_set_set) == "cast_set_set() -> Set[FrozenSet[str]]"
+    assert doc(m.load_set_set) == "load_set_set(arg0: Set[FrozenSet[str]]) -> bool"
+
+    s = m.cast_vector_set()
+    assert s == {(1, 2)}
+    s.add((3,))
+    assert m.load_vector_set(s)
+    assert doc(m.cast_vector_set) == "cast_vector_set() -> Set[Tuple[int, ...]]"
+    assert (
+        doc(m.load_vector_set) == "load_vector_set(arg0: Set[Tuple[int, ...]]) -> bool"
+    )
+
+
 def test_move_out_container():
     """Properties use the `reference_internal` policy by default. If the underlying function
     returns an rvalue, the policy is automatically changed to `move` to avoid referencing


### PR DESCRIPTION

## Description

Alternative to #3886
Inspired by https://github.com/pybind/pybind11/discussions/3836

Add frozenset as a pybind11 type.
Add freeze() function converting set to frozenset and list to tuple; use
it in std::set and std::map casters.
Add tests.

## Suggested changelog entry:

```rst
When used as keys (e.g. in std::map), sequence and set types now convert to tuple and frozenset (instead of unhashable list and set).
```

