### PR TITLE
ci: dependabot major versions for official actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,5 @@ updates:
       interval: "daily"
     ignore:
       # Official actions have moving tags like v1
-      # that are used, so they don't need updates here
-      - dependency-name: "actions/checkout"
-      - dependency-name: "actions/setup-python"
-      - dependency-name: "actions/cache"
-      - dependency-name: "actions/upload-artifact"
-      - dependency-name: "actions/download-artifact"
-      - dependency-name: "actions/labeler"
+      - dependency-name: "actions/*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,4 +46,4 @@ max-line-length = 120
 show_source = True
 exclude = .git, __pycache__, build, dist, docs, tools, venv
 extend-ignore = E203, E722, B950
-select = C,E,F,N,W,B,B9
+extend-select = B9


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Dependabot should still bump major versions of official actions.

Also using extend-select for flake8.

Noticed via https://scikit-hep.org/developer/reporeview?repo=pybind/pybind11&branch=master 


## Suggested changelog entry:
None.