### PR TITLE
Add anyset & frozenset, enable copying (cast) to std::set

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -910,6 +910,8 @@ struct pyobject_caster {
     template <typename T = type, enable_if_t<std::is_same<T, handle>::value, int> = 0>
     pyobject_caster() : value() {}
 
+    // `type` may not be default constructible (e.g. frozenset, anyset).  Initializing `value`
+    // to a nil handle is safe since it will only be accessed if `load` succeeds.
     template <typename T = type, enable_if_t<std::is_base_of<object, T>::value, int> = 0>
     pyobject_caster() : value(reinterpret_steal<type>(handle())) {}
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -908,6 +908,12 @@ struct handle_type_name<kwargs> {
 template <typename type>
 struct pyobject_caster {
     template <typename T = type, enable_if_t<std::is_same<T, handle>::value, int> = 0>
+    pyobject_caster() : value() {}
+
+    template <typename T = type, enable_if_t<std::is_base_of<object, T>::value, int> = 0>
+    pyobject_caster() : value(reinterpret_steal<type>(handle())) {}
+
+    template <typename T = type, enable_if_t<std::is_same<T, handle>::value, int> = 0>
     bool load(handle src, bool /* convert */) {
         value = src;
         return static_cast<bool>(value);

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1784,12 +1784,12 @@ class kwargs : public dict {
     PYBIND11_OBJECT_DEFAULT(kwargs, dict, PyDict_Check)
 };
 
-class any_set : public object {
+class anyset : public object {
 protected:
-    PYBIND11_OBJECT(any_set, object, PyAnySet_Check)
+    PYBIND11_OBJECT(anyset, object, PyAnySet_Check)
 
 public:
-    size_t size() const { return (size_t) PySet_Size(m_ptr); }
+    size_t size() const { return static_cast<size_t>(PySet_Size(m_ptr)); }
     bool empty() const { return size() == 0; }
     template <typename T>
     bool contains(T &&val) const {
@@ -1797,10 +1797,10 @@ public:
     }
 };
 
-class set : public any_set {
+class set : public anyset {
 public:
-    PYBIND11_OBJECT_CVT(set, any_set, PySet_Check, PySet_New)
-    set() : any_set(PySet_New(nullptr), stolen_t{}) {
+    PYBIND11_OBJECT_CVT(set, anyset, PySet_Check, PySet_New)
+    set() : anyset(PySet_New(nullptr), stolen_t{}) {
         if (!m_ptr) {
             pybind11_fail("Could not allocate set object!");
         }
@@ -1812,10 +1812,10 @@ public:
     void clear() /* py-non-const */ { PySet_Clear(m_ptr); }
 };
 
-class frozenset : public any_set {
+class frozenset : public anyset {
 public:
-    PYBIND11_OBJECT_CVT(frozenset, any_set, PyFrozenSet_Check, PyFrozenSet_New)
-    frozenset() : any_set(PyFrozenSet_New(nullptr), stolen_t{}) {
+    PYBIND11_OBJECT_CVT(frozenset, anyset, PyFrozenSet_Check, PyFrozenSet_New)
+    frozenset() : anyset(PyFrozenSet_New(nullptr), stolen_t{}) {
         if (!m_ptr) {
             pybind11_fail("Could not allocate frozenset object!");
         }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1815,11 +1815,6 @@ public:
 class frozenset : public anyset {
 public:
     PYBIND11_OBJECT_CVT(frozenset, anyset, PyFrozenSet_Check, PyFrozenSet_New)
-    frozenset() : anyset(PyFrozenSet_New(nullptr), stolen_t{}) {
-        if (!m_ptr) {
-            pybind11_fail("Could not allocate frozenset object!");
-        }
-    }
 };
 
 class function : public object {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1785,10 +1785,8 @@ class kwargs : public dict {
 };
 
 class anyset : public object {
-protected:
-    PYBIND11_OBJECT(anyset, object, PyAnySet_Check)
-
 public:
+    PYBIND11_OBJECT(anyset, object, PyAnySet_Check)
     size_t size() const { return static_cast<size_t>(PySet_Size(m_ptr)); }
     bool empty() const { return size() == 0; }
     template <typename T>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1784,9 +1784,9 @@ class kwargs : public dict {
     PYBIND11_OBJECT_DEFAULT(kwargs, dict, PyDict_Check)
 };
 
-class set_base : public object {
+class any_set : public object {
 protected:
-    PYBIND11_OBJECT(set_base, object, PyAnySet_Check)
+    PYBIND11_OBJECT(any_set, object, PyAnySet_Check)
 
 public:
     size_t size() const { return (size_t) PySet_Size(m_ptr); }
@@ -1797,10 +1797,10 @@ public:
     }
 };
 
-class set : public set_base {
+class set : public any_set {
 public:
-    PYBIND11_OBJECT_CVT(set, set_base, PySet_Check, PySet_New)
-    set() : set_base(PySet_New(nullptr), stolen_t{}) {
+    PYBIND11_OBJECT_CVT(set, any_set, PySet_Check, PySet_New)
+    set() : any_set(PySet_New(nullptr), stolen_t{}) {
         if (!m_ptr) {
             pybind11_fail("Could not allocate set object!");
         }
@@ -1812,10 +1812,10 @@ public:
     void clear() /* py-non-const */ { PySet_Clear(m_ptr); }
 };
 
-class frozenset : public set_base {
+class frozenset : public any_set {
 public:
-    PYBIND11_OBJECT_CVT(frozenset, set_base, PyFrozenSet_Check, PyFrozenSet_New)
-    frozenset() : set_base(PyFrozenSet_New(nullptr), stolen_t{}) {
+    PYBIND11_OBJECT_CVT(frozenset, any_set, PyFrozenSet_Check, PyFrozenSet_New)
+    frozenset() : any_set(PyFrozenSet_New(nullptr), stolen_t{}) {
         if (!m_ptr) {
             pybind11_fail("Could not allocate frozenset object!");
         }

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -55,10 +55,10 @@ struct set_caster {
     using key_conv = make_caster<Key>;
 
     bool load(handle src, bool convert) {
-        if (!isinstance<set_base>(src)) {
+        if (!isinstance<any_set>(src)) {
             return false;
         }
-        auto s = reinterpret_borrow<set_base>(src);
+        auto s = reinterpret_borrow<any_set>(src);
         value.clear();
         for (auto entry : s) {
             key_conv conv;

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -55,10 +55,10 @@ struct set_caster {
     using key_conv = make_caster<Key>;
 
     bool load(handle src, bool convert) {
-        if (!isinstance<pybind11::set>(src)) {
+        if (!isinstance<set_base>(src)) {
             return false;
         }
-        auto s = reinterpret_borrow<pybind11::set>(src);
+        auto s = reinterpret_borrow<set_base>(src);
         value.clear();
         for (auto entry : s) {
             key_conv conv;

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -55,10 +55,10 @@ struct set_caster {
     using key_conv = make_caster<Key>;
 
     bool load(handle src, bool convert) {
-        if (!isinstance<any_set>(src)) {
+        if (!isinstance<anyset>(src)) {
             return false;
         }
-        auto s = reinterpret_borrow<any_set>(src);
+        auto s = reinterpret_borrow<anyset>(src);
         value.clear();
         for (auto entry : s) {
             key_conv conv;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -100,6 +100,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("anyset_contains",
           [](const py::anyset &set, const py::object &key) { return set.contains(key); });
     m.def("anyset_contains", [](const py::anyset &set, const char *key) { return set.contains(key); });
+    m.def("set_add", [](py::set &set, const py::object &key) { set.add(key); });
+    m.def("set_clear", [](py::set &set) { set.clear(); });
 
     // test_dict
     m.def("get_dict", []() { return py::dict("key"_a = "value"); });
@@ -319,6 +321,7 @@ TEST_SUBMODULE(pytypes, m) {
                         "list"_a = py::list(d["list"]),
                         "dict"_a = py::dict(d["dict"]),
                         "set"_a = py::set(d["set"]),
+                        "frozenset"_a = py::frozenset(d["frozenset"]),
                         "memoryview"_a = py::memoryview(d["memoryview"]));
     });
 
@@ -334,6 +337,7 @@ TEST_SUBMODULE(pytypes, m) {
                         "list"_a = d["list"].cast<py::list>(),
                         "dict"_a = d["dict"].cast<py::dict>(),
                         "set"_a = d["set"].cast<py::set>(),
+                        "frozenset"_a = d["frozenset"].cast<py::frozenset>(),
                         "memoryview"_a = d["memoryview"].cast<py::memoryview>());
     });
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -99,7 +99,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("anyset_empty", [](const py::anyset &set) { return set.empty(); });
     m.def("anyset_contains",
           [](const py::anyset &set, const py::object &key) { return set.contains(key); });
-    m.def("anyset_contains", [](const py::anyset &set, const char *key) { return set.contains(key); });
+    m.def("anyset_contains",
+          [](const py::anyset &set, const char *key) { return set.contains(key); });
     m.def("set_add", [](py::set &set, const py::object &key) { set.add(key); });
     m.def("set_clear", [](py::set &set) { set.clear(); });
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -75,7 +75,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("get_none", [] { return py::none(); });
     m.def("print_none", [](const py::none &none) { py::print("none: {}"_s.format(none)); });
 
-    // test_set
+    // test_set, test_frozenset
     m.def("get_set", []() {
         py::set set;
         set.add(py::str("key1"));
@@ -83,14 +83,23 @@ TEST_SUBMODULE(pytypes, m) {
         set.add(std::string("key3"));
         return set;
     });
-    m.def("print_set", [](const py::set &set) {
+    m.def("get_frozenset", []() {
+        py::set set;
+        set.add(py::str("key1"));
+        set.add("key2");
+        set.add(std::string("key3"));
+        return py::frozenset(set);
+    });
+    m.def("print_anyset", [](const py::anyset &set) {
         for (auto item : set) {
             py::print("key:", item);
         }
     });
-    m.def("set_contains",
-          [](const py::set &set, const py::object &key) { return set.contains(key); });
-    m.def("set_contains", [](const py::set &set, const char *key) { return set.contains(key); });
+    m.def("anyset_size", [](const py::anyset &set) { return set.size(); });
+    m.def("anyset_empty", [](const py::anyset &set) { return set.empty(); });
+    m.def("anyset_contains",
+          [](const py::anyset &set, const py::object &key) { return set.contains(key); });
+    m.def("anyset_contains", [](const py::anyset &set, const char *key) { return set.contains(key); });
 
     // test_dict
     m.def("get_dict", []() { return py::dict("key"_a = "value"); });

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -69,8 +69,8 @@ def test_set(capture, doc):
     assert isinstance(s, set)
     assert s == {"key1", "key2", "key3"}
 
+    s.add("key4")
     with capture:
-        s.add("key4")
         m.print_anyset(s)
     assert (
         capture.unordered
@@ -82,18 +82,18 @@ def test_set(capture, doc):
     """
     )
 
-    assert m.anyset_size(set() == 0
-    assert m.anyset_size(s) == 4
+    m.set_add(s, "key5")
+    assert m.anyset_size(s) == 5
 
-    assert m.anyset_empty(set())
-    assert not m.anyset_empty({42})
+    m.set_clear(s)
+    assert m.anyset_empty(s)
 
     assert not m.anyset_contains(set(), 42)
     assert m.anyset_contains({42}, 42)
     assert m.anyset_contains({"foo"}, "foo")
 
     assert doc(m.get_set) == "get_set() -> set"
-    assert doc(m.print_anyset) == "print_anyset(arg0: set) -> None"
+    assert doc(m.print_anyset) == "print_anyset(arg0: anyset) -> None"
 
 
 def test_frozenset(capture, doc):
@@ -111,12 +111,8 @@ def test_frozenset(capture, doc):
         key: key3
     """
     )
-
-    assert m.anyset_size(frozenset()) == 0
     assert m.anyset_size(s) == 3
-
-    assert m.anyset_empty(frozenset())
-    assert not m.anyset_empty(frozenset({42}))
+    assert not m.anyset_empty(s)
 
     assert not m.anyset_contains(frozenset(), 42)
     assert m.anyset_contains(frozenset({42}), 42)
@@ -338,6 +334,7 @@ def test_constructors():
         list: range(3),
         dict: [("two", 2), ("one", 1), ("three", 3)],
         set: [4, 4, 5, 6, 6, 6],
+        frozenset: [4, 4, 5, 6, 6, 6],
         memoryview: b"abc",
     }
     inputs = {k.__name__: v for k, v in data.items()}

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -66,11 +66,12 @@ def test_none(capture, doc):
 
 def test_set(capture, doc):
     s = m.get_set()
+    assert isinstance(s, set)
     assert s == {"key1", "key2", "key3"}
 
     with capture:
         s.add("key4")
-        m.print_set(s)
+        m.print_anyset(s)
     assert (
         capture.unordered
         == """
@@ -81,12 +82,47 @@ def test_set(capture, doc):
     """
     )
 
-    assert not m.set_contains(set(), 42)
-    assert m.set_contains({42}, 42)
-    assert m.set_contains({"foo"}, "foo")
+    assert m.anyset_size(set() == 0
+    assert m.anyset_size(s) == 4
 
-    assert doc(m.get_list) == "get_list() -> list"
-    assert doc(m.print_list) == "print_list(arg0: list) -> None"
+    assert m.anyset_empty(set())
+    assert not m.anyset_empty({42})
+
+    assert not m.anyset_contains(set(), 42)
+    assert m.anyset_contains({42}, 42)
+    assert m.anyset_contains({"foo"}, "foo")
+
+    assert doc(m.get_set) == "get_set() -> set"
+    assert doc(m.print_anyset) == "print_anyset(arg0: set) -> None"
+
+
+def test_frozenset(capture, doc):
+    s = m.get_frozenset()
+    assert isinstance(s, frozenset)
+    assert s == frozenset({"key1", "key2", "key3"})
+
+    with capture:
+        m.print_anyset(s)
+    assert (
+        capture.unordered
+        == """
+        key: key1
+        key: key2
+        key: key3
+    """
+    )
+
+    assert m.anyset_size(frozenset()) == 0
+    assert m.anyset_size(s) == 3
+
+    assert m.anyset_empty(frozenset())
+    assert not m.anyset_empty(frozenset({42}))
+
+    assert not m.anyset_contains(frozenset(), 42)
+    assert m.anyset_contains(frozenset({42}), 42)
+    assert m.anyset_contains(frozenset({"foo"}), "foo")
+
+    assert doc(m.get_frozenset) == "get_frozenset() -> frozenset"
 
 
 def test_dict(capture, doc):

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -70,6 +70,7 @@ def test_set(doc):
     assert s == {"key1", "key2"}
     s.add("key3")
     assert m.load_set(s)
+    assert m.load_set(frozenset(s))
 
     assert doc(m.cast_set) == "cast_set() -> Set[str]"
     assert doc(m.load_set) == "load_set(arg0: Set[str]) -> bool"


### PR DESCRIPTION
## Description

Add `anyset` & `frozenset`, enable copying (cast) to `std::set`.

For the reverse direction, `std::set` still casts to `set`. This is in concordance with the behavior for sequence containers, where e.g. `tuple` casts to `std::vector`, but `std::vector` casts to `list`.

Extracted from https://github.com/pybind/pybind11/pull/3886.

## Suggested changelog entry:

`anyset` & `frozenset` were added, with copying (cast) to `std::set` (similar to `set`).