### PR TITLE
chore: rule of 3 for strdup guard

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -312,6 +312,12 @@ protected:
     // along the way.
     class strdup_guard {
     public:
+        strdup_guard() = default;
+        strdup_guard(const strdup_guard &) = delete;
+        strdup_guard(strdup_guard &&) noexcept = default;
+        strdup_guard &operator=(const strdup_guard &) = delete;
+        strdup_guard &operator=(strdup_guard &&) noexcept = default;
+
         ~strdup_guard() {
             for (auto *s : strings) {
                 std::free(s);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -314,9 +314,7 @@ protected:
     public:
         strdup_guard() = default;
         strdup_guard(const strdup_guard &) = delete;
-        strdup_guard(strdup_guard &&) noexcept = default;
         strdup_guard &operator=(const strdup_guard &) = delete;
-        strdup_guard &operator=(strdup_guard &&) noexcept = default;
 
         ~strdup_guard() {
             for (auto *s : strings) {


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
I noticed our strdup_guard wasn't properly following the rule of 5 and some of the implicit copy constructors / assignment operators could in theory cause a double free. This PR explicitly deletes the copy ctors to guard against accidents in future refactoring work.