### PR TITLE
Replace error printing code gated by NDEBUG with a new flag: PYBIND11_DETAILED_ERROR_MESSAGES 

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cast.h"
+#include "detail/common.h"
 
 #include <functional>
 
@@ -477,7 +478,7 @@ struct process_attribute<arg_v> : process_attribute_default<arg_v> {
         }
 
         if (!a.value) {
-#if !defined(NDEBUG)
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
             std::string descr("'");
             if (a.name) {
                 descr += std::string(a.name) + ": ";
@@ -498,7 +499,7 @@ struct process_attribute<arg_v> : process_attribute_default<arg_v> {
 #else
             pybind11_fail("arg(): could not convert default argument "
                           "into a Python object (type not registered yet?). "
-                          "Compile in debug mode for more information.");
+                          "#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for more information.");
 #endif
         }
         r->args.emplace_back(a.name, a.descr, a.value.inc_ref(), !a.flag_noconvert, a.flag_none);

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -1157,5 +1157,11 @@ constexpr inline bool silence_msvc_c4127(bool cond) { return cond; }
 #    define PYBIND11_SILENCE_MSVC_C4127(...) __VA_ARGS__
 #endif
 
+// Pybind offers detailed error messages by default for all builts that are debug (through the negation of ndebug).
+// This can also be manually enabled by users, for any builds, through defining PYBIND11_DETAILED_ERROR_MESSAGES. 
+#if !defined(PYBIND11_DETAILED_ERROR_MESSAGES) && !defined(NDEBUG)
+#    define PYBIND11_DETAILED_ERROR_MESSAGES
+#endif
+
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -394,15 +394,15 @@ instance::get_value_and_holder(const type_info *find_type /*= nullptr default in
         return value_and_holder();
     }
 
-#if defined(NDEBUG)
-    pybind11_fail("pybind11::detail::instance::get_value_and_holder: "
-                  "type is not a pybind11 base of the given instance "
-                  "(compile in debug mode for type details)");
-#else
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
     pybind11_fail("pybind11::detail::instance::get_value_and_holder: `"
                   + get_fully_qualified_tp_name(find_type->type)
                   + "' is not a pybind11 base of the given `"
                   + get_fully_qualified_tp_name(Py_TYPE(this)) + "' instance");
+#else 
+    pybind11_fail("pybind11::detail::instance::get_value_and_holder: "
+                  "type is not a pybind11 base of the given instance "
+                  "(#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for type details)");
 #endif
 }
 
@@ -612,14 +612,14 @@ public:
                 if (copy_constructor) {
                     valueptr = copy_constructor(src);
                 } else {
-#if defined(NDEBUG)
-                    throw cast_error("return_value_policy = copy, but type is "
-                                     "non-copyable! (compile in debug mode for details)");
-#else
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
                     std::string type_name(tinfo->cpptype->name());
                     detail::clean_type_id(type_name);
                     throw cast_error("return_value_policy = copy, but type " + type_name
                                      + " is non-copyable!");
+#else 
+                    throw cast_error("return_value_policy = copy, but type is "
+                        "non-copyable! (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)");                                     
 #endif
                 }
                 wrapper->owned = true;
@@ -631,15 +631,15 @@ public:
                 } else if (copy_constructor) {
                     valueptr = copy_constructor(src);
                 } else {
-#if defined(NDEBUG)
-                    throw cast_error("return_value_policy = move, but type is neither "
-                                     "movable nor copyable! "
-                                     "(compile in debug mode for details)");
-#else
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
                     std::string type_name(tinfo->cpptype->name());
                     detail::clean_type_id(type_name);
                     throw cast_error("return_value_policy = move, but type " + type_name
                                      + " is neither movable nor copyable!");
+#else 
+                    throw cast_error("return_value_policy = move, but type is neither "
+                                     "movable nor copyable! "
+                                     "(#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)");                                     
 #endif
                 }
                 wrapper->owned = true;

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -62,7 +62,7 @@ public:
 
         if (!tstate) {
             tstate = PyThreadState_New(internals.istate);
-#    if !defined(NDEBUG)
+#    if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
             if (!tstate) {
                 pybind11_fail("scoped_acquire: could not create thread state!");
             }
@@ -84,7 +84,7 @@ public:
 
     PYBIND11_NOINLINE void dec_ref() {
         --tstate->gilstate_counter;
-#    if !defined(NDEBUG)
+#    if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
         if (detail::get_thread_state_unchecked() != tstate) {
             pybind11_fail("scoped_acquire::dec_ref(): thread state must be current!");
         }
@@ -93,7 +93,7 @@ public:
         }
 #    endif
         if (tstate->gilstate_counter == 0) {
-#    if !defined(NDEBUG)
+#    if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
             if (!release) {
                 pybind11_fail("scoped_acquire::dec_ref(): internal error!");
             }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -370,7 +370,7 @@ protected:
         rec->is_constructor = (std::strcmp(rec->name, "__init__") == 0)
                               || (std::strcmp(rec->name, "__setstate__") == 0);
 
-#if !defined(NDEBUG) && !defined(PYBIND11_DISABLE_NEW_STYLE_INIT_WARNING)
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES) && !defined(PYBIND11_DISABLE_NEW_STYLE_INIT_WARNING)
         if (rec->is_constructor && !rec->is_new_style_constructor) {
             const auto class_name
                 = detail::get_fully_qualified_tp_name((PyTypeObject *) rec->scope.ptr());
@@ -518,8 +518,8 @@ protected:
             if (chain->is_method != rec->is_method) {
                 pybind11_fail(
                     "overloading a method with both static and instance methods is not supported; "
-#if defined(NDEBUG)
-                    "compile in debug mode for more details"
+#if !defined(PYBIND11_DETAILED_ERROR_MESSAGES)
+                    "#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for more details"
 #else
                     "error while attempting to bind "
                     + std::string(rec->is_method ? "instance" : "static") + " method "
@@ -906,7 +906,7 @@ protected:
 
 // 5. Put everything in a vector.  Not technically step 5, we've been building it
 // in `call.args` all along.
-#if !defined(NDEBUG)
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
                 if (call.args.size() != func.nargs || call.args_convert.size() != func.nargs) {
                     pybind11_fail("Internal error: function call dispatcher inserted wrong number "
                                   "of arguments!");

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -68,9 +68,9 @@ PYBIND11_MODULE(pybind11_tests, m) {
     bind_ConstructorStats(m);
 
 #if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
-    m.attr("debug_enabled") = true;
+    m.attr("detailed_error_messages_enabled") = true;
 #else
-    m.attr("debug_enabled") = false;
+    m.attr("detailed_error_messages_enabled") = false;
 #endif
 
     py::class_<UserType>(m, "UserType", "A `py::class_` type for testing")

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -67,7 +67,7 @@ PYBIND11_MODULE(pybind11_tests, m) {
 
     bind_ConstructorStats(m);
 
-#if !defined(NDEBUG)
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
     m.attr("debug_enabled") = true;
 #else
     m.attr("debug_enabled") = false;

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -361,7 +361,7 @@ TEST_SUBMODULE(methods_and_attributes, m) {
 
     // test_bad_arg_default
     // Issue/PR #648: bad arg default debugging output
-#if !defined(NDEBUG)
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
     m.attr("debug_enabled") = true;
 #else
     m.attr("debug_enabled") = false;

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -362,9 +362,9 @@ TEST_SUBMODULE(methods_and_attributes, m) {
     // test_bad_arg_default
     // Issue/PR #648: bad arg default debugging output
 #if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
-    m.attr("debug_enabled") = true;
+    m.attr("detailed_error_messages_enabled") = true;
 #else
-    m.attr("debug_enabled") = false;
+    m.attr("detailed_error_messages_enabled") = false;
 #endif
     m.def("bad_arg_def_named", [] {
         auto m = py::module_::import("pybind11_tests");

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -216,7 +216,7 @@ def test_metaclass_override():
 
 
 def test_no_mixed_overloads():
-    from pybind11_tests import debug_enabled
+    from pybind11_tests import detailed_error_messages_enabled
 
     with pytest.raises(RuntimeError) as excinfo:
         m.ExampleMandA.add_mixed_overloads1()
@@ -224,7 +224,7 @@ def test_no_mixed_overloads():
         excinfo.value
     ) == "overloading a method with both static and instance methods is not supported; " + (
         "#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for more details"
-        if not debug_enabled
+        if not detailed_error_messages_enabled
         else "error while attempting to bind static method ExampleMandA.overload_mixed1"
         "(arg0: float) -> str"
     )
@@ -235,7 +235,7 @@ def test_no_mixed_overloads():
         excinfo.value
     ) == "overloading a method with both static and instance methods is not supported; " + (
         "#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for more details"
-        if not debug_enabled
+        if not detailed_error_messages_enabled
         else "error while attempting to bind instance method ExampleMandA.overload_mixed2"
         "(self: pybind11_tests.methods_and_attributes.ExampleMandA, arg0: int, arg1: int)"
         " -> str"
@@ -344,14 +344,14 @@ def test_cyclic_gc():
 
 
 def test_bad_arg_default(msg):
-    from pybind11_tests import debug_enabled
+    from pybind11_tests import detailed_error_messages_enabled
 
     with pytest.raises(RuntimeError) as excinfo:
         m.bad_arg_def_named()
     assert msg(excinfo.value) == (
         "arg(): could not convert default argument 'a: UnregisteredType' in function "
         "'should_fail' into a Python object (type not registered yet?)"
-        if debug_enabled
+        if detailed_error_messages_enabled
         else "arg(): could not convert default argument into a Python object (type not registered "
         "yet?). #define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for more information."
     )
@@ -361,7 +361,7 @@ def test_bad_arg_default(msg):
     assert msg(excinfo.value) == (
         "arg(): could not convert default argument 'UnregisteredType' in function "
         "'should_fail' into a Python object (type not registered yet?)"
-        if debug_enabled
+        if detailed_error_messages_enabled
         else "arg(): could not convert default argument into a Python object (type not registered "
         "yet?). #define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for more information."
     )

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -223,7 +223,7 @@ def test_no_mixed_overloads():
     assert str(
         excinfo.value
     ) == "overloading a method with both static and instance methods is not supported; " + (
-        "compile in debug mode for more details"
+        "#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for more details"
         if not debug_enabled
         else "error while attempting to bind static method ExampleMandA.overload_mixed1"
         "(arg0: float) -> str"
@@ -234,7 +234,7 @@ def test_no_mixed_overloads():
     assert str(
         excinfo.value
     ) == "overloading a method with both static and instance methods is not supported; " + (
-        "compile in debug mode for more details"
+        "#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for more details"
         if not debug_enabled
         else "error while attempting to bind instance method ExampleMandA.overload_mixed2"
         "(self: pybind11_tests.methods_and_attributes.ExampleMandA, arg0: int, arg1: int)"
@@ -353,7 +353,7 @@ def test_bad_arg_default(msg):
         "'should_fail' into a Python object (type not registered yet?)"
         if debug_enabled
         else "arg(): could not convert default argument into a Python object (type not registered "
-        "yet?). Compile in debug mode for more information."
+        "yet?). #define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for more information."
     )
 
     with pytest.raises(RuntimeError) as excinfo:
@@ -363,7 +363,7 @@ def test_bad_arg_default(msg):
         "'should_fail' into a Python object (type not registered yet?)"
         if debug_enabled
         else "arg(): could not convert default argument into a Python object (type not registered "
-        "yet?). Compile in debug mode for more information."
+        "yet?). #define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for more information."
     )
 
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 import env
-from pybind11_tests import debug_enabled
+from pybind11_tests import detailed_error_messages_enabled
 from pybind11_tests import pytypes as m
 
 
@@ -416,7 +416,7 @@ def test_print(capture):
         m.print_failure()
     assert str(excinfo.value) == "Unable to convert call argument " + (
         "'1' of type 'UnregisteredType' to Python object"
-        if debug_enabled
+        if detailed_error_messages_enabled
         else "to Python object (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)"
     )
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -417,7 +417,7 @@ def test_print(capture):
     assert str(excinfo.value) == "Unable to convert call argument " + (
         "'1' of type 'UnregisteredType' to Python object"
         if debug_enabled
-        else "to Python object (compile in debug mode for details)"
+        else "to Python object (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)"
     )
 
 


### PR DESCRIPTION
## Description

Does what it says in the title. We have some internal use cases of pybind where we would love to get richer logging from within pybind, but are not running a debug build. 

