### PR TITLE
Fix issue #3912 : invalid docstring generation of std::array <-> list caster

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -251,12 +251,7 @@ public:
         return l.release();
     }
 
-    PYBIND11_TYPE_CASTER(ArrayType,
-                         const_name("List[") + value_conv::name
-                             + const_name<Resizable>(const_name(""),
-                                                     const_name("[") + const_name<Size>()
-                                                         + const_name("]"))
-                             + const_name("]"));
+    PYBIND11_TYPE_CASTER(ArrayType, const_name("List[") + value_conv::name + const_name("]"));
 };
 
 template <typename Type, size_t Size>

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -39,8 +39,8 @@ def test_array(doc):
     assert m.load_array(lst)
     assert m.load_array(tuple(lst))
 
-    assert doc(m.cast_array) == "cast_array() -> List[int[2]]"
-    assert doc(m.load_array) == "load_array(arg0: List[int[2]]) -> bool"
+    assert doc(m.cast_array) == "cast_array() -> List[int]"
+    assert doc(m.load_array) == "load_array(arg0: List[int]) -> bool"
 
 
 def test_valarray(doc):


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Fixes #3912, by removing size information from list, while this information is helpful, it generates invalid type signatures for mypy and other type checkers.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fixes doc generation for std::array-list caster. Previously, signatures included the size of the list in a non-standard, non-spec compliant way.
```

<!-- If the upgrade guide needs updating, note that here too -->
