### PR TITLE
Fix file extension on windows with cp36 and cp37

### DIFF
--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -127,10 +127,11 @@ if USE_SYSCONFIG:
         scheme = 'posix_prefix'
     print(s.get_path('platinclude', scheme))
     print(s.get_path('platlib'))
+    print(s.get_config_var('EXT_SUFFIX') or s.get_config_var('SO'))
 else:
     print(ds.get_python_inc(plat_specific=True));
     print(ds.get_python_lib(plat_specific=True));
-print(s.get_config_var('EXT_SUFFIX') or s.get_config_var('SO'));
+    print(ds.get_config_var('EXT_SUFFIX') or ds.get_config_var('SO'));
 print(hasattr(sys, 'gettotalrefcount')+0);
 print(struct.calcsize('@P'));
 print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));


### PR DESCRIPTION
Hi,

I noticed that with #3764 pybind11 modules now have `.pyd` as file extension on Windows for CPython 3.6 and CPython 3.7 while it previously was `.cp36-win_amd64.pyd` and `.cp37-win_amd64.pyd`, respectively. That was probably just an oversight, which should be fixed with this PR.

PS: Tried to be consistent with the usage of `;` but I don't know why it's used here in the first place.