### PR TITLE
chore: remove unused include from stl.h

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -15,6 +15,7 @@
 #include <deque>
 #include <list>
 #include <map>
+#include <ostream>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -13,7 +13,6 @@
 #include "detail/common.h"
 
 #include <deque>
-#include <iostream>
 #include <list>
 #include <map>
 #include <set>


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Removes the iostream include from stl.h. Only the header ostream is used which is included transitively. 
* Should help speed up compilation when pybind11/stl.h is included but istream objects are not needed.