### PR TITLE
[smart_holder] Fix "extra ';' outside of a function" warning

### DIFF
--- a/include/pybind11/detail/smart_holder_poc.h
+++ b/include/pybind11/detail/smart_holder_poc.h
@@ -106,7 +106,7 @@ inline void custom_delete(void *raw_ptr) {
 template <typename T, typename D>
 guarded_delete make_guarded_custom_deleter(bool armed_flag) {
     return guarded_delete(custom_delete<T, D>, armed_flag);
-};
+}
 
 template <typename T>
 inline bool is_std_default_delete(const std::type_info &rtti_deleter) {


### PR DESCRIPTION
Fix the following warning seen with clang:

include/pybind11/detail/smart_holder_poc.h:109:2: error: extra ';' outside of a function is incompatible with C++98 [-Werror,-Wc++98-compat-extra-semi]

Signed-off-by: Tomi Valkeinen <tomi.valkeinen@ideasonboard.com>
