### PR TITLE
Don't return pointers to static objects with return_value_policy::take_ownership.

### DIFF
--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -267,7 +267,7 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("lvalue_nested", []() -> const decltype(lvnested) & { return lvnested; });
 
     static std::pair<int, std::string> int_string_pair{2, "items"};
-    m.def("int_string_pair", []() { return &int_string_pair; });
+    m.def("int_string_pair", []() { return new decltype(int_string_pair){int_string_pair}; });
 
     // test_builtins_cast_return_none
     m.def("return_none_string", []() -> std::string * { return nullptr; });

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -267,7 +267,8 @@ TEST_SUBMODULE(builtin_casters, m) {
     m.def("lvalue_nested", []() -> const decltype(lvnested) & { return lvnested; });
 
     static std::pair<int, std::string> int_string_pair{2, "items"};
-    m.def("int_string_pair", []() { return new decltype(int_string_pair){int_string_pair}; });
+    m.def(
+        "int_string_pair", []() { return &int_string_pair; }, py::return_value_policy::reference);
 
     // test_builtins_cast_return_none
     m.def("return_none_string", []() -> std::string * { return nullptr; });

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -177,7 +177,8 @@ TEST_SUBMODULE(stl, m) {
           [](const std::vector<bool> &v) { return v.at(0) == true && v.at(1) == false; });
     // Unnumbered regression (caused by #936): pointers to stl containers aren't castable
     static std::vector<RValueCaster> lvv{2};
-    m.def("cast_ptr_vector", []() { return new decltype(lvv){lvv}; });
+    m.def(
+        "cast_ptr_vector", []() { return &lvv; }, py::return_value_policy::reference);
 
     // test_deque
     m.def("cast_deque", []() { return std::deque<int>{1}; });

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -177,7 +177,7 @@ TEST_SUBMODULE(stl, m) {
           [](const std::vector<bool> &v) { return v.at(0) == true && v.at(1) == false; });
     // Unnumbered regression (caused by #936): pointers to stl containers aren't castable
     static std::vector<RValueCaster> lvv{2};
-    m.def("cast_ptr_vector", []() { return &lvv; });
+    m.def("cast_ptr_vector", []() { return new decltype(lvv){lvv}; });
 
     // test_deque
     m.def("cast_deque", []() { return std::deque<int>{1}; });


### PR DESCRIPTION
This fixes -Wfree-nonheap-object warnings produced by GCC.

## Description

When compiling the pybind tests with the latest GCC, the following warnings are produced:

```
In function ‘cast’,
    inlined from ‘operator()’ at pybind11/include/pybind11/pybind11.h:249:33,
    inlined from ‘_FUN’ at pybind11/include/pybind11/pybind11.h:224:21:
pybind11/include/pybind11/detail/../cast.h:653:13: warning: ‘operator delete’ called on unallocated object ‘int_string_pair’ [-Wfree-nonheap-object]
  653 |             delete src;
      |             ^
pybind11/include/pybind11/detail/../cast.h: In function ‘_FUN’:
pybind11/tests/test_builtin_casters.cpp:269:40: note: declared here
  269 |     static std::pair<int, std::string> int_string_pair{2, "items"};
      |                                        ^
In function ‘cast’,
    inlined from ‘operator()’ at pybind11/include/pybind11/pybind11.h:249:33,
    inlined from ‘_FUN’ at pybind11/include/pybind11/pybind11.h:224:21:
pybind11/include/pybind11/stl.h:190:5: warning: ‘operator delete’ called on unallocated object ‘lvv’ [-Wfree-nonheap-object]
  190 |     PYBIND11_TYPE_CASTER(Type, const_name("List[") + value_conv::name + const_name("]"));
      |     ^
pybind11/include/pybind11/stl.h: In function ‘_FUN’:
pybind11/tests/test_stl.cpp:179: note: declared here
  179 |     static std::vector<RValueCaster> lvv{2};
      | 
```

Apparently two test cases were returning pointers to static objects with return_value_policy::take_ownership, which causes pybind to `delete` these objects later. This commit fixes that by allocating a copy and returning it instead of a pointer to the original.