### PR TITLE
Fix py::cast from pytype rvalue to pytype

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1009,7 +1009,8 @@ struct return_value_policy_override<
 // Basic python -> C++ casting; throws if casting fails
 template <typename T, typename SFINAE>
 type_caster<T, SFINAE> &load_type(type_caster<T, SFINAE> &conv, const handle &handle) {
-    static_assert(!detail::is_pyobject<T>::value, "Internal error: type_caster should only be used for C++ types");
+    static_assert(!detail::is_pyobject<T>::value,
+                  "Internal error: type_caster should only be used for C++ types");
     if (!conv.load(handle, true)) {
 #if !defined(PYBIND11_DETAILED_ERROR_MESSAGES)
         throw cast_error("Unable to cast Python instance to C++ type (#define "
@@ -1100,18 +1101,21 @@ detail::enable_if_t<!detail::move_never<T>::value, T> move(object &&obj) {
 // - If both movable and copyable, check ref count: if 1, move; otherwise copy
 // - Otherwise (not movable), copy.
 template <typename T>
-detail::enable_if_t<!detail::is_pyobject<T>::value && detail::move_always<T>::value, T> cast(object &&object) {
+detail::enable_if_t<!detail::is_pyobject<T>::value && detail::move_always<T>::value, T>
+cast(object &&object) {
     return move<T>(std::move(object));
 }
 template <typename T>
-detail::enable_if_t<!detail::is_pyobject<T>::value && detail::move_if_unreferenced<T>::value, T> cast(object &&object) {
+detail::enable_if_t<!detail::is_pyobject<T>::value && detail::move_if_unreferenced<T>::value, T>
+cast(object &&object) {
     if (object.ref_count() > 1) {
         return cast<T>(object);
     }
     return move<T>(std::move(object));
 }
 template <typename T>
-detail::enable_if_t<!detail::is_pyobject<T>::value && detail::move_never<T>::value, T> cast(object &&object) {
+detail::enable_if_t<!detail::is_pyobject<T>::value && detail::move_never<T>::value, T>
+cast(object &&object) {
     return cast<T>(object);
 }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1009,6 +1009,7 @@ struct return_value_policy_override<
 // Basic python -> C++ casting; throws if casting fails
 template <typename T, typename SFINAE>
 type_caster<T, SFINAE> &load_type(type_caster<T, SFINAE> &conv, const handle &handle) {
+    static_assert(!detail::is_pyobject<T>::value, "Internal error: type_caster should only be used for C++ types");
     if (!conv.load(handle, true)) {
 #if !defined(PYBIND11_DETAILED_ERROR_MESSAGES)
         throw cast_error("Unable to cast Python instance to C++ type (#define "
@@ -1099,19 +1100,25 @@ detail::enable_if_t<!detail::move_never<T>::value, T> move(object &&obj) {
 // - If both movable and copyable, check ref count: if 1, move; otherwise copy
 // - Otherwise (not movable), copy.
 template <typename T>
-detail::enable_if_t<detail::move_always<T>::value, T> cast(object &&object) {
+detail::enable_if_t<!detail::is_pyobject<T>::value && detail::move_always<T>::value, T> cast(object &&object) {
     return move<T>(std::move(object));
 }
 template <typename T>
-detail::enable_if_t<detail::move_if_unreferenced<T>::value, T> cast(object &&object) {
+detail::enable_if_t<!detail::is_pyobject<T>::value && detail::move_if_unreferenced<T>::value, T> cast(object &&object) {
     if (object.ref_count() > 1) {
         return cast<T>(object);
     }
     return move<T>(std::move(object));
 }
 template <typename T>
-detail::enable_if_t<detail::move_never<T>::value, T> cast(object &&object) {
+detail::enable_if_t<!detail::is_pyobject<T>::value && detail::move_never<T>::value, T> cast(object &&object) {
     return cast<T>(object);
+}
+
+// pytype rvalue -> pytype (calls converting constructor)
+template <typename T>
+detail::enable_if_t<detail::is_pyobject<T>::value, T> cast(object &&object) {
+    return T(std::move(object));
 }
 
 template <typename T>

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -289,4 +289,7 @@ TEST_SUBMODULE(copy_move_policies, m) {
         py::return_value_policy::move);
     m.def(
         "get_moveissue2", [](int i) { return MoveIssue2(i); }, py::return_value_policy::move);
+
+    // Make sure that cast from pytype rvalue to other pytype works
+    m.def("get_pytype_rvalue_castissue", [](double i) { return py::float_(i).cast<py::int_>(); });
 }

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -124,6 +124,7 @@ def test_move_fallback():
     m2 = m.get_moveissue2(2)
     assert m2.value == 2
 
+
 def test_pytype_rvalue_cast():
     """Make sure that cast from pytype rvalue to other pytype works"""
 

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -123,3 +123,9 @@ def test_move_fallback():
     assert m1.value == 1
     m2 = m.get_moveissue2(2)
     assert m2.value == 2
+
+def test_pytype_rvalue_cast():
+    """Make sure that cast from pytype rvalue to other pytype works"""
+
+    value = m.get_pytype_rvalue_castissue(1.0)
+    assert value == 1


### PR DESCRIPTION
Previously, py::cast blindly assumed that the destination type was a C++ type rather than a python type when the source type was an rvalue.

## Description

The following piece of code:
```
py::int_ value = py::float_(1.0).cast<py::int_>();
```
... results in the following bizarre runtime error:
```
RuntimeError: Unable to cast Python instance of type <class 'float'> to C++ type 'int_'
```
Whereas this works fine:
```
py::float_ temp = 1.0;
py::int_ value = temp.cast<py::int_>();
```
The problem seems to be that in the first case, the `py::float_` is an rvalue, which causes pybind to use a different implementation of `py::cast` which blindly assumes that the destination type is always a C++ type and attempts to use the `type_caster` mechanism - unlike the normal `py::cast` implementation which checks the destination type to determine whether to use `type_caster` or just call the constructor of the destination type.

This commit does three things:
- Add a static assertion to `load_type` such that if it gets invoked with a python type rather than a C++ type, it will produce a meaningful compile-time error rather than the bizarre runtime error shown above.
- Modify `py::cast(object &&)` such that it actually checks whether the destination type is a python object, and if so, invokes the move constructor instead of using `type_caster`.
- Add a test to make sure that the problem is fixed.

## Suggested changelog entry:

```rst
Fix cast from pytype rvalue to another pytype.
```