### PR TITLE
chore: add err guard to capsule destructor and add a move to iostream

### DIFF
--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -100,7 +100,7 @@ private:
 
             if (size > remainder) {
                 str line(pbase(), size - remainder);
-                pywrite(line);
+                pywrite(std::move(line));
                 pyflush();
             }
 

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -123,7 +123,7 @@ public:
         setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
     }
 
-    pythonbuf(pythonbuf &&) noexcept = default;
+    pythonbuf(pythonbuf &&) = default;
 
     /// Sync before destroy
     ~pythonbuf() override { _sync(); }

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -122,7 +122,7 @@ public:
         setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
     }
 
-    pythonbuf(pythonbuf &&) = default;
+    pythonbuf(pythonbuf &&) noexcept = default;
 
     /// Sync before destroy
     ~pythonbuf() override { _sync(); }
@@ -172,7 +172,7 @@ public:
     ~scoped_ostream_redirect() { costream.rdbuf(old); }
 
     scoped_ostream_redirect(const scoped_ostream_redirect &) = delete;
-    scoped_ostream_redirect(scoped_ostream_redirect &&other) = default;
+    scoped_ostream_redirect(scoped_ostream_redirect &&other) noexcept = default;
     scoped_ostream_redirect &operator=(const scoped_ostream_redirect &) = delete;
     scoped_ostream_redirect &operator=(scoped_ostream_redirect &&) = delete;
 };

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -23,7 +23,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <iostream>
 #include <iterator>
 #include <memory>
 #include <ostream>

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -123,7 +123,7 @@ public:
         setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
     }
 
-    pythonbuf(pythonbuf &&) = default;
+    pythonbuf(pythonbuf &&) noexcept = default;
 
     /// Sync before destroy
     ~pythonbuf() override { _sync(); }

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -123,7 +123,7 @@ public:
         setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
     }
 
-    pythonbuf(pythonbuf &&) noexcept = default;
+    pythonbuf(pythonbuf &&) = default;
 
     /// Sync before destroy
     ~pythonbuf() override { _sync(); }
@@ -173,7 +173,7 @@ public:
     ~scoped_ostream_redirect() { costream.rdbuf(old); }
 
     scoped_ostream_redirect(const scoped_ostream_redirect &) = delete;
-    scoped_ostream_redirect(scoped_ostream_redirect &&other) noexcept = default;
+    scoped_ostream_redirect(scoped_ostream_redirect &&other) = default;
     scoped_ostream_redirect &operator=(const scoped_ostream_redirect &) = delete;
     scoped_ostream_redirect &operator=(scoped_ostream_redirect &&) = delete;
 };

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <iostream>
 #include <iterator>
 #include <memory>
 #include <ostream>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1581,6 +1581,8 @@ public:
 
     capsule(const void *value, void (*destructor)(void *)) {
         m_ptr = PyCapsule_New(const_cast<void *>(value), nullptr, [](PyObject *o) {
+            // guard if destructor called while err indicator is set
+            error_scope error_guard;
             auto destructor = reinterpret_cast<void (*)(void *)>(PyCapsule_GetContext(o));
             if (destructor == nullptr) {
                 if (PyErr_Occurred()) {


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* One fixes a potential bug in pycapsule destructor by adding an error_guard to one of the dtors.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
