### PR TITLE
Experiment: error_already_set_terminate_if_gil_not_held

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2613,7 +2613,7 @@ void print(Args &&...args) {
 
 error_already_set::~error_already_set() {
     if (m_type) {
-        gil_scoped_acquire gil;
+        detail::terminate_if_gil_not_held(__FILE__, __LINE__);
         error_scope scope;
         m_type.release().dec_ref();
         m_value.release().dec_ref();


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Experimental/scratch PR, to answer this question:

```
catch (const py::error_already_set &e) {
    throw e; // Uses copy ctor. Are we sure we have the GIL in all situations?
}
```

The copy ctor uses INCREF, which could race if the GIL is not held.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
