### PR TITLE
Unladen `error_already_set`

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -326,7 +326,7 @@
     catch (pybind11::error_already_set &) {                                                       \
         std::string err_str = py::detail::error_string();                                         \
         PyErr_Clear();                                                                            \
-        PyErr_SetString(PyExc_ImportError, err_str.c_str());                                      \
+        PyErr_SetString(PyExc_ImportError, ("initialization failed: " + err_str).c_str());        \
         return nullptr;                                                                           \
     }                                                                                             \
     catch (const std::exception &e) {                                                             \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -324,9 +324,9 @@
 
 #define PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
     catch (pybind11::error_already_set &) {                                                       \
-        std::string err_str = pybind11::detail::error_string();                                   \
-        PyErr_Clear();                                                                            \
-        PyErr_SetString(PyExc_ImportError, ("initialization failed: " + err_str).c_str());        \
+        PyErr_SetString(                                                                          \
+            PyExc_ImportError,                                                                    \
+            ("initialization failed: " + pybind11::get_error_string_and_clear_error()).c_str());  \
         return nullptr;                                                                           \
     }                                                                                             \
     catch (const std::exception &e) {                                                             \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -324,7 +324,7 @@
 
 #define PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
     catch (pybind11::error_already_set &) {                                                       \
-        std::string err_str = py::detail::error_string();                                         \
+        std::string err_str = pybind11::detail::error_string();                                   \
         PyErr_Clear();                                                                            \
         PyErr_SetString(PyExc_ImportError, ("initialization failed: " + err_str).c_str());        \
         return nullptr;                                                                           \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -324,7 +324,9 @@
 
 #define PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
     catch (pybind11::error_already_set &) {                                                       \
-        pybind11::raise_from(PyExc_ImportError, "initialization failed");                         \
+        std::string err_str = py::detail::error_string();                                         \
+        PyErr_Clear();                                                                            \
+        PyErr_SetString(PyExc_ImportError, err_str.c_str());                                      \
         return nullptr;                                                                           \
     }                                                                                             \
     catch (const std::exception &e) {                                                             \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -323,8 +323,8 @@
     }
 
 #define PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
-    catch (pybind11::error_already_set & e) {                                                     \
-        pybind11::raise_from(e, PyExc_ImportError, "initialization failed");                      \
+    catch (pybind11::error_already_set &) {                                                       \
+        pybind11::raise_from(PyExc_ImportError, "initialization failed");                         \
         return nullptr;                                                                           \
     }                                                                                             \
     catch (const std::exception &e) {                                                             \

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -333,8 +333,7 @@ inline void translate_exception(std::exception_ptr p) {
     try {
         std::rethrow_exception(p);
     } catch (error_already_set &e) {
-        handle_nested_exception(e, p);
-        e.restore();
+        // The Python error reporting has already been handled.
         return;
     } catch (const builtin_exception &e) {
         // Could not use template since it's an abstract class.

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -332,7 +332,7 @@ inline void translate_exception(std::exception_ptr p) {
     }
     try {
         std::rethrow_exception(p);
-    } catch (error_already_set &e) {
+    } catch (error_already_set &) {
         // The Python error reporting has already been handled.
         return;
     } catch (const builtin_exception &e) {

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -390,8 +390,7 @@ inline void translate_local_exception(std::exception_ptr p) {
         if (p) {
             std::rethrow_exception(p);
         }
-    } catch (error_already_set &e) {
-        e.restore();
+    } catch (error_already_set &) {
         return;
     } catch (const builtin_exception &e) {
         e.set_error();

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -478,6 +478,8 @@ PYBIND11_NOINLINE std::string error_string() {
 
     error_scope scope; // Preserve error state
 
+    PyErr_NormalizeException(&scope.type, &scope.value, &scope.trace);
+
     std::string errorString;
     if (scope.type) {
         errorString += handle(scope.type).attr("__name__").cast<std::string>();
@@ -486,8 +488,6 @@ PYBIND11_NOINLINE std::string error_string() {
     if (scope.value) {
         errorString += (std::string) str(scope.value);
     }
-
-    PyErr_NormalizeException(&scope.type, &scope.value, &scope.trace);
 
     if (scope.trace != nullptr) {
         PyException_SetTraceback(scope.value, scope.trace);

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -143,6 +143,7 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
                                    const char *const *argv = nullptr,
                                    bool add_program_dir_to_path = true) {
     if (Py_IsInitialized() != 0) {
+        PyErr_Clear();
         pybind11_fail("The interpreter is already running");
     }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -972,7 +972,7 @@ protected:
                     }
                 }
             }
-        } catch (error_already_set &e) {
+        } catch (error_already_set &) {
             // The Python error reporting has already been handled.
             return nullptr;
 #ifdef __GLIBCXX__

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1175,9 +1175,16 @@ public:
             py::module_ m3 = m2.def_submodule("subsub", "A submodule of 'example.sub'");
     \endrst */
     module_ def_submodule(const char *name, const char *doc = nullptr) {
-        std::string full_name
-            = std::string(PyModule_GetName(m_ptr)) + std::string(".") + std::string(name);
-        auto result = reinterpret_borrow<module_>(PyImport_AddModule(full_name.c_str()));
+        const char *this_name = PyModule_GetName(m_ptr);
+        if (this_name == nullptr) {
+            throw error_already_set();
+        }
+        std::string full_name = std::string(this_name) + "." + name;
+        handle submodule = PyImport_AddModule(full_name.c_str());
+        if (!submodule) {
+            throw error_already_set();
+        }
+        auto result = reinterpret_borrow<module_>(submodule);
         if (doc && options::show_user_defined_docstrings()) {
             result.attr("__doc__") = pybind11::str(doc);
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1074,6 +1074,7 @@ protected:
                 try {
                     msg += pybind11::repr(args_[ti]);
                 } catch (const error_already_set &) {
+                    PyErr_Clear();
                     msg += "<repr raised Error>";
                 }
             }
@@ -1095,6 +1096,7 @@ protected:
                         try {
                             msg += pybind11::repr(kwarg.second);
                         } catch (const error_already_set &) {
+                            PyErr_Clear();
                             msg += "<repr raised Error>";
                         }
                     }
@@ -2587,6 +2589,7 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         try {
             file = module_::import("sys").attr("stdout");
         } catch (const error_already_set &) {
+            PyErr_Clear();
             /* If print() is called from code that is executed as
                part of garbage collection during interpreter shutdown,
                importing 'sys' can fail. Give up rather than crashing the

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1179,7 +1179,7 @@ public:
         if (this_name == nullptr) {
             throw error_already_set();
         }
-        std::string full_name = std::string(this_name) + "." + name;
+        std::string full_name = std::string(this_name) + '.' + name;
         handle submodule = PyImport_AddModule(full_name.c_str());
         if (!submodule) {
             throw error_already_set();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -973,7 +973,7 @@ protected:
                 }
             }
         } catch (error_already_set &e) {
-            e.restore();
+            // The Python error reporting has already been handled.
             return nullptr;
 #ifdef __GLIBCXX__
         } catch (abi::__forced_unwind &) {
@@ -2609,16 +2609,6 @@ template <return_value_policy policy = return_value_policy::automatic_reference,
 void print(Args &&...args) {
     auto c = detail::collect_arguments<policy>(std::forward<Args>(args)...);
     detail::print(c.args(), c.kwargs());
-}
-
-error_already_set::~error_already_set() {
-    if (m_type) {
-        gil_scoped_acquire gil;
-        error_scope scope;
-        m_type.release().dec_ref();
-        m_value.release().dec_ref();
-        m_trace.release().dec_ref();
-    }
 }
 
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -384,7 +384,15 @@ public:
     /// already knows the type and value of the error, so there is no need to repeat that. After
     /// this call, the current object no longer stores the error variables, and neither does
     /// Python.
-    void discard_as_unraisable(object err_context) { PyErr_WriteUnraisable(err_context.ptr()); }
+    void discard_as_unraisable(object err_context) {
+#if PY_VERSION_HEX < 0x03080000
+        PyObject *exc = nullptr, *val = nullptr, *tb = nullptr;
+        PyErr_Fetch(&exc, &val, &tb);
+        PyErr_NormalizeException(&exc, &val, &tb);
+        PyErr_Restore(exc, val, tb);
+#endif
+        PyErr_WriteUnraisable(err_context.ptr());
+    }
     /// An alternate version of `discard_as_unraisable()`, where a string provides information on
     /// the location of the error. For example, `__func__` could be helpful.
     void discard_as_unraisable(const char *err_context) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -414,6 +414,12 @@ public:
 #    pragma warning(pop)
 #endif
 
+inline std::string get_error_string_and_clear_error() {
+    std::string result = detail::error_string();
+    PyErr_Clear();
+    return result;
+}
+
 /// Replaces the current Python error indicator with the chosen error, performing a
 /// 'raise from' to indicate that the chosen error was caused by the original error.
 inline void raise_from(PyObject *type, const char *message) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -373,6 +373,11 @@ class PYBIND11_EXPORT_EXCEPTION error_already_set {
 public:
     virtual ~error_already_set() = default;
 
+    // Compatibility with older compilers.
+    error_already_set() = default;
+    error_already_set(const error_already_set &) = default;
+    error_already_set(error_already_set &&) = default;
+
     /// If it is impossible to raise the currently-held error, such as in a destructor, we can
     /// write it out using Python's unraisable hook (`sys.unraisablehook`). The error context
     /// should be some object whose `repr()` helps identify the location of the error. Python

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -128,15 +128,13 @@ TEST_CASE("Import error handling") {
     try {
         py::module_::import("throw_exception");
     } catch (const py::error_already_set &) {
-        REQUIRE(py::detail::error_string() == "ImportError: C++ Error");
-        PyErr_Clear();
+        REQUIRE(py::get_error_string_and_clear_error() == "ImportError: C++ Error");
     }
     try {
         py::module_::import("throw_error_already_set");
     } catch (const py::error_already_set &) {
-        REQUIRE_THAT(py::detail::error_string(),
+        REQUIRE_THAT(py::get_error_string_and_clear_error(),
                      Catch::Contains("ImportError: initialization failed"));
-        PyErr_Clear();
     }
 
     auto locals = py::dict("is_keyerror"_a = false, "message"_a = "not set");

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -144,8 +144,12 @@ TEST_CASE("Import error handling") {
         try:
             import throw_error_already_set
         except ImportError as e:
-            is_keyerror = type(e.__cause__) == KeyError
-            message = str(e.__cause__)
+            # TODO: Undo temporary workaround for PYBIND11_CATCH_INIT_EXCEPTIONS issue
+            #       that exists already on master (see PR #3965).
+            # is_keyerror = type(e.__cause__) == KeyError
+            # message = str(e.__cause__)
+            is_keyerror = "KeyError" in str(e)
+            message = str(e).split()[-1]
     )",
              py::globals(),
              locals);

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -73,6 +73,7 @@ TEST_SUBMODULE(eval_, m) {
         try {
             py::eval("nonsense code ...");
         } catch (py::error_already_set &) {
+            PyErr_Clear();
             return true;
         }
         return false;

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -228,9 +228,7 @@ TEST_SUBMODULE(exceptions, m) {
             PyErr_SetString(PyExc_ValueError, "foo");
             throw py::error_already_set();
         }
-        auto result = py::detail::error_string();
-        PyErr_Clear();
-        return result;
+        return py::get_error_string_and_clear_error();
     });
 
     m.def("python_call_in_destructor", [](const py::dict &d) {
@@ -258,9 +256,7 @@ TEST_SUBMODULE(exceptions, m) {
                   f(*args);
               } catch (py::error_already_set &ex) {
                   if (ex.matches(exc_type)) {
-                      auto msg = py::detail::error_string();
-                      PyErr_Clear();
-                      py::print(msg);
+                      py::print(py::get_error_string_and_clear_error());
                   } else {
                       throw;
                   }

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -14,9 +14,7 @@ def test_std_exception(msg):
 
 
 def test_error_already_set(msg):
-    with pytest.raises(RuntimeError) as excinfo:
-        m.throw_already_set(False)
-    assert msg(excinfo.value) == "Unknown internal error occurred"
+    assert m.throw_already_set(False) == "Unknown internal error occurred"
 
     with pytest.raises(ValueError) as excinfo:
         m.throw_already_set(True)

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -162,7 +162,8 @@ static int data_i = 42;
 TEST_SUBMODULE(numpy_array, sm) {
     try {
         py::module_::import("numpy");
-    } catch (...) {
+    } catch (const py::error_already_set &) {
+        PyErr_Clear();
         return;
     }
 

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -301,7 +301,8 @@ struct B {};
 TEST_SUBMODULE(numpy_dtypes, m) {
     try {
         py::module_::import("numpy");
-    } catch (...) {
+    } catch (py::error_already_set &) {
+        PyErr_Clear();
         return;
     }
 

--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -22,7 +22,8 @@ double my_func(int x, float y, double z) {
 TEST_SUBMODULE(numpy_vectorize, m) {
     try {
         py::module_::import("numpy");
-    } catch (...) {
+    } catch (py::error_already_set &) {
+        PyErr_Clear();
         return;
     }
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -243,11 +243,13 @@ TEST_SUBMODULE(pytypes, m) {
         try {
             o.attr("sub").attr("missing").ptr();
         } catch (const py::error_already_set &) {
+            PyErr_Clear();
             d["missing_attr_ptr"] = "raised"_s;
         }
         try {
             o.attr("missing").attr("doesn't matter");
         } catch (const py::error_already_set &) {
+            PyErr_Clear();
             d["missing_attr_chain"] = "raised"_s;
         }
 
@@ -269,6 +271,7 @@ TEST_SUBMODULE(pytypes, m) {
         try {
             existing_t[0] = 1;
         } catch (const py::error_already_set &) {
+            PyErr_Clear();
             // --> Python system error
             // Only new tuples (refcount == 1) are mutable
             auto new_t = py::tuple(3);

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -132,7 +132,8 @@ TEST_SUBMODULE(stl_binders, m) {
     // The rest depends on numpy:
     try {
         py::module_::import("numpy");
-    } catch (...) {
+    } catch (py::error_already_set &) {
+        PyErr_Clear();
         return;
     }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Adopts the Boost.Python approach for `error_already_set`.

Motivations (see PR #1895):

* Fixes undefined behavior of existing `error_already_set` copy constructor: it is very unlikely to trigger Python reference count corruption, but that is a possibility in the general case.
* Maximizes performance, in particular avoids building `what()`, which is very rarely actually used.

**This is a breaking change.**

Based on the changes to the unit tests, I believe most required adjustments in user code are backward compatible:

* Additionally needed `PyErr_Clear();` are no-ops with released pybind11 versions.

It seems to be very rare that `what()` is called. `#ifdef`s (in user code) will be needed to replace those calls in a backward-compatible way.

More work is needed to be sure that there are no bigger obstacles.

See also:
* https://github.com/pybind/pybind11/pull/1895#issuecomment-1124576917
* https://github.com/pybind/pybind11/pull/1895#issuecomment-1131356883

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
