### PR TITLE
(perf): use an rvalue cast in func_wrapper

### DIFF
--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -98,8 +98,8 @@ public:
             explicit func_wrapper(func_handle &&hf) noexcept : hfunc(std::move(hf)) {}
             Return operator()(Args... args) const {
                 gil_scoped_acquire acq;
-                object retval(hfunc.f(std::forward<Args>(args)...));
-                return retval.template cast<Return>();
+                // rvalue cast the returned object
+                return object(hfunc.f(std::forward<Args>(args)...)).template cast<Return>();
             }
         };
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
PR: #3949 Fixed rvalue casts to python objects. This allows us to do an rvalue cast on the return values from func_wrappers. This optimization removes an extra incref, decref, and may further optimize the ctors / dtor in C++17 through ellision depending on the return type.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* (perf): optimize c++ to python function casting by using rvalue an cast
```

<!-- If the upgrade guide needs updating, note that here too -->
