### PR TITLE
perf: Add object rvalue overload for accessors. Enables reference stealing

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2057,17 +2057,18 @@ struct enum_base {
             [](const object &arg) { return int_(arg); }, name("__hash__"), is_method(m_base));
     }
 
-    PYBIND11_NOINLINE void value(char const *name_, object value, const char *doc = nullptr) {
+    PYBIND11_NOINLINE void
+    value(char const *name_, const object &value, const char *doc = nullptr) {
         dict entries = m_base.attr("__entries");
         str name(name_);
         if (entries.contains(name)) {
             std::string type_name = (std::string) str(m_base.attr("__name__"));
-            throw value_error(type_name + ": element \"" + std::string(name_)
+            throw value_error(std::move(type_name) + ": element \"" + std::string(name_)
                               + "\" already exists!");
         }
 
         entries[name] = std::make_pair(value, doc);
-        m_base.attr(name) = value;
+        m_base.attr(std::move(name)) = value;
     }
 
     PYBIND11_NOINLINE void export_values() {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2610,7 +2610,7 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
     }
 
     auto write = file.attr("write");
-    write(line);
+    write(std::move(line));
     write(kwargs.contains("end") ? kwargs["end"] : str("\n"));
 
     if (kwargs.contains("flush") && kwargs["flush"].cast<bool>()) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2064,8 +2064,7 @@ struct enum_base {
             [](const object &arg) { return int_(arg); }, name("__hash__"), is_method(m_base));
     }
 
-    PYBIND11_NOINLINE void
-    value(char const *name_, const object &value, const char *doc = nullptr) {
+    PYBIND11_NOINLINE void value(char const *name_, object value, const char *doc = nullptr) {
         dict entries = m_base.attr("__entries");
         str name(name_);
         if (entries.contains(name)) {
@@ -2075,7 +2074,7 @@ struct enum_base {
         }
 
         entries[name] = std::make_pair(value, doc);
-        m_base.attr(std::move(name)) = value;
+        m_base.attr(std::move(name)) = std::move(value);
     }
 
     PYBIND11_NOINLINE void export_values() {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -87,7 +87,7 @@ public:
     item_accessor operator[](handle key) const;
     /// See above (the only difference is that they key is provided as a string literal)
     item_accessor operator[](const char *key) const;
-    /// See above (the only difference is that they key's reference is stolen)
+    /// See above (the only difference is that the key's reference is stolen)
     item_accessor operator[](object &&key) const;
 
     /** \rst
@@ -99,7 +99,7 @@ public:
     obj_attr_accessor attr(handle key) const;
     /// See above (the only difference is that they key is provided as a string literal)
     str_attr_accessor attr(const char *key) const;
-    /// See below  (only difference is that the key's reference is stolen)
+    /// See above (only difference is that the key's reference is stolen)
     obj_attr_accessor attr(object &&key) const;
 
     /** \rst

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -85,7 +85,7 @@ public:
         or `object` subclass causes a call to ``__setitem__``.
     \endrst */
     item_accessor operator[](handle key) const;
-    /// See above (the only difference is that they key is provided as a string literal)
+    /// See above (the only difference is that the key is provided as a string literal)
     item_accessor operator[](const char *key) const;
     /// See above (the only difference is that the key's reference is stolen)
     item_accessor operator[](object &&key) const;
@@ -97,9 +97,9 @@ public:
         or `object` subclass causes a call to ``setattr``.
     \endrst */
     obj_attr_accessor attr(handle key) const;
-    /// See above (the only difference is that they key is provided as a string literal)
+    /// See above (the only difference is that the key is provided as a string literal)
     str_attr_accessor attr(const char *key) const;
-    /// See above (only difference is that the key's reference is stolen)
+    /// See above (the only difference is that the key's reference is stolen)
     obj_attr_accessor attr(object &&key) const;
 
     /** \rst

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -85,10 +85,10 @@ public:
         or `object` subclass causes a call to ``__setitem__``.
     \endrst */
     item_accessor operator[](handle key) const;
-    /// See above (the only difference is that the key is provided as a string literal)
-    item_accessor operator[](const char *key) const;
     /// See above (the only difference is that the key's reference is stolen)
     item_accessor operator[](object &&key) const;
+    /// See above (the only difference is that the key is provided as a string literal)
+    item_accessor operator[](const char *key) const;
 
     /** \rst
         Return an internal functor to access the object's attributes. Casting the
@@ -97,10 +97,10 @@ public:
         or `object` subclass causes a call to ``setattr``.
     \endrst */
     obj_attr_accessor attr(handle key) const;
-    /// See above (the only difference is that the key is provided as a string literal)
-    str_attr_accessor attr(const char *key) const;
     /// See above (the only difference is that the key's reference is stolen)
     obj_attr_accessor attr(object &&key) const;
+    /// See above (the only difference is that the key is provided as a string literal)
+    str_attr_accessor attr(const char *key) const;
 
     /** \rst
         Matches * unpacking in Python, e.g. to unpack arguments out of a ``tuple``

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1687,7 +1687,7 @@ public:
     bool empty() const { return size() == 0; }
     detail::tuple_accessor operator[](size_t index) const { return {*this, index}; }
     detail::item_accessor operator[](handle h) const { return object::operator[](h); }
-    detail::item_accessor operator[](object &&k) const { return object::operator[](k); }
+    detail::item_accessor operator[](object &&o) const { return object::operator[](std::move(o)); }
     detail::tuple_iterator begin() const { return {*this, 0}; }
     detail::tuple_iterator end() const { return {*this, PyTuple_GET_SIZE(m_ptr)}; }
 };
@@ -1748,7 +1748,7 @@ public:
     bool empty() const { return size() == 0; }
     detail::sequence_accessor operator[](size_t index) const { return {*this, index}; }
     detail::item_accessor operator[](handle h) const { return object::operator[](h); }
-    detail::item_accessor operator[](object &&k) const { return object::operator[](k); }
+    detail::item_accessor operator[](object &&o) const { return object::operator[](std::move(o)); }
     detail::sequence_iterator begin() const { return {*this, 0}; }
     detail::sequence_iterator end() const { return {*this, PySequence_Size(m_ptr)}; }
 };
@@ -1768,7 +1768,7 @@ public:
     bool empty() const { return size() == 0; }
     detail::list_accessor operator[](size_t index) const { return {*this, index}; }
     detail::item_accessor operator[](handle h) const { return object::operator[](h); }
-    detail::item_accessor operator[](object &&k) const { return object::operator[](k); }
+    detail::item_accessor operator[](object &&o) const { return object::operator[](std::move(o)); }
     detail::list_iterator begin() const { return {*this, 0}; }
     detail::list_iterator end() const { return {*this, PyList_GET_SIZE(m_ptr)}; }
     template <typename T>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -689,8 +689,8 @@ public:
     }
 
 private:
-    object ensure_object(object &&o) { return std::move(o); }
-    object ensure_object(handle h) { return reinterpret_borrow<object>(h); }
+    static object ensure_object(object &&o) { return std::move(o); }
+    static object ensure_object(handle h) { return reinterpret_borrow<object>(h); }
 
     object &get_cache() const {
         if (!cache) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -661,7 +661,7 @@ public:
     }
     template <typename T>
     void operator=(T &&value) & {
-        get_cache() = reinterpret_borrow<object>(object_or_cast(std::forward<T>(value)));
+        get_cache() = ensure_object(object_or_cast(std::forward<T>(value)));
     }
 
     template <typename T = Policy>
@@ -689,6 +689,9 @@ public:
     }
 
 private:
+    object ensure_object(object &&o) { return std::move(o); }
+    object ensure_object(handle h) { return reinterpret_borrow<object>(h); }
+
     object &get_cache() const {
         if (!cache) {
             cache = Policy::get(obj, key);

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1689,8 +1689,10 @@ public:
     size_t size() const { return (size_t) PyTuple_Size(m_ptr); }
     bool empty() const { return size() == 0; }
     detail::tuple_accessor operator[](size_t index) const { return {*this, index}; }
-    detail::item_accessor operator[](handle h) const { return object::operator[](h); }
-    detail::item_accessor operator[](object &&o) const { return object::operator[](std::move(o)); }
+    template <typename T, detail::enable_if_t<detail::is_pyobject<T>::value, int> = 0>
+    detail::item_accessor operator[](T o) const {
+        return object::operator[](std::forward<T>(o));
+    }
     detail::tuple_iterator begin() const { return {*this, 0}; }
     detail::tuple_iterator end() const { return {*this, PyTuple_GET_SIZE(m_ptr)}; }
 };
@@ -1750,8 +1752,10 @@ public:
     }
     bool empty() const { return size() == 0; }
     detail::sequence_accessor operator[](size_t index) const { return {*this, index}; }
-    detail::item_accessor operator[](handle h) const { return object::operator[](h); }
-    detail::item_accessor operator[](object &&o) const { return object::operator[](std::move(o)); }
+    template <typename T, detail::enable_if_t<detail::is_pyobject<T>::value, int> = 0>
+    detail::item_accessor operator[](T o) const {
+        return object::operator[](std::forward<T>(o));
+    }
     detail::sequence_iterator begin() const { return {*this, 0}; }
     detail::sequence_iterator end() const { return {*this, PySequence_Size(m_ptr)}; }
 };
@@ -1770,8 +1774,10 @@ public:
     size_t size() const { return (size_t) PyList_Size(m_ptr); }
     bool empty() const { return size() == 0; }
     detail::list_accessor operator[](size_t index) const { return {*this, index}; }
-    detail::item_accessor operator[](handle h) const { return object::operator[](h); }
-    detail::item_accessor operator[](object &&o) const { return object::operator[](std::move(o)); }
+    template <typename T, detail::enable_if_t<detail::is_pyobject<T>::value, int> = 0>
+    detail::item_accessor operator[](T o) const {
+        return object::operator[](std::forward<T>(o));
+    }
     detail::list_iterator begin() const { return {*this, 0}; }
     detail::list_iterator end() const { return {*this, PyList_GET_SIZE(m_ptr)}; }
     template <typename T>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2073,24 +2073,24 @@ iterator object_api<D>::end() const {
     return iterator::sentinel();
 }
 template <typename D>
-item_accessor object_api<D>::operator[](object &&key) const {
-    return {derived(), std::move(key)};
-}
-template <typename D>
 item_accessor object_api<D>::operator[](handle key) const {
     return {derived(), reinterpret_borrow<object>(key)};
+}
+template <typename D>
+item_accessor object_api<D>::operator[](object &&key) const {
+    return {derived(), std::move(key)};
 }
 template <typename D>
 item_accessor object_api<D>::operator[](const char *key) const {
     return {derived(), pybind11::str(key)};
 }
 template <typename D>
-obj_attr_accessor object_api<D>::attr(object &&key) const {
-    return {derived(), std::move(key)};
-}
-template <typename D>
 obj_attr_accessor object_api<D>::attr(handle key) const {
     return {derived(), reinterpret_borrow<object>(key)};
+}
+template <typename D>
+obj_attr_accessor object_api<D>::attr(object &&key) const {
+    return {derived(), std::move(key)};
 }
 template <typename D>
 str_attr_accessor object_api<D>::attr(const char *key) const {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1690,7 +1690,7 @@ public:
     bool empty() const { return size() == 0; }
     detail::tuple_accessor operator[](size_t index) const { return {*this, index}; }
     template <typename T, detail::enable_if_t<detail::is_pyobject<T>::value, int> = 0>
-    detail::item_accessor operator[](T o) const {
+    detail::item_accessor operator[](T &&o) const {
         return object::operator[](std::forward<T>(o));
     }
     detail::tuple_iterator begin() const { return {*this, 0}; }
@@ -1753,7 +1753,7 @@ public:
     bool empty() const { return size() == 0; }
     detail::sequence_accessor operator[](size_t index) const { return {*this, index}; }
     template <typename T, detail::enable_if_t<detail::is_pyobject<T>::value, int> = 0>
-    detail::item_accessor operator[](T o) const {
+    detail::item_accessor operator[](T &&o) const {
         return object::operator[](std::forward<T>(o));
     }
     detail::sequence_iterator begin() const { return {*this, 0}; }
@@ -1775,7 +1775,7 @@ public:
     bool empty() const { return size() == 0; }
     detail::list_accessor operator[](size_t index) const { return {*this, index}; }
     template <typename T, detail::enable_if_t<detail::is_pyobject<T>::value, int> = 0>
-    detail::item_accessor operator[](T o) const {
+    detail::item_accessor operator[](T &&o) const {
         return object::operator[](std::forward<T>(o));
     }
     detail::list_iterator begin() const { return {*this, 0}; }

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -128,7 +128,7 @@ struct map_caster {
             if (!key || !value) {
                 return handle();
             }
-            d[key] = value;
+            d[std::move(key)] = std::move(value);
         }
         return d.release();
     }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -613,8 +613,8 @@ TEST_SUBMODULE(pytypes, m) {
         return v * v;
     });
 
-    m.def("tuple_rvalue_attr", [](const py::tuple &tup) {
-        // tests assigning rvalue objects to tuple
+    m.def("tuple_rvalue_getter", [](const py::tuple &tup) {
+        // tests accessing tuple object with rvalue int
         for (size_t i = 0; i < tup.size(); i++) {
             auto o = py::handle(tup[py::int_(i)]);
             if (!o) {
@@ -623,8 +623,8 @@ TEST_SUBMODULE(pytypes, m) {
         }
         return tup;
     });
-    m.def("list_rvalue_attr", [](const py::list &l) {
-        // tests assigning rvalue objects to tuple
+    m.def("list_rvalue_getter", [](const py::list &l) {
+        // tests accessing list with rvalue int
         for (size_t i = 0; i < l.size(); i++) {
             auto o = py::handle(l[py::int_(i)]);
             if (!o) {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -633,4 +633,11 @@ TEST_SUBMODULE(pytypes, m) {
         }
         return l;
     });
+    m.def("populate_dict_rvalue", [](int population) {
+        auto d = py::dict();
+        for (int i = 0; i < population; i++) {
+            d[py::int_(i)] = py::int_(i);
+        }
+        return d;
+    });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -640,4 +640,10 @@ TEST_SUBMODULE(pytypes, m) {
         }
         return d;
     });
+    m.def("populate_obj_str_attrs", [](py::object &o, int population) {
+        for (int i = 0; i < population; i++) {
+            o.attr(py::str(py::int_(i))) = py::str(py::int_(i));
+        }
+        return o;
+    });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -7,7 +7,6 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include "pybind11/detail/common.h"
 #include "pybind11_tests.h"
 
 #include <utility>

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -7,6 +7,7 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
+#include "pybind11/detail/common.h"
 #include "pybind11_tests.h"
 
 #include <utility>
@@ -611,5 +612,26 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("square_float_", [](const external::float_ &x) -> double {
         double v = x.get_value();
         return v * v;
+    });
+
+    m.def("tuple_rvalue_attr", [](const py::tuple &tup) {
+        // tests assigning rvalue objects to tuple
+        for (size_t i = 0; i < tup.size(); i++) {
+            auto o = py::handle(tup[py::int_(i)]);
+            if (!o) {
+                throw py::value_error("tuple is malformed");
+            }
+        }
+        return tup;
+    });
+    m.def("list_rvalue_attr", [](const py::list &l) {
+        // tests assigning rvalue objects to tuple
+        for (size_t i = 0; i < l.size(); i++) {
+            auto o = py::handle(l[py::int_(i)]);
+            if (!o) {
+                throw py::value_error("list is malformed");
+            }
+        }
+        return l;
     });
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -700,13 +700,13 @@ def test_external_float_():
     assert r1 == 4.0
 
 
-def test_tuple_rvalue_attr():
+def test_tuple_rvalue_getter():
     pop = 1000
     tup = tuple(range(pop))
-    m.tuple_rvalue_attr(tup)
+    m.tuple_rvalue_getter(tup)
 
 
-def test_list_rvalue_attr():
+def test_list_rvalue_getter():
     pop = 1000
     my_list = list(range(pop))
-    m.list_rvalue_attr(my_list)
+    m.list_rvalue_getter(my_list)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -698,3 +698,15 @@ def test_implementation_details():
 def test_external_float_():
     r1 = m.square_float_(2.0)
     assert r1 == 4.0
+
+
+def test_tuple_rvalue_attr():
+    pop = 1000
+    tup = tuple(range(pop))
+    m.tuple_rvalue_attr(tup)
+
+
+def test_list_rvalue_attr():
+    pop = 1000
+    my_list = list(range(pop))
+    m.list_rvalue_attr(my_list)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -710,3 +710,9 @@ def test_list_rvalue_getter():
     pop = 1000
     my_list = list(range(pop))
     m.list_rvalue_getter(my_list)
+
+
+def test_populate_dict_rvalue():
+    pop = 1000
+    my_dict = {i: i for i in range(pop)}
+    assert m.populate_dict_rvalue(pop) == my_dict

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -322,7 +322,7 @@ def test_accessor_moves():
     inc_refs = m.accessor_moves()
     if inc_refs:
         # To be changed in PR #3970: [1, 0, 1, 0, ...]
-        assert inc_refs == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        assert inc_refs == [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
     else:
         pytest.skip("Not defined: PYBIND11_HANDLE_REF_DEBUG")
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1,5 +1,6 @@
 import contextlib
 import sys
+import types
 
 import pytest
 
@@ -716,3 +717,12 @@ def test_populate_dict_rvalue():
     pop = 1000
     my_dict = {i: i for i in range(pop)}
     assert m.populate_dict_rvalue(pop) == my_dict
+
+
+def test_populate_obj_str_attrs():
+    pop = 1000
+    o = types.SimpleNamespace(**{str(i): i for i in range(pop)})
+    new_o = m.populate_obj_str_attrs(o, pop)
+    new_attrs = {k: v for k, v in new_o.__dict__.items() if not k.startswith("_")}
+    assert all(isinstance(v, str) for v in new_attrs.values())
+    assert len(new_attrs) == pop

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -321,7 +321,6 @@ def test_accessors():
 def test_accessor_moves():
     inc_refs = m.accessor_moves()
     if inc_refs:
-        # To be changed in PR #3970: [1, 0, 1, 0, ...]
         assert inc_refs == [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
     else:
         pytest.skip("Not defined: PYBIND11_HANDLE_REF_DEBUG")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The attr accessors had a fairly inefficient code path. Specifically, every access of that use a py::object to access it (like a py::str, py::int_, etc...), was converted to a handle and then copied back into an object, causing unnecessary reference count operations (INCREF/DECREF). We can simplify this significantly for the common case of accessing an attr using an rvalue. We just need to add an additional `object&&` specialization and using the corresponding move ctor. This doesn't change directly observable behavior, it's just a simple performance optimization eliminating unnecessary reference count operations by using the object's move ctor. 

Testing has observed up to 30% speed up in code with heavy attr accesses. Any code that accesses key or values of accessor with rvalues should benefit. 
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Added an accessor overload of `(object &&key)`to reference steal the object when using python types as keys. This prevents unnecessary reference count overhead for attr, dictionary, tuple, and sequence look ups. Added additional regression tests.
* Fixed a performance bug the caused accessor assignments to potentially perform unnecessary copies. 
```

<!-- If the upgrade guide needs updating, note that here too -->
