### PR TITLE
Move `PyErr_NormalizeException()` up a few lines

### DIFF
--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -478,6 +478,8 @@ PYBIND11_NOINLINE std::string error_string() {
 
     error_scope scope; // Preserve error state
 
+    PyErr_NormalizeException(&scope.type, &scope.value, &scope.trace);
+
     std::string errorString;
     if (scope.type) {
         errorString += handle(scope.type).attr("__name__").cast<std::string>();
@@ -486,9 +488,6 @@ PYBIND11_NOINLINE std::string error_string() {
     if (scope.value) {
         errorString += (std::string) str(scope.value);
     }
-
-    PyErr_NormalizeException(&scope.type, &scope.value, &scope.trace);
-
     if (scope.trace != nullptr) {
         PyException_SetTraceback(scope.value, scope.trace);
     }

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -479,6 +479,9 @@ PYBIND11_NOINLINE std::string error_string() {
     error_scope scope; // Preserve error state
 
     PyErr_NormalizeException(&scope.type, &scope.value, &scope.trace);
+    if (scope.trace != nullptr) {
+        PyException_SetTraceback(scope.value, scope.trace);
+    }
 
     std::string errorString;
     if (scope.type) {
@@ -487,9 +490,6 @@ PYBIND11_NOINLINE std::string error_string() {
     }
     if (scope.value) {
         errorString += (std::string) str(scope.value);
-    }
-    if (scope.trace != nullptr) {
-        PyException_SetTraceback(scope.value, scope.trace);
     }
 
 #if !defined(PYPY_VERSION)

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -305,6 +305,6 @@ TEST_SUBMODULE(exceptions, m) {
         std::string what = py::error_already_set().what();
         bool py_err_set_after_what = (PyErr_Occurred() != nullptr);
         PyErr_Clear();
-        return py::make_tuple(what, py_err_set_after_what);
+        return py::make_tuple(std::move(what), py_err_set_after_what);
     });
 }

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -299,4 +299,12 @@ TEST_SUBMODULE(exceptions, m) {
             std::throw_with_nested(std::runtime_error("Outer Exception"));
         }
     });
+
+    m.def("error_already_set_what", [](const py::object &exc_type, const py::object &exc_value) {
+        PyErr_SetObject(exc_type.ptr(), exc_value.ptr());
+        std::string what = py::error_already_set().what();
+        bool py_err_set_after_what = (PyErr_Occurred() != nullptr);
+        PyErr_Clear();
+        return py::make_tuple(what, py_err_set_after_what);
+    });
 }

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -270,3 +270,54 @@ def test_local_translator(msg):
         m.throws_local_simple_error()
     assert not isinstance(excinfo.value, cm.LocalSimpleException)
     assert msg(excinfo.value) == "this mod"
+
+
+class FlakyException(Exception):
+    def __init__(self, failure_point):
+        if failure_point == "failure_point_init":
+            raise ValueError("triggered_failure_point_init")
+        self.failure_point = failure_point
+
+    def __str__(self):
+        if self.failure_point == "failure_point_str":
+            raise ValueError("triggered_failure_point_str")
+        return "FlakyException.__str__"
+
+
+@pytest.mark.parametrize(
+    "exc_type, exc_value, expected_what",
+    (
+        (ValueError, "plain_str", "ValueError: plain_str"),
+        (ValueError, ("tuple_elem",), "ValueError: ('tuple_elem',)"),
+        (FlakyException, ("happy",), "FlakyException: ('happy',)"),
+    ),
+)
+def test_error_already_set_what_with_happy_exceptions(
+    exc_type, exc_value, expected_what
+):
+    what, py_err_set_after_what = m.error_already_set_what(exc_type, exc_value)
+    assert not py_err_set_after_what
+    assert what == expected_what
+
+
+def test_flaky_exception_failure_point_init():
+    what, py_err_set_after_what = m.error_already_set_what(
+        FlakyException, ("failure_point_init",)
+    )
+    assert not py_err_set_after_what
+    lines = what.splitlines()
+    # PyErr_NormalizeException replaces the original FlakyException with ValueError:
+    assert lines[:3] == ["FlakyException: ('failure_point_init',)", "", "At:"]
+    # Checking the first two lines of the traceback as formatted in error_string(),
+    # which is actually for a different exception (ValueError)!
+    assert "test_exceptions.py(" in lines[3]
+    assert lines[3].endswith("): __init__")
+    assert lines[4].endswith("): test_flaky_exception_failure_point_init")
+
+
+def test_flaky_exception_failure_point_str():
+    what, py_err_set_after_what = m.error_already_set_what(
+        FlakyException, ("failure_point_str",)
+    )
+    assert not py_err_set_after_what
+    assert what == "FlakyException: ('failure_point_str',)"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -300,6 +300,7 @@ def test_error_already_set_what_with_happy_exceptions(
     assert what == expected_what
 
 
+@pytest.mark.skipif("env.PYPY", reason="PyErr_NormalizeException Segmentation fault")
 def test_flaky_exception_failure_point_init():
     what, py_err_set_after_what = m.error_already_set_what(
         FlakyException, ("failure_point_init",)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The only production code change is to move `PyErr_NormalizeException()` up a few lines in `detail::error_string()`.

The 1st commit (e564142bb5e2c324e581a7bac8371f0c0ff5dc36) purely adds test coverage, without making changes to the production code. This effectively documents the current `error_already_set::what()` behavior.

The 2nd commit (254bfeb2a0f906b523c62825999d1ab8a2a4da7c) moves `PyErr_NormalizeException()` up a few lines in `detail::error_string()` and adjusts the new tests accordingly, effectively documenting the behavior change, which can be summarized as:

* It fixes the "happy" tests.
* The behavior for the two corner cases has more integrity but is still not really great. This was already addressed under PR #1895.

Note that all existing tests pass as-is! Only the newly added tests need adjustments.

Background: The production code change was adopted from PR #3964. The new tests are based on similar code under PR #1895. PR #1895 has several behavior changes. This PR handles one behavior change in isolation, for easier review and a clearer development history.
 
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
`error_already_set::what()` now handles non-normalized exceptions correctly.
```

<!-- If the upgrade guide needs updating, note that here too -->
