### PR TITLE
Add missing error handling to `module_::def_submodule`

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1173,9 +1173,16 @@ public:
             py::module_ m3 = m2.def_submodule("subsub", "A submodule of 'example.sub'");
     \endrst */
     module_ def_submodule(const char *name, const char *doc = nullptr) {
-        std::string full_name
-            = std::string(PyModule_GetName(m_ptr)) + std::string(".") + std::string(name);
-        auto result = reinterpret_borrow<module_>(PyImport_AddModule(full_name.c_str()));
+        const char *this_name = PyModule_GetName(m_ptr);
+        if (this_name == nullptr) {
+            throw error_already_set();
+        }
+        std::string full_name = std::string(this_name) + "." + name;
+        handle submodule = PyImport_AddModule(full_name.c_str());
+        if (!submodule) {
+            throw error_already_set();
+        }
+        auto result = reinterpret_borrow<module_>(submodule);
         if (doc && options::show_user_defined_docstrings()) {
             result.attr("__doc__") = pybind11::str(doc);
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1177,7 +1177,7 @@ public:
         if (this_name == nullptr) {
             throw error_already_set();
         }
-        std::string full_name = std::string(this_name) + "." + name;
+        std::string full_name = std::string(this_name) + '.' + name;
         handle submodule = PyImport_AddModule(full_name.c_str());
         if (!submodule) {
             throw error_already_set();

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -120,4 +120,6 @@ TEST_SUBMODULE(modules, m) {
 
         return failures;
     });
+
+    m.def("def_submodule", [](py::module_ m, const char *name) { return m.def_submodule(name); });
 }

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,5 +1,6 @@
 import pytest
 
+import env
 from pybind11_tests import ConstructorStats
 from pybind11_tests import modules as m
 from pybind11_tests.modules import subsubmodule as ms
@@ -93,23 +94,28 @@ def test_builtin_key_type():
     assert {type(k) for k in keys} == {str}
 
 
+@pytest.mark.xfail("env.PYPY", reason="PyModule_GetName()")
 def test_def_submodule_failures():
     sm = m.def_submodule(m, b"ScratchSubModuleName")  # Using bytes to show it works.
     assert sm.__name__ == m.__name__ + "." + "ScratchSubModuleName"
     malformed_utf8 = b"\x80"
-    # Meant to exercise PyModule_GetName():
-    sm_name_orig = sm.__name__
-    sm.__name__ = malformed_utf8
-    try:
-        with pytest.raises(Exception):
-            # Seen with Python 3.9: SystemError: nameless module
-            # But we do not want to exercise the internals of PyModule_GetName(), which could
-            # change in future versions of Python, but a bad __name__ is very likely to cause
-            # some kind of failure indefinitely.
-            m.def_submodule(sm, b"SubSubModuleName")
-    finally:
-        # Clean up to ensure nothing gets upset by a module with an invalid __name__.
-        sm.__name__ = sm_name_orig  # Purely precautionary.
-    # Meant to exercise PyImport_AddModule():
+    if env.PYPY:
+        # It is not worth the effort finding a trigger for a failure when running with PyPy.
+        pytest.skip("Sufficiently exercised on platforms other than PyPy.")
+    else:
+        # Meant to trigger PyModule_GetName() failure:
+        sm_name_orig = sm.__name__
+        sm.__name__ = malformed_utf8
+        try:
+            with pytest.raises(Exception):
+                # Seen with Python 3.9: SystemError: nameless module
+                # But we do not want to exercise the internals of PyModule_GetName(), which could
+                # change in future versions of Python, but a bad __name__ is very likely to cause
+                # some kind of failure indefinitely.
+                m.def_submodule(sm, b"SubSubModuleName")
+        finally:
+            # Clean up to ensure nothing gets upset by a module with an invalid __name__.
+            sm.__name__ = sm_name_orig  # Purely precautionary.
+    # Meant to trigger PyImport_AddModule() failure:
     with pytest.raises(UnicodeDecodeError):
         m.def_submodule(sm, malformed_utf8)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Extracted from PR #3964, where the missing error handling happened to cause some confusion.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
`module_::def_submodule` was missing proper error handling. This is fixe now.
```

<!-- If the upgrade guide needs updating, note that here too -->
