### PR TITLE
Avoid `catch (...)` for expected `import numpy` failures

### DIFF
--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -162,7 +162,7 @@ static int data_i = 42;
 TEST_SUBMODULE(numpy_array, sm) {
     try {
         py::module_::import("numpy");
-    } catch (...) {
+    } catch (const py::error_already_set &) {
         return;
     }
 

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -301,7 +301,7 @@ struct B {};
 TEST_SUBMODULE(numpy_dtypes, m) {
     try {
         py::module_::import("numpy");
-    } catch (py::error_already_set &) {
+    } catch (const py::error_already_set &) {
         return;
     }
 

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -301,7 +301,7 @@ struct B {};
 TEST_SUBMODULE(numpy_dtypes, m) {
     try {
         py::module_::import("numpy");
-    } catch (...) {
+    } catch (py::error_already_set &) {
         return;
     }
 

--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -22,7 +22,7 @@ double my_func(int x, float y, double z) {
 TEST_SUBMODULE(numpy_vectorize, m) {
     try {
         py::module_::import("numpy");
-    } catch (py::error_already_set &) {
+    } catch (const py::error_already_set &) {
         return;
     }
 

--- a/tests/test_numpy_vectorize.cpp
+++ b/tests/test_numpy_vectorize.cpp
@@ -22,7 +22,7 @@ double my_func(int x, float y, double z) {
 TEST_SUBMODULE(numpy_vectorize, m) {
     try {
         py::module_::import("numpy");
-    } catch (...) {
+    } catch (py::error_already_set &) {
         return;
     }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Extracted from PR #3964, where the `catch (...)` happened to cause significant confusion because they are silently dropping any kind of error. This is likely to cause more confusion in future development work. Narrowing down to `catch (const py::error_already_set &)` is a simple way to significantly reduce the potential for silently dropping important errors (although that is still not perfect).

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
