### PR TITLE
Replace "Unknown internal error occurred" with a more helpful message.

### DIFF
--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -228,7 +228,10 @@ TEST_SUBMODULE(exceptions, m) {
             throw py::error_already_set();
         } catch (const std::runtime_error &e) {
             if ((err && e.what() != std::string("ValueError: foo"))
-                || (!err && e.what() != std::string("Unknown internal error occurred"))) {
+                || (!err
+                    && e.what()
+                           != std::string("Internal error: pybind11::error_already_set called "
+                                          "while Python error indicator not set."))) {
                 PyErr_Clear();
                 throw std::runtime_error("error message mismatch");
             }

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -16,7 +16,10 @@ def test_std_exception(msg):
 def test_error_already_set(msg):
     with pytest.raises(RuntimeError) as excinfo:
         m.throw_already_set(False)
-    assert msg(excinfo.value) == "Unknown internal error occurred"
+    assert (
+        msg(excinfo.value)
+        == "Internal error: pybind11::error_already_set called while Python error indicator not set."
+    )
 
     with pytest.raises(ValueError) as excinfo:
         m.throw_already_set(True)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This PR extracts one particular pair of related behavior changes from PR #1895, to make the development history easier to follow.

* For the public `error_already_set`, the usual net observable behavior change is simply a changed message; see changes in test_exceptions.py. Internally the detour through an artificially generated Python exception is eliminated, a `std::runtime_error` is thrown immediately from the `error_already_set` constructor. The rationale is that the root issue is obviously a C++ coding error.

* The non-public `detail::error_string()` no longer has the surprising side-effect of setting an "Unknown internal error occurred" Python `RuntimeError` if the Python error indicator is not actually set when the function is called. A `std::runtime_error` is thrown instead. Again, the rationale is that the root issue is obviously a C++ coding error.

The source code comments are updated to reflect the behavior changes. While at it, existing behavior & limitations are more fully documented.

Note that these behavior changes passed Google-global testing via PR #1895, without any adjustments to user code. The main benefit of this PR is to improve the development experience (debugging).

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
The behavior or `error_already_set` was made safer and the highly opaque "Unknown internal error occurred" message was replaced with a more helpful message.
```

<!-- If the upgrade guide needs updating, note that here too -->
