### PR TITLE
STL map bind naming fix for Sphinx and Pylance

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -674,11 +674,11 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args &&
 
     Class_ cl(scope, name.c_str(), pybind11::module_local(local), std::forward<Args>(args)...);
     class_<KeysView> keys_view(
-        scope, ("KeysView[" + name + "]").c_str(), pybind11::module_local(local));
+        scope, ("KeysView_" + name).c_str(), pybind11::module_local(local));
     class_<ValuesView> values_view(
-        scope, ("ValuesView[" + name + "]").c_str(), pybind11::module_local(local));
+        scope, ("ValuesView_" + name).c_str(), pybind11::module_local(local));
     class_<ItemsView> items_view(
-        scope, ("ItemsView[" + name + "]").c_str(), pybind11::module_local(local));
+        scope, ("ItemsView_" + name).c_str(), pybind11::module_local(local));
 
     cl.def(init<>());
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Addresses a change in: https://github.com/pybind/pybind11/pull/3310
Discussion/rationale can be found over at: https://github.com/pybind/pybind11/pull/3310#discussion_r887191310

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Fixes the class names generated by ``bind_map``:
- Change the naming from ``*View[name]`` to ``*View_name``
```