### PR TITLE
enable two new clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ cppcoreguidelines-pro-type-static-cast-downcast,
 cppcoreguidelines-slicing,
 google-explicit-constructor,
 llvm-namespace-comment,
+misc-definitions-in-headers,
 misc-misplaced-const,
 misc-non-copyable-objects,
 misc-static-assert,
@@ -17,6 +18,7 @@ misc-throw-by-value-catch-by-reference,
 misc-uniqueptr-reset-release,
 misc-unused-parameters,
 modernize-avoid-bind,
+modernize-loop-convert,
 modernize-make-shared,
 modernize-redundant-void-arg,
 modernize-replace-auto-ptr,
@@ -62,6 +64,8 @@ readability-uniqueptr-delete-release,
 
 CheckOptions:
 - key:             performance-for-range-copy.WarnOnAllAutoCopies
+  value:           true
+- key:             performance-inefficient-string-concatenation.StrictMode
   value:           true
 - key:             performance-unnecessary-value-param.AllowedTypes
   value:           'exception_ptr$;'

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -31,8 +31,8 @@ py::bytes return_bytes() {
 std::string print_bytes(const py::bytes &bytes) {
     std::string ret = "bytes[";
     const auto value = static_cast<std::string>(bytes);
-    for (size_t i = 0; i < value.length(); ++i) {
-        ret += std::to_string(static_cast<int>(value[i])) + " ";
+    for (char i : value) {
+        ret += std::to_string(static_cast<int>(i)) + ' ';
     }
     ret.back() = ']';
     return ret;

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -31,8 +31,8 @@ py::bytes return_bytes() {
 std::string print_bytes(const py::bytes &bytes) {
     std::string ret = "bytes[";
     const auto value = static_cast<std::string>(bytes);
-    for (char i : value) {
-        ret += std::to_string(static_cast<int>(i)) + ' ';
+    for (char c : value) {
+        ret += std::to_string(static_cast<int>(c)) + ' ';
     }
     ret.back() = ']';
     return ret;


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
I enabled a few new clang-tidy checks to harden the code bases. First, misc-definition-in-headers complains about headers issues that are likely to cause ODR problems when included from multiple translation units. The main one is forgetting to ensure that functions are all inline in headers. The 2nd check tries to use modernized for each loops. Luckily, we were already using these in pybind11 except for one test case which has been fixed in this PR. Finally, I changed a default setting for inefficient-string-concatenation to strict mode. We are already following strict mode, so this mainly will just prevent new issues from cropping up.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Enables clang-tidy checks misc-definitions-in-headers and modernize-loop-convert.
```

<!-- If the upgrade guide needs updating, note that here too -->
