### PR TITLE
chore: remove redundant ctor in function cast

### DIFF
--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -99,7 +99,7 @@ public:
             Return operator()(Args... args) const {
                 gil_scoped_acquire acq;
                 // casts the returned object as a rvalue to the return type
-                return object(hfunc.f(std::forward<Args>(args)...)).template cast<Return>();
+                return hfunc.f(std::forward<Args>(args)...).template cast<Return>();
             }
         };
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* I was messing around with some static analysis tools to try to remove all the cstyle casts and realized that the extra ctor was unnecessary and we should always just call cast<>. Some C++ compilers may ellide this ctor, but better to remove it for those that cannot.
<!-- Include relevant issues or PRs here, describe what changed and why -->
