### PR TITLE
chore: optimize dictionary access in strip_padding numpy

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -648,10 +648,9 @@ private:
         std::vector<field_descr> field_descriptors;
         field_descriptors.reserve(field_dict.size());
 
-        for (auto field : field_dict.attr("items")()) {
-            auto spec = field.cast<tuple>();
-            auto name = spec[0].cast<pybind11::str>();
-            auto spec_fo = spec[1].cast<tuple>();
+        for (auto field : field_dict) {
+            auto name = field.first.cast<pybind11::str>();
+            auto spec_fo = field.second.cast<tuple>();
             auto format = spec_fo[0].cast<dtype>();
             auto offset = spec_fo[1].cast<pybind11::int_>();
             if ((len(name) == 0u) && format.kind() == 'V') {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -648,9 +648,10 @@ private:
         std::vector<field_descr> field_descriptors;
         field_descriptors.reserve(field_dict.size());
 
-        for (auto kv_item : field_dict) {
-            auto name = reinterpret_borrow<pybind11::str>(kv_item.first);
-            auto spec_fo = reinterpret_borrow<tuple>(kv_item.second);
+        for (auto field : field_dict.attr("items")()) {
+            auto spec = field.cast<tuple>();
+            auto name = spec[0].cast<pybind11::str>();
+            auto spec_fo = spec[1].cast<tuple>();
             auto format = spec_fo[0].cast<dtype>();
             auto offset = spec_fo[1].cast<pybind11::int_>();
             if ((len(name) == 0u) && format.kind() == 'V') {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -644,9 +644,11 @@ private:
             field_descr(pybind11::str &&name, object &&format, pybind11::int_ &&offset)
                 : name{std::move(name)}, format{std::move(format)}, offset{std::move(offset)} {};
         };
+        auto field_dict = attr("fields").cast<dict>();
         std::vector<field_descr> field_descriptors;
+        field_descriptors.reserve(field_dict.size());
 
-        for (auto field : attr("fields").attr("items")()) {
+        for (auto field : std::move(field_dict).attr("items")()) {
             auto spec = field.cast<tuple>();
             auto name = spec[0].cast<pybind11::str>();
             auto spec_fo = spec[1].cast<tuple>();

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -648,9 +648,9 @@ private:
         std::vector<field_descr> field_descriptors;
         field_descriptors.reserve(field_dict.size());
 
-        for (auto field : field_dict) {
-            auto name = field.first.cast<pybind11::str>();
-            auto spec_fo = field.second.cast<tuple>();
+        for (auto kv_item : field_dict) {
+            auto name = reinterpret_borrow<pybind11::str>(kv_item.first);
+            auto spec_fo = reinterpret_borrow<tuple>(kv_item.second);
             auto format = spec_fo[0].cast<dtype>();
             auto offset = spec_fo[1].cast<pybind11::int_>();
             if ((len(name) == 0u) && format.kind() == 'V') {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -641,6 +641,8 @@ private:
             pybind11::str name;
             object format;
             pybind11::int_ offset;
+            field_descr(pybind11::str &&name, object &&format, pybind11::int_ &&offset)
+                : name{std::move(name)}, format{std::move(format)}, offset{std::move(offset)} {};
         };
         std::vector<field_descr> field_descriptors;
 
@@ -653,8 +655,8 @@ private:
             if ((len(name) == 0u) && format.kind() == 'V') {
                 continue;
             }
-            field_descriptors.push_back(
-                {(pybind11::str) name, format.strip_padding(format.itemsize()), offset});
+            field_descriptors.emplace_back(
+                std::move(name), format.strip_padding(format.itemsize()), std::move(offset));
         }
 
         std::sort(field_descriptors.begin(),

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -648,7 +648,7 @@ private:
         std::vector<field_descr> field_descriptors;
         field_descriptors.reserve(field_dict.size());
 
-        for (auto field : std::move(field_dict).attr("items")()) {
+        for (auto field : field_dict.attr("items")()) {
             auto spec = field.cast<tuple>();
             auto name = spec[0].cast<pybind11::str>();
             auto spec_fo = spec[1].cast<tuple>();


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Further optimize strip_padding by making construction of field_descriptors faster by adding a ctor, using emplace, and trying to use the native C++ APIs for iterating through the dictionary.
<!-- Include relevant issues or PRs here, describe what changed and why -->

