### PR TITLE
Make dtype::num() return type consistent with other functions

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -604,7 +604,7 @@ public:
     }
 
     /// type number of dtype.
-    ssize_t num() const {
+    int num() const {
         // Note: The signature, `dtype::num` follows the naming of NumPy's public
         // Python API (i.e., ``dtype.num``), rather than its internal
         // C API (``PyArray_Descr::type_num``).


### PR DESCRIPTION
## Description

Pybind uses `int` to represent dtype numbers everywhere in the API, except for the newly added `dtype::num()` function, which for some reason uses ssize_t. This commit fixes that and makes it consistent with the other functions.