### PR TITLE
Support loading `unique_ptr<Derived>` as `unique_ptr<Base>`.

### DIFF
--- a/include/pybind11/detail/smart_holder_poc.h
+++ b/include/pybind11/detail/smart_holder_poc.h
@@ -183,8 +183,8 @@ struct smart_holder {
             ensure_vptr_is_using_builtin_delete(context);
         } else if (!(*rtti_requested == *rtti_uqp_del)) {
             if (!(vptr_is_using_builtin_delete && is_std_default_delete<T>(*rtti_requested))) {
-                throw std::invalid_argument(std::string("Incompatible unique_ptr deleter (") + context
-                                            + ").");
+                throw std::invalid_argument(std::string("Incompatible unique_ptr deleter (")
+                                            + context + ").");
             }
         }
     }

--- a/include/pybind11/detail/smart_holder_poc.h
+++ b/include/pybind11/detail/smart_holder_poc.h
@@ -181,11 +181,11 @@ struct smart_holder {
                                             + ").");
             }
             ensure_vptr_is_using_builtin_delete(context);
-        } else if (!(*rtti_requested == *rtti_uqp_del)) {
-            if (!(vptr_is_using_builtin_delete && is_std_default_delete<T>(*rtti_requested))) {
-                throw std::invalid_argument(std::string("Incompatible unique_ptr deleter (")
-                                            + context + ").");
-            }
+        } else if (!(*rtti_requested == *rtti_uqp_del)
+                   && !(vptr_is_using_builtin_delete
+                        && is_std_default_delete<T>(*rtti_requested))) {
+            throw std::invalid_argument(std::string("Incompatible unique_ptr deleter (") + context
+                                        + ").");
         }
     }
 

--- a/include/pybind11/detail/smart_holder_poc.h
+++ b/include/pybind11/detail/smart_holder_poc.h
@@ -182,8 +182,10 @@ struct smart_holder {
             }
             ensure_vptr_is_using_builtin_delete(context);
         } else if (!(*rtti_requested == *rtti_uqp_del)) {
-            throw std::invalid_argument(std::string("Incompatible unique_ptr deleter (") + context
-                                        + ").");
+            if (!(vptr_is_using_builtin_delete && is_std_default_delete<T>(*rtti_requested))) {
+                throw std::invalid_argument(std::string("Incompatible unique_ptr deleter (") + context
+                                            + ").");
+            }
         }
     }
 

--- a/tests/pure_cpp/smart_holder_poc_test.cpp
+++ b/tests/pure_cpp/smart_holder_poc_test.cpp
@@ -39,12 +39,12 @@ private:
 
 struct base {
     virtual int get() { return 10; }
-    virtual ~base() { }
+    virtual ~base() {}
 };
 
-struct derived: public base {
+struct derived : public base {
     int get() override { return 100; }
-    ~derived() override { }
+    ~derived() override {}
 };
 
 } // namespace helpers
@@ -247,8 +247,8 @@ TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base", "[E]") {
 }
 
 TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base2", "[E]") {
-    std::unique_ptr<helpers::derived, helpers::functor_other_delete<helpers::derived>>
-        orig_owner(new helpers::derived());
+    std::unique_ptr<helpers::derived, helpers::functor_other_delete<helpers::derived>> orig_owner(
+        new helpers::derived());
     auto hld = smart_holder::from_unique_ptr(std::move(orig_owner));
     REQUIRE(orig_owner.get() == nullptr);
     REQUIRE_THROWS_WITH(

--- a/tests/pure_cpp/smart_holder_poc_test.cpp
+++ b/tests/pure_cpp/smart_holder_poc_test.cpp
@@ -44,7 +44,6 @@ struct base {
 
 struct derived : public base {
     int get() override { return 100; }
-    ~derived() override = default;
 };
 
 } // namespace helpers
@@ -237,7 +236,7 @@ TEST_CASE("from_unique_ptr+as_shared_ptr", "[S]") {
     REQUIRE(*new_owner == 19);
 }
 
-TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base", "[E]") {
+TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base", "[S]") {
     std::unique_ptr<helpers::derived> orig_owner(new helpers::derived());
     auto hld = smart_holder::from_unique_ptr(std::move(orig_owner));
     REQUIRE(orig_owner.get() == nullptr);
@@ -246,7 +245,7 @@ TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base", "[E]") {
     REQUIRE(new_owner->get() == 100);
 }
 
-TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base2", "[E]") {
+TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base2", "[S]") {
     std::unique_ptr<helpers::derived, helpers::functor_other_delete<helpers::derived>> orig_owner(
         new helpers::derived());
     auto hld = smart_holder::from_unique_ptr(std::move(orig_owner));

--- a/tests/pure_cpp/smart_holder_poc_test.cpp
+++ b/tests/pure_cpp/smart_holder_poc_test.cpp
@@ -39,12 +39,12 @@ private:
 
 struct base {
     virtual int get() { return 10; }
-    virtual ~base() {}
+    virtual ~base() = default;
 };
 
 struct derived : public base {
     int get() override { return 100; }
-    ~derived() override {}
+    ~derived() override = default;
 };
 
 } // namespace helpers

--- a/tests/pure_cpp/smart_holder_poc_test.cpp
+++ b/tests/pure_cpp/smart_holder_poc_test.cpp
@@ -251,8 +251,9 @@ TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base2", "[E]") {
         orig_owner(new helpers::derived());
     auto hld = smart_holder::from_unique_ptr(std::move(orig_owner));
     REQUIRE(orig_owner.get() == nullptr);
-    REQUIRE_THROWS_WITH((hld.as_unique_ptr<int, helpers::functor_builtin_delete<int>>()),
-                        "Incompatible unique_ptr deleter (as_unique_ptr).");
+    REQUIRE_THROWS_WITH(
+        (hld.as_unique_ptr<helpers::base, helpers::functor_builtin_delete<helpers::base>>()),
+        "Incompatible unique_ptr deleter (as_unique_ptr).");
 }
 
 TEST_CASE("from_unique_ptr_with_deleter+as_lvalue_ref", "[S]") {

--- a/tests/pure_cpp/smart_holder_poc_test.cpp
+++ b/tests/pure_cpp/smart_holder_poc_test.cpp
@@ -245,7 +245,7 @@ TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base", "[S]") {
     REQUIRE(new_owner->get() == 100);
 }
 
-TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base2", "[S]") {
+TEST_CASE("from_unique_ptr_derived+as_unique_ptr_base2", "[E]") {
     std::unique_ptr<helpers::derived, helpers::functor_other_delete<helpers::derived>> orig_owner(
         new helpers::derived());
     auto hld = smart_holder::from_unique_ptr(std::move(orig_owner));


### PR DESCRIPTION
## Description
This is to support the following use case. C++ code:
```
class Base {
 public:
  Base() = default;
  virtual int get() { return 10; }
  virtual ~Base() { }
};

class Derived: public Base {
 public:
  static std::unique_ptr<Derived> create() {
    return std::make_unique<Derived>();
  }
  int get() override { return 100; }
  ~Derived() override { }
};

int consume_base(std::unique_ptr<Base> base) {
  return base->get();
}
```

The following should be allowed, but without the change, it raises exception `Incompatible unique_ptr deleter (as_unique_ptr).`:
```
derived = Derived.create();
unique_ptr_deleter.consume_base(derived)
```