### PR TITLE
[docs] Fix "Enumerations and internal types" example

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -482,7 +482,8 @@ The binding code for this example looks as follows:
         .value("Cat", Pet::Kind::Cat)
         .export_values();
 
-    py::class_<Pet::Attributes> attributes(pet, "Attributes")
+    py::class_<Pet::Attributes> attributes(pet, "Attributes");
+    attributes
         .def(py::init<>())
         .def_readwrite("age", &Pet::Attributes::age);
 

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -482,8 +482,7 @@ The binding code for this example looks as follows:
         .value("Cat", Pet::Kind::Cat)
         .export_values();
 
-    py::class_<Pet::Attributes> attributes(pet, "Attributes");
-    attributes
+    py::class_<Pet::Attributes>(pet, "Attributes")
         .def(py::init<>())
         .def_readwrite("age", &Pet::Attributes::age);
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This is a patch for the example mentioned in the title to be built because when building the snippet, I got the build error which includes:

```console
    src/main.cpp:71:60: error: expected ';' at end of declaration
      py::class_<Pet::Attributes> attributes(pet, "Attributes")
                                                               ^
                                                               ;
    1 error generated.

```

Could you kindly let me know if there's a better change?

<!-- Include relevant issues or PRs here, describe what changed and why -->

<!--
## Suggested changelog entry:
-->
<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

<!--
```rst

```
-->

<!-- If the upgrade guide needs updating, note that here too -->
