### PR TITLE
Report `C++ Info:` via `pytest_report_header()`

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -38,6 +38,7 @@
 #            define PYBIND11_CPP17
 #            if __cplusplus >= 202002L
 #                define PYBIND11_CPP20
+// Please update tests/pybind11_tests.cpp `cpp_std()` when adding a macro here.
 #            endif
 #        endif
 #    endif

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,15 +196,18 @@ def gc_collect():
 
 
 def pytest_configure():
-    print(
-        "C++ Info:",
-        pybind11_tests.compiler_info,
-        pybind11_tests.cpp_std,
-        pybind11_tests.PYBIND11_INTERNALS_ID,
-        flush=True,
-    )
+    pytest.suppress = suppress
+    pytest.gc_collect = gc_collect
+
+
+def pytest_report_header(config):
+    del config  # Unused.
     assert (
         pybind11_tests.compiler_info is not None
     ), "Please update pybind11_tests.cpp if this assert fails."
-    pytest.suppress = suppress
-    pytest.gc_collect = gc_collect
+    return (
+        "C++ Info:"
+        f" {pybind11_tests.compiler_info}"
+        f" {pybind11_tests.cpp_std}"
+        f" {pybind11_tests.PYBIND11_INTERNALS_ID}"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import textwrap
 import pytest
 
 # Early diagnostic for failed imports
-import pybind11_tests  # noqa: F401
+import pybind11_tests
 
 _long_marker = re.compile(r"([0-9])L")
 _hexadecimal = re.compile(r"0x[0-9a-fA-F]+")
@@ -196,5 +196,15 @@ def gc_collect():
 
 
 def pytest_configure():
+    print(
+        "C++ Info:",
+        pybind11_tests.compiler_info,
+        pybind11_tests.cpp_std,
+        pybind11_tests.PYBIND11_INTERNALS_ID,
+        flush=True,
+    )
+    assert (
+        pybind11_tests.compiler_info is not None
+    ), "Please update pybind11_tests.cpp if this assert fails."
     pytest.suppress = suppress
     pytest.gc_collect = gc_collect

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -62,8 +62,33 @@ void bind_ConstructorStats(py::module_ &m) {
         });
 }
 
+const char *cpp_std() {
+    return
+#if defined(PYBIND11_CPP20)
+        "C++20";
+#elif defined(PYBIND11_CPP17)
+        "C++17";
+#elif defined(PYBIND11_CPP14)
+        "C++14";
+#else
+        "C++11";
+#endif
+}
+
 PYBIND11_MODULE(pybind11_tests, m) {
     m.doc() = "pybind11 test module";
+
+    // Intentionally kept minimal to not create a maintenance chore
+    // ("just enough" to be conclusive).
+#if defined(_MSC_FULL_VER)
+    m.attr("compiler_info") = "MSVC " PYBIND11_TOSTRING(_MSC_FULL_VER);
+#elif defined(__VERSION__)
+    m.attr("compiler_info") = __VERSION__;
+#else
+    m.attr("compiler_info") = py::none();
+#endif
+    m.attr("cpp_std") = cpp_std();
+    m.attr("PYBIND11_INTERNALS_ID") = PYBIND11_INTERNALS_ID;
 
     bind_ConstructorStats(m);
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Report `C++ Info:` via `pytest_report_header()`, to ease harvesting CI logs, and validating that ci.yml & cmake are working as intended.

Example output with context:
```
Running tests in directory "/usr/local/google/home/rwgk/forked/pybind11/tests":
=========================================================== test session starts ============================================================
platform linux -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
C++ Info: Debian Clang 13.0.1 C++17 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002__
rootdir: /usr/local/google/home/rwgk/forked/pybind11/tests, configfile: pytest.ini
collected 557 items

test_async.py ..                                                                                                                     [  0%]
...
```

Note that there appears to be an existing inconsistency (to be looked at separately):
```
$ grep 'C++ Info:' 3______3_____GCC_10_____C++20____x64.txt

2022-07-06T22:59:10.4150865Z C++ Info: 10.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1014__
```

All results:

* https://github.com/pybind/pybind11/actions/runs/2626097567

```
$ unzip logs_21206.zip

$ simplify_filenames.py .

$ grep 'C++ Info:' *.txt | sed 's/2022-07-06T[^Z]*Z //' | sort -n

1______3.6_____MSVC_2019_____x86.txt:  C++ Info: MSVC 192930145 C++14 __pybind11_internals_v4_msvc_debug__
1______3.6_____ubuntu-latest_____x64_-DPYBIND11_FINDPYTHON=ON_-DCM.txt:C++ Info: 9.4.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
1______3.6_____ubuntu-latest_____x64_-DPYBIND11_FINDPYTHON=ON_-DCM.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v10000000_gcc_libstdcpp_cxxabi1013__
1______3.6_____ubuntu-latest_____x64_-DPYBIND11_FINDPYTHON=ON_-DCM.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
1______3.7_____Debian_____x86______Install.txt:C++ Info: 8.3.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
1______3.8_____CUDA_11.2_____Ubuntu_20.04.txt:C++ Info: 9.4.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
1______3.8_____MSVC_2019__Debug______x86_-DCMAKE_CXX_STANDARD=17.txt:  C++ Info: MSVC 192930145 C++17 __pybind11_internals_v4_msvc_debug__
1______3.9-dbg__deadsnakes______Valgrind_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
1______3.9-dbg__deadsnakes______Valgrind_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
1______3.9_____MSVC_2022_C++20_____x64.txt:  C++ Info: MSVC 193231332 C++20 __pybind11_internals_v4_msvc_debug__
1______3_____CentOS7__PGI_22.3_____x64.txt:C++ Info: EDG g++ 4.8.5 mode C++11 __pybind11_internals_v4_pgi_libstdcpp__
1______3_____centos7_____x64.txt:C++ Info: 4.8.5 20150623 (Red Hat 4.8.5-44) C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1002__
1______3_____Clang_3.6_____C++11_____x64.txt:C++ Info: 4.2.1 Compatible Clang 3.6.2 (tags/RELEASE_362/final) C++11 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002__
1______3_____GCC_7_____C++11____x64.txt:C++ Info: 7.5.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1011__
1______3_____ICC_latest_____x64.txt:C++ Info: Intel(R) C++ g++ 9.4 mode C++11 __pybind11_internals_v4_icc_libstdcpp_cxxabi1010__
1______3_____ICC_latest_____x64.txt:C++ Info: Intel(R) C++ g++ 9.4 mode C++17 __pybind11_internals_v4_icc_libstdcpp_cxxabi1010__
1______3_____windows-latest_____mingw64.txt:C++ Info: 12.1.0 C++11 __pybind11_internals_v4_mingw_libstdcpp_cxxabi1017__
1______3_____windows-latest_____mingw64.txt:C++ Info: 12.1.0 C++14 __pybind11_internals_v4_mingw_libstdcpp_cxxabi1017__
1______3_____windows-latest_____mingw64.txt:C++ Info: 12.1.0 C++17 __pybind11_internals_v4_mingw_libstdcpp_cxxabi1017__
2______3.11-dev__deadsnakes______x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
2______3.7_____MSVC_2019_____x86.txt:  C++ Info: MSVC 192930145 C++14 __pybind11_internals_v4_msvc_debug__
2______3.9_____MSVC_2019__Debug______x86_-DCMAKE_CXX_STANDARD=20.txt:  C++ Info: MSVC 192930145 C++20 __pybind11_internals_v4_msvc_debug__
2______3.9_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
2______3.9_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v10000000_gcc_libstdcpp_cxxabi1013__
2______3.9_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
2______3_____almalinux8_____x64.txt:C++ Info: 8.5.0 20210514 (Red Hat 8.5.0-10) C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
2______3_____Clang_3.7_____C++11_____x64.txt:C++ Info: 4.2.1 Compatible Clang 3.7.1 (tags/RELEASE_371/final) C++11 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002__
2______3_____GCC_latest_____C++11____x64.txt:C++ Info: 12.1.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1017__
2______3_____windows-latest_____mingw32.txt:C++ Info: 12.1.0 C++11 __pybind11_internals_v4_mingw_libstdcpp_cxxabi1017__
2______3_____windows-latest_____mingw32.txt:C++ Info: 12.1.0 C++14 __pybind11_internals_v4_mingw_libstdcpp_cxxabi1017__
2______3_____windows-latest_____mingw32.txt:C++ Info: 12.1.0 C++17 __pybind11_internals_v4_mingw_libstdcpp_cxxabi1017__
3______3.10_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
3______3.10_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v10000000_gcc_libstdcpp_cxxabi1013__
3______3.10_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
3______3.8_____MSVC_2019_____x86_-DCMAKE_CXX_STANDARD=17.txt:  C++ Info: MSVC 192930145 C++17 __pybind11_internals_v4_msvc_debug__
3______3_____almalinux9_____x64.txt:C++ Info: 11.2.1 20220127 (Red Hat 11.2.1-9) C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1016__
3______3_____Clang_3.9_____C++11_____x64.txt:C++ Info: 4.2.1 Compatible Clang 3.9.1 (tags/RELEASE_391/final) C++11 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002__
3______3_____GCC_10_____C++20____x64.txt:C++ Info: 10.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1014__
4______3.11-dev_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
4______3.11-dev_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v10000000_gcc_libstdcpp_cxxabi1013__
4______3.11-dev_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
4______3.9_____MSVC_2019_____x86_-DCMAKE_CXX_STANDARD=20.txt:  C++ Info: MSVC 192930145 C++20 __pybind11_internals_v4_msvc_debug__
4______3_____Clang_7_____C++11_____x64.txt:C++ Info: 4.2.1 Compatible Clang 7.0.1 (tags/RELEASE_701/final) C++11 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002__
5______3_____Clang_9_____C++11_____x64.txt:C++ Info: Clang 9.0.0 (tags/RELEASE_900/final) C++11 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002__
5______pypy-3.7_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
5______pypy-3.7_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v10000000_gcc_libstdcpp_cxxabi1013__
5______pypy-3.7_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
6______3_____Clang_dev_____C++11_____x64.txt:C++ Info: Debian Clang 15.0.0 C++11 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002__
6______pypy-3.8_____ubuntu-latest_____x64_-DPYBIND11_FINDPYTHON=ON.txt:C++ Info: 9.4.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
6______pypy-3.8_____ubuntu-latest_____x64_-DPYBIND11_FINDPYTHON=ON.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v10000000_gcc_libstdcpp_cxxabi1013__
6______pypy-3.8_____ubuntu-latest_____x64_-DPYBIND11_FINDPYTHON=ON.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
7______3_____Clang_5_____C++14_____x64.txt:C++ Info: 4.2.1 Compatible Clang 5.0.2 (tags/RELEASE_502/final) C++14 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002__
7______pypy-3.9_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++11 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
7______pypy-3.9_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v10000000_gcc_libstdcpp_cxxabi1013__
7______pypy-3.9_____ubuntu-latest_____x64.txt:C++ Info: 9.4.0 C++17 __pybind11_internals_v4_gcc_libstdcpp_cxxabi1013__
8______3.6_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++14 __pybind11_internals_v4_msvc_debug__
8______3.6_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v10000000_msvc_debug__
8______3.6_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v4_msvc_debug__
8______3_____Clang_10_____C++20_____x64.txt:C++ Info: Clang 10.0.0  C++20 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002__
9______3.9_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++14 __pybind11_internals_v4_msvc_debug__
9______3.9_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v10000000_msvc_debug__
9______3.9_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v4_msvc_debug__
9______3_____Clang_10_____C++17_____x64.txt:C++ Info: Clang 10.0.0  C++17 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002__
10______3.10_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++14 __pybind11_internals_v4_msvc_debug__
10______3.10_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v10000000_msvc_debug__
10______3.10_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v4_msvc_debug__
11______3.11-dev_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++14 __pybind11_internals_v4_msvc_debug__
11______3.11-dev_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v10000000_msvc_debug__
11______3.11-dev_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v4_msvc_debug__
12______pypy-3.7_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++14 __pybind11_internals_v4_msvc_debug__
12______pypy-3.7_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v10000000_msvc_debug__
12______pypy-3.7_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v4_msvc_debug__
13______pypy-3.8_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++14 __pybind11_internals_v4_msvc_debug__
13______pypy-3.8_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v10000000_msvc_debug__
13______pypy-3.8_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v4_msvc_debug__
14______pypy-3.9_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++14 __pybind11_internals_v4_msvc_debug__
14______pypy-3.9_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v10000000_msvc_debug__
14______pypy-3.9_____windows-2022_____x64.txt:  C++ Info: MSVC 193231332 C++17 __pybind11_internals_v4_msvc_debug__
15______3.6_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++11 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
15______3.6_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v10000000_clang_libcpp_cxxabi1002__
15______3.6_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
16______3.9_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++11 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
16______3.9_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v10000000_clang_libcpp_cxxabi1002__
16______3.9_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
17______3.10_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++11 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
17______3.10_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v10000000_clang_libcpp_cxxabi1002__
17______3.10_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
18______3.11-dev_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++11 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
18______3.11-dev_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v10000000_clang_libcpp_cxxabi1002__
18______3.11-dev_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
19______pypy-3.7_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++11 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
19______pypy-3.7_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v10000000_clang_libcpp_cxxabi1002__
19______pypy-3.7_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
20______pypy-3.8_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++11 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
20______pypy-3.8_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v10000000_clang_libcpp_cxxabi1002__
20______pypy-3.8_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
21______pypy-3.9_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++11 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
21______pypy-3.9_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v10000000_clang_libcpp_cxxabi1002__
21______pypy-3.9_____macos-latest_____x64.txt:C++ Info: Apple LLVM 13.0.0 (clang-1300.0.29.30) C++17 __pybind11_internals_v4_clang_libcpp_cxxabi1002__
22______3.6_____windows-2019_____x64_-DPYBIND11_FINDPYTHON=ON.txt:  C++ Info: MSVC 192930145 C++14 __pybind11_internals_v4_msvc_debug__
22______3.6_____windows-2019_____x64_-DPYBIND11_FINDPYTHON=ON.txt:  C++ Info: MSVC 192930145 C++17 __pybind11_internals_v10000000_msvc_debug__
22______3.6_____windows-2019_____x64_-DPYBIND11_FINDPYTHON=ON.txt:  C++ Info: MSVC 192930145 C++17 __pybind11_internals_v4_msvc_debug__
23______3.9_____windows-2019_____x64.txt:  C++ Info: MSVC 192930145 C++14 __pybind11_internals_v4_msvc_debug__
23______3.9_____windows-2019_____x64.txt:  C++ Info: MSVC 192930145 C++17 __pybind11_internals_v10000000_msvc_debug__
23______3.9_____windows-2019_____x64.txt:  C++ Info: MSVC 192930145 C++17 __pybind11_internals_v4_msvc_debug__
```
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
