### PR TITLE
Properly visit self in >=3.9 traverse

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -531,6 +531,7 @@ extern "C" inline int pybind11_set_dict(PyObject *self, PyObject *new_dict, void
 extern "C" inline int pybind11_traverse(PyObject *self, visitproc visit, void *arg) {
     PyObject *&dict = *_PyObject_GetDictPtr(self);
     Py_VISIT(dict);
+// https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_traverse
 #if PY_VERSION_HEX >= 0x03090000
     Py_VISIT(Py_TYPE(self));
 #endif

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -531,6 +531,9 @@ extern "C" inline int pybind11_set_dict(PyObject *self, PyObject *new_dict, void
 extern "C" inline int pybind11_traverse(PyObject *self, visitproc visit, void *arg) {
     PyObject *&dict = *_PyObject_GetDictPtr(self);
     Py_VISIT(dict);
+#if PY_VERSION_HEX >= 0x03090000
+    Py_VISIT(Py_TYPE(self));
+#endif
     return 0;
 }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* This PR fixes a small bug that was already fixed in nanobind. Specifically, the our traverse behavior does not follow the [clarified behavior of the tp-traverse function Python >=3.9](https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_traverse). 
* I originally discovered this bug when researching the 3.11 fixes, but this did not fix the root cause there. Still, it's better to have proper behavior for >= 3.9 so this PR cherry picks that fix and ensure we properly traverse the classes when calling gc on dynamically allocated classes.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Ensure proper behavior when garbage collecting classes with dynamic attributes in Python >=3.9.
```

<!-- If the upgrade guide needs updating, note that here too -->
