### PR TITLE
chore: optimize sparse matrix casting with python tuple

### DIFF
--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -692,9 +692,9 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
         array outerIndices((rowMajor ? src.rows() : src.cols()) + 1, src.outerIndexPtr());
         array innerIndices(src.nonZeros(), src.innerIndexPtr());
 
-        return matrix_type(std::make_tuple(
+        return matrix_type(pybind11::make_tuple(
                                std::move(data), std::move(innerIndices), std::move(outerIndices)),
-                           std::make_pair(src.rows(), src.cols()))
+                           pybind11::make_tuple(src.rows(), src.cols()))
             .release();
     }
 

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -654,7 +654,7 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
 
         if (!type::handle_of(obj).is(matrix_type)) {
             try {
-                obj = matrix_type(obj);
+                obj = matrix_type(std::move(obj));
             } catch (const error_already_set &) {
                 return false;
             }

--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -654,7 +654,7 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
 
         if (!type::handle_of(obj).is(matrix_type)) {
             try {
-                obj = matrix_type(std::move(obj));
+                obj = matrix_type(obj);
             } catch (const error_already_set &) {
                 return false;
             }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Optimizes the Eigen sparse matrix construction by using a py::tuple instead of requiring a cast from std::tuple.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* optimizes Eigen sparse matrix casting by removing unnecessary temporary.
```

<!-- If the upgrade guide needs updating, note that here too -->
