### PR TITLE
CI job name "🐍 3 • GCC 10 • C++2a • x64" (changed from C++20, which is misleading)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,6 +465,7 @@ jobs:
       shell: bash
       run: >
         cmake -S . -B build
+        -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DCMAKE_CXX_STANDARD=${{ matrix.std }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,7 @@ jobs:
           - 11
         include:
           - gcc: 10
-            std: 20
+            std: 2a
 
     name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }}• x64"
     container: "gcc:${{ matrix.gcc }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,13 +440,16 @@ jobs:
         gcc:
           - 7
           - latest
-        std:
+        cmake_cxx_standard:
+          - 11
+        std_passed_to_compiler:
           - 11
         include:
           - gcc: 10
-            std: 2a
+            cmake_cxx_standard: 20
+            std_passed_to_compiler: 2a # pybind11 defines PYBIND11_CPP17 but not PYBIND11_CPP20
 
-    name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }}• x64"
+    name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std_passed_to_compiler }} • x64"
     container: "gcc:${{ matrix.gcc }}"
 
     steps:
@@ -468,7 +471,7 @@ jobs:
         -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
-        -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+        -DCMAKE_CXX_STANDARD=${{ matrix.cmake_cxx_standard }}
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Distinguish `cmake_cxx_standard` & `std_passed_to_compiler`, to make it more obvious what is actually being tested, and why `PYBIND11_CPP20` is not defined.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
