### PR TITLE
For PyPy only, re-enable old behavior (runs the risk of masking bugs)

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -459,7 +459,7 @@ struct error_fetch_and_normalize {
 #if defined(PYPY_VERSION)
         // This behavior runs the risk of masking errors in the error handling, but avoids a
         // conflict with PyPy, which relies on the normalization here to change OSError to
-        // FileNotFoundError (https://github.com/pybind/pybind11/issues/4075 for background).
+        // FileNotFoundError (https://github.com/pybind/pybind11/issues/4075).
         m_lazy_error_string = exc_type_name_norm;
 #else
         if (exc_type_name_norm != m_lazy_error_string) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -456,9 +456,10 @@ struct error_fetch_and_normalize {
                           + " failed to obtain the name "
                             "of the normalized active exception type.");
         }
-#if defined(YPYP_EVSROIN)
-        // This behavior masks errors in the error handling, but avoids a PyPy segfault (root
-        // cause unknown). See https://github.com/pybind/pybind11/issues/4075 for background.
+#if defined(PYPY_VERSION)
+        // This behavior runs the risk of masking errors in the error handling, but avoids a
+        // conflict with PyPy, which relies on the normalization here to change OSError to
+        // FileNotFoundError (https://github.com/pybind/pybind11/issues/4075 for background).
         m_lazy_error_string = exc_type_name_norm;
 #else
         if (exc_type_name_norm != m_lazy_error_string) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -456,7 +456,7 @@ struct error_fetch_and_normalize {
                           + " failed to obtain the name "
                             "of the normalized active exception type.");
         }
-#if defined(PYPY_VERSION)
+#if defined(YPYP_EVSROIN)
         // This behavior masks errors in the error handling, but avoids a PyPy segfault (root
         // cause unknown). See https://github.com/pybind/pybind11/issues/4075 for background.
         m_lazy_error_string = exc_type_name_norm;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -456,6 +456,11 @@ struct error_fetch_and_normalize {
                           + " failed to obtain the name "
                             "of the normalized active exception type.");
         }
+#if defined(PYPY_VERSION)
+        // This behavior masks errors in the error handling, but avoids a PyPy segfault (root
+        // cause unknown). See https://github.com/pybind/pybind11/issues/4075 for background.
+        m_lazy_error_string = exc_type_name_norm;
+#else
         if (exc_type_name_norm != m_lazy_error_string) {
             std::string msg = std::string(called)
                               + ": MISMATCH of original and normalized "
@@ -467,6 +472,7 @@ struct error_fetch_and_normalize {
             msg += ": " + format_value_and_trace();
             pybind11_fail(msg);
         }
+#endif
     }
 
     error_fetch_and_normalize(const error_fetch_and_normalize &) = delete;

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -334,4 +334,14 @@ TEST_SUBMODULE(exceptions, m) {
             e.restore();
         }
     });
+
+    // https://github.com/pybind/pybind11/issues/4075
+    m.def("test_pypy_oserror_normalization", []() {
+        try {
+            py::module_::import("io").attr("open")("this_filename_must_not_exist", "r");
+        } catch (const py::error_already_set &e) {
+            return py::str(e.what()); // str must be built before e goes out of scope.
+        }
+        return py::str("UNEXPECTED");
+    });
 }

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -360,3 +360,9 @@ def test_error_already_set_double_restore():
         "Internal error: pybind11::detail::error_fetch_and_normalize::restore()"
         " called a second time. ORIGINAL ERROR: ValueError: Random error."
     )
+
+
+def test_pypy_oserror_normalization():
+    # https://github.com/pybind/pybind11/issues/4075
+    what = m.test_pypy_oserror_normalization()
+    assert "this_filename_must_not_exist" in what

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -303,28 +303,18 @@ def test_error_already_set_what_with_happy_exceptions(
     assert what == expected_what
 
 
+@pytest.mark.skipif("env.PYPY", reason="PyErr_NormalizeException Segmentation fault")
 def test_flaky_exception_failure_point_init():
-    if env.PYPY:
-        # This behavior masks errors in the error handling, but avoids a PyPy segfault (root
-        # cause unknown). See https://github.com/pybind/pybind11/issues/4075 for background.
-        what, py_err_set_after_what = m.error_already_set_what(
-            FlakyException, ("failure_point_init",)
-        )
-        assert not py_err_set_after_what
-        lines = what.splitlines()
-        # PyErr_NormalizeException replaces the original FlakyException with ValueError:
-        assert lines[:3] == ["ValueError: triggered_failure_point_init", "", "At:"]
-    else:
-        with pytest.raises(RuntimeError) as excinfo:
-            m.error_already_set_what(FlakyException, ("failure_point_init",))
-        lines = str(excinfo.value).splitlines()
-        # PyErr_NormalizeException replaces the original FlakyException with ValueError:
-        assert lines[:3] == [
-            "pybind11::error_already_set: MISMATCH of original and normalized active exception types:"
-            " ORIGINAL FlakyException REPLACED BY ValueError: triggered_failure_point_init",
-            "",
-            "At:",
-        ]
+    with pytest.raises(RuntimeError) as excinfo:
+        m.error_already_set_what(FlakyException, ("failure_point_init",))
+    lines = str(excinfo.value).splitlines()
+    # PyErr_NormalizeException replaces the original FlakyException with ValueError:
+    assert lines[:3] == [
+        "pybind11::error_already_set: MISMATCH of original and normalized active exception types:"
+        " ORIGINAL FlakyException REPLACED BY ValueError: triggered_failure_point_init",
+        "",
+        "At:",
+    ]
     # Checking the first two lines of the traceback as formatted in error_string():
     assert "test_exceptions.py(" in lines[3]
     assert lines[3].endswith("): __init__")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This workaround runs the risk of masking errors in the error handling, but avoids a conflict with PyPy, which relies on the normalization in pybind11 to change `OSError` to `FileNotFoundError`.

Change prompted by https://github.com/pybind/pybind11/issues/4075

<!-- Include relevant issues or PRs here, describe what changed and why -->

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
A workaround for PyPy was added in the `py::error_already_set` implementation, related to PR #1895 released with v2.10.0.
```

<!-- If the upgrade guide needs updating, note that here too -->
