### PR TITLE
More systematic gcc & clang coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,13 +437,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gcc:
-          - 7
-          - latest
-        std:
-          - 11
+        include:
+          - gcc: 7
+            std: 11
+        include:
+          - gcc: 7
+            std: 17
+        include:
+          - gcc: 8
+            std: 14
+        include:
+          - gcc: 8
+            std: 17
         include:
           - gcc: 10
+            std: 17
+        include:
+          - gcc: 11
+            std: 20
+        include:
+          - gcc: 12
             std: 20
 
     name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }}• x64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,26 +438,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - gcc: 7
-            std: 11
-        include:
-          - gcc: 7
-            std: 17
-        include:
-          - gcc: 8
-            std: 14
-        include:
-          - gcc: 8
-            std: 17
-        include:
-          - gcc: 10
-            std: 17
-        include:
-          - gcc: 11
-            std: 20
-        include:
-          - gcc: 12
-            std: 20
+          - { gcc: 7, std: 11 }
+          - { gcc: 7, std: 17 }
+          - { gcc: 8, std: 14 }
+          - { gcc: 8, std: 17 }
+          - { gcc: 10, std: 17 }
+          - { gcc: 11, std: 20 }
+          - { gcc: 12, std: 20 }
 
     name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }}• x64"
     container: "gcc:${{ matrix.gcc }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,12 @@ jobs:
             std: 20
           - clang: 10
             std: 17
+          - clang: 11
+            std: 20
+          - clang: 12
+            std: 20
+          - clang: 13
+            std: 20
           - clang: 14
             std: 20
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -1158,6 +1158,24 @@ constexpr inline bool silence_msvc_c4127(bool cond) { return cond; }
 #    define PYBIND11_SILENCE_MSVC_C4127(...) __VA_ARGS__
 #endif
 
+#if defined(__clang__)                                                                            \
+    && (defined(__apple_build_version__) /* AppleClang 13.0.0.13000029 was the only data point    \
+                                            available. */                                         \
+        || (__clang_major__ >= 7                                                                  \
+            && __clang_major__ <= 12) /* Clang 3, 5, 13, 14, 15 do not generate the warning. */   \
+    )
+#    define PYBIND11_DETECTED_CLANG_WITH_MISLEADING_CALL_STD_MOVE_EXPLICITLY_WARNING
+// Example:
+// tests/test_kwargs_and_defaults.cpp:46:68: error: local variable 'args' will be copied despite
+// being returned by name [-Werror,-Wreturn-std-move]
+//     m.def("args_function", [](py::args args) -> py::tuple { return args; });
+//                                                                    ^~~~
+// test_kwargs_and_defaults.cpp:46:68: note: call 'std::move' explicitly to avoid copying
+//     m.def("args_function", [](py::args args) -> py::tuple { return args; });
+//                                                                    ^~~~
+//                                                                    std::move(args)
+#endif
+
 // Pybind offers detailed error messages by default for all builts that are debug (through the
 // negation of ndebug). This can also be manually enabled by users, for any builds, through
 // defining PYBIND11_DETAILED_ERROR_MESSAGES.

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1865,6 +1865,10 @@ private:
         }
 
         auto result = returned_array::create(trivial, shape);
+#ifdef PYBIND11_DETECTED_CLANG_WITH_MISLEADING_CALL_STD_MOVE_EXPLICITLY_WARNING
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wreturn-std-move"
+#endif
 
         if (size == 0) {
             return result;
@@ -1879,6 +1883,9 @@ private:
         }
 
         return result;
+#ifdef PYBIND11_DETECTED_CLANG_WITH_MISLEADING_CALL_STD_MOVE_EXPLICITLY_WARNING
+#    pragma clang diagnostic pop
+#endif
     }
 
     template <size_t... Index, size_t... VIndex, size_t... BIndex>

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1867,7 +1867,7 @@ private:
         auto result = returned_array::create(trivial, shape);
 
         if (size == 0) {
-            return std::move(result);
+            return result;
         }
 
         /* Call the function */
@@ -1878,7 +1878,7 @@ private:
             apply_trivial(buffers, params, mutable_data, size, i_seq, vi_seq, bi_seq);
         }
 
-        return std::move(result);
+        return result;
     }
 
     template <size_t... Index, size_t... VIndex, size_t... BIndex>

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -43,7 +43,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     m.def("kw_func_udl_z", kw_func, "x"_a, "y"_a = 0);
 
     // test_args_and_kwargs
-    m.def("args_function", [](py::args args) -> py::tuple { return std::move(args); });
+    m.def("args_function", [](py::args args) -> py::tuple { return args; });
     m.def("args_kwargs_function", [](const py::args &args, const py::kwargs &kwargs) {
         return py::make_tuple(args, kwargs);
     });

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -43,7 +43,16 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     m.def("kw_func_udl_z", kw_func, "x"_a, "y"_a = 0);
 
     // test_args_and_kwargs
-    m.def("args_function", [](py::args args) -> py::tuple { return args; });
+    m.def("args_function", [](py::args args) -> py::tuple {
+#ifdef PYBIND11_DETECTED_CLANG_WITH_MISLEADING_CALL_STD_MOVE_EXPLICITLY_WARNING
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wreturn-std-move"
+#endif
+        return args;
+#ifdef PYBIND11_DETECTED_CLANG_WITH_MISLEADING_CALL_STD_MOVE_EXPLICITLY_WARNING
+#    pragma clang diagnostic pop
+#endif
+    });
     m.def("args_kwargs_function", [](const py::args &args, const py::kwargs &kwargs) {
         return py::make_tuple(args, kwargs);
     });


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Based on https://github.com/pybind/pybind11/pull/4074#issuecomment-1188385580

Drops GCC 10 `--std=c++2a` (because it is an odd choice), adds 6 GCC / `-std` combinations not covered already but assumed to be what users would pick.

Also adds clang 11, 12, 13 (not covered at all before), with `--std=c++20`.

Resolves GCC 11 & 12 "redundant move in return statement" warnings.

Suppresses misleading clang warnings in the same locations.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
