### PR TITLE
Open pybind11 namespace with consistent visility.

### DIFF
--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -38,7 +38,7 @@ type is explicitly allowed.
 
 .. code-block:: cpp
 
-    namespace pybind11 { namespace detail {
+    namespace PYBIND11_NAMESPACE { namespace detail {
         template <> struct type_caster<inty> {
         public:
             /**
@@ -78,7 +78,7 @@ type is explicitly allowed.
                 return PyLong_FromLong(src.long_value);
             }
         };
-    }} // namespace pybind11::detail
+    }} // namespace PYBIND11_NAMESPACE::detail
 
 .. note::
 

--- a/docs/advanced/cast/stl.rst
+++ b/docs/advanced/cast/stl.rst
@@ -42,7 +42,7 @@ types:
 .. code-block:: cpp
 
     // `boost::optional` as an example -- can be any `std::optional`-like container
-    namespace pybind11 { namespace detail {
+    namespace PYBIND11_NAMESPACE { namespace detail {
         template <typename T>
         struct type_caster<boost::optional<T>> : optional_caster<boost::optional<T>> {};
     }}
@@ -54,7 +54,7 @@ for custom variant types:
 .. code-block:: cpp
 
     // `boost::variant` as an example -- can be any `std::variant`-like container
-    namespace pybind11 { namespace detail {
+    namespace PYBIND11_NAMESPACE { namespace detail {
         template <typename... Ts>
         struct type_caster<boost::variant<Ts...>> : variant_caster<boost::variant<Ts...>> {};
 
@@ -66,7 +66,7 @@ for custom variant types:
                 return boost::apply_visitor(args...);
             }
         };
-    }} // namespace pybind11::detail
+    }} // namespace PYBIND11_NAMESPACE::detail
 
 The ``visit_helper`` specialization is not required if your ``name::variant`` provides
 a ``name::visit()`` function. For any other function name, the specialization must be

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -1228,7 +1228,7 @@ whether a downcast is safe, you can proceed by specializing the
         std::string bark() const { return sound; }
     };
 
-    namespace pybind11 {
+    namespace PYBIND11_NAMESPACE {
         template<> struct polymorphic_type_hook<Pet> {
             static const void *get(const Pet *src, const std::type_info*& type) {
                 // note that src may be nullptr
@@ -1239,7 +1239,7 @@ whether a downcast is safe, you can proceed by specializing the
                 return src;
             }
         };
-    } // namespace pybind11
+    } // namespace PYBIND11_NAMESPACE
 
 When pybind11 wants to convert a C++ pointer of type ``Base*`` to a
 Python object, it calls ``polymorphic_type_hook<Base>::get()`` to

--- a/docs/advanced/smart_ptrs.rst
+++ b/docs/advanced/smart_ptrs.rst
@@ -157,7 +157,7 @@ specialized:
     PYBIND11_DECLARE_HOLDER_TYPE(T, SmartPtr<T>);
 
     // Only needed if the type's `.get()` goes by another name
-    namespace pybind11 { namespace detail {
+    namespace PYBIND11_NAMESPACE { namespace detail {
         template <typename T>
         struct holder_helper<SmartPtr<T>> { // <-- specialization
             static const T *get(const SmartPtr<T> &p) { return p.getPointer(); }

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -21,7 +21,7 @@ public:
 };
 class ArgAlwaysConverts {};
 
-namespace pybind11 {
+namespace PYBIND11_NAMESPACE {
 namespace detail {
 template <>
 struct type_caster<ArgInspector1> {
@@ -74,7 +74,7 @@ public:
     }
 };
 } // namespace detail
-} // namespace pybind11
+} // namespace PYBIND11_NAMESPACE
 
 // test_custom_caster_destruction
 class DestructionTester {
@@ -92,7 +92,7 @@ public:
         return *this;
     }
 };
-namespace pybind11 {
+namespace PYBIND11_NAMESPACE {
 namespace detail {
 template <>
 struct type_caster<DestructionTester> {
@@ -104,7 +104,7 @@ struct type_caster<DestructionTester> {
     }
 };
 } // namespace detail
-} // namespace pybind11
+} // namespace PYBIND11_NAMESPACE
 
 // Define type caster outside of `pybind11::detail` and then alias it.
 namespace other_lib {
@@ -112,7 +112,7 @@ struct MyType {};
 // Corrupt `py` shorthand alias for surrounding context.
 namespace py {}
 // Corrupt unqualified relative `pybind11` namespace.
-namespace pybind11 {}
+namespace PYBIND11_NAMESPACE {}
 // Correct alias.
 namespace py_ = ::pybind11;
 // Define caster. This is effectively no-op, we only ensure it compiles and we
@@ -127,12 +127,12 @@ struct my_caster {
 };
 } // namespace other_lib
 // Effectively "alias" it into correct namespace (via inheritance).
-namespace pybind11 {
+namespace PYBIND11_NAMESPACE {
 namespace detail {
 template <>
 struct type_caster<other_lib::MyType> : public other_lib::my_caster {};
 } // namespace detail
-} // namespace pybind11
+} // namespace PYBIND11_NAMESPACE
 
 TEST_SUBMODULE(custom_type_casters, m) {
     // test_custom_type_casters

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -266,14 +266,14 @@ struct ElementList {
 // It is always possible to construct a ref<T> from an Object* pointer without
 // possible inconsistencies, hence the 'true' argument at the end.
 // Make pybind11 aware of the non-standard getter member function
-namespace pybind11 {
+namespace PYBIND11_NAMESPACE {
 namespace detail {
 template <typename T>
 struct holder_helper<ref<T>> {
     static const T *get(const ref<T> &p) { return p.get_ptr(); }
 };
 } // namespace detail
-} // namespace pybind11
+} // namespace PYBIND11_NAMESPACE
 
 // Make pybind aware of the ref-counted wrapper type (s):
 PYBIND11_DECLARE_HOLDER_TYPE(T, ref<T>, true);

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -23,7 +23,7 @@
 #if defined(PYBIND11_TEST_BOOST)
 #    include <boost/optional.hpp>
 
-namespace pybind11 {
+namespace PYBIND11_NAMESPACE {
 namespace detail {
 template <typename T>
 struct type_caster<boost::optional<T>> : optional_caster<boost::optional<T>> {};
@@ -31,7 +31,7 @@ struct type_caster<boost::optional<T>> : optional_caster<boost::optional<T>> {};
 template <>
 struct type_caster<boost::none_t> : void_caster<boost::none_t> {};
 } // namespace detail
-} // namespace pybind11
+} // namespace PYBIND11_NAMESPACE
 #endif
 
 // Test with `std::variant` in C++17 mode, or with `boost::variant` in C++11/14
@@ -43,7 +43,7 @@ using std::variant;
 #    define PYBIND11_TEST_VARIANT 1
 using boost::variant;
 
-namespace pybind11 {
+namespace PYBIND11_NAMESPACE {
 namespace detail {
 template <typename... Ts>
 struct type_caster<boost::variant<Ts...>> : variant_caster<boost::variant<Ts...>> {};
@@ -56,7 +56,7 @@ struct visit_helper<boost::variant> {
     }
 };
 } // namespace detail
-} // namespace pybind11
+} // namespace PYBIND11_NAMESPACE
 #endif
 
 PYBIND11_MAKE_OPAQUE(std::vector<std::string, std::allocator<std::string>>);
@@ -159,13 +159,13 @@ private:
     std::vector<T> storage;
 };
 
-namespace pybind11 {
+namespace PYBIND11_NAMESPACE {
 namespace detail {
 template <typename T>
 struct type_caster<ReferenceSensitiveOptional<T>>
     : optional_caster<ReferenceSensitiveOptional<T>> {};
 } // namespace detail
-} // namespace pybind11
+} // namespace PYBIND11_NAMESPACE
 
 TEST_SUBMODULE(stl, m) {
     // test_vector

--- a/tests/test_tagbased_polymorphic.cpp
+++ b/tests/test_tagbased_polymorphic.cpp
@@ -117,7 +117,7 @@ std::string Animal::name_of_kind(Kind kind) {
     return raw_name;
 }
 
-namespace pybind11 {
+namespace PYBIND11_NAMESPACE {
 template <typename itype>
 struct polymorphic_type_hook<itype, detail::enable_if_t<std::is_base_of<Animal, itype>::value>> {
     static const void *get(const itype *src, const std::type_info *&type) {
@@ -125,7 +125,7 @@ struct polymorphic_type_hook<itype, detail::enable_if_t<std::is_base_of<Animal, 
         return src;
     }
 };
-} // namespace pybind11
+} // namespace PYBIND11_NAMESPACE
 
 TEST_SUBMODULE(tagbased_polymorphic, m) {
     py::class_<Animal>(m, "Animal").def_readonly("name", &Animal::name);


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Pybind opens the `pybind11` namespace in its library code via `PYBIND11_NAMESPACE` to capture visibility settings. The documentation does not open the `pybind11` namespace the same way, This implies that forward declaring some pybind11 classes can be done without `PYBIND11_NAMESPACE`, but this is incorrect in the general case. Ultimately this leads to visibility mismatches depending on definition and include order.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Users should use `PYBIND11_NAMESPACE` instead of using `pybind11` when opening namespaces. Using namespace declarations and namespace qualification remain the same as `pybind11`. This is done to ensure consistent symbol visibility.
```

<!-- If the upgrade guide needs updating, note that here too -->
