### PR TITLE
feat: add type signatures to docstrings of properties.

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1378,14 +1378,32 @@ protected:
                                   handle fset,
                                   detail::function_record *rec_func) {
         const auto is_static = (rec_func != nullptr) && !(rec_func->is_method && rec_func->scope);
-        const auto has_doc = (rec_func != nullptr) && (rec_func->doc != nullptr)
-                             && pybind11::options::show_user_defined_docstrings();
+
+        std::string doc;
+        if (rec_func != nullptr) {
+            if (pybind11::options::show_function_signatures()) {
+                doc += name;
+                if (rec_func->signature != nullptr) {
+                    std::string sig = rec_func->signature;
+                    size_t ret = sig.rfind(" -> ");
+                    if (ret != std::string::npos) {
+                        doc += ": ";
+                        doc += sig.substr(ret + 4);
+                    }
+                }
+                doc += "\n\n";
+            }
+            if (rec_func->doc != nullptr && pybind11::options::show_user_defined_docstrings()) {
+                doc += rec_func->doc;
+            }
+        }
+
         auto property = handle(
             (PyObject *) (is_static ? get_internals().static_property_type : &PyProperty_Type));
         attr(name) = property(fget.ptr() ? fget : none(),
                               fset.ptr() ? fset : none(),
                               /*deleter*/ none(),
-                              pybind11::str(has_doc ? rec_func->doc : ""));
+                              pybind11::str(doc));
     }
 };
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -88,7 +88,14 @@ def test_docstrings(doc):
         Get value using a method
     """
     )
-    assert doc(UserType.value) == "Get/set value using a property"
+    assert (
+        doc(UserType.value)
+        == """
+        value: int
+
+        Get/set value using a property
+    """
+    )
 
     assert (
         doc(m.NoConstructor.new_instance)

--- a/tests/test_docstring_options.cpp
+++ b/tests/test_docstring_options.cpp
@@ -79,10 +79,31 @@ TEST_SUBMODULE(docstring_options, m) {
             void setValue(int v) { value = v; }
             int getValue() const { return value; }
         };
-        py::class_<DocstringTestFoo>(m, "DocstringTestFoo", "This is a class docstring")
-            .def_property("value_prop",
+        py::class_<DocstringTestFoo> c(m, "DocstringTestFoo", "This is a class docstring");
+
+        c.def_property("value_prop1",
                           &DocstringTestFoo::getValue,
                           &DocstringTestFoo::setValue,
                           "This is a property docstring");
+
+        {
+            py::options nested_options;
+            nested_options.enable_user_defined_docstrings();
+
+            c.def_property("value_prop2",
+                          &DocstringTestFoo::getValue,
+                          &DocstringTestFoo::setValue,
+                          "This is a property docstring");
+
+            c.def_property("value_prop3",
+                          &DocstringTestFoo::getValue,
+                          &DocstringTestFoo::setValue);
+
+            options.disable_function_signatures();
+
+            c.def_property("value_prop4",
+                          &DocstringTestFoo::getValue,
+                          &DocstringTestFoo::setValue);
+        }
     }
 }

--- a/tests/test_docstring_options.py
+++ b/tests/test_docstring_options.py
@@ -38,4 +38,11 @@ def test_docstring_options():
 
     # Suppression of user-defined docstrings for non-function objects
     assert not m.DocstringTestFoo.__doc__
-    assert not m.DocstringTestFoo.value_prop.__doc__
+
+    assert m.DocstringTestFoo.value_prop1.__doc__ == "value_prop1: int\n\n"
+
+    assert m.DocstringTestFoo.value_prop2.__doc__ == "value_prop2: int\n\nThis is a property docstring"
+
+    assert m.DocstringTestFoo.value_prop3.__doc__ == "value_prop3: int\n\n"
+
+    assert not m.DocstringTestFoo.value_prop4.__doc__


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Currently signatures with type information are generated into docstrings for functions.

This PR adds type information in docstrings of properties, like
```
value_property: int

Property documentation.
```

Generation of this type information is enabled by default, but can be disabled/enabled with the same setting `py::options::disable_function_signatures` as for functions.
I did not consider it necessary to have separate settings for function and property signatures.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Add type signatures in docstrings of properties.
```

<!-- If the upgrade guide needs updating, note that here too -->
