### PR TITLE
chore: remove unnecessary temporary std::pair in enum pybind11 class

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2073,7 +2073,7 @@ struct enum_base {
                               + "\" already exists!");
         }
 
-        entries[name] = std::make_pair(value, doc);
+        entries[name] = pybind11::make_tuple(value, doc);
         m_base.attr(std::move(name)) = std::move(value);
     }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* I noticed that one of the enum values was using casting a std::pair into a tuple immediately. We can avoid the std::pair -> python tuple cast entirely by just filling the corresponding tuple using pybind11::make_tuple defined in cast.h which is already a dependency. This change serves two purposes:
1. Make the code more readable by showing that we are just adding a tuple to a python dictionary
2. Slight code/code gen optimization by removing a temporary std::pair casting.
<!-- Include relevant issues or PRs here, describe what changed and why -->

