### PR TITLE
chore: Use PyObject_GenericGetDict and PyObject_GenericSetDict functions

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -533,11 +533,16 @@ inline void enable_dynamic_attributes(PyHeapTypeObject *heap_type) {
     type->tp_traverse = pybind11_traverse;
     type->tp_clear = pybind11_clear;
 
-    static PyGetSetDef getset[] = {{const_cast<char *>("__dict__"),
-                                    PyObject_GenericGetDict,
-                                    PyObject_GenericSetDict,
-                                    nullptr,
-                                    nullptr},
+    static PyGetSetDef getset[] = {{
+#if PY_VERSION_HEX <= 0x03060000
+                                       const_cast<char *>("__dict__"),
+#else
+                                       "__dict__",
+#endif
+                                       PyObject_GenericGetDict,
+                                       PyObject_GenericSetDict,
+                                       nullptr,
+                                       nullptr},
                                    {nullptr, nullptr, nullptr, nullptr, nullptr}};
     type->tp_getset = getset;
 }

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -534,7 +534,7 @@ inline void enable_dynamic_attributes(PyHeapTypeObject *heap_type) {
     type->tp_clear = pybind11_clear;
 
     static PyGetSetDef getset[] = {{
-#if PY_VERSION_HEX <= 0x03060000
+#if PY_VERSION_HEX < 0x03070000
                                        const_cast<char *>("__dict__"),
 #else
                                        "__dict__",


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Remove custom implementation of PyObject_GenericGetDict and PyObject_GenericSetDict. These functions have been exposed since Python 3.3 and have both been part of the stable API since 3.10. Since we don't support Python 2 anymore, there is no reason to keep them around. 
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Use the modern PyObject_GenericGetDict and PyObject_GenericSetDict for handling dynamic attribute dictionaries.
```

<!-- If the upgrade guide needs updating, note that here too -->
