### PR TITLE
embed.h Python 3.11 `config.use_environment=1` + `PYTHONPATH` test

### DIFF
--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -166,6 +166,9 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
         throw std::runtime_error(PyStatus_IsError(status) ? status.err_msg
                                                           : "Failed to init CPython");
     }
+    // Emulates established behavior (prior to Python 3.11 implemented by PySys_SetArgvEx()).
+    PyRun_SimpleString("import sys, os; "
+                       "sys.path[:0] = os.environ.get('PYTHONPATH', []).split(os.pathsep)");
     if (add_program_dir_to_path) {
         PyRun_SimpleString("import sys, os.path; "
                            "sys.path.insert(0, "

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -150,6 +150,8 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
 #else
     PyConfig config;
     PyConfig_InitIsolatedConfig(&config);
+    config.isolated = 0;
+    config.use_environment = 1;
     config.install_signal_handlers = init_signal_handlers ? 1 : 0;
 
     PyStatus status = PyConfig_SetBytesArgv(&config, argc, const_cast<char *const *>(argv));
@@ -166,9 +168,6 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
         throw std::runtime_error(PyStatus_IsError(status) ? status.err_msg
                                                           : "Failed to init CPython");
     }
-    // Emulates established behavior (prior to Python 3.11 implemented by PySys_SetArgvEx()).
-    PyRun_SimpleString("import sys, os; "
-                       "sys.path[:0] = os.environ.get('PYTHONPATH', []).split(os.pathsep)");
     if (add_program_dir_to_path) {
         PyRun_SimpleString("import sys, os.path; "
                            "sys.path.insert(0, "

--- a/tests/test_embed/catch.cpp
+++ b/tests/test_embed/catch.cpp
@@ -21,7 +21,7 @@ namespace py = pybind11;
 
 int main(int argc, char *argv[]) {
     // Setup for TEST_CASE in test_interpreter.cpp, tagging on a large random number:
-    std::string updated_pythonpath("/pybind11_test_embed_PYTHONPATH_2099743835476552");
+    std::string updated_pythonpath("pybind11_test_embed_PYTHONPATH_2099743835476552");
     const char *preexisting_pythonpath = getenv("PYTHONPATH");
     if (preexisting_pythonpath != nullptr) {
 #if defined(_WIN32)

--- a/tests/test_embed/catch.cpp
+++ b/tests/test_embed/catch.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
 #if defined(_WIN32)
     _putenv_s("PYTHONPATH", updated_pythonpath.c_str());
 #else
-    setenv("PYTHONPATH", updated_pythonpath.c_str(), /*overwrite=*/1);
+    setenv("PYTHONPATH", updated_pythonpath.c_str(), /*replace=*/1);
 #endif
 
     py::scoped_interpreter guard{};

--- a/tests/test_embed/catch.cpp
+++ b/tests/test_embed/catch.cpp
@@ -20,7 +20,21 @@
 namespace py = pybind11;
 
 int main(int argc, char *argv[]) {
+    // Setup for TEST_CASE in test_interpreter.cpp, tagging on a large random number:
+    std::string updated_pythonpath("/pybind11_test_embed_PYTHONPATH_2099743835476552");
+    const char *preexisting_pythonpath = getenv("PYTHONPATH");
+    if (preexisting_pythonpath != nullptr) {
+#if defined(_MSC_VER) || defined(__MINGW32__)
+        updated_pythonpath += ';';
+#else
+        updated_pythonpath += ':';
+#endif
+        updated_pythonpath += preexisting_pythonpath;
+    }
+    setenv("PYTHONPATH", updated_pythonpath.c_str(), /*overwrite=*/1);
+
     py::scoped_interpreter guard{};
+
     auto result = Catch::Session().run(argc, argv);
 
     return result < 0xff ? result : 0xff;

--- a/tests/test_embed/catch.cpp
+++ b/tests/test_embed/catch.cpp
@@ -24,14 +24,18 @@ int main(int argc, char *argv[]) {
     std::string updated_pythonpath("/pybind11_test_embed_PYTHONPATH_2099743835476552");
     const char *preexisting_pythonpath = getenv("PYTHONPATH");
     if (preexisting_pythonpath != nullptr) {
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_WIN32)
         updated_pythonpath += ';';
 #else
         updated_pythonpath += ':';
 #endif
         updated_pythonpath += preexisting_pythonpath;
     }
+#if defined(_WIN32)
+    _putenv_s("PYTHONPATH", updated_pythonpath.c_str());
+#else
     setenv("PYTHONPATH", updated_pythonpath.c_str(), /*overwrite=*/1);
+#endif
 
     py::scoped_interpreter guard{};
 

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -77,7 +77,7 @@ PYBIND11_EMBEDDED_MODULE(throw_error_already_set, ) {
 
 TEST_CASE("PYTHONPATH is used to update sys.path") {
     // The setup for this TEST_CASE is in catch.cpp!
-    auto sys_path = py::module_::import("sys").attr("path").attr("__str__")().cast<std::string>();
+    auto sys_path = py::str(py::module_::import("sys").attr("path")).cast<std::string>();
     REQUIRE_THAT(sys_path,
                  Catch::Matchers::Contains("pybind11_test_embed_PYTHONPATH_2099743835476552"));
 }

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -75,6 +75,14 @@ PYBIND11_EMBEDDED_MODULE(throw_error_already_set, ) {
     d["missing"].cast<py::object>();
 }
 
+TEST_CASE("PYTHONPATH is used to update sys.path") {
+    // The setup for this TEST_CASE is in catch.cpp!
+    std::string sys_path
+        = py::module_::import("sys").attr("path").attr("__str__")().cast<std::string>();
+    REQUIRE_THAT(sys_path,
+                 Catch::Matchers::Contains("/pybind11_test_embed_PYTHONPATH_2099743835476552"));
+}
+
 TEST_CASE("Pass classes and data between modules defined in C++ and Python") {
     auto module_ = py::module_::import("test_interpreter");
     REQUIRE(py::hasattr(module_, "DerivedWidget"));
@@ -173,18 +181,6 @@ bool has_pybind11_internals_static() {
 
 TEST_CASE("Restart the interpreter") {
     // Verify pre-restart state.
-    fprintf(stdout,
-            "\nLOOOK PYTHONPATH %s\n",
-            py::module_::import("os")
-                .attr("environ")
-                .attr("get")("PYTHONPATH")
-                .attr("__str__")()
-                .cast<std::string>()
-                .c_str());
-    fflush(stdout);
-    auto sys_path = py::module_::import("sys").attr("path").attr("__str__")().cast<std::string>();
-    fprintf(stdout, "\nLOOOK sys.path %s\n", sys_path.c_str());
-    fflush(stdout);
     REQUIRE(py::module_::import("widget_module").attr("add")(1, 2).cast<int>() == 3);
     REQUIRE(has_pybind11_internals_builtin());
     REQUIRE(has_pybind11_internals_static());

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -173,6 +173,18 @@ bool has_pybind11_internals_static() {
 
 TEST_CASE("Restart the interpreter") {
     // Verify pre-restart state.
+    fprintf(stdout,
+            "\nLOOOK PYTHONPATH %s\n",
+            py::module_::import("os")
+                .attr("environ")
+                .attr("get")("PYTHONPATH")
+                .attr("__str__")()
+                .cast<std::string>()
+                .c_str());
+    fflush(stdout);
+    auto sys_path = py::module_::import("sys").attr("path").attr("__str__")().cast<std::string>();
+    fprintf(stdout, "\nLOOOK sys.path %s\n", sys_path.c_str());
+    fflush(stdout);
     REQUIRE(py::module_::import("widget_module").attr("add")(1, 2).cast<int>() == 3);
     REQUIRE(has_pybind11_internals_builtin());
     REQUIRE(has_pybind11_internals_static());

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -79,7 +79,7 @@ TEST_CASE("PYTHONPATH is used to update sys.path") {
     // The setup for this TEST_CASE is in catch.cpp!
     auto sys_path = py::module_::import("sys").attr("path").attr("__str__")().cast<std::string>();
     REQUIRE_THAT(sys_path,
-                 Catch::Matchers::Contains("/pybind11_test_embed_PYTHONPATH_2099743835476552"));
+                 Catch::Matchers::Contains("pybind11_test_embed_PYTHONPATH_2099743835476552"));
 }
 
 TEST_CASE("Pass classes and data between modules defined in C++ and Python") {

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -77,8 +77,7 @@ PYBIND11_EMBEDDED_MODULE(throw_error_already_set, ) {
 
 TEST_CASE("PYTHONPATH is used to update sys.path") {
     // The setup for this TEST_CASE is in catch.cpp!
-    std::string sys_path
-        = py::module_::import("sys").attr("path").attr("__str__")().cast<std::string>();
+    auto sys_path = py::module_::import("sys").attr("path").attr("__str__")().cast<std::string>();
     REQUIRE_THAT(sys_path,
                  Catch::Matchers::Contains("/pybind11_test_embed_PYTHONPATH_2099743835476552"));
 }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
With pybind11 v2.10.0 & Python 3.11, the `PyConfig` in embed.h does not update `sys.path` from `PYTHONPATH`, which is incompatible with the behavior for all Python versions before 3.11. This PR changes embed.h so that `PYTHONPATH` is used also with Python 3.11.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
embed.h was changed so that `PYTHONPATH` is used also with Python 3.11 (established behavior).
```

<!-- If the upgrade guide needs updating, note that here too -->
