### PR TITLE
fix(cmake): support vcpkg, try 2

### DIFF
--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -115,6 +115,7 @@ if(PYTHON_IS_DEBUG)
     PROPERTY INTERFACE_COMPILE_DEFINITIONS Py_DEBUG)
 endif()
 
+# The <3.11 code here does not support release/debug builds at the same time, like on vcpkg
 if(CMAKE_VERSION VERSION_LESS 3.11)
   set_property(
     TARGET pybind11::module
@@ -130,16 +131,19 @@ if(CMAKE_VERSION VERSION_LESS 3.11)
     APPEND
     PROPERTY INTERFACE_LINK_LIBRARIES pybind11::pybind11 $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
 else()
+  # The IMPORTED INTERFACE library here is to ensure that "debug" and "release" get processed outside
+  # of a generator expression - https://gitlab.kitware.com/cmake/cmake/-/issues/18424, as they are
+  # target_link_library keywords rather than real libraries.
+  add_library(pybind11::_ClassicPythonLibraries IMPORTED INTERFACE)
+  target_link_libraries(pybind11::_ClassicPythonLibraries INTERFACE ${PYTHON_LIBRARIES})
   target_link_libraries(
     pybind11::module
     INTERFACE
       pybind11::python_link_helper
-      "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:$<BUILD_INTERFACE:${PYTHON_LIBRARIES}>>"
-  )
+      "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:pybind11::_ClassicPythonLibraries>")
 
   target_link_libraries(pybind11::embed INTERFACE pybind11::pybind11
-                                                  $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
-
+                                                  pybind11::_ClassicPythonLibraries)
 endif()
 
 function(pybind11_extension name)


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Closes https://github.com/pybind/pybind11/issues/3891. `PYTHON_LIBRARIES` actually has `target_link_library` keywords embedded into it. :facepalm:

I wish everyone would move to FindPython...

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Followup to #3948, fixing vcpkg again
```

<!-- If the upgrade guide needs updating, note that here too -->
