### PR TITLE
Qualify `detail::forward_like` to avoid conflict with C++23

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -78,7 +78,7 @@ struct set_caster {
         pybind11::set s;
         for (auto &&value : src) {
             auto value_ = reinterpret_steal<object>(
-                key_conv::cast(forward_like<T>(value), policy, parent));
+                key_conv::cast(detail::forward_like<T>(value), policy, parent));
             if (!value_ || !s.add(std::move(value_))) {
                 return handle();
             }
@@ -122,9 +122,9 @@ struct map_caster {
         }
         for (auto &&kv : src) {
             auto key = reinterpret_steal<object>(
-                key_conv::cast(forward_like<T>(kv.first), policy_key, parent));
+                key_conv::cast(detail::forward_like<T>(kv.first), policy_key, parent));
             auto value = reinterpret_steal<object>(
-                value_conv::cast(forward_like<T>(kv.second), policy_value, parent));
+                value_conv::cast(detail::forward_like<T>(kv.second), policy_value, parent));
             if (!key || !value) {
                 return handle();
             }
@@ -178,7 +178,7 @@ public:
         ssize_t index = 0;
         for (auto &&value : src) {
             auto value_ = reinterpret_steal<object>(
-                value_conv::cast(forward_like<T>(value), policy, parent));
+                value_conv::cast(detail::forward_like<T>(value), policy, parent));
             if (!value_) {
                 return handle();
             }
@@ -242,7 +242,7 @@ public:
         ssize_t index = 0;
         for (auto &&value : src) {
             auto value_ = reinterpret_steal<object>(
-                value_conv::cast(forward_like<T>(value), policy, parent));
+                value_conv::cast(detail::forward_like<T>(value), policy, parent));
             if (!value_) {
                 return handle();
             }


### PR DESCRIPTION
Qualify `detail::forward_like` to avoid conflict with C++23's feature P2445R1 `std::forward_like`.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

C++23 has added a feature [P2445R1](https://wg21.link/P2445R1) `std::forward_like`, and MSVC's STL has implemented it by merging https://github.com/microsoft/STL/pull/2974 (which will be available in VS 2022 17.4 Preview 3). When building pybind11 with the updated STL in `/std:c++latest` mode, there are compiler errors because pybind11 has its own `forward_like` in a `detail` namespace. Qualifying the callsites is necessary to avoid ambiguity.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Fixed compiler errors when C++23 std::forward_like is available.
```

<!-- If the upgrade guide needs updating, note that here too -->
