### PR TITLE
chore: Add pytests for constructing pytypes from iterable

### DIFF
--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -109,9 +109,9 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("get_iterator", [] { return py::iterator(); });
     // test_iterable
     m.def("get_iterable", [] { return py::iterable(); });
-    m.def("get_set_from_iterable", [](const py::iterable &iter) { return py::set(iter); });
     m.def("get_frozenset_from_iterable",
           [](const py::iterable &iter) { return py::frozenset(iter); });
+    m.def("get_set_from_iterable", [](const py::iterable &iter) { return py::set(iter); });
     m.def("get_tuple_from_iterable", [](const py::iterable &iter) { return py::tuple(iter); });
     m.def("get_list_from_iterable", [](const py::iterable &iter) { return py::list(iter); });
     // test_float

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -111,9 +111,9 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("get_iterable", [] { return py::iterable(); });
     m.def("get_frozenset_from_iterable",
           [](const py::iterable &iter) { return py::frozenset(iter); });
+    m.def("get_list_from_iterable", [](const py::iterable &iter) { return py::list(iter); });
     m.def("get_set_from_iterable", [](const py::iterable &iter) { return py::set(iter); });
     m.def("get_tuple_from_iterable", [](const py::iterable &iter) { return py::tuple(iter); });
-    m.def("get_list_from_iterable", [](const py::iterable &iter) { return py::list(iter); });
     // test_float
     // test_float
     // test_float

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -109,6 +109,13 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("get_iterator", [] { return py::iterator(); });
     // test_iterable
     m.def("get_iterable", [] { return py::iterable(); });
+    m.def("get_set_from_iterable", [](const py::iterable &iter) { return py::set(iter); });
+    m.def("get_frozenset_from_iterable",
+          [](const py::iterable &iter) { return py::frozenset(iter); });
+    m.def("get_tuple_from_iterable", [](const py::iterable &iter) { return py::tuple(iter); });
+    m.def("get_list_from_iterable", [](const py::iterable &iter) { return py::list(iter); });
+    // test_float
+    // test_float
     // test_float
     m.def("get_float", [] { return py::float_(0.0f); });
     // test_list

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -29,9 +29,9 @@ def test_iterator(doc):
 @pytest.mark.parametrize(
     "pytype, from_iter_func",
     [
-        (set, m.get_set_from_iterable),
         (frozenset, m.get_frozenset_from_iterable),
         (list, m.get_list_from_iterable),
+        (set, m.get_set_from_iterable),
         (tuple, m.get_tuple_from_iterable),
     ],
 )

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -26,6 +26,22 @@ def test_iterator(doc):
     assert doc(m.get_iterator) == "get_iterator() -> Iterator"
 
 
+@pytest.mark.parametrize(
+    "pytype, from_iter_func",
+    [
+        (set, m.get_set_from_iterable),
+        (frozenset, m.get_frozenset_from_iterable),
+        (list, m.get_list_from_iterable),
+        (tuple, m.get_tuple_from_iterable),
+    ],
+)
+def test_from_iterable(capture, doc, pytype, from_iter_func):
+    my_iter = iter(range(10))
+    s = from_iter_func(my_iter)
+    assert type(s) == pytype
+    assert s == pytype(range(10))
+
+
 def test_iterable(doc):
     assert doc(m.get_iterable) == "get_iterable() -> Iterable"
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -35,7 +35,7 @@ def test_iterator(doc):
         (tuple, m.get_tuple_from_iterable),
     ],
 )
-def test_from_iterable(capture, doc, pytype, from_iter_func):
+def test_from_iterable(pytype, from_iter_func):
     my_iter = iter(range(10))
     s = from_iter_func(my_iter)
     assert type(s) == pytype


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* I was going through the code and wanted to add some tests for the iterable to pytype ctors since I noticed are unit tests for the iterable class are working. Since I wrote the tests to verify this use case worked properly, I thought I might as well commit them.
<!-- Include relevant issues or PRs here, describe what changed and why -->
