### PR TITLE
chore: Mark detail:forward_like as constexpr

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -45,7 +45,7 @@ using forwarded_type = conditional_t<std::is_lvalue_reference<T>::value,
 /// Forwards a value U as rvalue or lvalue according to whether T is rvalue or lvalue; typically
 /// used for forwarding a container's elements.
 template <typename T, typename U>
-forwarded_type<T, U> forward_like(U &&u) {
+constexpr forwarded_type<T, U> forward_like(U &&u) {
     return std::forward<detail::forwarded_type<T, U>>(std::forward<U>(u));
 }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Well looking into the new std::forward_like, I realized our detail:forward_like should also be constexpr at the very least. This is a small change and seems to work on C++11. 
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:
<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Mark detail::forward_like as constexpr
```

<!-- If the upgrade guide needs updating, note that here too -->
