### PR TITLE
Words matter updates

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1401,7 +1401,7 @@ PYBIND11_NOINLINE void register_structured_dtype(any_container<field_descriptor>
     oss << '}';
     auto format_str = oss.str();
 
-    // Sanity check: verify that NumPy properly parses our buffer format string
+    // Smoke test: verify that NumPy properly parses our buffer format string
     auto &api = npy_api::get();
     auto arr = array(buffer_info(nullptr, itemsize, format_str, 1));
     if (!api.PyArray_EquivTypes_(dtype_ptr, arr.dtype().ptr())) {

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -251,14 +251,14 @@ def array_copy_but_one(a, r, c, v):
 def test_eigen_return_references():
     """Tests various ways of returning references and non-referencing copies"""
 
-    master = np.ones((10, 10))
+    main = np.ones((10, 10))
     a = m.ReturnTester()
     a_get1 = a.get()
     assert not a_get1.flags.owndata and a_get1.flags.writeable
-    assign_both(a_get1, master, 3, 3, 5)
+    assign_both(a_get1, main, 3, 3, 5)
     a_get2 = a.get_ptr()
     assert not a_get2.flags.owndata and a_get2.flags.writeable
-    assign_both(a_get1, master, 2, 3, 6)
+    assign_both(a_get1, main, 2, 3, 6)
 
     a_view1 = a.view()
     assert not a_view1.flags.owndata and not a_view1.flags.writeable
@@ -271,25 +271,25 @@ def test_eigen_return_references():
 
     a_copy1 = a.copy_get()
     assert a_copy1.flags.owndata and a_copy1.flags.writeable
-    np.testing.assert_array_equal(a_copy1, master)
+    np.testing.assert_array_equal(a_copy1, main)
     a_copy1[7, 7] = -44  # Shouldn't affect anything else
-    c1want = array_copy_but_one(master, 7, 7, -44)
+    c1want = array_copy_but_one(main, 7, 7, -44)
     a_copy2 = a.copy_view()
     assert a_copy2.flags.owndata and a_copy2.flags.writeable
-    np.testing.assert_array_equal(a_copy2, master)
+    np.testing.assert_array_equal(a_copy2, main)
     a_copy2[4, 4] = -22  # Shouldn't affect anything else
-    c2want = array_copy_but_one(master, 4, 4, -22)
+    c2want = array_copy_but_one(main, 4, 4, -22)
 
     a_ref1 = a.ref()
     assert not a_ref1.flags.owndata and a_ref1.flags.writeable
-    assign_both(a_ref1, master, 1, 1, 15)
+    assign_both(a_ref1, main, 1, 1, 15)
     a_ref2 = a.ref_const()
     assert not a_ref2.flags.owndata and not a_ref2.flags.writeable
     with pytest.raises(ValueError):
         a_ref2[5, 5] = 33
     a_ref3 = a.ref_safe()
     assert not a_ref3.flags.owndata and a_ref3.flags.writeable
-    assign_both(a_ref3, master, 0, 7, 99)
+    assign_both(a_ref3, main, 0, 7, 99)
     a_ref4 = a.ref_const_safe()
     assert not a_ref4.flags.owndata and not a_ref4.flags.writeable
     with pytest.raises(ValueError):
@@ -297,23 +297,23 @@ def test_eigen_return_references():
 
     a_copy3 = a.copy_ref()
     assert a_copy3.flags.owndata and a_copy3.flags.writeable
-    np.testing.assert_array_equal(a_copy3, master)
+    np.testing.assert_array_equal(a_copy3, main)
     a_copy3[8, 1] = 11
-    c3want = array_copy_but_one(master, 8, 1, 11)
+    c3want = array_copy_but_one(main, 8, 1, 11)
     a_copy4 = a.copy_ref_const()
     assert a_copy4.flags.owndata and a_copy4.flags.writeable
-    np.testing.assert_array_equal(a_copy4, master)
+    np.testing.assert_array_equal(a_copy4, main)
     a_copy4[8, 4] = 88
-    c4want = array_copy_but_one(master, 8, 4, 88)
+    c4want = array_copy_but_one(main, 8, 4, 88)
 
     a_block1 = a.block(3, 3, 2, 2)
     assert not a_block1.flags.owndata and a_block1.flags.writeable
     a_block1[0, 0] = 55
-    master[3, 3] = 55
+    main[3, 3] = 55
     a_block2 = a.block_safe(2, 2, 3, 2)
     assert not a_block2.flags.owndata and a_block2.flags.writeable
     a_block2[2, 1] = -123
-    master[4, 3] = -123
+    main[4, 3] = -123
     a_block3 = a.block_const(6, 7, 4, 3)
     assert not a_block3.flags.owndata and not a_block3.flags.writeable
     with pytest.raises(ValueError):
@@ -321,18 +321,18 @@ def test_eigen_return_references():
 
     a_copy5 = a.copy_block(2, 2, 2, 3)
     assert a_copy5.flags.owndata and a_copy5.flags.writeable
-    np.testing.assert_array_equal(a_copy5, master[2:4, 2:5])
+    np.testing.assert_array_equal(a_copy5, main[2:4, 2:5])
     a_copy5[1, 1] = 777
-    c5want = array_copy_but_one(master[2:4, 2:5], 1, 1, 777)
+    c5want = array_copy_but_one(main[2:4, 2:5], 1, 1, 777)
 
     a_corn1 = a.corners()
     assert not a_corn1.flags.owndata and a_corn1.flags.writeable
     a_corn1 *= 50
     a_corn1[1, 1] = 999
-    master[0, 0] = 50
-    master[0, 9] = 50
-    master[9, 0] = 50
-    master[9, 9] = 999
+    main[0, 0] = 50
+    main[0, 9] = 50
+    main[9, 0] = 50
+    main[9, 9] = 999
     a_corn2 = a.corners_const()
     assert not a_corn2.flags.owndata and not a_corn2.flags.writeable
     with pytest.raises(ValueError):
@@ -340,22 +340,22 @@ def test_eigen_return_references():
 
     # All of the changes made all the way along should be visible everywhere
     # now (except for the copies, of course)
-    np.testing.assert_array_equal(a_get1, master)
-    np.testing.assert_array_equal(a_get2, master)
-    np.testing.assert_array_equal(a_view1, master)
-    np.testing.assert_array_equal(a_view2, master)
-    np.testing.assert_array_equal(a_ref1, master)
-    np.testing.assert_array_equal(a_ref2, master)
-    np.testing.assert_array_equal(a_ref3, master)
-    np.testing.assert_array_equal(a_ref4, master)
-    np.testing.assert_array_equal(a_block1, master[3:5, 3:5])
-    np.testing.assert_array_equal(a_block2, master[2:5, 2:4])
-    np.testing.assert_array_equal(a_block3, master[6:10, 7:10])
+    np.testing.assert_array_equal(a_get1, main)
+    np.testing.assert_array_equal(a_get2, main)
+    np.testing.assert_array_equal(a_view1, main)
+    np.testing.assert_array_equal(a_view2, main)
+    np.testing.assert_array_equal(a_ref1, main)
+    np.testing.assert_array_equal(a_ref2, main)
+    np.testing.assert_array_equal(a_ref3, main)
+    np.testing.assert_array_equal(a_ref4, main)
+    np.testing.assert_array_equal(a_block1, main[3:5, 3:5])
+    np.testing.assert_array_equal(a_block2, main[2:5, 2:4])
+    np.testing.assert_array_equal(a_block3, main[6:10, 7:10])
     np.testing.assert_array_equal(
-        a_corn1, master[0 :: master.shape[0] - 1, 0 :: master.shape[1] - 1]
+        a_corn1, main[0 :: main.shape[0] - 1, 0 :: main.shape[1] - 1]
     )
     np.testing.assert_array_equal(
-        a_corn2, master[0 :: master.shape[0] - 1, 0 :: master.shape[1] - 1]
+        a_corn2, main[0 :: main.shape[0] - 1, 0 :: main.shape[1] - 1]
     )
 
     np.testing.assert_array_equal(a_copy1, c1want)

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -251,14 +251,14 @@ def array_copy_but_one(a, r, c, v):
 def test_eigen_return_references():
     """Tests various ways of returning references and non-referencing copies"""
 
-    main = np.ones((10, 10))
+    primary = np.ones((10, 10))
     a = m.ReturnTester()
     a_get1 = a.get()
     assert not a_get1.flags.owndata and a_get1.flags.writeable
-    assign_both(a_get1, main, 3, 3, 5)
+    assign_both(a_get1, primary, 3, 3, 5)
     a_get2 = a.get_ptr()
     assert not a_get2.flags.owndata and a_get2.flags.writeable
-    assign_both(a_get1, main, 2, 3, 6)
+    assign_both(a_get1, primary, 2, 3, 6)
 
     a_view1 = a.view()
     assert not a_view1.flags.owndata and not a_view1.flags.writeable
@@ -271,25 +271,25 @@ def test_eigen_return_references():
 
     a_copy1 = a.copy_get()
     assert a_copy1.flags.owndata and a_copy1.flags.writeable
-    np.testing.assert_array_equal(a_copy1, main)
+    np.testing.assert_array_equal(a_copy1, primary)
     a_copy1[7, 7] = -44  # Shouldn't affect anything else
-    c1want = array_copy_but_one(main, 7, 7, -44)
+    c1want = array_copy_but_one(primary, 7, 7, -44)
     a_copy2 = a.copy_view()
     assert a_copy2.flags.owndata and a_copy2.flags.writeable
-    np.testing.assert_array_equal(a_copy2, main)
+    np.testing.assert_array_equal(a_copy2, primary)
     a_copy2[4, 4] = -22  # Shouldn't affect anything else
-    c2want = array_copy_but_one(main, 4, 4, -22)
+    c2want = array_copy_but_one(primary, 4, 4, -22)
 
     a_ref1 = a.ref()
     assert not a_ref1.flags.owndata and a_ref1.flags.writeable
-    assign_both(a_ref1, main, 1, 1, 15)
+    assign_both(a_ref1, primary, 1, 1, 15)
     a_ref2 = a.ref_const()
     assert not a_ref2.flags.owndata and not a_ref2.flags.writeable
     with pytest.raises(ValueError):
         a_ref2[5, 5] = 33
     a_ref3 = a.ref_safe()
     assert not a_ref3.flags.owndata and a_ref3.flags.writeable
-    assign_both(a_ref3, main, 0, 7, 99)
+    assign_both(a_ref3, primary, 0, 7, 99)
     a_ref4 = a.ref_const_safe()
     assert not a_ref4.flags.owndata and not a_ref4.flags.writeable
     with pytest.raises(ValueError):
@@ -297,23 +297,23 @@ def test_eigen_return_references():
 
     a_copy3 = a.copy_ref()
     assert a_copy3.flags.owndata and a_copy3.flags.writeable
-    np.testing.assert_array_equal(a_copy3, main)
+    np.testing.assert_array_equal(a_copy3, primary)
     a_copy3[8, 1] = 11
-    c3want = array_copy_but_one(main, 8, 1, 11)
+    c3want = array_copy_but_one(primary, 8, 1, 11)
     a_copy4 = a.copy_ref_const()
     assert a_copy4.flags.owndata and a_copy4.flags.writeable
-    np.testing.assert_array_equal(a_copy4, main)
+    np.testing.assert_array_equal(a_copy4, primary)
     a_copy4[8, 4] = 88
-    c4want = array_copy_but_one(main, 8, 4, 88)
+    c4want = array_copy_but_one(primary, 8, 4, 88)
 
     a_block1 = a.block(3, 3, 2, 2)
     assert not a_block1.flags.owndata and a_block1.flags.writeable
     a_block1[0, 0] = 55
-    main[3, 3] = 55
+    primary[3, 3] = 55
     a_block2 = a.block_safe(2, 2, 3, 2)
     assert not a_block2.flags.owndata and a_block2.flags.writeable
     a_block2[2, 1] = -123
-    main[4, 3] = -123
+    primary[4, 3] = -123
     a_block3 = a.block_const(6, 7, 4, 3)
     assert not a_block3.flags.owndata and not a_block3.flags.writeable
     with pytest.raises(ValueError):
@@ -321,18 +321,18 @@ def test_eigen_return_references():
 
     a_copy5 = a.copy_block(2, 2, 2, 3)
     assert a_copy5.flags.owndata and a_copy5.flags.writeable
-    np.testing.assert_array_equal(a_copy5, main[2:4, 2:5])
+    np.testing.assert_array_equal(a_copy5, primary[2:4, 2:5])
     a_copy5[1, 1] = 777
-    c5want = array_copy_but_one(main[2:4, 2:5], 1, 1, 777)
+    c5want = array_copy_but_one(primary[2:4, 2:5], 1, 1, 777)
 
     a_corn1 = a.corners()
     assert not a_corn1.flags.owndata and a_corn1.flags.writeable
     a_corn1 *= 50
     a_corn1[1, 1] = 999
-    main[0, 0] = 50
-    main[0, 9] = 50
-    main[9, 0] = 50
-    main[9, 9] = 999
+    primary[0, 0] = 50
+    primary[0, 9] = 50
+    primary[9, 0] = 50
+    primary[9, 9] = 999
     a_corn2 = a.corners_const()
     assert not a_corn2.flags.owndata and not a_corn2.flags.writeable
     with pytest.raises(ValueError):
@@ -340,22 +340,22 @@ def test_eigen_return_references():
 
     # All of the changes made all the way along should be visible everywhere
     # now (except for the copies, of course)
-    np.testing.assert_array_equal(a_get1, main)
-    np.testing.assert_array_equal(a_get2, main)
-    np.testing.assert_array_equal(a_view1, main)
-    np.testing.assert_array_equal(a_view2, main)
-    np.testing.assert_array_equal(a_ref1, main)
-    np.testing.assert_array_equal(a_ref2, main)
-    np.testing.assert_array_equal(a_ref3, main)
-    np.testing.assert_array_equal(a_ref4, main)
-    np.testing.assert_array_equal(a_block1, main[3:5, 3:5])
-    np.testing.assert_array_equal(a_block2, main[2:5, 2:4])
-    np.testing.assert_array_equal(a_block3, main[6:10, 7:10])
+    np.testing.assert_array_equal(a_get1, primary)
+    np.testing.assert_array_equal(a_get2, primary)
+    np.testing.assert_array_equal(a_view1, primary)
+    np.testing.assert_array_equal(a_view2, primary)
+    np.testing.assert_array_equal(a_ref1, primary)
+    np.testing.assert_array_equal(a_ref2, primary)
+    np.testing.assert_array_equal(a_ref3, primary)
+    np.testing.assert_array_equal(a_ref4, primary)
+    np.testing.assert_array_equal(a_block1, primary[3:5, 3:5])
+    np.testing.assert_array_equal(a_block2, primary[2:5, 2:4])
+    np.testing.assert_array_equal(a_block3, primary[6:10, 7:10])
     np.testing.assert_array_equal(
-        a_corn1, main[0 :: main.shape[0] - 1, 0 :: main.shape[1] - 1]
+        a_corn1, primary[0 :: primary.shape[0] - 1, 0 :: primary.shape[1] - 1]
     )
     np.testing.assert_array_equal(
-        a_corn2, main[0 :: main.shape[0] - 1, 0 :: main.shape[1] - 1]
+        a_corn2, primary[0 :: primary.shape[0] - 1, 0 :: primary.shape[1] - 1]
     )
 
     np.testing.assert_array_equal(a_copy1, c1want)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
An industry trend towards inclusive language ([IBM's stance](https://www.ibm.com/blogs/think/2020/08/words-matter-driving-thoughtful-change-toward-inclusive-language-in-technology/), [Inclusive Naming](https://inclusivenaming.org/), [INCITS](https://www.incits.org/news-events/news-coverage/incits-leads-the-way-in-adopting-inclusive-terminology-in-standards)), has us scrubbing code and documentation of outdated terms and connotations as much as possible in favor of friendlier alternatives.

A scan of pybind caught the below changes that were easy to get. There were others regarding `PYBIND11_MASTER_PROJECT` and the like I deemed too aggressive because it would be a fundamental alteration to the build system. Any thoughts on that would be appreciated though.

Thanks!
