### PR TITLE
Implement classmethod pytype

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1578,6 +1578,18 @@ public:
         return *this;
     }
 
+    template <typename Func, typename... Extra>
+    class_ &def_classmethod(const char *name_, Func &&f, const Extra &...extra) {
+        cpp_function cf(std::forward<Func>(f),
+                        name(name_),
+                        is_method(*this),
+                        sibling(getattr(*this, name_, none())),
+                        extra...);
+        auto cf_name = cf.name();
+        attr(std::move(cf_name)) = classmethod(std::move(cf));
+        return *this;
+    }
+
     template <detail::op_id id, detail::op_type ot, typename L, typename R, typename... Extra>
     class_ &def(const detail::op_<id, ot, L, R> &op, const Extra &...extra) {
         op.execute(*this, extra...);

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1224,6 +1224,7 @@ inline bool PyUnicode_Check_Permissive(PyObject *o) {
 #endif
 
 inline bool PyStaticMethod_Check(PyObject *o) { return o->ob_type == &PyStaticMethod_Type; }
+inline bool PyClassMethod_Check(PyObject *o) { return o->ob_type == &PyClassMethod_Type; }
 
 class kwargs_proxy : public handle {
 public:
@@ -2087,6 +2088,11 @@ public:
 class staticmethod : public object {
 public:
     PYBIND11_OBJECT_CVT(staticmethod, object, detail::PyStaticMethod_Check, PyStaticMethod_New)
+};
+
+class classmethod : public object {
+public:
+    PYBIND11_OBJECT_CVT(classmethod, object, detail::PyClassMethod_Check, PyClassMethod_New)
 };
 
 class buffer : public object {

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -62,7 +62,15 @@ TEST_SUBMODULE(class_, m) {
     };
 
     py::class_<NoConstructor>(m, "NoConstructor")
-        .def_static("new_instance", &NoConstructor::new_instance, "Return an instance");
+        .def_static("new_instance", &NoConstructor::new_instance, "Return an instance")
+        .def_classmethod(
+            "new_instance_uuid",
+            [](py::object &cls) {
+                py::int_ uuid = getattr(cls, "uuid", py::int_(0));
+                cls.attr("uuid") = uuid + py::int_(1);
+                return NoConstructorNew::new_instance();
+            },
+            "Returns a new instance and then increment the uuid");
 
     py::class_<NoConstructorNew>(m, "NoConstructorNew")
         .def(py::init([](const NoConstructorNew &self) { return self; })) // Need a NOOP __init__

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -31,6 +31,12 @@ def test_instance_new(msg):
     assert cstats.alive() == 0
 
 
+def test_classmethod(num_instances=10):
+    for i in range(num_instances):
+        assert getattr(m.NoConstructor, "uuid", 0) == i
+        m.NoConstructor.new_instance_uuid()
+
+
 def test_type():
     assert m.check_type(1) == m.DerivedClass1
     with pytest.raises(RuntimeError) as execinfo:


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
I've been mulling over how to implement this for a while now and finally got it working without segfaults.

Closes #1693 and implements classmethod support in pybind11. This allows defining classmethods which have the class of the caller automatically prepended to the list of args. This is nice because it allows adding/modifying class variables through the python bindings directly without a helper C++ class or struct.

NB: One thing I have noticed during my testing is that while `__new__` has a classmethod signature, it is actually implemented as a static method. Therefore trying to add a classmethod onto `__new__` will cause errors.

@rwgk I would like some thoughts on how to think about designing some proper tests for this functionality as there are probably a lot of edge cases having to do with potential mem leaks and other odd behavior. We also do play fast and loose with the terminology of classmethod with our add_classmethod function in pybind11 so I might need to refactor this. 

Tests that may need to be added:
1. memleaks? (I am not if the added attributes are properly cleaned up).
2. docstring
3. overloading precedence / siblings

Additional things needed: documentation.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Implement classmethod support
```

<!-- If the upgrade guide needs updating, note that here too -->
