### PR TITLE
fix: Python-3.12 compatibility

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -55,6 +55,9 @@ extern "C" inline int pybind11_static_set(PyObject *self, PyObject *obj, PyObjec
     return PyProperty_Type.tp_descr_set(self, cls, value);
 }
 
+// Forward declaration to use in `make_static_property_type()`
+inline void enable_dynamic_attributes(PyHeapTypeObject *heap_type);
+
 /** A `static_property` is the same as a `property` but the `__get__()` and `__set__()`
     methods are modified to always use the object type instead of a concrete instance.
     Return value: New reference. */
@@ -86,7 +89,11 @@ inline PyTypeObject *make_static_property_type() {
     if (PyType_Ready(type) < 0) {
         pybind11_fail("make_static_property_type(): failure in PyType_Ready()!");
     }
-
+#    if PY_VERSION_HEX >= 0x030C0000
+    // Since Python-3.12 property-derived types are required to
+    // have dynamic attributes (to set `__doc__`)
+    enable_dynamic_attributes(heap_type);
+#    endif
     setattr((PyObject *) type, "__module__", str("pybind11_builtins"));
     PYBIND11_SET_OLDPY_QUALNAME(type, name_obj);
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -89,11 +89,14 @@ inline PyTypeObject *make_static_property_type() {
     if (PyType_Ready(type) < 0) {
         pybind11_fail("make_static_property_type(): failure in PyType_Ready()!");
     }
+
 #    if PY_VERSION_HEX >= 0x030C0000
+    // PRE 3.12 FEATURE FREEZE. PLEASE REVIEW AFTER FREEZE.
     // Since Python-3.12 property-derived types are required to
     // have dynamic attributes (to set `__doc__`)
     enable_dynamic_attributes(heap_type);
 #    endif
+
     setattr((PyObject *) type, "__module__", str("pybind11_builtins"));
     PYBIND11_SET_OLDPY_QUALNAME(type, name_obj);
 


### PR DESCRIPTION
Enable dynamic attributes for `pybind11_static_property` for compatility with  cpython-3.12

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

The problem is that `property`-derived classes now use `__doc__` attribute, which in turn requires to enable "dynamic attributes". All that seems like a pessimisation which is not welcome here. I'm submitting the PR to demonstrate a possible solution if the compatibility issue will be solved on pybind side.

Sorry for all the trouble. I thought I'd been fixing `cpython`, not breaking `pybind`. :disappointed:  

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Enable dynamic attributes for `pybind11_static_property` for Python-3.12
```

<!-- If the upgrade guide needs updating, note that here too -->
Closes #4115