### PR TITLE
chore: Delete copy ctor/assign for GIL RAIIs

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -412,6 +412,8 @@ PYBIND11_NOINLINE internals &get_internals() {
     // Cannot use py::gil_scoped_acquire here since that constructor calls get_internals.
     struct gil_scoped_acquire_local {
         gil_scoped_acquire_local() : state(PyGILState_Ensure()) {}
+        gil_scoped_acquire_local(const gil_scoped_acquire_local &) = delete;
+        gil_scoped_acquire_local &operator=(const gil_scoped_acquire_local &) = delete;
         ~gil_scoped_acquire_local() { PyGILState_Release(state); }
         const PyGILState_STATE state;
     } gil;

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -195,7 +195,7 @@ class gil_scoped_release {
 
 public:
     gil_scoped_release() { state = PyEval_SaveThread(); }
-    gil_scoped_release(const gil_scoped_release) = delete;
+    gil_scoped_release(const gil_scoped_release &) = delete;
     gil_scoped_release &operator=(const gil_scoped_acquire &) = delete;
     ~gil_scoped_release() { PyEval_RestoreThread(state); }
     void disarm() {}

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -80,6 +80,9 @@ public:
         inc_ref();
     }
 
+    gil_scoped_acquire(const gil_scoped_acquire &) = delete;
+    gil_scoped_acquire &operator=(const gil_scoped_acquire &) = delete;
+
     void inc_ref() { ++tstate->gilstate_counter; }
 
     PYBIND11_NOINLINE void dec_ref() {
@@ -144,6 +147,9 @@ public:
         }
     }
 
+    gil_scoped_release(const gil_scoped_acquire &) = delete;
+    gil_scoped_release &operator=(const gil_scoped_acquire &) = delete;
+
     /// This method will disable the PyThreadState_DeleteCurrent call and the
     /// GIL won't be acquired. This method should be used if the interpreter
     /// could be shutting down when this is called, as thread deletion is not
@@ -178,6 +184,8 @@ class gil_scoped_acquire {
 
 public:
     gil_scoped_acquire() { state = PyGILState_Ensure(); }
+    gil_scoped_acquire(const gil_scoped_acquire &) = delete;
+    gil_scoped_acquire &operator=(const gil_scoped_acquire &) = delete;
     ~gil_scoped_acquire() { PyGILState_Release(state); }
     void disarm() {}
 };
@@ -187,6 +195,8 @@ class gil_scoped_release {
 
 public:
     gil_scoped_release() { state = PyEval_SaveThread(); }
+    gil_scoped_release(const gil_scoped_release) = delete;
+    gil_scoped_release &operator=(const gil_scoped_acquire &) = delete;
     ~gil_scoped_release() { PyEval_RestoreThread(state); }
     void disarm() {}
 };


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
I noticed some of the GIL RAIIs still had their potential copy assignment operators so I made sure they were explicitly deleted. This should prevent bugprone behavior of trying to copy them / move them around.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* GIL RAII scopes are non-copyable to avoid potential bugs.
```

<!-- If the upgrade guide needs updating, note that here too -->
