### PR TITLE
chore: optimize buffer_info ctors with some extra std::move

### DIFF
--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -11,6 +11,8 @@
 
 #include "detail/common.h"
 
+#include <utility>
+
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 PYBIND11_NAMESPACE_BEGIN(detail)
@@ -56,12 +58,12 @@ struct buffer_info {
 
     buffer_info(void *ptr,
                 ssize_t itemsize,
-                const std::string &format,
+                std::string format,
                 ssize_t ndim,
                 detail::any_container<ssize_t> shape_in,
                 detail::any_container<ssize_t> strides_in,
                 bool readonly = false)
-        : ptr(ptr), itemsize(itemsize), size(1), format(format), ndim(ndim),
+        : ptr(ptr), itemsize(itemsize), size(1), format(std::move(format)), ndim(ndim),
           shape(std::move(shape_in)), strides(std::move(strides_in)), readonly(readonly) {
         if (ndim != (ssize_t) shape.size() || ndim != (ssize_t) strides.size()) {
             pybind11_fail("buffer_info: ndim doesn't match shape and/or strides length");

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -87,12 +87,9 @@ struct buffer_info {
                       std::move(strides_in),
                       readonly) {}
 
-    buffer_info(void *ptr,
-                ssize_t itemsize,
-                const std::string &format,
-                ssize_t size,
-                bool readonly = false)
-        : buffer_info(ptr, itemsize, format, 1, {size}, {itemsize}, readonly) {}
+    buffer_info(
+        void *ptr, ssize_t itemsize, std::string format, ssize_t size, bool readonly = false)
+        : buffer_info(ptr, itemsize, std::move(format), 1, {size}, {itemsize}, readonly) {}
 
     template <typename T>
     buffer_info(T *ptr, ssize_t size, bool readonly = false)
@@ -158,13 +155,18 @@ private:
     buffer_info(private_ctr_tag,
                 void *ptr,
                 ssize_t itemsize,
-                const std::string &format,
+                std::string &&format,
                 ssize_t ndim,
                 detail::any_container<ssize_t> &&shape_in,
                 detail::any_container<ssize_t> &&strides_in,
                 bool readonly)
-        : buffer_info(
-            ptr, itemsize, format, ndim, std::move(shape_in), std::move(strides_in), readonly) {}
+        : buffer_info(ptr,
+                      itemsize,
+                      std::move(format),
+                      ndim,
+                      std::move(shape_in),
+                      std::move(strides_in),
+                      readonly) {}
 
     Py_buffer *m_view = nullptr;
     bool ownview = false;


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
chore: remove some extra potential copies of strings in the buffer info ctors at the expense of a few extra std::move operations.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* chore: reduce some extra copies / allocations in pybind11 buffer_info the ctors
```

<!-- If the upgrade guide needs updating, note that here too -->
