### PR TITLE
Fix for Windows compiler, missing object initializer

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -1037,7 +1037,7 @@ template <typename... Args>
         || (defined(__clang__) && __clang_major__ == 5)
 static constexpr detail::overload_cast_impl<Args...> overload_cast = {};
 #    else
-static constexpr detail::overload_cast_impl<Args...> overload_cast;
+static constexpr detail::overload_cast_impl<Args...> overload_cast{};
 #    endif
 #endif
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -1033,12 +1033,7 @@ PYBIND11_NAMESPACE_END(detail)
 ///  - regular: static_cast<Return (Class::*)(Arg0, Arg1, Arg2)>(&Class::func)
 ///  - sweet:   overload_cast<Arg0, Arg1, Arg2>(&Class::func)
 template <typename... Args>
-#    if (defined(_MSC_VER) && _MSC_VER < 1920) /* MSVC 2017 */                                    \
-        || (defined(__clang__) && __clang_major__ == 5)
-static constexpr detail::overload_cast_impl<Args...> overload_cast = {};
-#    else
 static constexpr detail::overload_cast_impl<Args...> overload_cast{};
-#    endif
 #endif
 
 /// Const member function selector for overload_cast


### PR DESCRIPTION
## Description

Added missing object initializer due to error while compiling with Visual Studio 2019 MSC v. 1924:
```
error: C2737: 'pybind11::overload_cast': 'constexpr' object must be initialized
```

## Suggested changelog entry:

```rst
* Fix MSVC 2019 v.1924 & C++14 mode error for `overload_cast`.
```