### PR TITLE
Avoid local_internals destruction

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -517,7 +517,8 @@ inline local_internals &get_local_internals() {
     // Current static can be created in the interpreter finalization routine. If the later will be
     // destroyed in another static variable destructor, creation of this static there will cause
     // static deinitialization fiasco. In order to avoid it we avoid destruction of the
-    // local_internals static.
+    // local_internals static. One can read more about the problem and current solution here:
+    // https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables
     static auto *locals = new local_internals();
     return *locals;
 }

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -514,8 +514,12 @@ struct local_internals {
 
 /// Works like `get_internals`, but for things which are locally registered.
 inline local_internals &get_local_internals() {
-    static local_internals locals;
-    return locals;
+    // Current static can be created in the interpreter finalization routine. If the later will be
+    // destroyed in another static variable destructor, creation of this static there will cause
+    // static deinitialization fiasco. In order to avoid it we avoid destruction of the
+    // local_internals static.
+    static auto *locals = new local_internals();
+    return *locals;
 }
 
 /// Constructs a std::string with the given arguments, stores it in `internals`, and returns its


### PR DESCRIPTION
The first call of `get_local_internals()` creates static variable. It can be, that the first call to `get_local_internals()` happens in the `finalize_interpreter()`. If this function is called from another static object destructor, code violates the order of static variable destruction. Such situation can happen, for example, if one decides to store `scoped_interpreter` in a singleton class. The broken order of the destruction of statics can result in program freezing inside `finalize_interpreter` (at least on Windows it does).

By making `local_internals` a pointer we avoid its destruction and the problem goes away.

This PR allows to avoid explicit call to `detail::get_local_internals()` from the user side in the situation described in this issue
https://github.com/pybind/pybind11/issues/4172

Application of this change is wider than it is shown in the issue above. It also solves the problem if user calls `finalize_interpreter` directly in the destructor or situation, when interpreter was created after the singleton wrapper constructor returned.



