### PR TITLE
perf: call reserve method in set and map casters

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -50,7 +50,7 @@ constexpr forwarded_type<T, U> forward_like(U &&u) {
 }
 
 // Checks if a container has a STL style reserve method.
-// The reserve method should also have a void return type.
+// This will only return true for a `reserve()` with a `void` return.
 template <typename C>
 using has_reserve_method = std::is_same<decltype(std::declval<C>().reserve(0)), void>;
 

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -59,6 +59,14 @@ struct set_caster {
     using type = Type;
     using key_conv = make_caster<Key>;
 
+private:
+    template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
+    void reserve_maybe(const anyset &s, Type *) {
+        value.reserve(s.size());
+    }
+    void reserve_maybe(const anyset &, void *) {}
+
+public:
     bool load(handle src, bool convert) {
         if (!isinstance<anyset>(src)) {
             return false;
@@ -93,13 +101,6 @@ struct set_caster {
     }
 
     PYBIND11_TYPE_CASTER(type, const_name("Set[") + key_conv::name + const_name("]"));
-
-private:
-    template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
-    void reserve_maybe(const anyset &s, Type *) {
-        value.reserve(s.size());
-    }
-    void reserve_maybe(const anyset &, void *) {}
 };
 
 template <typename Type, typename Key, typename Value>
@@ -107,6 +108,14 @@ struct map_caster {
     using key_conv = make_caster<Key>;
     using value_conv = make_caster<Value>;
 
+private:
+    template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
+    void reserve_maybe(const dict &d, Type *) {
+        value.reserve(d.size());
+    }
+    void reserve_maybe(const dict &, void *) {}
+
+public:
     bool load(handle src, bool convert) {
         if (!isinstance<dict>(src)) {
             return false;
@@ -150,13 +159,6 @@ struct map_caster {
     PYBIND11_TYPE_CASTER(Type,
                          const_name("Dict[") + key_conv::name + const_name(", ") + value_conv::name
                              + const_name("]"));
-
-private:
-    template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
-    void reserve_maybe(const dict &d, Type *) {
-        value.reserve(d.size());
-    }
-    void reserve_maybe(const dict &, void *) {}
 };
 
 template <typename Type, typename Value>

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -49,6 +49,11 @@ constexpr forwarded_type<T, U> forward_like(U &&u) {
     return std::forward<detail::forwarded_type<T, U>>(std::forward<U>(u));
 }
 
+// Checks if a container has a STL style reserve method.
+// The reserve method should also have a void return type.
+template <typename C>
+using has_reserve_method = std::is_same<decltype(std::declval<C>().reserve(0)), void>;
+
 template <typename Type, typename Key>
 struct set_caster {
     using type = Type;
@@ -90,9 +95,7 @@ struct set_caster {
     PYBIND11_TYPE_CASTER(type, const_name("Set[") + key_conv::name + const_name("]"));
 
 private:
-    template <
-        typename T = Type,
-        enable_if_t<std::is_same<decltype(std::declval<T>().reserve(0)), void>::value, int> = 0>
+    template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
     void reserve_maybe(const anyset &s, Type *) {
         value.reserve(s.size());
     }
@@ -149,9 +152,7 @@ struct map_caster {
                              + const_name("]"));
 
 private:
-    template <
-        typename T = Type,
-        enable_if_t<std::is_same<decltype(std::declval<T>().reserve(0)), void>::value, int> = 0>
+    template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
     void reserve_maybe(const dict &d, Type *) {
         value.reserve(d.size());
     }
@@ -180,9 +181,7 @@ struct list_caster {
     }
 
 private:
-    template <
-        typename T = Type,
-        enable_if_t<std::is_same<decltype(std::declval<T>().reserve(0)), void>::value, int> = 0>
+    template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
     void reserve_maybe(const sequence &s, Type *) {
         value.reserve(s.size());
     }

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -60,6 +60,7 @@ struct set_caster {
         }
         auto s = reinterpret_borrow<anyset>(src);
         value.clear();
+        reserve_maybe(s, &value);
         for (auto entry : s) {
             key_conv conv;
             if (!conv.load(entry, convert)) {
@@ -87,6 +88,15 @@ struct set_caster {
     }
 
     PYBIND11_TYPE_CASTER(type, const_name("Set[") + key_conv::name + const_name("]"));
+
+private:
+    template <
+        typename T = Type,
+        enable_if_t<std::is_same<decltype(std::declval<T>().reserve(0)), void>::value, int> = 0>
+    void reserve_maybe(const anyset &s, Type *) {
+        value.reserve(s.size());
+    }
+    void reserve_maybe(const anyset &, void *) {}
 };
 
 template <typename Type, typename Key, typename Value>
@@ -100,6 +110,7 @@ struct map_caster {
         }
         auto d = reinterpret_borrow<dict>(src);
         value.clear();
+        reserve_maybe(d, &value);
         for (auto it : d) {
             key_conv kconv;
             value_conv vconv;
@@ -136,6 +147,15 @@ struct map_caster {
     PYBIND11_TYPE_CASTER(Type,
                          const_name("Dict[") + key_conv::name + const_name(", ") + value_conv::name
                              + const_name("]"));
+
+private:
+    template <
+        typename T = Type,
+        enable_if_t<std::is_same<decltype(std::declval<T>().reserve(0)), void>::value, int> = 0>
+    void reserve_maybe(const dict &d, Type *) {
+        value.reserve(d.size());
+    }
+    void reserve_maybe(const dict &, void *) {}
 };
 
 template <typename Type, typename Value>


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Our STL caster was smart enough to reserve space in the list_caster. However, std::unordered_map and std::unordered_set also have the ability to reserve space ahead of time. This PR updates our other casters to make use of this. Reserving the size of the container is even more important for these types than list_caster since resizes will also call all elements to be rehashed. I am rather surprised it took so long for someone to notice this issue.
* I wanted to separate out the messy enable_if_t condition into a has_reserve_method alias, but kept getting syntax errors.
* Tested by adding static_assert false to make sure the proper reserve_method overload is called when appropriate.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Reserve space in set and STL map casters if possible. This will prevent unnecessary rehashing / resizing by knowing the number of keys ahead of time for Python to C++ casting. This improvement will greatly speed up the casting of large unordered maps and sets.
```

<!-- If the upgrade guide needs updating, note that here too -->
