### PR TITLE
fix: add flag for overriding classic Python search values

### DIFF
--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -95,8 +95,23 @@ if(NOT PythonLibsNew_FIND_VERSION)
   set(PythonLibsNew_FIND_VERSION "3.6")
 endif()
 
+# Save variables that get set by PythonInterp
+macro(_PYBIND11_PUSH_IF_DEFINED name)
+  if(DEFINED "${name}")
+    set("_PYBIND11_ORIG_${name}" "${${name}}")
+  endif()
+endmacro()
+
+_pybind11_push_if_defined(PYTHON_INCLUDE_DIR)
+_pybind11_push_if_defined(PYTHON_MODULE_EXTENSION)
+_pybind11_push_if_defined(PYTHON_IS_DEBUG)
+
 find_package(PythonInterp ${PythonLibsNew_FIND_VERSION} ${_pythonlibs_required}
              ${_pythonlibs_quiet})
+
+unset(PYTHON_INCLUDE_DIR)
+unset(PYTHON_MODULE_EXTENSION)
+unset(PYTHON_IS_DEBUG)
 
 if(NOT PYTHONINTERP_FOUND)
   set(PYTHONLIBS_FOUND FALSE)
@@ -153,7 +168,9 @@ endif()
 
 # Can manually set values when cross-compiling
 macro(_PYBIND11_GET_IF_UNDEF lst index name)
-  if(NOT DEFINED "${name}")
+  if(DEFINED "_PYBIND11_ORIG_${name}")
+    set("${name}" "${_PYBIND11_ORIG_${name}}")
+  elseif(NOT DEFINED "${name}")
     list(GET "${lst}" "${index}" "${name}")
   endif()
 endmacro()

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -95,23 +95,8 @@ if(NOT PythonLibsNew_FIND_VERSION)
   set(PythonLibsNew_FIND_VERSION "3.6")
 endif()
 
-# Save variables that get set by PythonInterp
-macro(_PYBIND11_PUSH_IF_DEFINED name)
-  if(DEFINED "${name}")
-    set("_PYBIND11_ORIG_${name}" "${${name}}")
-  endif()
-endmacro()
-
-_pybind11_push_if_defined(PYTHON_INCLUDE_DIR)
-_pybind11_push_if_defined(PYTHON_MODULE_EXTENSION)
-_pybind11_push_if_defined(PYTHON_IS_DEBUG)
-
 find_package(PythonInterp ${PythonLibsNew_FIND_VERSION} ${_pythonlibs_required}
              ${_pythonlibs_quiet})
-
-unset(PYTHON_INCLUDE_DIR)
-unset(PYTHON_MODULE_EXTENSION)
-unset(PYTHON_IS_DEBUG)
 
 if(NOT PYTHONINTERP_FOUND)
   set(PYTHONLIBS_FOUND FALSE)
@@ -166,11 +151,13 @@ if(NOT _PYTHON_SUCCESS MATCHES 0)
   return()
 endif()
 
+option(
+  PYBIND11_PYTHONLIBS_OVERRWRITE
+  "Overwrite cached values read from Python library (classic search). Turn off if cross-compiling and manually setting these values."
+  ON)
 # Can manually set values when cross-compiling
 macro(_PYBIND11_GET_IF_UNDEF lst index name)
-  if(DEFINED "_PYBIND11_ORIG_${name}")
-    set("${name}" "${_PYBIND11_ORIG_${name}}")
-  elseif(NOT DEFINED "${name}")
+  if(PYBIND11_PYTHONLIBS_OVERRWRITE OR NOT DEFINED "${name}")
     list(GET "${lst}" "${index}" "${name}")
   endif()
 endmacro()

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -152,12 +152,12 @@ if(NOT _PYTHON_SUCCESS MATCHES 0)
 endif()
 
 option(
-  PYBIND11_PYTHONLIBS_OVERRWRITE
+  PYBIND11_PYTHONLIBS_OVERWRITE
   "Overwrite cached values read from Python library (classic search). Turn off if cross-compiling and manually setting these values."
   ON)
 # Can manually set values when cross-compiling
 macro(_PYBIND11_GET_IF_UNDEF lst index name)
-  if(PYBIND11_PYTHONLIBS_OVERRWRITE OR NOT DEFINED "${name}")
+  if(PYBIND11_PYTHONLIBS_OVERWRITE OR NOT DEFINED "${name}")
     list(GET "${lst}" "${index}" "${name}")
   endif()
 endmacro()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Should fix https://github.com/pybind/scikit_build_example/pull/45.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* CMake: revert overwrite behavior, now opt-in with ``PYBIND11_PYTHONLIBS_OVERRWRITE OFF``
```

<!-- If the upgrade guide needs updating, note that here too -->
