### PR TITLE
[smart_holder] Add `gil_scoped_acquire` to `shared_ptr_trampoline_self_life_support` ctor.

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -400,7 +400,7 @@ struct shared_ptr_trampoline_self_life_support {
     PyObject *self;
     explicit shared_ptr_trampoline_self_life_support(instance *inst)
         : self{reinterpret_cast<PyObject *>(inst)} {
-        gil_scoped_acquire gil;
+        if (!PyGILState_Check()) throw std::runtime_error("NEEDED HERE: gil_scoped_acquire gil;");
         Py_INCREF(self);
     }
     void operator()(void *) {

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -400,7 +400,7 @@ struct shared_ptr_trampoline_self_life_support {
     PyObject *self;
     explicit shared_ptr_trampoline_self_life_support(instance *inst)
         : self{reinterpret_cast<PyObject *>(inst)} {
-        if (!PyGILState_Check()) throw std::runtime_error("NEEDED HERE: gil_scoped_acquire gil;");
+        gil_scoped_acquire gil;
         Py_INCREF(self);
     }
     void operator()(void *) {

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -400,6 +400,7 @@ struct shared_ptr_trampoline_self_life_support {
     PyObject *self;
     explicit shared_ptr_trampoline_self_life_support(instance *inst)
         : self{reinterpret_cast<PyObject *>(inst)} {
+        gil_scoped_acquire gil;
         Py_INCREF(self);
     }
     void operator()(void *) {

--- a/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.cpp
+++ b/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.cpp
@@ -69,6 +69,9 @@ TEST_SUBMODULE(class_sh_trampoline_shared_ptr_cpp_arg, m) {
         .def("has_python_instance", &SpBase::has_python_instance);
 
     m.def("pass_through_shd_ptr", pass_through_shd_ptr);
+    m.def("pass_through_shd_ptr_release_gil",
+          pass_through_shd_ptr,
+          py::call_guard<py::gil_scoped_release>()); // PR #4196
 
     py::classh<SpBaseTester>(m, "SpBaseTester")
         .def(py::init<>())

--- a/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.py
+++ b/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.py
@@ -132,12 +132,15 @@ def test_infinite():
         break  # Comment out for manual leak checking (use `top` command).
 
 
-def test_std_make_shared_factory():
+@pytest.mark.parametrize(
+    "pass_through_func", [m.pass_through_shd_ptr, m.pass_through_shd_ptr_release_gil]
+)
+def test_std_make_shared_factory(pass_through_func):
     class PyChild(m.SpBase):
         def __init__(self):
             super().__init__(0)
 
     obj = PyChild()
     while True:
-        assert m.pass_through_shd_ptr(obj) is obj
+        assert pass_through_func(obj) is obj
         break  # Comment out for manual leak checking (use `top` command).


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This change fixes 9 failing targets discovered via Google-internal global testing with added `PyGILState_Check()` `assert`s in `Py_INCREF()` and `Py_DECREF()` (diff below).

Python 3.9 Include/object.h:
```diff
 PyAPI_FUNC(void) _Py_Dealloc(PyObject *);

+PyAPI_FUNC(int) PyGILState_Check(void); /* Include/cpython/pystate.h */
+
 static inline void _Py_INCREF(PyObject *op)
 {
+    assert(PyGILState_Check());
 #ifdef Py_REF_DEBUG
     _Py_RefTotal++;
 #endif
@@ -433,6 +436,7 @@ static inline void _Py_DECREF(
 #endif
     PyObject *op)
 {
+    assert(PyGILState_Check());
 #ifdef Py_REF_DEBUG
     _Py_RefTotal--;
 #endif
```

Internal testing ID: OCL:441666819:BASE:476672625:1664085876295:2e44fcc

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
