### PR TITLE
bugfix: py contains raises errors when appropiate

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1967,7 +1967,11 @@ public:
     void clear() /* py-non-const */ { PyDict_Clear(ptr()); }
     template <typename T>
     bool contains(T &&key) const {
-        return PyDict_Contains(m_ptr, detail::object_or_cast(std::forward<T>(key)).ptr()) == 1;
+        auto result = PyDict_Contains(m_ptr, detail::object_or_cast(std::forward<T>(key)).ptr());
+        if (result == -1) {
+            throw error_already_set();
+        }
+        return result == 1;
     }
 
 private:
@@ -2053,7 +2057,11 @@ public:
     bool empty() const { return size() == 0; }
     template <typename T>
     bool contains(T &&val) const {
-        return PySet_Contains(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr()) == 1;
+        auto result = PySet_Contains(m_ptr, detail::object_or_cast(std::forward<T>(val)).ptr());
+        if (result == -1) {
+            throw error_already_set();
+        }
+        return result == 1;
     }
 };
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2357,7 +2357,11 @@ args_proxy object_api<D>::operator*() const {
 template <typename D>
 template <typename T>
 bool object_api<D>::contains(T &&item) const {
-    return attr("__contains__")(std::forward<T>(item)).template cast<bool>();
+    auto ret = attr("__contains__")(std::forward<T>(item)).template cast<bool>();
+    if (PyErr_Occurred()) { // TODO test this with a class that override this
+        throw error_already_set();
+    }
+    return ret;
 }
 
 template <typename D>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2357,11 +2357,7 @@ args_proxy object_api<D>::operator*() const {
 template <typename D>
 template <typename T>
 bool object_api<D>::contains(T &&item) const {
-    auto ret = attr("__contains__")(std::forward<T>(item)).template cast<bool>();
-    if (PyErr_Occurred()) {
-        throw error_already_set();
-    }
-    return ret;
+    return attr("__contains__")(std::forward<T>(item)).template cast<bool>();
 }
 
 template <typename D>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2358,7 +2358,7 @@ template <typename D>
 template <typename T>
 bool object_api<D>::contains(T &&item) const {
     auto ret = attr("__contains__")(std::forward<T>(item)).template cast<bool>();
-    if (PyErr_Occurred()) { // TODO test this with a class that override this
+    if (PyErr_Occurred()) {
         throw error_already_set();
     }
     return ret;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -538,6 +538,9 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.def("hash_function", [](py::object obj) { return py::hash(std::move(obj)); });
 
+    m.def("obj_contains",
+          [](py::object &obj, py::object key) { return obj.contains(std::move(key)); });
+
     m.def("test_number_protocol", [](const py::object &a, const py::object &b) {
         py::list l;
         l.append(a.equal(b));

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -183,7 +183,7 @@ TEST_SUBMODULE(pytypes, m) {
         return d2;
     });
     m.def("dict_contains",
-          [](const py::dict &dict, py::object val) { return dict.contains(val); });
+          [](const py::dict &dict, const py::object &val) { return dict.contains(val); });
     m.def("dict_contains",
           [](const py::dict &dict, const char *val) { return dict.contains(val); });
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -539,7 +539,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("hash_function", [](py::object obj) { return py::hash(std::move(obj)); });
 
     m.def("obj_contains",
-          [](py::object &obj, py::object key) { return obj.contains(std::move(key)); });
+          [](py::object &obj, const py::object &key) { return obj.contains(key); });
 
     m.def("test_number_protocol", [](const py::object &a, const py::object &b) {
         py::list l;

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -175,7 +175,7 @@ class CustomContains:
         return m in self.d
 
 
-@pytest.mark.xfail("env.PYPY and sys.pypy_version_info < (7, 3, 7)")
+@pytest.mark.xfail("env.PYPY and sys.pypy_version_info < (7, 3, 10)")
 @pytest.mark.parametrize(
     "arg,func",
     [

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -168,13 +168,28 @@ def test_dict(capture, doc):
     assert m.dict_keyword_constructor() == {"x": 1, "y": 2, "z": 3}
 
 
-@pytest.mark.parametrize("func", [m.anyset_contains, m.dict_contains])
-def test_unhashable_exceptions(func):
+class CustomContains:
+    d = {"key": None}
+
+    def __contains__(self, m):
+        return m in self.d
+
+
+@pytest.mark.parametrize(
+    "arg,func",
+    [
+        (set(), m.anyset_contains),
+        (dict(), m.dict_contains),
+        (CustomContains(), m.obj_contains),
+    ],
+)
+def test_unhashable_exceptions(arg, func):
     class Unhashable:
         __hash__ = None
 
-    with pytest.raises(TypeError):
-        func(Unhashable())
+    with pytest.raises(TypeError) as exc_info:
+        func(arg, Unhashable())
+    assert "unhashable type:" in str(exc_info.value)
 
 
 def test_tuple():

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -175,7 +175,6 @@ class CustomContains:
         return m in self.d
 
 
-@pytest.mark.xfail("env.PYPY and sys.pypy_version_info < (7, 3, 10)")
 @pytest.mark.parametrize(
     "arg,func",
     [
@@ -184,6 +183,7 @@ class CustomContains:
         (CustomContains(), m.obj_contains),
     ],
 )
+@pytest.mark.xfail("env.PYPY and sys.pypy_version_info < (7, 3, 10)", strict=False)
 def test_unhashable_exceptions(arg, func):
     class Unhashable:
         __hash__ = None

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -178,8 +178,13 @@ class CustomContains:
 @pytest.mark.parametrize(
     "arg,func",
     [
-        (set(), m.anyset_contains),
-        (dict(), m.dict_contains),
+        (
+            {
+                1,
+            },
+            m.anyset_contains,
+        ),
+        ({0: 0}, m.dict_contains),
         (CustomContains(), m.obj_contains),
     ],
 )

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -168,6 +168,15 @@ def test_dict(capture, doc):
     assert m.dict_keyword_constructor() == {"x": 1, "y": 2, "z": 3}
 
 
+@pytest.mark.parametrize("func", [m.anyset_contains, m.dict_contains])
+def test_unhashable_exceptions(func):
+    class Unhashable:
+        __hash__ = None
+
+    with pytest.raises(TypeError):
+        func(Unhashable())
+
+
 def test_tuple():
     assert m.tuple_no_args() == ()
     assert m.tuple_ssize_t() == ()

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -175,16 +175,12 @@ class CustomContains:
         return m in self.d
 
 
+@pytest.mark.xfail("env.PYPY and sys.pypy_version_info < (7, 3, 7)")
 @pytest.mark.parametrize(
     "arg,func",
     [
-        (
-            {
-                1,
-            },
-            m.anyset_contains,
-        ),
-        ({0: 0}, m.dict_contains),
+        (set(), m.anyset_contains),
+        (dict(), m.dict_contains),
         (CustomContains(), m.obj_contains),
     ],
 )


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Previously our contains functions just swallowed errors like TypeErrors for unhashable types. This is poorly defined and only really worked with dict and sets (but set the Python API in a bad state).  @rwgk Could you do some global testing to see how widespread the problem is off using contains to check if a key is hashable.
* There is a similar problem with PySet_Add(), but we abuse that ourselves in the STL casters, so we will need some utilities to check if an object is hashable first.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Properly raise exceptions in contains methods (like when an object in unhashable).
```

<!-- If the upgrade guide needs updating, note that here too -->
