### PR TITLE
test_eigen.py test_nonunit_stride_to_python bug fix (ASAN failure)

### DIFF
--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -197,11 +197,38 @@ TEST_SUBMODULE(eigen, m) {
 
     // Return a block of a matrix (gives non-standard strides)
     m.def("block",
-          [](const Eigen::Ref<const Eigen::MatrixXd> &x,
-             int start_row,
-             int start_col,
-             int block_rows,
-             int block_cols) { return x.block(start_row, start_col, block_rows, block_cols); });
+          [m](const py::object &x_obj,
+              int start_row,
+              int start_col,
+              int block_rows,
+              int block_cols) {
+              return m.attr("_block")(x_obj, x_obj, start_row, start_col, block_rows, block_cols);
+          });
+
+    m.def(
+        "_block",
+        [](const py::object &x_obj,
+           const Eigen::Ref<const Eigen::MatrixXd> &x,
+           int start_row,
+           int start_col,
+           int block_rows,
+           int block_cols) {
+            auto i0 = py::make_tuple(0, 0);
+            auto x0_orig = x_obj[*i0].cast<double>();
+            if (x(0, 0) != x0_orig) {
+                throw std::runtime_error(
+                    "Something in the type_caster for Eigen::Ref is terribly wrong.");
+            }
+            double x0_mod = x0_orig + 1;
+            x_obj[*i0] = x0_mod;
+            auto copy_detected = (x(0, 0) != x0_mod);
+            x_obj[*i0] = x0_orig;
+            if (copy_detected) {
+                throw std::runtime_error("type_caster for Eigen::Ref made a copy.");
+            }
+            return x.block(start_row, start_col, block_rows, block_cols);
+        },
+        py::keep_alive<0, 1>());
 
     // test_eigen_return_references, test_eigen_keepalive
     // return value referencing/copying tests:

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -213,6 +213,8 @@ TEST_SUBMODULE(eigen, m) {
            int start_col,
            int block_rows,
            int block_cols) {
+            // See PR #4217 for background. This test is a bit over the top, but might be useful
+            // as a concrete example to point to when explaining the dangling reference trap.
             auto i0 = py::make_tuple(0, 0);
             auto x0_orig = x_obj[*i0].cast<double>();
             if (x(0, 0) != x0_orig) {

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -201,7 +201,14 @@ TEST_SUBMODULE(eigen, m) {
              int start_row,
              int start_col,
              int block_rows,
-             int block_cols) { return x.block(start_row, start_col, block_rows, block_cols); });
+             int block_cols) {
+              // In case x is a copy made in the type_caster for Eigen::Ref
+              // (https://pybind11.readthedocs.io/en/stable/advanced/cast/eigen.html#pass-by-reference),
+              // returning the Eigen::Ref returned by x.block() will lead to heap-use-after-free,
+              // because the block references the copy, which is destroyed when this function
+              // returns. Therefore the block needs to be returned by value.
+              return Eigen::MatrixXd{x.block(start_row, start_col, block_rows, block_cols)};
+          });
 
     // test_eigen_return_references, test_eigen_keepalive
     // return value referencing/copying tests:

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -201,14 +201,7 @@ TEST_SUBMODULE(eigen, m) {
              int start_row,
              int start_col,
              int block_rows,
-             int block_cols) {
-              // In case x is a copy made in the type_caster for Eigen::Ref
-              // (https://pybind11.readthedocs.io/en/stable/advanced/cast/eigen.html#pass-by-reference),
-              // returning the Eigen::Ref returned by x.block() will lead to heap-use-after-free,
-              // because the block references the copy, which is destroyed when this function
-              // returns. Therefore the block needs to be returned by value.
-              return Eigen::MatrixXd{x.block(start_row, start_col, block_rows, block_cols)};
-          });
+             int block_cols) { return x.block(start_row, start_col, block_rows, block_cols); });
 
     // test_eigen_return_references, test_eigen_keepalive
     // return value referencing/copying tests:

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -223,6 +223,7 @@ def test_nonunit_stride_to_python():
     for i in range(-5, 7):
         assert np.all(m.diagonal_n(ref, i) == ref.diagonal(i)), f"m.diagonal_n({i})"
 
+    return  # TODO(rwgk): Fix ASAN failure.
     assert np.all(m.block(ref, 2, 1, 3, 3) == ref[2:5, 1:4])
     assert np.all(m.block(ref, 1, 4, 4, 2) == ref[1:, 4:])
     assert np.all(m.block(ref, 1, 4, 3, 2) == ref[1:4, 4:])

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -223,7 +223,6 @@ def test_nonunit_stride_to_python():
     for i in range(-5, 7):
         assert np.all(m.diagonal_n(ref, i) == ref.diagonal(i)), f"m.diagonal_n({i})"
 
-    return  # TODO(rwgk): Fix ASAN failure.
     assert np.all(m.block(ref, 2, 1, 3, 3) == ref[2:5, 1:4])
     assert np.all(m.block(ref, 1, 4, 4, 2) == ref[1:, 4:])
     assert np.all(m.block(ref, 1, 4, 3, 2) == ref[1:4, 4:])


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The bug is in the implementation of "block" in test_eigen.cpp, which returns a dangling reference.

Initial analysis provided by @hawkinsp:
________
We are passing a C-contiguous array, but pybind11 ends up copying it to a temporary F-contiguous array so it can pass it to Eigen. The eigen reference returned by "block" points into this temporary array, but the temporary array does not outlive the call.

e.g., this works around the problem by avoiding the temporary copy:
```
    rf = np.asarray(ref, order='F')
    assert np.all(m.block(rf, 2, 1, 3, 3) == ref[2:5, 1:4])
```
________

Note that this bug was discovered only after patching the numpy sources Google-internally, to turn off caching when testing with sanitizers. The valgrind tests in the pybind11 github CI use the original numpy sources, therefore valgrind is blind to this bug.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
