### PR TITLE
chore: steal arg_v.value from copied arg in unpacking_collector

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1545,7 +1545,7 @@ private:
             throw cast_error_unable_to_convert_call_arg(a.name, a.type);
 #endif
         }
-        m_kwargs[a.name] = a.value;
+        m_kwargs[a.name] = std::move(a.value);
     }
 
     void process(list & /*args_list*/, detail::kwargs_proxy kp) {


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* I was looking through the include cast and noticed we could steal the `arg_v.value` for the copied arg in the process list. This should remove one inc-ref / dec-ref from py::object and therefore potentially speed up the processing of a function with lots of specified arg_v values.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* chore: optimize unpacking_collector when processing arg_v arguments.
```

<!-- If the upgrade guide needs updating, note that here too -->
