### PR TITLE
Work-Around: NVCC 11.4.0 - 11.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,8 +324,8 @@ jobs:
   # Testing NVCC; forces sources to behave like .cu files
   cuda:
     runs-on: ubuntu-latest
-    name: "🐍 3.8 • CUDA 11.2 • Ubuntu 20.04"
-    container: nvidia/cuda:11.2.2-devel-ubuntu20.04
+    name: "🐍 3.10 • CUDA 11.7 • Ubuntu 22.04"
+    container: nvidia/cuda:11.7.0-devel-ubuntu22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1578,6 +1578,21 @@ public:
         return *this;
     }
 
+// Nvidia's NVCC is broken between 11.4.0 and 11.8.0
+//   https://github.com/pybind/pybind11/issues/4193
+#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 4) && (__CUDACC_VER_MINOR__ <= 8)
+    template <typename T, typename... Extra>
+    class_ &def(const T &op, const Extra &...extra) {
+        op.execute(*this, extra...);
+        return *this;
+    }
+
+    template <typename T, typename... Extra>
+    class_ &def_cast(const T &op, const Extra &...extra) {
+        op.execute_cast(*this, extra...);
+        return *this;
+    }
+#else
     template <detail::op_id id, detail::op_type ot, typename L, typename R, typename... Extra>
     class_ &def(const detail::op_<id, ot, L, R> &op, const Extra &...extra) {
         op.execute(*this, extra...);
@@ -1589,6 +1604,7 @@ public:
         op.execute_cast(*this, extra...);
         return *this;
     }
+#endif
 
     template <typename... Args, typename... Extra>
     class_ &def(const detail::initimpl::constructor<Args...> &init, const Extra &...extra) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1580,7 +1580,8 @@ public:
 
 // Nvidia's NVCC is broken between 11.4.0 and 11.8.0
 //   https://github.com/pybind/pybind11/issues/4193
-#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 4) && (__CUDACC_VER_MINOR__ <= 8)
+#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 4)            \
+    && (__CUDACC_VER_MINOR__ <= 8)
     template <typename T, typename... Extra>
     class_ &def(const T &op, const Extra &...extra) {
         op.execute(*this, extra...);


### PR DESCRIPTION
Adds a targeted NVCC work around for limited number of CUDA releases. Fixed in NVCC development.

Fix #4193

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* work-around for Nvidia's CUDA nvcc compiler in versions 11.4.0 - 11.8.0
```

<!-- If the upgrade guide needs updating, note that here too -->
