### PR TITLE
chore: Improve PyCapsule exception handling

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1834,7 +1834,7 @@ public:
             }
             const char *name = get_name_in_error_scope(o);
             void *ptr = PyCapsule_GetPointer(o, name);
-            if (ptr == nullptr && PyErr_Occurred()) {
+            if (ptr == nullptr) {
                 throw error_already_set();
             }
 
@@ -1852,13 +1852,10 @@ public:
         m_ptr = PyCapsule_New(reinterpret_cast<void *>(destructor), nullptr, [](PyObject *o) {
             const char *name = get_name_in_error_scope(o);
             auto destructor = reinterpret_cast<void (*)()>(PyCapsule_GetPointer(o, name));
-            if (destructor != nullptr) {
-                destructor();
-            } else {
-                if (PyErr_Occurred()) {
-                    throw error_already_set();
-                }
+            if (destructor == nullptr) {
+                throw error_already_set();
             }
+            destructor();
         });
 
         if (!m_ptr) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1829,7 +1829,7 @@ public:
             // guard if destructor called while err indicator is set
             error_scope error_guard;
             auto destructor = reinterpret_cast<void (*)(void *)>(PyCapsule_GetContext(o));
-            if (PyErr_Occurred()) {
+            if (destructor == nullptr && PyErr_Occurred()) {
                 throw error_already_set();
             }
             const char *name = get_name_in_error_scope(o);
@@ -1843,7 +1843,7 @@ public:
             }
         });
 
-        if (!m_ptr || PyCapsule_SetContext(m_ptr, (void *) destructor) != 0) {
+        if (!m_ptr || PyCapsule_SetContext(m_ptr, reinterpret_cast<void *>(destructor)) != 0) {
             throw error_already_set();
         }
     }
@@ -1852,10 +1852,13 @@ public:
         m_ptr = PyCapsule_New(reinterpret_cast<void *>(destructor), nullptr, [](PyObject *o) {
             const char *name = get_name_in_error_scope(o);
             auto destructor = reinterpret_cast<void (*)()>(PyCapsule_GetPointer(o, name));
-            if (destructor == nullptr) {
-                throw error_already_set();
+            if (destructor != nullptr) {
+                destructor();
+            } else {
+                if (PyErr_Occurred()) {
+                    throw error_already_set();
+                }
             }
-            destructor();
         });
 
         if (!m_ptr) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1834,7 +1834,7 @@ public:
             }
             const char *name = get_name_in_error_scope(o);
             void *ptr = PyCapsule_GetPointer(o, name);
-            if (ptr == nullptr) {
+            if (ptr == nullptr && PyErr_Occurred()) {
                 throw error_already_set();
             }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This further improves another error in exception handling pointed out by #4221 . 
It makes the following changes
* Only check if PyErrOccurred() only if the destructor is nullptr (the exceptions are only set in if the destructor is nullptr according the spec). This should be a bit faster and be more robust as it better follows the spec.
* ~There is a pretty rare edge case that could occur when wrapping a capsule around a function ptr if the destructor was somehow changed to nullptr. I couldn't actually get this one to fire at all, however, it's better to have proper handling in case this corner case is every encountered since it's a valid return state according the CPython API.~ I checked the code and it is actually impossible to get to have GetPointer return a nullptr and NOT set up an exception
* Change a cstyle cast to an explicit C++ reinterpret_cast for readability.
<!-- Include relevant issues or PRs here, describe what changed and why -->