### PR TITLE
perf: Optimize iterator advance() call

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1382,7 +1382,7 @@ public:
 private:
     void advance() {
         value = reinterpret_steal<object>(PyIter_Next(m_ptr));
-        if (PyErr_Occurred()) {
+        if (value.ptr() == nullptr && PyErr_Occurred()) {
             throw error_already_set();
         }
     }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Inspired by #4232, I found one other place where we ignore the return value of C-API function and blindly call PyErr_Occurred(). Worse, it's in a very hot piece of code, (the advance() function for iterators in C++ bindings). The official [C-API documentation example code](https://docs.python.org/3/c-api/iter.html) clearly shows that PyErr_Occurred() check is only necessary when the iteration terminates (ie. the next pointer returned is not null). `PyErrOccurred()` involves a good deal of pointer chasing so best to avoid having to so every step: https://github.com/vstinner/pythondev/blob/d7a8d069e5a5d7ad26503f98a2d29c1508a03e73/assembly.rst
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* perf: optimize iterator advancement in C++ bindings.
```

<!-- If the upgrade guide needs updating, note that here too -->
