### PR TITLE
`pybind11::handle` `inc_ref()` & `dec_ref()` `PyGILState_Check()` **excluding** `nullptr`

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -262,7 +262,9 @@
 #    define PYBIND11_HAS_U8STRING
 #endif
 
+// See description of PR #4246:
 #if !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF)                                \
+    && !(defined(PYPY_VERSION) && defined(_MSC_VER)) /* Tests hang indefinitely at startup. */    \
     && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -262,6 +262,11 @@
 #    define PYBIND11_HAS_U8STRING
 #endif
 
+#if !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF)                                \
+    && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
+#    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
+#endif
+
 // #define PYBIND11_STR_LEGACY_PERMISSIVE
 // If DEFINED, pybind11::str can hold PyUnicodeObject or PyBytesObject
 //             (probably surprising and never documented, but this was the

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -264,7 +264,9 @@
 
 // See description of PR #4246:
 #if !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF)                                \
-    && !(defined(PYPY_VERSION) && defined(_MSC_VER)) /* Tests hang indefinitely at startup. */    \
+    && !(defined(PYPY_VERSION)                                                                    \
+         && defined(_MSC_VER)) /* PyPy Windows: pytest hangs indefinitely at the end of the       \
+                                  process (see PR #4268) */                                       \
     && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -247,6 +247,11 @@ public:
 #ifdef PYBIND11_HANDLE_REF_DEBUG
         inc_ref_counter(1);
 #endif
+#if defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
+        if (m_ptr != nullptr && !PyGILState_Check()) {
+            throw std::runtime_error("pybind11::handle::inc_ref() PyGILState_Check() failure.");
+        }
+#endif
         Py_XINCREF(m_ptr);
         return *this;
     }
@@ -257,6 +262,11 @@ public:
         this function automatically. Returns a reference to itself.
     \endrst */
     const handle &dec_ref() const & {
+#if defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
+        if (m_ptr != nullptr && !PyGILState_Check()) {
+            throw std::runtime_error("pybind11::handle::dec_ref() PyGILState_Check() failure.");
+        }
+#endif
         Py_XDECREF(m_ptr);
         return *this;
     }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Background: https://docs.python.org/3/glossary.html#term-global-interpreter-lock

The GIL must be held when calling any Python C API functions. In multithreaded applications that use callbacks this requirement can easily be violated by accident. A general tool to ensure GIL health is not available, but the this PR integrates a very simple basic health check into `pybind11::handle`.

A comparison of test runtimes with and without this PR showed that **the runtime overhead for the added checks is practically undetectable for non-optimized builds**, but Google global testing with this PR uncovered a number (10+) of often very subtle GIL-not-held issues, including bugs in a few 3rd party projects (e.g. [pikepdf](https://github.com/pikepdf/pikepdf/commit/9fdb4740e0d94fc80fb91393e0d810736ec86258)).

The added GIL checks are guarded by `PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF`, which is the default only if `NDEBUG` is *not* defined:

```diff
+#if !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF)                                \
+    && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
+#    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
+#endif
```

The test for the `PY_ASSERT_GIL_HELD_INCREF_DECREF` macro is for cooperation with a more general patch in the Python sources, inserting the GIL checks directly in `Py_INCREF` & `Py_DECREF`, which makes the checks in pybind11 redundant.

Note that the GIL checks are skipped if `py::handle` `ptr() == nullptr`. This could mask bugs, in particular for classes with `py::object` members for which `ptr() == nullptr` in all unit tests, but not in production. Unfortunately Google global testing revealed that such members are much more common than one might expect. It is currently unclear if the cleanup cost for enforcing that the GIL is held even for `nullptr` is commensurate with the benefits of preventing a potentially only very small number of production bugs.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
`PyGILState_Check()`s were integrated to `pybind11::handle` `inc_ref()` & `dec_ref()`. The added GIL checks are guarded by `PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF`, which is the default only if `NDEBUG` is not defined
```

<!-- If the upgrade guide needs updating, note that here too -->
