### PR TITLE
Ensure config, build, toolchain, spelling, etc. issues are not masked.

### DIFF
--- a/include/pybind11/eigen/matrix.h
+++ b/include/pybind11/eigen/matrix.h
@@ -11,7 +11,6 @@
 
 #include "../numpy.h"
 
-// Similar to comments & pragma block in eigen_tensor.h. PLEASE KEEP IN SYNC.
 /* HINT: To suppress warnings originating from the Eigen headers, use -isystem.
    See also:
        https://stackoverflow.com/questions/2579576/i-dir-vs-isystem-dir

--- a/tests/test_eigen_tensor.py
+++ b/tests/test_eigen_tensor.py
@@ -9,8 +9,16 @@ try:
     from pybind11_tests import eigen_tensor_avoid_stl_array as avoid
 
     submodules += [avoid.c_style, avoid.f_style]
-except ImportError:
-    pass
+except ImportError as e:
+    # Ensure config, build, toolchain, etc. issues are not masked here:
+    raise RuntimeError(
+        "import pybind11_tests.eigen_tensor_avoid_stl_array FAILED, while "
+        "import pybind11_tests.eigen_tensor succeeded. "
+        "Please ensure that "
+        "test_eigen_tensor.cpp & "
+        "test_eigen_tensor_avoid_stl_array.cpp "
+        "are built together (or both are not built if Eigen is not available)."
+    ) from e
 
 tensor_ref = np.empty((3, 5, 2), dtype=np.int64)
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Improve safety & remove obsolete comment line.

Example:

```
Running tests in directory "/usr/local/google/home/rwgk/forked/pybind11/tests/test_embed":
===============================================================================
All tests passed (1554 assertions in 12 test cases)

Running tests in directory "/usr/local/google/home/rwgk/forked/pybind11/tests":

============================= test session starts ==============================
platform linux -- Python 3.10.7, pytest-7.1.2, pluggy-1.0.0
C++ Info: Debian Clang 14.0.6 C++17 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002_sh_def__
rootdir: /usr/local/google/home/rwgk/forked/pybind11/tests, configfile: pytest.ini
collected 769 items / 1 error

==================================== ERRORS ====================================
____________________ ERROR collecting test_eigen_tensor.py _____________________
test_eigen_tensor.py:9: in <module>
    from pybind11_tests import egen_tensor_avoid_stl_array as avoid
E   ImportError: cannot import name 'egen_tensor_avoid_stl_array' from 'pybind11_tests' (/usr/local/google/home/rwgk/forked/build_clang/lib/pybind11_tests.so)
        __builtins__ = <builtins>
        __cached__ = '/usr/local/google/home/rwgk/forked/pybind11/tests/__pycache__/test_eigen_tensor.cpython-310.pyc'
        __doc__    = None
        __file__   = '/usr/local/google/home/rwgk/forked/pybind11/tests/test_eigen_tensor.py'
        __loader__ = <_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fb9e51516f0>
        __name__   = 'test_eigen_tensor'
        __package__ = ''
        __spec__   = ModuleSpec(name='test_eigen_tensor', loader=<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fb9e51516f0>, origin='/usr/local/google/home/rwgk/forked/pybind11/tests/test_eigen_tensor.py')
        eigen_tensor = <module 'pybind11_tests.eigen_tensor'>
        np         = <module 'numpy' from '/usr/lib/python3/dist-packages/numpy/__init__.py'>
        pytest     = <module 'pytest' from '/usr/local/lib/python3.10/dist-packages/pytest/__init__.py'>
        submodules = [<module 'pybind11_tests.eigen_tensor.c_style'>, <module 'pybind11_tests.eigen_tensor.f_style'>]
        sys        = <module 'sys' (built-in)>

The above exception was the direct cause of the following exception:
test_eigen_tensor.py:14: in <module>
    raise RuntimeError(
E   RuntimeError: import pybind11_tests.eigen_tensor_avoid_stl_array FAILED, while import pybind11_tests.eigen_tensor succeeded. Please ensure that test_eigen_tensor.cpp & test_eigen_tensor_avoid_stl_array.cpp are built together (or both are not built if Eigen is not available).
        __builtins__ = <builtins>
        __cached__ = '/usr/local/google/home/rwgk/forked/pybind11/tests/__pycache__/test_eigen_tensor.cpython-310.pyc'
        __doc__    = None
        __file__   = '/usr/local/google/home/rwgk/forked/pybind11/tests/test_eigen_tensor.py'
        __loader__ = <_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fb9e51516f0>
        __name__   = 'test_eigen_tensor'
        __package__ = ''
        __spec__   = ModuleSpec(name='test_eigen_tensor', loader=<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fb9e51516f0>, origin='/usr/local/google/home/rwgk/forked/pybind11/tests/test_eigen_tensor.py')
        eigen_tensor = <module 'pybind11_tests.eigen_tensor'>
        np         = <module 'numpy' from '/usr/lib/python3/dist-packages/numpy/__init__.py'>
        pytest     = <module 'pytest' from '/usr/local/lib/python3.10/dist-packages/pytest/__init__.py'>
        submodules = [<module 'pybind11_tests.eigen_tensor.c_style'>, <module 'pybind11_tests.eigen_tensor.f_style'>]
        sys        = <module 'sys' (built-in)>
=========================== short test summary info ============================
ERROR test_eigen_tensor.py - RuntimeError: import pybind11_tests.eigen_tensor...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.35s ===============================

```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
