### PR TITLE
fix: PREFIX_PATH not MODULE_PATH

### DIFF
--- a/tools/setup_main.py.in
+++ b/tools/setup_main.py.in
@@ -39,7 +39,7 @@ setup(
         "pipx.run": [
              "pybind11 = pybind11.__main__:main",
         ],
-        "cmake.modules": [
+        "cmake.prefix": [
             "pybind11 = pybind11.share.cmake.pybind11",
         ]
     },


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Quick naming update - this actually has to set `PREFIX_PATH`, not `MODULE_PATH` (my instructions were right, but I hadn't noticed I forgot to change the name). Suggested usage:

```python

module_dirs = importlib.metadata.entry_points(group="cmake.prefix")
dirs = (importlib.resources.files(ep.load()) for ep in module_dirs)
paths_str = ";".join(str(p) for p in dirs)
cmake_arg = f"-DCMAKE_PREFIX_PATH={paths_str}"

```

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

- Will update #4258.

<!-- If the upgrade guide needs updating, note that here too -->
