### PR TITLE
chore: Cleanup casters to avoid unnecessary ref counting

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -248,7 +248,7 @@ public:
         return false;
     }
     static handle cast(T, return_value_policy /* policy */, handle /* parent */) {
-        return none().inc_ref();
+        return none().release();
     }
     PYBIND11_TYPE_CASTER(T, const_name("None"));
 };
@@ -291,7 +291,7 @@ public:
         if (ptr) {
             return capsule(ptr).release();
         }
-        return none().inc_ref();
+        return none().release();
     }
 
     template <typename T>
@@ -537,7 +537,7 @@ public:
 
     static handle cast(const CharT *src, return_value_policy policy, handle parent) {
         if (src == nullptr) {
-            return pybind11::none().inc_ref();
+            return pybind11::none().release();
         }
         return StringCaster::cast(StringType(src), policy, parent);
     }

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -110,7 +110,7 @@ public:
     template <typename Func>
     static handle cast(Func &&f_, return_value_policy policy, handle /* parent */) {
         if (!f_) {
-            return none().inc_ref();
+            return none().release();
         }
 
         auto result = f_.template target<function_type>();

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -311,7 +311,7 @@ struct optional_caster {
     template <typename T>
     static handle cast(T &&src, return_value_policy policy, handle parent) {
         if (!src) {
-            return none().inc_ref();
+            return none().release();
         }
         if (!std::is_lvalue_reference<T>::value) {
             policy = return_value_policy_override<Value>::policy(policy);


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* I noticed some style inconsistency where we inc_ref() 'None()' when returning them in casters. In reality, we should be calling release() on them to simply return the existing handle from the underlying object. 
* In other words, currently we call inc_ref() twice and dec_ref() once to increase the ref count by one (once in ctor, once manually, once in the dor). This change makes it so we only call it once in the ctor.
* This also makes the style more consistent for when people write their own casters.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Optimize casting C++ object to None.
```

<!-- If the upgrade guide needs updating, note that here too -->
