### PR TITLE
Revert "feat: add entrypoint for cmake modules dir"

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -103,9 +103,6 @@ Performance and style:
 
 Build system improvements:
 
-* Experimental support for ``cmake.modules`` entrypoint.
-  `#4258 <https://github.com/pybind/pybind11/pull/4258>`_
-
 * Include a pkg-config file when installing pybind11, such as in the Python
   package.
   `#4077 <https://github.com/pybind/pybind11/pull/4077>`_

--- a/setup.py
+++ b/setup.py
@@ -144,8 +144,6 @@ with remove_output("pybind11/include", "pybind11/share"):
             stdout=sys.stdout,
             stderr=sys.stderr,
         )
-        if not global_sdist:
-            Path("pybind11/share/cmake/pybind11/__init__.py").touch()
 
     txt = get_and_replace(setup_py, version=version, extra_cmd=extra_cmd)
     code = compile(txt, setup_py, "exec")

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -166,7 +166,6 @@ def test_build_sdist(monkeypatch, tmpdir):
     files |= {f"pybind11{n}" for n in local_sdist_files}
     files.add("pybind11.egg-info/entry_points.txt")
     files.add("pybind11.egg-info/requires.txt")
-    files.add("pybind11/share/cmake/pybind11/__init__.py")
     assert simpler == files
 
     with open(os.path.join(MAIN_DIR, "tools", "setup_main.py.in"), "rb") as f:
@@ -253,7 +252,6 @@ def tests_build_wheel(monkeypatch, tmpdir):
         "dist-info/entry_points.txt",
         "dist-info/top_level.txt",
     }
-    files.add("pybind11/share/cmake/pybind11/__init__.py")
 
     with zipfile.ZipFile(str(wheel)) as z:
         names = z.namelist()

--- a/tools/setup_main.py.in
+++ b/tools/setup_main.py.in
@@ -38,9 +38,6 @@ setup(
         ],
         "pipx.run": [
              "pybind11 = pybind11.__main__:main",
-        ],
-        "cmake.modules": [
-            "pybind11 = pybind11.share.cmake.pybind11",
         ]
     },
     cmdclass=cmdclass


### PR DESCRIPTION
Going to back out on #4258 before we release, we can add it more carefully later, I don't want to get the name and suggested usage wrong.