### PR TITLE
Fix casts to void*

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1179,11 +1179,9 @@ enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&)
     pybind11_fail("Internal error: cast_safe fallback invoked");
 }
 template <typename T>
-enable_if_t<std::is_same<void, intrinsic_t<T>>::value, void> cast_safe(object &&) {}
+enable_if_t<std::is_same<void, T>::value, void> cast_safe(object &&) {}
 template <typename T>
-enable_if_t<detail::none_of<cast_is_temporary_value_reference<T>,
-                            std::is_same<void, intrinsic_t<T>>>::value,
-            T>
+enable_if_t<detail::none_of<cast_is_temporary_value_reference<T>, std::is_same<void, T>>::value, T>
 cast_safe(object &&o) {
     return pybind11::cast<T>(std::move(o));
 }

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,6 +1,7 @@
 import pytest
 
 import env  # noqa: F401
+import ctypes
 from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import class_ as m
 
@@ -313,6 +314,7 @@ def test_bind_protected_functions():
 
     b = m.ProtectedB()
     assert b.foo() == 42
+    assert m.read_foo(b.void_foo()) == 42
 
     class C(m.ProtectedB):
         def __init__(self):

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,7 +1,8 @@
+import ctypes
+
 import pytest
 
 import env  # noqa: F401
-import ctypes
 from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import class_ as m
 


### PR DESCRIPTION
## Description

The current code is broken for safe casts to void* as those are incorrectly converted to casts to void. This fixes the problem.

Fixes #4117, needed for #4125
