### PR TITLE
Fix casts to void*

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1179,11 +1179,9 @@ enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&)
     pybind11_fail("Internal error: cast_safe fallback invoked");
 }
 template <typename T>
-enable_if_t<std::is_same<void, intrinsic_t<T>>::value, void> cast_safe(object &&) {}
+enable_if_t<std::is_same<void, T>::value, void> cast_safe(object &&) {}
 template <typename T>
-enable_if_t<detail::none_of<cast_is_temporary_value_reference<T>,
-                            std::is_same<void, intrinsic_t<T>>>::value,
-            T>
+enable_if_t<detail::none_of<cast_is_temporary_value_reference<T>, std::is_same<void, T>>::value, T>
 cast_safe(object &&o) {
     return pybind11::cast<T>(std::move(o));
 }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1179,9 +1179,9 @@ enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&)
     pybind11_fail("Internal error: cast_safe fallback invoked");
 }
 template <typename T>
-enable_if_t<std::is_same<void, T>::value, void> cast_safe(object &&) {}
+enable_if_t<std::is_void<T>::value, void> cast_safe(object &&) {}
 template <typename T>
-enable_if_t<detail::none_of<cast_is_temporary_value_reference<T>, std::is_same<void, T>>::value, T>
+enable_if_t<detail::none_of<cast_is_temporary_value_reference<T>, std::is_void<T>>::value, T>
 cast_safe(object &&o) {
     return pybind11::cast<T>(std::move(o));
 }

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -385,6 +385,7 @@ TEST_SUBMODULE(class_, m) {
     protected:
         virtual int foo() const { return value; }
         virtual void *void_foo() { return (void *) &value; }
+        virtual void *get_self() { return (void *) this; }
 
     private:
         int value = 42;
@@ -394,6 +395,7 @@ TEST_SUBMODULE(class_, m) {
     public:
         int foo() const override { PYBIND11_OVERRIDE(int, ProtectedB, foo, ); }
         void *void_foo() override { PYBIND11_OVERRIDE(void *, ProtectedB, void_foo, ); }
+        void *get_self() override { PYBIND11_OVERRIDE(void *, ProtectedB, get_self, ); }
     };
 
     class PublicistB : public ProtectedB {
@@ -404,6 +406,7 @@ TEST_SUBMODULE(class_, m) {
         ~PublicistB() override{}; // NOLINT(modernize-use-equals-default)
         using ProtectedB::foo;
         using ProtectedB::void_foo;
+        using ProtectedB::get_self;
     };
 
     m.def("read_foo", [](const void *original) {
@@ -411,10 +414,15 @@ TEST_SUBMODULE(class_, m) {
         return *ptr;
     });
 
+    m.def("pointers_equal", [](const void *original, const void* comparison) {
+        return original == comparison;
+    });
+
     py::class_<ProtectedB, TrampolineB>(m, "ProtectedB")
         .def(py::init<>())
         .def("foo", &PublicistB::foo)
-        .def("void_foo", &PublicistB::void_foo);
+        .def("void_foo", &PublicistB::void_foo)
+        .def("get_self", &PublicistB::get_self);
 
     // test_brace_initialization
     struct BraceInitialization {

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -384,8 +384,8 @@ TEST_SUBMODULE(class_, m) {
 
     protected:
         virtual int foo() const { return value; }
-        virtual void *void_foo() { return (void *) &value; }
-        virtual void *get_self() { return (void *) this; }
+        virtual void *void_foo() { return static_cast<void *>(&value); }
+        virtual void *get_self() { return static_cast<void *>(this); }
 
     private:
         int value = 42;

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -405,8 +405,8 @@ TEST_SUBMODULE(class_, m) {
         // (in Debug builds only, tested with icpc (ICC) 2021.1 Beta 20200827)
         ~PublicistB() override{}; // NOLINT(modernize-use-equals-default)
         using ProtectedB::foo;
-        using ProtectedB::void_foo;
         using ProtectedB::get_self;
+        using ProtectedB::void_foo;
     };
 
     m.def("read_foo", [](const void *original) {
@@ -414,9 +414,8 @@ TEST_SUBMODULE(class_, m) {
         return *ptr;
     });
 
-    m.def("pointers_equal", [](const void *original, const void* comparison) {
-        return original == comparison;
-    });
+    m.def("pointers_equal",
+          [](const void *original, const void *comparison) { return original == comparison; });
 
     py::class_<ProtectedB, TrampolineB>(m, "ProtectedB")
         .def(py::init<>())

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,5 +1,3 @@
-import ctypes
-
 import pytest
 
 import env  # noqa: F401
@@ -316,6 +314,7 @@ def test_bind_protected_functions():
     b = m.ProtectedB()
     assert b.foo() == 42
     assert m.read_foo(b.void_foo()) == 42
+    assert m.pointers_equal(b.get_self(), b)
 
     class C(m.ProtectedB):
         def __init__(self):

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,3 +1,5 @@
+import ctypes
+
 import pytest
 
 import env  # noqa: F401
@@ -313,6 +315,7 @@ def test_bind_protected_functions():
 
     b = m.ProtectedB()
     assert b.foo() == 42
+    assert m.read_foo(b.void_foo()) == 42
 
     class C(m.ProtectedB):
         def __init__(self):


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

The current code is broken for safe casts to void* as those are incorrectly converted to casts to void. This fixes the problem.

Fixes #4117, needed for #4125

This is a reopened version of #4273 with some minor test changes. Closes #4117.


## Suggested changelog entry:

```rst
* Fix support for safe casts to void* (regression in 2.10.0)
```
