### PR TITLE
Fix char8_t support

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -205,10 +205,6 @@
 #    endif
 #endif
 
-#if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
-#    define PYBIND11_HAS_U8STRING
-#endif
-
 #include <Python.h>
 #if PY_VERSION_HEX < 0x03060000
 #    error "PYTHON < 3.6 IS UNSUPPORTED. pybind11 v2.9 was the last to support Python 2 and 3.5."
@@ -257,6 +253,11 @@
 #    if __has_include(<version>)
 #        include <version>
 #    endif
+#endif
+
+// Must be after including <version> or one of the other headers specified by the standard
+#if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
+#    define PYBIND11_HAS_U8STRING
 #endif
 
 // #define PYBIND11_STR_LEGACY_PERMISSIVE


### PR DESCRIPTION
## Description
Standard library macro __cpp_lib_char8_t is only available after including standard header

Fixes #4277
