### PR TITLE
fix: improve bytes to str decoding error handling

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1432,6 +1432,9 @@ public:
     str(const char *c, const SzType &n)
         : object(PyUnicode_FromStringAndSize(c, ssize_t_cast(n)), stolen_t{}) {
         if (!m_ptr) {
+            if (PyErr_Occurred()) {
+                throw error_already_set();
+            }
             pybind11_fail("Could not allocate string object!");
         }
     }
@@ -1441,6 +1444,9 @@ public:
     // NOLINTNEXTLINE(google-explicit-constructor)
     str(const char *c = "") : object(PyUnicode_FromString(c), stolen_t{}) {
         if (!m_ptr) {
+            if (PyErr_Occurred()) {
+                throw error_already_set();
+            }
             pybind11_fail("Could not allocate string object!");
         }
     }
@@ -1598,6 +1604,9 @@ inline str::str(const bytes &b) {
     }
     auto obj = reinterpret_steal<object>(PyUnicode_FromStringAndSize(buffer, length));
     if (!obj) {
+        if (PyErr_Occurred()) {
+            throw error_already_set();
+        }
         pybind11_fail("Could not allocate string object!");
     }
     m_ptr = obj.release().ptr();

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -219,6 +219,9 @@ TEST_SUBMODULE(pytypes, m) {
         return py::make_tuple(s1, s2);
     });
 
+    m.def("bytes_to_str_explicit",
+          [](const py::bytes &encoded_str) { return py::str(encoded_str); });
+
     // test_bytes
     m.def("bytes_from_char_ssize_t", []() { return py::bytes{"green", (py::ssize_t) 5}; });
     m.def("bytes_from_char_size_t", []() { return py::bytes{"purple", (py::size_t) 6}; });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -207,7 +207,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("str_from_char_size_t", []() { return py::str{"blue", (py::size_t) 4}; });
     m.def("str_from_string", []() { return py::str(std::string("baz")); });
     m.def("str_from_string_input", [](const std::string &stri) { return py::str(stri); });
-    m.def("str_from_cstr_input", [](const std::string &stri) { return py::str(stri.c_str()); });
+    m.def("str_from_cstr_input", [](const char *c_str) { return py::str(c_str); });
     m.def("str_from_bytes", []() { return py::str(py::bytes("boo", 3)); });
     m.def("str_from_bytes_input",
           [](const py::bytes &encoded_str) { return py::str(encoded_str); });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -206,11 +206,12 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("str_from_char_ssize_t", []() { return py::str{"red", (py::ssize_t) 3}; });
     m.def("str_from_char_size_t", []() { return py::str{"blue", (py::size_t) 4}; });
     m.def("str_from_string", []() { return py::str(std::string("baz")); });
-    m.def("str_from_string_input", [](const std::string &stri) { return py::str(stri); });
+    m.def("str_from_std_string_input", [](const std::string &stri) { return py::str(stri); });
     m.def("str_from_cstr_input", [](const char *c_str) { return py::str(c_str); });
     m.def("str_from_bytes", []() { return py::str(py::bytes("boo", 3)); });
     m.def("str_from_bytes_input",
           [](const py::bytes &encoded_str) { return py::str(encoded_str); });
+
     m.def("str_from_object", [](const py::object &obj) { return py::str(obj); });
     m.def("repr_from_object", [](const py::object &obj) { return py::repr(obj); });
     m.def("str_from_handle", [](py::handle h) { return py::str(h); });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -207,6 +207,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("str_from_char_size_t", []() { return py::str{"blue", (py::size_t) 4}; });
     m.def("str_from_string", []() { return py::str(std::string("baz")); });
     m.def("str_from_bytes", []() { return py::str(py::bytes("boo", 3)); });
+    m.def("str_from_bytes_input",
+          [](const py::bytes &encoded_str) { return py::str(encoded_str); });
     m.def("str_from_object", [](const py::object &obj) { return py::str(obj); });
     m.def("repr_from_object", [](const py::object &obj) { return py::repr(obj); });
     m.def("str_from_handle", [](py::handle h) { return py::str(h); });
@@ -218,9 +220,6 @@ TEST_SUBMODULE(pytypes, m) {
         auto s2 = "{a} + {b} = {c}"_s.format("a"_a = 1, "b"_a = 2, "c"_a = 3);
         return py::make_tuple(s1, s2);
     });
-
-    m.def("bytes_to_str_explicit",
-          [](const py::bytes &encoded_str) { return py::str(encoded_str); });
 
     // test_bytes
     m.def("bytes_from_char_ssize_t", []() { return py::bytes{"green", (py::ssize_t) 5}; });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -207,6 +207,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("str_from_char_size_t", []() { return py::str{"blue", (py::size_t) 4}; });
     m.def("str_from_string", []() { return py::str(std::string("baz")); });
     m.def("str_from_string_input", [](const std::string &stri) { return py::str(stri); });
+    m.def("str_from_cstr_input", [](const std::string &stri) { return py::str(stri.c_str()); });
     m.def("str_from_bytes", []() { return py::str(py::bytes("boo", 3)); });
     m.def("str_from_bytes_input",
           [](const py::bytes &encoded_str) { return py::str(encoded_str); });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -206,6 +206,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("str_from_char_ssize_t", []() { return py::str{"red", (py::ssize_t) 3}; });
     m.def("str_from_char_size_t", []() { return py::str{"blue", (py::size_t) 4}; });
     m.def("str_from_string", []() { return py::str(std::string("baz")); });
+    m.def("str_from_string_input", [](const std::string &stri) { return py::str(stri); });
     m.def("str_from_bytes", []() { return py::str(py::bytes("boo", 3)); });
     m.def("str_from_bytes_input",
           [](const py::bytes &encoded_str) { return py::str(encoded_str); });

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -247,7 +247,7 @@ def test_str(doc):
 def test_surrogate_pairs_unicode_error():
     input_str = "\ud83d\ude4f".encode("utf-8", "surrogatepass")
     with pytest.raises(UnicodeDecodeError):
-        m.bytes_to_str_explicit(input_str)
+        m.str_from_bytes_input(input_str)
 
 
 def test_bytes(doc):

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -244,6 +244,12 @@ def test_str(doc):
         m.str_from_string_from_str(ucs_surrogates_str)
 
 
+def test_surrogate_pairs_unicode_error():
+    input_str = "\ud83d\ude4f".encode("utf-8", "surrogatepass")
+    with pytest.raises(UnicodeDecodeError):
+        m.bytes_to_str_explicit(input_str)
+
+
 def test_bytes(doc):
     assert m.bytes_from_char_ssize_t().decode() == "green"
     assert m.bytes_from_char_size_t().decode() == "purple"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -244,7 +244,10 @@ def test_str(doc):
         m.str_from_string_from_str(ucs_surrogates_str)
 
 
-def test_surrogate_pairs_unicode_error():
+@pytest.mark.parametrize(
+    "func", [m.str_from_bytes_input, m.str_from_string_input, m.str_from_object]
+)
+def test_surrogate_pairs_unicode_error(func):
     input_str = "\ud83d\ude4f".encode("utf-8", "surrogatepass")
     with pytest.raises(UnicodeDecodeError):
         m.str_from_bytes_input(input_str)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -249,7 +249,7 @@ def test_str(doc):
     [
         m.str_from_bytes_input,
         m.str_from_cstr_input,
-        m.str_from_string_input,
+        m.str_from_std_string_input,
     ],
 )
 def test_surrogate_pairs_unicode_error(func):

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -245,7 +245,13 @@ def test_str(doc):
 
 
 @pytest.mark.parametrize(
-    "func", [m.str_from_bytes_input, m.str_from_string_input, m.str_from_object]
+    "func",
+    [
+        m.str_from_bytes_input,
+        m.str_from_string_input,
+        m.str_from_cstr_input,
+        m.str_from_object,
+    ],
 )
 def test_surrogate_pairs_unicode_error(func):
     input_str = "\ud83d\ude4f".encode("utf-8", "surrogatepass")

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -248,15 +248,14 @@ def test_str(doc):
     "func",
     [
         m.str_from_bytes_input,
-        m.str_from_string_input,
         m.str_from_cstr_input,
-        m.str_from_object,
+        m.str_from_string_input,
     ],
 )
 def test_surrogate_pairs_unicode_error(func):
     input_str = "\ud83d\ude4f".encode("utf-8", "surrogatepass")
     with pytest.raises(UnicodeDecodeError):
-        m.str_from_bytes_input(input_str)
+        func(input_str)
 
 
 def test_bytes(doc):


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* I tried to replicate the bug reported where an error occurred in decoding surrogate pairs #4288. My initial try failed to reproduce the error, but discovered some bugs which I have patched and add tests for.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fixed a bug where ``UnicodeDecodeError`` was not propagated from various ``py::str`` ctors when decoding surrogate utf characters.
```

<!-- If the upgrade guide needs updating, note that here too -->
