### PR TITLE
Fix & test for issue #4288 (unicode surrogate character in Python exception message).

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -501,9 +501,10 @@ struct error_fetch_and_normalize {
         std::string message_error_string;
         if (m_value) {
             auto value_str = reinterpret_steal<object>(PyObject_Str(m_value.ptr()));
+            const char *message_unavailable_exc = "<MESSAGE UNAVAILABLE DUE TO ANOTHER EXCEPTION>";
             if (!value_str) {
                 message_error_string = detail::error_string();
-                result = "<MESSAGE UNAVAILABLE DUE TO ANOTHER EXCEPTION>";
+                result = message_unavailable_exc;
             } else {
                 // Not using `value_str.cast<std::string>()`, to not potentially throw a secondary
                 // error_already_set that will then result in process termination (#4288).
@@ -511,13 +512,13 @@ struct error_fetch_and_normalize {
                     PyUnicode_AsEncodedString(value_str.ptr(), "utf-8", "backslashreplace"));
                 if (!value_bytes) {
                     message_error_string = detail::error_string();
-                    result = "<MESSAGE UNAVAILABLE DUE TO ANOTHER EXCEPTION>";
+                    result = message_unavailable_exc;
                 } else {
                     char *buffer = nullptr;
                     Py_ssize_t length = 0;
                     if (PyBytes_AsStringAndSize(value_bytes.ptr(), &buffer, &length) == -1) {
                         message_error_string = detail::error_string();
-                        result = "<MESSAGE UNAVAILABLE DUE TO ANOTHER EXCEPTION>";
+                        result = message_unavailable_exc;
                     } else {
                         result = std::string(buffer, static_cast<std::size_t>(length));
                     }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -501,7 +501,8 @@ struct error_fetch_and_normalize {
         std::string message_error_string;
         if (m_value) {
             auto value_str = reinterpret_steal<object>(PyObject_Str(m_value.ptr()));
-            constexpr const char *message_unavailable_exc = "<MESSAGE UNAVAILABLE DUE TO ANOTHER EXCEPTION>";
+            constexpr const char *message_unavailable_exc
+                = "<MESSAGE UNAVAILABLE DUE TO ANOTHER EXCEPTION>";
             if (!value_str) {
                 message_error_string = detail::error_string();
                 result = message_unavailable_exc;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -501,7 +501,7 @@ struct error_fetch_and_normalize {
         std::string message_error_string;
         if (m_value) {
             auto value_str = reinterpret_steal<object>(PyObject_Str(m_value.ptr()));
-            const char *message_unavailable_exc = "<MESSAGE UNAVAILABLE DUE TO ANOTHER EXCEPTION>";
+            constexpr const char *message_unavailable_exc = "<MESSAGE UNAVAILABLE DUE TO ANOTHER EXCEPTION>";
             if (!value_str) {
                 message_error_string = detail::error_string();
                 result = message_unavailable_exc;

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -105,11 +105,6 @@ struct PythonAlreadySetInDestructor {
     py::str s;
 };
 
-std::string error_already_set_what(const py::object &exc_type, const py::object &exc_value) {
-    PyErr_SetObject(exc_type.ptr(), exc_value.ptr());
-    return py::error_already_set().what();
-}
-
 TEST_SUBMODULE(exceptions, m) {
     m.def("throw_std_exception",
           []() { throw std::runtime_error("This exception was intentionally thrown."); });

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -275,6 +275,20 @@ def test_local_translator(msg):
     assert msg(excinfo.value) == "this mod"
 
 
+def test_error_already_set_message_with_unicode_surrogate():  # Issue #4288
+    assert m.error_already_set_what(RuntimeError, "\ud927") == (
+        "RuntimeError: \\ud927",
+        False,
+    )
+
+
+def test_error_already_set_message_with_malformed_utf8():
+    assert m.error_already_set_what(RuntimeError, b"\x80") == (
+        "RuntimeError: b'\\x80'",
+        False,
+    )
+
+
 class FlakyException(Exception):
     def __init__(self, failure_point):
         if failure_point == "failure_point_init":


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Closes #4288. See there for background.

While at it:

* Also adding `test_error_already_set_message_with_malformed_utf8()` (passes without changes).
* Removing a stray block of code (oversight in #1895).

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Bug fix: Unicode surrogate character in Python exception message leads to process termination in `error_already_set::what()`.
```

<!-- If the upgrade guide needs updating, note that here too -->
