### PR TITLE
Change macOS handling of undefined symbols

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -583,12 +583,12 @@ using ``pip`` or ``conda``. If it hasn't, you can also manually specify
 ``python3-config --includes``.
 
 On macOS: the build command is almost the same but it also requires passing
-the ``-undefined dynamic_lookup`` flag so as to ignore missing symbols when
+the ``-undefined suppress -flat_namespace`` flag so as to ignore missing symbols when
 building the module:
 
 .. code-block:: bash
 
-    $ c++ -O3 -Wall -shared -std=c++11 -undefined dynamic_lookup $(python3 -m pybind11 --includes) example.cpp -o example$(python3-config --extension-suffix)
+    $ c++ -O3 -Wall -shared -std=c++11 -undefined suppress -flat_namespace $(python3 -m pybind11 --includes) example.cpp -o example$(python3-config --extension-suffix)
 
 In general, it is advisable to include several additional build parameters
 that can considerably reduce the size of the created binary. Refer to section

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -75,7 +75,7 @@ if(CMAKE_VERSION VERSION_LESS 3.13)
   set_property(
     TARGET pybind11::python_link_helper
     APPEND
-    PROPERTY INTERFACE_LINK_LIBRARIES "$<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>")
+    PROPERTY INTERFACE_LINK_LIBRARIES "$<$<PLATFORM_ID:Darwin>:-undefined suppress -flat_namespace>")
 else()
   # link_options was added in 3.13+
   # This is safer, because you are ensured the deduplication pass in CMake will not consider
@@ -83,7 +83,7 @@ else()
   set_property(
     TARGET pybind11::python_link_helper
     APPEND
-    PROPERTY INTERFACE_LINK_OPTIONS "$<$<PLATFORM_ID:Darwin>:LINKER:-undefined,dynamic_lookup>")
+    PROPERTY INTERFACE_LINK_OPTIONS "$<$<PLATFORM_ID:Darwin>:LINKER:-undefined,suppress,-flat_namespace>")
 endif()
 
 # ------------------------ Windows extras -------------------------


### PR DESCRIPTION
Newer version of XCode deprecate the ``-undefined dynamic_lookup`` flag that pybind11 has used to avoid linking to a specific Python shared library. Every use of it now lead to the following noisy warning message.
```
ld: warning: -undefined dynamic_lookup may not work with chained fixups
```
More details on this are available here:
https://mjtsai.com/blog/2021/06/30/faster-app-launching-in-ios-15-and-monterey/

While this seems somewhat specific to Swift, it is problematic if a core linker feature that pybind11 depends on is declared unreliable.

I have been able to replace these flags with
```
-undefined suppress -flat_namespace
```

I am not sure if this suits everyone. The purpose of the PR is to raise the issue and starts a discussion on what to do.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
