### PR TITLE
Use `multiprocessing` `start_method` `"spawn"`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ Adds docstring and exceptions message sanitizers.
 import contextlib
 import difflib
 import gc
+import multiprocessing
+import os
 import re
 import textwrap
 
@@ -14,6 +16,9 @@ import pytest
 
 # Early diagnostic for failed imports
 import pybind11_tests
+
+if os.name != "nt":
+    multiprocessing.set_start_method("spawn")
 
 _long_marker = re.compile(r"([0-9])L")
 _hexadecimal = re.compile(r"0x[0-9a-fA-F]+")

--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -144,7 +144,7 @@ def _intentional_deadlock():
 
 
 ALL_BASIC_TESTS_PLUS_INTENTIONAL_DEADLOCK = ALL_BASIC_TESTS + (_intentional_deadlock,)
-SKIP_IF_DEADLOCK = True  # See PR #4216
+SKIP_IF_DEADLOCK = False  # See PR #4216
 
 
 def _run_in_process(target, *args, **kwargs):
@@ -154,7 +154,8 @@ def _run_in_process(target, *args, **kwargs):
         test_fn = args[0]
     # Do not need to wait much, 10s should be more than enough.
     timeout = 0.1 if test_fn is _intentional_deadlock else 10
-    process = multiprocessing.Process(target=target, args=args, kwargs=kwargs)
+    mp_ctx = multiprocessing.get_context("spawn")
+    process = mp_ctx.Process(target=target, args=args, kwargs=kwargs)
     process.daemon = True
     try:
         t_start = time.time()

--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -154,8 +154,7 @@ def _run_in_process(target, *args, **kwargs):
         test_fn = args[0]
     # Do not need to wait much, 10s should be more than enough.
     timeout = 0.1 if test_fn is _intentional_deadlock else 10
-    mp_ctx = multiprocessing.get_context("spawn")
-    process = mp_ctx.Process(target=target, args=args, kwargs=kwargs)
+    process = multiprocessing.Process(target=target, args=args, kwargs=kwargs)
     process.daemon = True
     try:
         t_start = time.time()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Quoting from

https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

* fork

  ... Note that safely forking a multithreaded process is problematic.

  Available on Unix only. The default on Unix.

The idea to try `"spawn"` is the result of deadlock debugging. After reviewing tracebacks @jbms wrote:

> This actually looks like a general fork thread-safety issue, not related to pybind11. Using fork in a multithreaded program is generally not safe.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
