### PR TITLE
Use `multiprocessing` `start_method` `"forkserver"`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ Adds docstring and exceptions message sanitizers.
 import contextlib
 import difflib
 import gc
+import multiprocessing
+import os
 import re
 import textwrap
 
@@ -14,6 +16,9 @@ import pytest
 
 # Early diagnostic for failed imports
 import pybind11_tests
+
+if os.name != "nt":
+    multiprocessing.set_start_method("forkserver")
 
 _long_marker = re.compile(r"([0-9])L")
 _hexadecimal = re.compile(r"0x[0-9a-fA-F]+")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,13 @@ import pytest
 import pybind11_tests
 
 if os.name != "nt":
-    # https://github.com/pybind/pybind11/issues/4105#issuecomment-1301004592
+    # Full background: https://github.com/pybind/pybind11/issues/4105#issuecomment-1301004592
+    # In a nutshell: fork() after starting threads == flakiness in the form of deadlocks.
+    # It is actually a well-known pitfall, unfortunately without guard rails.
+    # "forkserver" is more performant than "spawn" (~9s vs ~13s for tests/test_gil_scoped.py,
+    # visit the issuecomment link above for details).
+    # Windows does not have fork() and the associated pitfall, therefore it is best left
+    # running with defaults.
     multiprocessing.set_start_method("forkserver")
 
 _long_marker = re.compile(r"([0-9])L")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ import pytest
 import pybind11_tests
 
 if os.name != "nt":
+    # https://github.com/pybind/pybind11/issues/4105#issuecomment-1301004592
     multiprocessing.set_start_method("forkserver")
 
 _long_marker = re.compile(r"([0-9])L")

--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -144,7 +144,7 @@ def _intentional_deadlock():
 
 
 ALL_BASIC_TESTS_PLUS_INTENTIONAL_DEADLOCK = ALL_BASIC_TESTS + (_intentional_deadlock,)
-SKIP_IF_DEADLOCK = True  # See PR #4216
+SKIP_IF_DEADLOCK = False  # See PR #4216
 
 
 def _run_in_process(target, *args, **kwargs):

--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -145,7 +145,6 @@ def _intentional_deadlock():
 
 
 ALL_BASIC_TESTS_PLUS_INTENTIONAL_DEADLOCK = ALL_BASIC_TESTS + (_intentional_deadlock,)
-SKIP_IF_DEADLOCK = False  # See PR #4216
 
 
 def _run_in_process(target, *args, **kwargs):
@@ -182,7 +181,7 @@ def _run_in_process(target, *args, **kwargs):
         elif process.exitcode is None:
             assert t_delta > 0.9 * timeout
             msg = "DEADLOCK, most likely, exactly what this test is meant to detect."
-            if SKIP_IF_DEADLOCK or (env.PYPY and env.WIN):
+            if env.PYPY and env.WIN:
                 pytest.skip(msg)
             raise RuntimeError(msg)
         return process.exitcode

--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -5,6 +5,7 @@ import time
 
 import pytest
 
+import env
 from pybind11_tests import gil_scoped as m
 
 
@@ -181,7 +182,7 @@ def _run_in_process(target, *args, **kwargs):
         elif process.exitcode is None:
             assert t_delta > 0.9 * timeout
             msg = "DEADLOCK, most likely, exactly what this test is meant to detect."
-            if SKIP_IF_DEADLOCK:
+            if SKIP_IF_DEADLOCK or (env.PYPY and env.WIN):
                 pytest.skip(msg)
             raise RuntimeError(msg)
         return process.exitcode


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Please see https://github.com/pybind/pybind11/issues/4105#issuecomment-1301004592 for full background.

Alternative to PR #4305

Quoting from

https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

* fork

  ... Note that safely forking a multithreaded process is problematic.

  Available on Unix only. The default on Unix.

The idea to try `"spawn"` or `"forkserver"`is the result of deadlock debugging. After reviewing tracebacks @jbms wrote:

> This actually looks like a general fork thread-safety issue, not related to pybind11. Using fork in a multithreaded program is generally not safe.

This stackoverflow posting provides some details:

* https://stackoverflow.com/questions/6078712/is-it-safe-to-fork-from-within-a-thread

Excerpts:

>  The problem is that fork() only copies the calling thread, and any mutexes held in child threads will be forever locked in the forked child.
...
> The problem is that the order that pthread_atfork handlers are called for unrelated libraries is undefined (it depends on the order that the libraries are loaded by the program). So this means that technically a deadlock can happen inside of a prefork handler because of a race condition.
________

Note that this PR only changes how test_gil_scoped.py is run, therefore a changelog entry is not needed.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
