### PR TITLE
Minimal reproducer for clash when binding types defined in the unnamed namespace.

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -117,20 +117,7 @@ inline void tls_replace_value(PYBIND11_TLS_KEY_REF key, void *value) {
 #if defined(__GLIBCXX__)
 inline bool same_type(const std::type_info &lhs, const std::type_info &rhs) { return lhs == rhs; }
 using type_hash = std::hash<std::type_index>;
-// using type_equal_to = std::equal_to<std::type_index>;
-struct type_equal_to {
-    bool operator()(const std::type_index &lhs, const std::type_index &rhs) const {
-        bool result = (lhs == rhs);
-        printf("\nLOOOK __GLIBCXX__ [lhs=%s] %s:%d\n", lhs.name(), __FILE__, __LINE__);
-        printf("LOOOK __GLIBCXX__ [rhs=%s] %s:%d\n", rhs.name(), __FILE__, __LINE__);
-        printf("LOOOK __GLIBCXX__ [(lhs==rhs)=%s] %s:%d\n",
-               (result ? "TRUE" : "FALSE"),
-               __FILE__,
-               __LINE__);
-        fflush(stdout);
-        return result;
-    }
-};
+using type_equal_to = std::equal_to<std::type_index>;
 #else
 inline bool same_type(const std::type_info &lhs, const std::type_info &rhs) {
     return lhs.name() == rhs.name() || std::strcmp(lhs.name(), rhs.name()) == 0;
@@ -149,16 +136,7 @@ struct type_hash {
 
 struct type_equal_to {
     bool operator()(const std::type_index &lhs, const std::type_index &rhs) const {
-        // return lhs.name() == rhs.name() || std::strcmp(lhs.name(), rhs.name()) == 0;
-        bool result = (lhs.name() == rhs.name() || std::strcmp(lhs.name(), rhs.name()) == 0);
-        printf("\nLOOOK ___OTHER___ [lhs=%s] %s:%d\n", lhs.name(), __FILE__, __LINE__);
-        printf("LOOOK ___OTHER___ [rhs=%s] %s:%d\n", rhs.name(), __FILE__, __LINE__);
-        printf("LOOOK ___OTHER___ [(lhs==rhs)=%s] %s:%d\n",
-               (result ? "TRUE" : "FALSE"),
-               __FILE__,
-               __LINE__);
-        fflush(stdout);
-        return result;
+        return lhs.name() == rhs.name() || std::strcmp(lhs.name(), rhs.name()) == 0;
     }
 };
 #endif

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -117,7 +117,20 @@ inline void tls_replace_value(PYBIND11_TLS_KEY_REF key, void *value) {
 #if defined(__GLIBCXX__)
 inline bool same_type(const std::type_info &lhs, const std::type_info &rhs) { return lhs == rhs; }
 using type_hash = std::hash<std::type_index>;
-using type_equal_to = std::equal_to<std::type_index>;
+// using type_equal_to = std::equal_to<std::type_index>;
+struct type_equal_to {
+    bool operator()(const std::type_index &lhs, const std::type_index &rhs) const {
+        bool result = (lhs == rhs);
+        printf("\nLOOOK __GLIBCXX__ [lhs=%s] %s:%d\n", lhs.name(), __FILE__, __LINE__);
+        printf("LOOOK __GLIBCXX__ [rhs=%s] %s:%d\n", rhs.name(), __FILE__, __LINE__);
+        printf("LOOOK __GLIBCXX__ [(lhs==rhs)=%s] %s:%d\n",
+               (result ? "TRUE" : "FALSE"),
+               __FILE__,
+               __LINE__);
+        fflush(stdout);
+        return result;
+    }
+};
 #else
 inline bool same_type(const std::type_info &lhs, const std::type_info &rhs) {
     return lhs.name() == rhs.name() || std::strcmp(lhs.name(), rhs.name()) == 0;
@@ -136,7 +149,16 @@ struct type_hash {
 
 struct type_equal_to {
     bool operator()(const std::type_index &lhs, const std::type_index &rhs) const {
-        return lhs.name() == rhs.name() || std::strcmp(lhs.name(), rhs.name()) == 0;
+        // return lhs.name() == rhs.name() || std::strcmp(lhs.name(), rhs.name()) == 0;
+        bool result = (lhs.name() == rhs.name() || std::strcmp(lhs.name(), rhs.name()) == 0);
+        printf("\nLOOOK ___OTHER___ [lhs=%s] %s:%d\n", lhs.name(), __FILE__, __LINE__);
+        printf("LOOOK ___OTHER___ [rhs=%s] %s:%d\n", rhs.name(), __FILE__, __LINE__);
+        printf("LOOOK ___OTHER___ [(lhs==rhs)=%s] %s:%d\n",
+               (result ? "TRUE" : "FALSE"),
+               __FILE__,
+               __LINE__);
+        fflush(stdout);
+        return result;
     }
 };
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -156,6 +156,8 @@ set(PYBIND11_TEST_FILES
     test_tagbased_polymorphic
     test_thread
     test_union
+    test_unnamed_namespace_a
+    test_unnamed_namespace_b
     test_virtual_functions)
 
 # Invoking cmake with something like:

--- a/tests/test_unnamed_namespace_a.cpp
+++ b/tests/test_unnamed_namespace_a.cpp
@@ -1,0 +1,9 @@
+#include "pybind11_tests.h"
+
+namespace {
+struct any_struct {};
+} // namespace
+
+TEST_SUBMODULE(unnamed_namespace_a, m) {
+    py::class_<any_struct>(m, "unnamed_namespace_a_any_struct");
+}

--- a/tests/test_unnamed_namespace_a.py
+++ b/tests/test_unnamed_namespace_a.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from pybind11_tests import unnamed_namespace_a as m
+
+
+def test_have_type():
+    assert hasattr(m, "unnamed_namespace_a_any_struct")

--- a/tests/test_unnamed_namespace_a.py
+++ b/tests/test_unnamed_namespace_a.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pybind11_tests import unnamed_namespace_a as m
 
 

--- a/tests/test_unnamed_namespace_b.cpp
+++ b/tests/test_unnamed_namespace_b.cpp
@@ -1,0 +1,9 @@
+#include "pybind11_tests.h"
+
+namespace {
+struct any_struct {};
+} // namespace
+
+TEST_SUBMODULE(unnamed_namespace_b, m) {
+    py::class_<any_struct>(m, "unnamed_namespace_b_any_struct");
+}

--- a/tests/test_unnamed_namespace_b.py
+++ b/tests/test_unnamed_namespace_b.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from pybind11_tests import unnamed_namespace_b as m
+
+
+def test_have_type():
+    assert hasattr(m, "unnamed_namespace_b_any_struct")

--- a/tests/test_unnamed_namespace_b.py
+++ b/tests/test_unnamed_namespace_b.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pybind11_tests import unnamed_namespace_b as m
 
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This PR

* works as expected only with **gcc**, but
* fails with any **clang** in otherwise identical environments, and also
* fails with any **MSVC**.

The root cause for the failures is:

* here for clang except macOS https://github.com/pybind/pybind11/blob/ee2b5226295d67b690faddd446a329bb2840a1a8/include/pybind11/detail/internals.h#L120
* here  for MSVC and clang macOS https://github.com/pybind/pybind11/blob/ee2b5226295d67b690faddd446a329bb2840a1a8/include/pybind11/detail/internals.h#L139)

Full details of which platform is or is not using the `__GLIBCXX__` branch: https://github.com/pybind/pybind11/pull/4313#issuecomment-1303436722

**Unknown**: How could this be fixed?

@wjakob Are you aware of this situation already? — Reason for bringing this up now: If the `internals` version is bumped, this would be a good fix to include (assuming the fix might be an ABI break, which isn't clear until we have a fix).

@charlesbeattie FYI It turns out the root cause is not [what we thought it is](https://github.com/pybind/pybind11/blob/ee2b5226295d67b690faddd446a329bb2840a1a8/include/pybind11/detail/typeid.h#L39) when we looked at this back in February.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
