### PR TITLE
Add macos_brew_install_llvm to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1072,6 +1072,8 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install -r tests/requirements.txt
+          python3 -m pip install numpy
+          python3 -m pip install scipy
 
       - name: Show CMake version
         run: cmake --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1037,3 +1037,68 @@ jobs:
 
       - name: Clean directory
         run: git clean -fdx
+
+  macos_brew_install_llvm:
+    name: "macos-latest • brew install llvm"
+    runs-on: macos-latest
+
+    env:
+      # https://apple.stackexchange.com/questions/227026/how-to-install-recent-clang-with-homebrew
+      LDFLAGS: '-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib'
+
+    steps:
+      - name: Update PATH
+        run: echo "/usr/local/opt/llvm/bin" >> $GITHUB_PATH
+
+      - name: Show env
+        run: env
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Show Clang++ version before brew install llvm
+        run: clang++ --version
+
+      - name: brew install llvm
+        run: brew install llvm
+
+      - name: Show Clang++ version after brew install llvm
+        run: clang++ --version
+
+      - name: Update CMake
+        uses: jwlawson/actions-setup-cmake@v1.13
+
+      - name: Run pip installs
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r tests/requirements.txt
+
+      - name: Show CMake version
+        run: cmake --version
+
+      - name: CMake Configure
+        run: >
+          cmake -S . -B .
+          -DCMAKE_VERBOSE_MAKEFILE=ON
+          -DPYBIND11_WERROR=ON
+          -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF
+          -DDOWNLOAD_CATCH=ON
+          -DDOWNLOAD_EIGEN=ON
+          -DCMAKE_CXX_COMPILER=clang++
+          -DCMAKE_CXX_STANDARD=17
+          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
+
+      - name: Build
+        run: cmake --build . -j 2
+
+      - name: Python tests
+        run: cmake --build . --target pytest -j 2
+
+      - name: C++ tests
+        run: cmake --build . --target cpptest -j 2
+
+      - name: Interface test
+        run: cmake --build . --target test_cmake_build -j 2
+
+      - name: Clean directory
+        run: git clean -fdx

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,6 +4,7 @@ import pytest
 
 import env
 import pybind11_cross_module_tests as cm
+import pybind11_tests  # noqa: F401
 from pybind11_tests import exceptions as m
 
 
@@ -72,9 +73,9 @@ def test_cross_module_exceptions(msg):
 
 # TODO: FIXME
 @pytest.mark.xfail(
-    "env.PYPY and env.MACOS",
+    "env.MACOS and (env.PYPY or pybind11_tests.compiler_info.startswith('Homebrew Clang'))",
     raises=RuntimeError,
-    reason="Expected failure with PyPy and libc++ (Issue #2847 & PR #2999)",
+    reason="See Issue #2847, PR #2999, PR #4324",
 )
 def test_cross_module_exception_translator():
     with pytest.raises(KeyError):


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Previously tested under PRs #4324, #4319

Primary motivation: inform #4319

Note that `test_cross_module_exception_translator` fails for the new job (1569415d9a5e9fbd30cac6b80f5b9bbd8b7fb1a1). See also https://github.com/pybind/pybind11/pull/4319#discussion_r1019269298.

Note that #4324 — but not this PR — includes this change:
```diff
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -96,7 +96,7 @@
 #endif

 #if !defined(PYBIND11_EXPORT_EXCEPTION)
-#    if defined(__apple_build_version__)
+#    if defined(_LIBCPP_VERSION)
 #        define PYBIND11_EXPORT_EXCEPTION PYBIND11_EXPORT
 #    else
 #        define PYBIND11_EXPORT_EXCEPTION
```

That diff is not included here because it does not make a difference for the new job (`test_cross_module_exception_translator` fails with and without it). It is probably a good change to make in general, but left for a separate PR.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
```

<!-- If the upgrade guide needs updating, note that here too -->
