### PR TITLE
scoped_interpreter. overloaded constructor: PyConfig param

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ platform:
 - x86
 environment:
   matrix:
-  - PYTHON: 36
+  - PYTHON: 38
     CONFIG: Debug
 install:
 - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ platform:
 - x86
 environment:
   matrix:
-  - PYTHON: 38
+  - PYTHON: 36
     CONFIG: Debug
 install:
 - ps: |

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -55,7 +55,7 @@
         PYBIND11_TOSTRING(name), PYBIND11_CONCAT(pybind11_init_impl_, name));                     \
     void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_                                \
                                                & variable) // NOLINT(bugprone-macro-parentheses)
-#define PYBIND11_PYCONFIG_SUPPORT_PY_VERSION (0x030B0000)
+#define PYBIND11_PYCONFIG_SUPPORT_PY_VERSION (0x03080000)
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -99,18 +99,18 @@ inline void initialize_interpreter(PyConfig *config,
                                    const char *const *argv = nullptr,
                                    bool add_program_dir_to_path = true) {
     PyStatus status = PyConfig_SetBytesArgv(config, argc, const_cast<char *const *>(argv));
-    if (PyStatus_Exception(status)) {
+    if (PyStatus_Exception(status) != 0) {
         // A failure here indicates a character-encoding failure or the python
         // interpreter out of memory. Give up.
         PyConfig_Clear(config);
-        throw std::runtime_error(PyStatus_IsError(status) ? status.err_msg
-                                                          : "Failed to prepare CPython");
+        throw std::runtime_error(PyStatus_IsError(status) != 0 ? status.err_msg
+                                                               : "Failed to prepare CPython");
     }
     status = Py_InitializeFromConfig(config);
-    if (PyStatus_Exception(status)) {
+    if (PyStatus_Exception(status) != 0) {
         PyConfig_Clear(config);
-        throw std::runtime_error(PyStatus_IsError(status) ? status.err_msg
-                                                          : "Failed to init CPython");
+        throw std::runtime_error(PyStatus_IsError(status) != 0 ? status.err_msg
+                                                               : "Failed to init CPython");
     }
     if (add_program_dir_to_path) {
         PyRun_SimpleString("import sys, os.path; "

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -95,13 +95,13 @@ inline void precheck_interpreter() {
 }
 
 #if PY_VERSION_HEX >= 0x030B0000
-class config_guard
-{
+class config_guard {
 public:
-    config_guard(PyConfig& config): m_config{config}{}
-    ~config_guard(){PyConfig_Clear(&m_config);}
+    config_guard(PyConfig &config) : m_config{config} {}
+    ~config_guard() { PyConfig_Clear(&m_config); }
+
 private:
-    PyConfig& m_config;
+    PyConfig &m_config;
 };
 
 /*!

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -264,6 +264,25 @@ public:
         initialize_interpreter(init_signal_handlers, argc, argv, add_program_dir_to_path);
     }
 
+#if PY_VERSION_HEX >= 0x030B0000
+    explicit scoped_interpreter(const PyConfig& config,
+                                bool add_program_dir_to_path = true) {
+        if (Py_IsInitialized() != 0) {
+            pybind11_fail("The interpreter is already running");
+        }
+        PyStatus status = Py_InitializeFromConfig(&config);
+        if (PyStatus_Exception(status)) {
+            throw std::runtime_error(PyStatus_IsError(status) ? status.err_msg : "Failed to init CPython");
+        }
+        if (add_program_dir_to_path) {
+            PyRun_SimpleString("import sys, os.path; "
+                               "sys.path.insert(0, "
+                               "os.path.abspath(os.path.dirname(sys.argv[0])) "
+                               "if sys.argv and os.path.exists(sys.argv[0]) else '')");
+        }
+    }
+#endif
+
     scoped_interpreter(const scoped_interpreter &) = delete;
     scoped_interpreter(scoped_interpreter &&other) noexcept { other.is_valid = false; }
     scoped_interpreter &operator=(const scoped_interpreter &) = delete;

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -93,11 +93,14 @@ inline void precheck_interpreter() {
     }
 }
 
+PYBIND11_NAMESPACE_END(detail)
+
 #if PY_VERSION_HEX >= PYBIND11_PYCONFIG_SUPPORT_PY_VERSION_HEX
 inline void initialize_interpreter(PyConfig *config,
                                    int argc = 0,
                                    const char *const *argv = nullptr,
                                    bool add_program_dir_to_path = true) {
+    detail::precheck_interpreter();
     PyStatus status = PyConfig_SetBytesArgv(config, argc, const_cast<char *const *>(argv));
     if (PyStatus_Exception(status) != 0) {
         // A failure here indicates a character-encoding failure or the python
@@ -125,6 +128,7 @@ inline void initialize_interpreter_pre_pyconfig(bool init_signal_handlers,
                                                 int argc,
                                                 const char *const *argv,
                                                 bool add_program_dir_to_path) {
+    detail::precheck_interpreter();
     Py_InitializeEx(init_signal_handlers ? 1 : 0);
 #    if defined(WITH_THREAD) && PY_VERSION_HEX < 0x03070000
     PyEval_InitThreads();
@@ -161,8 +165,6 @@ inline void initialize_interpreter_pre_pyconfig(bool init_signal_handlers,
 }
 #endif
 
-PYBIND11_NAMESPACE_END(detail)
-
 /** \rst
     Initialize the Python interpreter. No other pybind11 or CPython API functions can be
     called before this is done; with the exception of `PYBIND11_EMBEDDED_MODULE`. The
@@ -186,17 +188,15 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
                                    int argc = 0,
                                    const char *const *argv = nullptr,
                                    bool add_program_dir_to_path = true) {
-    detail::precheck_interpreter();
 #if PY_VERSION_HEX < PYBIND11_PYCONFIG_SUPPORT_PY_VERSION_HEX
-    detail::initialize_interpreter_pre_pyconfig(
-        init_signal_handlers, argc, argv, add_program_dir_to_path);
+    initialize_interpreter_pre_pyconfig(init_signal_handlers, argc, argv, add_program_dir_to_path);
 #else
     PyConfig config;
     PyConfig_InitIsolatedConfig(&config);
     config.isolated = 0;
     config.use_environment = 1;
     config.install_signal_handlers = init_signal_handlers ? 1 : 0;
-    detail::initialize_interpreter(&config, argc, argv, add_program_dir_to_path);
+    initialize_interpreter(&config, argc, argv, add_program_dir_to_path);
 #endif
 }
 
@@ -289,8 +289,7 @@ public:
                                 int argc = 0,
                                 const char *const *argv = nullptr,
                                 bool add_program_dir_to_path = true) {
-        detail::precheck_interpreter();
-        detail::initialize_interpreter(config, argc, argv, add_program_dir_to_path);
+        initialize_interpreter(config, argc, argv, add_program_dir_to_path);
     }
 #endif
 

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -265,14 +265,14 @@ public:
     }
 
 #if PY_VERSION_HEX >= 0x030B0000
-    explicit scoped_interpreter(const PyConfig& config,
-                                bool add_program_dir_to_path = true) {
+    explicit scoped_interpreter(const PyConfig &config, bool add_program_dir_to_path = true) {
         if (Py_IsInitialized() != 0) {
             pybind11_fail("The interpreter is already running");
         }
         PyStatus status = Py_InitializeFromConfig(&config);
         if (PyStatus_Exception(status)) {
-            throw std::runtime_error(PyStatus_IsError(status) ? status.err_msg : "Failed to init CPython");
+            throw std::runtime_error(PyStatus_IsError(status) ? status.err_msg
+                                                              : "Failed to init CPython");
         }
         if (add_program_dir_to_path) {
             PyRun_SimpleString("import sys, os.path; "

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -98,8 +98,7 @@ inline void initialize_interpreter(PyConfig *config,
                                    int argc = 0,
                                    const char *const *argv = nullptr,
                                    bool add_program_dir_to_path = true) {
-    PyStatus status
-        = PyConfig_SetBytesArgv(config, argc, const_cast<char *const *>(argv));
+    PyStatus status = PyConfig_SetBytesArgv(config, argc, const_cast<char *const *>(argv));
     if (PyStatus_Exception(status)) {
         // A failure here indicates a character-encoding failure or the python
         // interpreter out of memory. Give up.
@@ -123,9 +122,9 @@ inline void initialize_interpreter(PyConfig *config,
 }
 #else
 inline void initialize_interpreter_pre_pyconfig(bool init_signal_handlers,
-                                           int argc,
-                                           const char *const *argv,
-                                           bool add_program_dir_to_path) {
+                                                int argc,
+                                                const char *const *argv,
+                                                bool add_program_dir_to_path) {
     Py_InitializeEx(init_signal_handlers ? 1 : 0);
 #    if defined(WITH_THREAD) && PY_VERSION_HEX < 0x03070000
     PyEval_InitThreads();
@@ -189,7 +188,8 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
                                    bool add_program_dir_to_path = true) {
     detail::precheck_interpreter();
 #if PY_VERSION_HEX < PYBIND11_PYCONFIG_SUPPORT_PY_VERSION_HEX
-    detail::initialize_interpreter_pre_pyconfig(init_signal_handlers, argc, argv, add_program_dir_to_path);
+    detail::initialize_interpreter_pre_pyconfig(
+        init_signal_handlers, argc, argv, add_program_dir_to_path);
 #else
     PyConfig config;
     PyConfig_InitIsolatedConfig(&config);

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -55,7 +55,7 @@
         PYBIND11_TOSTRING(name), PYBIND11_CONCAT(pybind11_init_impl_, name));                     \
     void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_                                \
                                                & variable) // NOLINT(bugprone-macro-parentheses)
-#define PYCONFIG_SUPPORT_PY_VERSION (0x030B0000)
+#define PYBIND11_PYCONFIG_SUPPORT_PY_VERSION (0x030B0000)
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
@@ -93,7 +93,7 @@ inline void precheck_interpreter() {
     }
 }
 
-#if PY_VERSION_HEX >= PYCONFIG_SUPPORT_PY_VERSION
+#if PY_VERSION_HEX >= PYBIND11_PYCONFIG_SUPPORT_PY_VERSION
 inline void initialize_interpreter(const PyConfig &config, bool add_program_dir_to_path) {
     PyStatus status = Py_InitializeFromConfig(&config);
     if (PyStatus_Exception(status)) {
@@ -111,7 +111,7 @@ inline void initialize_interpreter(const PyConfig &config, bool add_program_dir_
 
 PYBIND11_NAMESPACE_END(detail)
 
-#if PY_VERSION_HEX >= PYCONFIG_SUPPORT_PY_VERSION
+#if PY_VERSION_HEX >= PYBIND11_PYCONFIG_SUPPORT_PY_VERSION
 struct scoped_config {
     scoped_config() = default;
     ~scoped_config() { PyConfig_Clear(&config); };
@@ -148,7 +148,7 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
                                    bool add_program_dir_to_path = true) {
     detail::precheck_interpreter();
 
-#if PY_VERSION_HEX < PYCONFIG_SUPPORT_PY_VERSION
+#if PY_VERSION_HEX < PYBIND11_PYCONFIG_SUPPORT_PY_VERSION
 
     Py_InitializeEx(init_signal_handlers ? 1 : 0);
 #    if defined(WITH_THREAD) && PY_VERSION_HEX < 0x03070000
@@ -286,7 +286,7 @@ public:
         initialize_interpreter(init_signal_handlers, argc, argv, add_program_dir_to_path);
     }
 
-#if PY_VERSION_HEX >= PYCONFIG_SUPPORT_PY_VERSION
+#if PY_VERSION_HEX >= PYBIND11_PYCONFIG_SUPPORT_PY_VERSION
     explicit scoped_interpreter(const PyConfig &config, bool add_program_dir_to_path = true) {
         detail::precheck_interpreter();
         detail::initialize_interpreter(config, add_program_dir_to_path);
@@ -307,5 +307,7 @@ public:
 private:
     bool is_valid = true;
 };
+
+#undef PYBIND11_PYCONFIG_SUPPORT_PY_VERSION
 
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -168,6 +168,18 @@ TEST_CASE("There can be only one interpreter") {
     py::initialize_interpreter();
 }
 
+TEST_CASE("Custom PyConfig") {
+    py::finalize_interpreter();
+    pybind11::scoped_config conf{};
+    PyConfig_InitPythonConfig(&conf.config);
+    REQUIRE_NOTHROW(py::scoped_interpreter{conf.config});
+    {
+        py::scoped_interpreter p{conf.config};
+        REQUIRE(py::module_::import("widget_module").attr("add")(1, 41).cast<int>() == 42);
+    }
+    py::initialize_interpreter();
+}
+
 bool has_pybind11_internals_builtin() {
     auto builtins = py::handle(PyEval_GetBuiltins());
     return builtins.contains(PYBIND11_INTERNALS_ID);

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -168,17 +168,19 @@ TEST_CASE("There can be only one interpreter") {
     py::initialize_interpreter();
 }
 
+#if PY_VERSION_HEX >= PYBIND11_PYCONFIG_SUPPORT_PY_VERSION_HEX
 TEST_CASE("Custom PyConfig") {
     py::finalize_interpreter();
-    pybind11::scoped_config conf{};
-    PyConfig_InitPythonConfig(&conf.config);
-    REQUIRE_NOTHROW(py::scoped_interpreter{conf.config});
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+    REQUIRE_NOTHROW(py::scoped_interpreter{&config});
     {
-        py::scoped_interpreter p{conf.config};
+        py::scoped_interpreter p{&config};
         REQUIRE(py::module_::import("widget_module").attr("add")(1, 41).cast<int>() == 42);
     }
     py::initialize_interpreter();
 }
+#endif
 
 bool has_pybind11_internals_builtin() {
     auto builtins = py::handle(PyEval_GetBuiltins());

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -210,15 +210,15 @@ TEST_CASE("Add program dir to path") {
         sys_path_default_size = get_sys_path_size();
     }
     {
-        py::scoped_interpreter scoped_interp{}; // expected to append 1 elem to sys.path
-        REQUIRE(get_sys_path_size() == sys_path_default_size + 1);
+        py::scoped_interpreter scoped_interp{}; // expected to append some to sys.path
+        REQUIRE(get_sys_path_size() > sys_path_default_size);
     }
 #if PY_VERSION_HEX >= PYBIND11_PYCONFIG_SUPPORT_PY_VERSION_HEX
     {
         PyConfig config;
         PyConfig_InitPythonConfig(&config);
-        py::scoped_interpreter scoped_interp{&config}; // expected to append 1 elem to sys.path
-        REQUIRE(get_sys_path_size() == sys_path_default_size + 1);
+        py::scoped_interpreter scoped_interp{&config}; // expected to append some to sys.path
+        REQUIRE(get_sys_path_size() > sys_path_default_size);
     }
 #endif
     py::initialize_interpreter();

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -196,7 +196,6 @@ TEST_CASE("Custom PyConfig with argv") {
         REQUIRE(cpp_widget.argv0() == "");
     }
     py::initialize_interpreter();
-
 }
 
 TEST_CASE("Add program dir to path") {


### PR DESCRIPTION
## Description

In some cases it is convenient to have an opportunity to construct a scoped_interpreter with a custom PyConfig instance supplied.

```rst
PyConfig my_config{};
//...
pybind11::scoped_interpreter{my_config}
```
## Suggested changelog entry:

```rst
* feat: scoped_interpreter overloaded ctor: PyConfig param
* tests: Add program dir to path, Custom PyConfig, Custom PyConfig with argv
```

<!-- If the upgrade guide needs updating, note that here too -->
