### PR TITLE
Include GLIBCXX==20160726 in list of exceptional versions

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -367,7 +367,7 @@ using is_pod_struct
                                          // we need a standard layout type
 #if defined(__GLIBCXX__)                                                                          \
     && (__GLIBCXX__ < 20150422 || __GLIBCXX__ == 20150426 || __GLIBCXX__ == 20150623              \
-        || __GLIBCXX__ == 20150626 || __GLIBCXX__ == 20160803)
+        || __GLIBCXX__ == 20150626 || __GLIBCXX__ == 20160726 || __GLIBCXX__ == 20160803)
              // libstdc++ < 5 (including versions 4.8.5, 4.9.3 and 4.9.4 which were released after
              // 5) don't implement is_trivially_copyable, so approximate it
              std::is_trivially_destructible<T>,


### PR DESCRIPTION
std::is_trivially_copyable is not available in 20160726, so include it in the list of exceptional versions.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
