### PR TITLE
Change include_guard to check target only

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -9,8 +9,6 @@ if(CMAKE_VERSION VERSION_LESS 3.12)
   message(FATAL_ERROR "You cannot use the new FindPython module with CMake < 3.12")
 endif()
 
-include_guard(GLOBAL)
-
 get_property(
   is_config
   TARGET pybind11::headers
@@ -135,7 +133,9 @@ if(DEFINED ${_Python}_INCLUDE_DIRS)
   # This needs to be a target to be included after the local pybind11
   # directory, just in case there there is an installed pybind11 sitting
   # next to Python's includes. It also ensures Python is a SYSTEM library.
-  add_library(pybind11::python_headers INTERFACE IMPORTED)
+  if (NOT TARGET pybind11::python_headers)
+    add_library(pybind11::python_headers INTERFACE IMPORTED)
+  endif()
   set_property(
     TARGET pybind11::python_headers PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                                              "$<BUILD_INTERFACE:${${_Python}_INCLUDE_DIRS}>")


### PR DESCRIPTION
include_guard seems to break all contained logic to handle use case of building for multiple Python versions.

## Description

Use case: trying to create multiple targets for different Python versions

Issue: some variables are not updated on subsequent targets, most noticeably the SUFFIX, resulting in (as example) all .pyd files being named <name>.cp39-win_amd64.pyd (despite linking against 3.9, 3.10, etc.)

There seems to be a lot of logic to handle this case on subsequently entering this file, however a fix (likely related to changed in Conan) added an include guard to prevent errors about creating the same target twice. This also sabotages all of that above logic, since it will not execute another time and nothing gets updated after switching Python versions.

Removing the include_guard and instead only create the target if it doesn't exist already seems to fix that. However, someone with deeper understanding of the dependencies and flows should verify that this won't have unexpected and fatal side effects.

