### PR TITLE
Add a new return value policy `_clif_automatic`

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -478,7 +478,16 @@ enum class return_value_policy : uint8_t {
         but the purpose of _return_as_bytes is certain to be orthogonal, because
         C++ strings are always copied to Python `bytes` or `str`.
         NOTE: This policy is NOT available on master. */
-    _return_as_bytes
+    _return_as_bytes,
+
+    /** This policy should only be used by PyCLIF to automatically select a
+        return value policy. Legacy PyCLIF automatically decides object lifetime
+        management based on their properties:
+        https://github.com/google/clif/tree/main/clif/python#pointers-references-and-object-ownership
+        With this policy, the return value policy selection is consistent with
+        legacy PyCLIF.
+        NOTE: This policy is NOT available on master. */
+    _clif_automatic
 };
 
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -795,6 +795,7 @@ struct smart_holder_type_caster<std::shared_ptr<T>> : smart_holder_type_caster_l
                 break;
             case return_value_policy::reference_internal:
             case return_value_policy::_return_as_bytes:
+            case return_value_policy::_clif_automatic:
                 break;
         }
         if (!src) {


### PR DESCRIPTION
## Description

This new policy is for making PyCLIF generate pybind11 bindings code. 

PyCLIF automatically chooses lifetime management of return values based on the properties of them: https://github.com/google/clif/tree/main/clif/python#pointers-references-and-object-ownership. We would like make the lifetime management of the generated pybind11 code consistent with legacy PyCLIF. 

However, this is hard for nested types. For example, for `pair<int, const T*>` return values, to be consistent with legacy PyCLIF, we would like to apply `return_value_policy::copy` to `int`, and `return_value_policy::reference` to `const T*`. This  is hard to achieve from top down. With the new return value policy, we can implement this from bottom up. 