### PR TITLE
Use `PyEval_InitThreads()` as intended

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -468,9 +468,6 @@ PYBIND11_NOINLINE internals &get_internals() {
         internals_ptr = new internals();
 #if defined(WITH_THREAD)
 
-#    if PY_VERSION_HEX < 0x03090000
-        PyEval_InitThreads();
-#    endif
         PyThreadState *tstate = PyThreadState_Get();
         if (!PYBIND11_TLS_KEY_CREATE(internals_ptr->tstate)) {
             pybind11_fail("get_internals: could not successfully initialize the tstate TSS key!");

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -118,7 +118,7 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
 #if PY_VERSION_HEX < 0x030B0000
 
     Py_InitializeEx(init_signal_handlers ? 1 : 0);
-#    if PY_VERSION_HEX < 0x03070000
+#    if defined(WITH_THREAD) && PY_VERSION_HEX < 0x03070000
     PyEval_InitThreads();
 #    endif
 
@@ -171,7 +171,7 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
         throw std::runtime_error(PyStatus_IsError(status) ? status.err_msg
                                                           : "Failed to init CPython");
     }
-#    if PY_VERSION_HEX < 0x03070000
+#    if defined(WITH_THREAD) && PY_VERSION_HEX < 0x03070000
     PyEval_InitThreads();
 #    endif
     if (add_program_dir_to_path) {

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -118,6 +118,9 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
 #if PY_VERSION_HEX < 0x030B0000
 
     Py_InitializeEx(init_signal_handlers ? 1 : 0);
+#    if PY_VERSION_HEX < 0x03070000
+    PyEval_InitThreads();
+#    endif
 
     // Before it was special-cased in python 3.8, passing an empty or null argv
     // caused a segfault, so we have to reimplement the special case ourselves.
@@ -168,6 +171,9 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
         throw std::runtime_error(PyStatus_IsError(status) ? status.err_msg
                                                           : "Failed to init CPython");
     }
+#    if PY_VERSION_HEX < 0x03070000
+    PyEval_InitThreads();
+#    endif
     if (add_program_dir_to_path) {
         PyRun_SimpleString("import sys, os.path; "
                            "sys.path.insert(0, "

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -171,9 +171,6 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
         throw std::runtime_error(PyStatus_IsError(status) ? status.err_msg
                                                           : "Failed to init CPython");
     }
-#    if defined(WITH_THREAD) && PY_VERSION_HEX < 0x03070000
-    PyEval_InitThreads();
-#    endif
     if (add_program_dir_to_path) {
         PyRun_SimpleString("import sys, os.path; "
                            "sys.path.insert(0, "


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This PR actually matters

* only for Python 3.6 (according to the Python documentation),
* only with `-DPYBIND11_SIMPLE_GIL_MANAGEMENT=ON` (evidently, based on CI flakes observed since PR #4216 was merged),
* and only if embed.h is used.

Hypothesis: `-DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF` covers up that `PyEval_InitThreads()` was misplaced.

This PR almost does not matter anymore at all:

* https://docs.python.org/3.11/c-api/init.html#c.PyEval_InitThreads

> Changed in version 3.7: This function is now called by `Py_Initialize()`, so you don’t have to call it yourself anymore.

Note that Python 3.6 EOL was 2021-12-23 (https://endoflife.date/python), but since PR #4216 was merged we had distracting CI flakes that this PR aims to get rid of, e.g.:

* 🐍 3.6 • windows-2022 • x64

```
Run cmake --build .  --target cpptest -j 2
MSBuild version 17.3.1+2badb37d1 for .NET Framework
  Checking File Globs
  external_module.vcxproj -> D:\a\pybind11\pybind11\tests\test_embed\external_module.cp36-win_amd64.pyd
  test_embed.vcxproj -> D:\a\pybind11\pybind11\tests\test_embed\Debug\test_embed.exe
CUSTOMBUILD : Fatal Python error : This thread state must be current when releasing [D:\a\pybind11\pybind11\tests\test_embed\cpptest.vcxproj]
  
  Current thread 0x0000[14](https://github.com/pybind/pybind11/actions/runs/3511087576/jobs/5881522679#step:13:15)84 (most recent call first):
  
  Thread 0x00000fc4 (most recent call first):
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(247,5): error MSB8066: Custom build for 'D:\a\pybind11\pybind11\CMakeFiles\bf7d1[16](https://github.com/pybind/pybind11/actions/runs/3511087576/jobs/5881522679#step:13:17)f1[18](https://github.com/pybind/pybind11/actions/runs/3511087576/jobs/5881522679#step:13:19)90487c30aedc390ae4de7\cpptest.rule;D:\a\pybind11\pybind11\tests\test_embed\CMakeLists.txt' exited with code -1073740791. [D:\a\pybind11\pybind11\tests\test_embed\cpptest.vcxproj]
Error: Process completed with exit code 1.
```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Bug fix affecting only Python 3.6 under very specific, uncommon conditions: correction of misplaced `PyEval_InitThreads()` call.
```

<!-- If the upgrade guide needs updating, note that here too -->
