### PR TITLE
fix(.github): fix bug-report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -21,10 +21,11 @@ body:
         - label: Consider asking first in the [Gitter chat room](https://gitter.im/pybind/Lobby) or in a [Discussion](https:/pybind/pybind11/discussions/new).
           required: false
 
-  - type: Input
+  - type: input
     id: version
     attributes:
       label: What version (or hash if on master) of pybind11 are you using?
+    validations:
       required: true
 
   - type: textarea
@@ -52,7 +53,7 @@ body:
         starting point for working out fixes.
       render: text
 
-  - type: Input
+  - type: input
     id: regression
     attributes:
       label: Is this a regression? Put the last known working version here if it is.


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Documented in [Building communities / Issue & PR templates / Syntax for GitHub's form schema #Keys](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys)

The correct type is `input` rather than `Input`. The bug-report template is not enabled at all and users cannot create a bug-report on the issue page [here](https://github.com/pybind/pybind11/issues/new/choose).

![image](https://user-images.githubusercontent.com/16078332/203964220-28f0b52b-8df3-4521-ad00-bc884eaf9f97.png)

Related issue #4276.