### PR TITLE
[smart_holder] Special case for `_clif_automatic` policy in `return_value_policy_override`

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1042,6 +1042,7 @@ struct return_value_policy_override<
                         void>> {
     static return_value_policy policy(return_value_policy p) {
         return !std::is_lvalue_reference<Return>::value && !std::is_pointer<Return>::value
+                       && p != return_value_policy::_clif_automatic
                    ? return_value_policy::move
                    : p;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -167,6 +167,7 @@ set(PYBIND11_TEST_FILES
     test_operator_overloading
     test_pickling
     test_pytypes
+    test_return_value_policy_override
     test_sequences_and_iterators
     test_smart_ptr
     test_stl

--- a/tests/test_return_value_policy_override.cpp
+++ b/tests/test_return_value_policy_override.cpp
@@ -1,0 +1,82 @@
+#include "pybind11_tests.h"
+
+namespace test_return_value_policy_override {
+
+struct some_type {};
+
+} // namespace test_return_value_policy_override
+
+using test_return_value_policy_override::some_type;
+
+namespace pybind11 {
+namespace detail {
+
+const char *return_value_policy_name(return_value_policy policy) {
+    switch (policy) {
+        case return_value_policy::automatic:
+            return "automatic";
+        case return_value_policy::automatic_reference:
+            return "automatic_reference";
+        case return_value_policy::take_ownership:
+            return "take_ownership";
+        case return_value_policy::copy:
+            return "copy";
+        case return_value_policy::move:
+            return "move";
+        case return_value_policy::reference:
+            return "reference";
+        case return_value_policy::reference_internal:
+            return "reference_internal";
+        case return_value_policy::_return_as_bytes:
+            return "_return_as_bytes";
+        case return_value_policy::_clif_automatic:
+            return "_clif_automatic";
+        default:
+            return "Expected to be unreachable.";
+    }
+};
+
+template <>
+struct type_caster<some_type> : type_caster_base<some_type> {
+
+    static handle cast(some_type &&, return_value_policy policy, handle /*parent*/) {
+        return str(std::string(return_value_policy_name(policy))).release().ptr();
+    }
+
+    static handle cast(some_type *, return_value_policy policy, handle /*parent*/) {
+        return str(std::string(return_value_policy_name(policy))).release().ptr();
+    }
+};
+
+} // namespace detail
+} // namespace pybind11
+
+TEST_SUBMODULE(return_value_policy_override, m) {
+    m.def("return_value_with_default_policy", []() { return some_type(); });
+    m.def(
+        "return_value_with_policy_copy",
+        []() { return some_type(); },
+        py::return_value_policy::copy);
+    m.def(
+        "return_value_with_policy_clif_automatic",
+        []() { return some_type(); },
+        py::return_value_policy::_clif_automatic);
+    m.def("return_pointer_with_default_policy", []() {
+        static some_type value;
+        return &value;
+    });
+    m.def(
+        "return_pointer_with_policy_move",
+        []() {
+            static some_type value;
+            return &value;
+        },
+        py::return_value_policy::move);
+    m.def(
+        "return_pointer_with_policy_clif_automatic",
+        []() {
+            static some_type value;
+            return &value;
+        },
+        py::return_value_policy::_clif_automatic);
+}

--- a/tests/test_return_value_policy_override.py
+++ b/tests/test_return_value_policy_override.py
@@ -1,0 +1,13 @@
+from pybind11_tests import return_value_policy_override as m
+
+
+def test_return_value():
+    assert m.return_value_with_default_policy() == "move"
+    assert m.return_value_with_policy_copy() == "move"
+    assert m.return_value_with_policy_clif_automatic() == "_clif_automatic"
+
+
+def test_return_pointer():
+    assert m.return_pointer_with_default_policy() == "automatic"
+    assert m.return_pointer_with_policy_move() == "move"
+    assert m.return_pointer_with_policy_clif_automatic() == "_clif_automatic"


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Special case for `_clif_automatic` policy in `return_value_policy_override`

Immediate use case: pybind11_abseil/bstatus_caster.h

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
