### PR TITLE
chore: Convert direct multiprocessing.set_start_method("forkserver") call to a pytest fixture.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,15 +17,19 @@ import pytest
 # Early diagnostic for failed imports
 import pybind11_tests
 
-if os.name != "nt":
-    # Full background: https://github.com/pybind/pybind11/issues/4105#issuecomment-1301004592
-    # In a nutshell: fork() after starting threads == flakiness in the form of deadlocks.
-    # It is actually a well-known pitfall, unfortunately without guard rails.
-    # "forkserver" is more performant than "spawn" (~9s vs ~13s for tests/test_gil_scoped.py,
-    # visit the issuecomment link above for details).
-    # Windows does not have fork() and the associated pitfall, therefore it is best left
-    # running with defaults.
-    multiprocessing.set_start_method("forkserver")
+
+@pytest.fixture(scope="session", autouse=True)
+def always_forkserver_on_unix():
+    if os.name != "nt":
+        # Full background: https://github.com/pybind/pybind11/issues/4105#issuecomment-1301004592
+        # In a nutshell: fork() after starting threads == flakiness in the form of deadlocks.
+        # It is actually a well-known pitfall, unfortunately without guard rails.
+        # "forkserver" is more performant than "spawn" (~9s vs ~13s for tests/test_gil_scoped.py,
+        # visit the issuecomment link above for details).
+        # Windows does not have fork() and the associated pitfall, therefore it is best left
+        # running with defaults.
+        multiprocessing.set_start_method("forkserver")
+
 
 _long_marker = re.compile(r"([0-9])L")
 _hexadecimal = re.compile(r"0x[0-9a-fA-F]+")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,15 +20,17 @@ import pybind11_tests
 
 @pytest.fixture(scope="session", autouse=True)
 def always_forkserver_on_unix():
-    if os.name != "nt":
-        # Full background: https://github.com/pybind/pybind11/issues/4105#issuecomment-1301004592
-        # In a nutshell: fork() after starting threads == flakiness in the form of deadlocks.
-        # It is actually a well-known pitfall, unfortunately without guard rails.
-        # "forkserver" is more performant than "spawn" (~9s vs ~13s for tests/test_gil_scoped.py,
-        # visit the issuecomment link above for details).
-        # Windows does not have fork() and the associated pitfall, therefore it is best left
-        # running with defaults.
-        multiprocessing.set_start_method("forkserver")
+    if os.name == "nt":
+        return
+
+    # Full background: https://github.com/pybind/pybind11/issues/4105#issuecomment-1301004592
+    # In a nutshell: fork() after starting threads == flakiness in the form of deadlocks.
+    # It is actually a well-known pitfall, unfortunately without guard rails.
+    # "forkserver" is more performant than "spawn" (~9s vs ~13s for tests/test_gil_scoped.py,
+    # visit the issuecomment link above for details).
+    # Windows does not have fork() and the associated pitfall, therefore it is best left
+    # running with defaults.
+    multiprocessing.set_start_method("forkserver")
 
 
 _long_marker = re.compile(r"([0-9])L")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* This PR updates the conftest logic to call multiprocessing.set_start_method in a fixture from #4306. This should be a bit safer since it ensure it can only be called once and if we import anything from conftest for whatever reason, it won't try to run the code snippit again. This is what we should have done at the start as putting any "raw" code in conftest.py is ill advised and bugprone.
* [This doc](https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session) has some really good explanation about the order the fixtures are called and when. a scope='session` is called once when pytest startups and its state is shared among all tests that include it. By adding autouse=True, it is automatically added to all tests affected by conftest.py meaning that it is run regardless of which test is run, and it is only once per session (hence scope="session"). You can also have fixtures run once per module, once per class, etc... to store global state, or to have a piece of code run once before the first instance of the class is created etc...
* Prevents this code from being run twice through use of `importlib.reload` or autoreload etc from Jupyter notebooks and better documents what functions are affecting the global state before a test is run
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* multiprocessing_set_spawn in pytest fixture for added safety.
```

<!-- If the upgrade guide needs updating, note that here too -->
