### PR TITLE
chore: update clang-tidy to 15

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -235,8 +235,8 @@ directory inside your pybind11 git clone. Files will be modified in place,
 so you can use git to monitor the changes.
 
 ```bash
-docker run --rm -v $PWD:/mounted_pybind11 -it silkeh/clang:13
-apt-get update && apt-get install -y python3-dev python3-pytest
+docker run --rm -v $PWD:/mounted_pybind11 -it silkeh/clang:15-bullseye
+apt-get update && apt-get install -y git python3-dev python3-pytest
 cmake -S /mounted_pybind11/ -B build -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);--use-color" -DDOWNLOAD_EIGEN=ON -DDOWNLOAD_CATCH=ON -DCMAKE_CXX_STANDARD=17
 cmake --build build -j 2
 ```

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -36,7 +36,7 @@ jobs:
     # in .github/CONTRIBUTING.md and update as needed.
     name: Clang-Tidy
     runs-on: ubuntu-latest
-    container: silkeh/clang:13
+    container: silkeh/clang:15-bullseye
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install requirements
-      run: apt-get update && apt-get install -y python3-dev python3-pytest
+      run: apt-get update && apt-get install -y git python3-dev python3-pytest
 
     - name: Configure
       run: >

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -77,6 +77,7 @@ inline PyObject *make_object_base_type(PyTypeObject *metaclass);
 #    else
 #        define PYBIND11_TLS_KEY_REF Py_tss_t *
 #        define PYBIND11_TLS_KEY_INIT(var) Py_tss_t *var = nullptr;
+// NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
 #        define PYBIND11_TLS_KEY_CREATE(var)                                                      \
             (((var) = PyThread_tss_alloc()) != nullptr && (PyThread_tss_create((var)) == 0))
 #        define PYBIND11_TLS_GET_VALUE(key) PyThread_tss_get((key))

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -516,6 +516,7 @@ struct local_internals {
     struct shared_loader_life_support_data {
         PYBIND11_TLS_KEY_INIT(loader_life_support_tls_key)
         shared_loader_life_support_data() {
+            // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
             if (!PYBIND11_TLS_KEY_CREATE(loader_life_support_tls_key)) {
                 pybind11_fail("local_internals: could not successfully initialize the "
                               "loader_life_support TLS key!");

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -77,7 +77,6 @@ inline PyObject *make_object_base_type(PyTypeObject *metaclass);
 #    else
 #        define PYBIND11_TLS_KEY_REF Py_tss_t *
 #        define PYBIND11_TLS_KEY_INIT(var) Py_tss_t *var = nullptr;
-// NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
 #        define PYBIND11_TLS_KEY_CREATE(var)                                                      \
             (((var) = PyThread_tss_alloc()) != nullptr && (PyThread_tss_create((var)) == 0))
 #        define PYBIND11_TLS_GET_VALUE(key) PyThread_tss_get((key))
@@ -470,12 +469,14 @@ PYBIND11_NOINLINE internals &get_internals() {
 #if defined(WITH_THREAD)
 
         PyThreadState *tstate = PyThreadState_Get();
+        // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
         if (!PYBIND11_TLS_KEY_CREATE(internals_ptr->tstate)) {
             pybind11_fail("get_internals: could not successfully initialize the tstate TSS key!");
         }
         PYBIND11_TLS_REPLACE_VALUE(internals_ptr->tstate, tstate);
 
 #    if PYBIND11_INTERNALS_VERSION > 4
+        // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
         if (!PYBIND11_TLS_KEY_CREATE(internals_ptr->loader_life_support_tls_key)) {
             pybind11_fail("get_internals: could not successfully initialize the "
                           "loader_life_support TSS key!");

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -316,6 +316,7 @@ struct optional_caster {
         if (!std::is_lvalue_reference<T>::value) {
             policy = return_value_policy_override<Value>::policy(policy);
         }
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         return value_conv::cast(*std::forward<T>(src), policy, parent);
     }
 

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -354,11 +354,15 @@ void vector_accessor(enable_if_t<vector_needs_copy<Vector>::value, Class_> &cl) 
     cl.def("__getitem__", [](const Vector &v, DiffType i) -> T {
         if (i < 0) {
             i += v.size();
+            if (i < 0) {
+                throw index_error();
+            }
         }
-        if (i < 0 || (SizeType) i >= v.size()) {
+        auto i_st = static_cast<SizeType>(i);
+        if (i_st >= v.size()) {
             throw index_error();
         }
-        return v[(SizeType) i];
+        return v[i_st];
     });
 
     cl.def(

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -354,11 +354,8 @@ void vector_accessor(enable_if_t<vector_needs_copy<Vector>::value, Class_> &cl) 
     cl.def("__getitem__", [](const Vector &v, DiffType i) -> T {
         if (i < 0) {
             i += v.size();
-            if (i < 0) {
-                throw index_error();
-            }
         }
-        if ((SizeType) i >= v.size()) {
+        if (i < 0 || (SizeType) i >= v.size()) {
             throw index_error();
         }
         return v[(SizeType) i];

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -352,9 +352,11 @@ void vector_accessor(enable_if_t<vector_needs_copy<Vector>::value, Class_> &cl) 
     using DiffType = typename Vector::difference_type;
     using ItType = typename Vector::iterator;
     cl.def("__getitem__", [](const Vector &v, DiffType i) -> T {
-        // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
-        if (i < 0 && (i += v.size()) < 0) {
-            throw index_error();
+        if (i < 0) {
+            i += v.size();
+            if (i < 0) {
+                throw index_error();
+            }
         }
         if ((SizeType) i >= v.size()) {
             throw index_error();

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -352,6 +352,7 @@ void vector_accessor(enable_if_t<vector_needs_copy<Vector>::value, Class_> &cl) 
     using DiffType = typename Vector::difference_type;
     using ItType = typename Vector::iterator;
     cl.def("__getitem__", [](const Vector &v, DiffType i) -> T {
+        // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
         if (i < 0 && (i += v.size()) < 0) {
             throw index_error();
         }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Update clang-tidy docker container to clang 15 and the new way of installing / generating Silekh docker containers. 
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Update clang-tidy to 15 in CI
```

<!-- If the upgrade guide needs updating, note that here too -->
