### PR TITLE
Add flake8 `--ignore=B905,N818,W503`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,6 +112,7 @@ repos:
   hooks:
   - id: flake8
     exclude: ^(docs/.*|tools/.*)$
+    args: ["--ignore=B905,N818,W503"]
     additional_dependencies: *flake8_dependencies
 
 # PyLint has native support - not always usable, but works for us


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
I believe (but I'm not actually sure) that the recent flake8 dependabot upgrade from 5.0.4 to 6.0.0, combined with github switching ubuntu-latest from 20.04 to 22.04, is leading to these pre-commit failures:
```
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

tests/test_smart_ptr.py:49:17: B905 `zip()` without an explicit `strict=` parameter.
    for i, o in zip(
                ^
tests/test_smart_ptr.py:72:17: B905 `zip()` without an explicit `strict=` parameter.
    for i, o in zip(
                ^
tests/test_stl_binders.py:192:17: B905 `zip()` without an explicit `strict=` parameter.
    assert list(zip(um.keys(), um.values())) == list(um.items())
                ^
```
This is one of the "Opinionated warnings" and for Python >= 3.10 only:

* https://github.com/PyCQA/flake8-bugbear#opinionated-warnings

> The strict= argument was added in Python 3.10, so don't enable this flag for code that should work on < 3.10.

I.e. we cannot enable it until we drop 3.9 (https://endoflife.date/python for 3.9 is October 2025).

That led me to try:

```
   hooks:
   - id: flake8
     exclude: ^(docs/.*|tools/.*)$
+    args: ["--ignore=B905"]
     additional_dependencies: *flake8_dependencies
```

That led to a small flooding of `W503` errors, and one `N818` error.  —  I'm guessing specifying `--ignore` is turning off default suppressions.

I tried to add `# noqa: N818` in tests/test_exceptions.py, and with that flake8 was happy, but the `yesqa` hook right above in .pre-commit-config.yaml helpfully removed it again immediately.

So I gave in and added that to the `--ignore` list as well.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
