### PR TITLE
chore: future safe bugbear opinionated warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,5 +46,5 @@ zip_safe = False
 max-line-length = 120
 show_source = True
 exclude = .git, __pycache__, build, dist, docs, tools, venv
-extend-ignore = E203, E722, B903, B905, B950
-extend-select = B9
+extend-ignore = E203, E722
+extend-select = B902, B904


### PR DESCRIPTION
Future safe version of #4391. I've been applying this fix elsewhere.

The opinionated checks are not something you can just enable anymore, after B905 shows that non-EoL Pythons can be required for them. Instead, just turn on the ones that are helpful, and if more are added in the future, we can add them if we like them.