### PR TITLE
[KNOWN TRAP]: segfault with stl.h wrapper for std::map (and no optimization enabled)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
               -DPYBIND11_FINDPYTHON=ON
               -DCMAKE_CXX_FLAGS="-D_=1"
           - runs-on: ubuntu-20.04
+            python: '3.8'
+            # Add a build with no optimizations
+            args: >
+              -DPYBIND11_FINDPYTHON=ON
+              -DCMAKE_BUILD_TYPE=none -DCMAKE_CXX_FLAGS="-DNDEBUG"
+          - runs-on: ubuntu-20.04
             python: 'pypy-3.8'
             args: >
               -DPYBIND11_FINDPYTHON=ON
@@ -293,6 +299,9 @@ jobs:
             std: 20
           - clang: 14
             std: 20
+          - clang: 10
+            std: 14
+            args: -DCMAKE_BUILD_TYPE=none -DCMAKE_CXX_FLAGS="-DNDEBUG"
 
     name: "🐍 3 • Clang ${{ matrix.clang }} • C++${{ matrix.std }} • x64"
     container: "silkeh/clang:${{ matrix.clang }}"
@@ -310,6 +319,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+        ${{ matrix.args }}
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -526,7 +526,7 @@ set(PYBIND11_TEST_PREFIX_COMMAND
 # A single command to compile and run the tests
 add_custom_target(
   pytest
-  COMMAND ${PYBIND11_TEST_PREFIX_COMMAND} ${PYTHON_EXECUTABLE} -m pytest
+  COMMAND ${PYBIND11_TEST_PREFIX_COMMAND} ${PYTHON_EXECUTABLE} -m pytest -v
           ${PYBIND11_ABS_PYTEST_FILES}
   DEPENDS ${test_targets}
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -204,6 +204,7 @@ TEST_SUBMODULE(stl, m) {
     m.def("load_map", [](const std::map<std::string, std::string> &map) {
         return map.at("key") == "value" && map.at("key2") == "value2";
     });
+    m.def("copy_map", [](std::map<std::string, double> map) { auto m = std::move(map); });
 
     // test_set
     m.def("cast_set", []() { return std::set<std::string>{"key1", "key2"}; });

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -204,7 +204,10 @@ TEST_SUBMODULE(stl, m) {
     m.def("load_map", [](const std::map<std::string, std::string> &map) {
         return map.at("key") == "value" && map.at("key2") == "value2";
     });
-    m.def("copy_map", [](std::map<std::string, double> map) { auto m = std::move(map); });
+    m.def("copy_map", [](std::map<std::string, double> map) {
+        std::cerr << "copy_map: " << &map << " #: " << map.size() << std::endl;
+        auto m = std::move(map);
+    });
 
     // test_set
     m.def("cast_set", []() { return std::set<std::string>{"key1", "key2"}; });

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -67,6 +67,11 @@ def test_map(doc):
     assert doc(m.load_map) == "load_map(arg0: Dict[str, str]) -> bool"
 
 
+def test_copy_map():
+    # this segfaults in my use case, but not here:
+    m.copy_map({"pi": 3.14, "zero": 0.0, "one": 0.0})
+
+
 def test_set(doc):
     """std::set <-> set"""
     s = m.cast_set()


### PR DESCRIPTION
## Description

When using both, a `Debug` build and the `stl.h` wrapper for `std::map`, I ran into a surprising segfault. 
I spent a whole day tracking that error down to pybind11 being compiled with no optimization options enabled.
I tried to come up with a minimal example reproducing exactly my issue - but I failed.

However, I was able to reproduce the issue in a different context. For now, this PR provides this minimal example.
What is really weird is that adding a new wrapper in `test_stl.cpp` triggers a bug in `test_stl_binders`.

Note, that I had to add additional gcc and clang build configs to CI (with optimizations disabled) to trigger the bug in Linux. On Windows, it shows up with the existing jobs already.