### PR TITLE
[smart_holder] Demonstrate ODR VIOLATION DETECTED for PR #4395

### DIFF
--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -204,6 +204,7 @@ TEST_SUBMODULE(stl, m) {
     m.def("load_map", [](const std::map<std::string, std::string> &map) {
         return map.at("key") == "value" && map.at("key2") == "value2";
     });
+    m.def("pass_map_string_double", [](const std::map<std::string, double> &) {});
 
     // test_set
     m.def("cast_set", []() { return std::set<std::string>{"key1", "key2"}; });


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
See the description of PR #4022 for background.

```
clang++ -o pybind11/tests/test_stl.os -c -std=c++17 -fPIC -fvisibility=hidden -O0 -g -Wall -Wextra -Wconversion -Wcast-qual -Wdeprecated -Wundef -Wnon-virtual-dtor -Wunused-result -Werror -isystem /usr/include/python3.10 -isystem /usr/include/eigen3 -DPYBIND11_STRICT_ASSERTS_CLASS_HOLDER_VS_TYPE_CASTER_MIX -DPYBIND11_ENABLE_TYPE_CASTER_ODR_GUARD_IF_AVAILABLE -DPYBIND11_TEST_BOOST -Ipybind11/include -I/usr/local/google/home/rwgk/forked/pybind11/include -I/usr/local/google/home/rwgk/clone/pybind11/include /usr/local/google/home/rwgk/forked/pybind11/tests/test_stl.cpp
...
Running tests in directory "/usr/local/google/home/rwgk/forked/pybind11/tests":
terminate called after throwing an instance of 'std::system_error'
  what():  ODR VIOLATION DETECTED: pybind11::detail::type_caster<std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, double> > >>: SourceLocation1="/usr/local/google/home/rwgk/forked/pybind11/include/pybind11/stl.h:161", SourceLocation2="/usr/local/google/home/rwgk/forked/pybind11/include/pybind11/detail/type_caster_base.h:913": State not recoverable
```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
