### PR TITLE
Systematically add `-DCMAKE_VERBOSE_MAKEFILE=ON` in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
     - name: Configure C++11 ${{ matrix.args }}
       run: >
         cmake -S . -B .
+        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DPYBIND11_SIMPLE_GIL_MANAGEMENT=ON
         -DDOWNLOAD_CATCH=ON
@@ -135,6 +136,7 @@ jobs:
     - name: Configure C++17
       run: >
         cmake -S . -B build2
+        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF
         -DDOWNLOAD_CATCH=ON
@@ -157,6 +159,7 @@ jobs:
     - name: Configure (unstable ABI)
       run: >
         cmake -S . -B build3
+        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
@@ -243,6 +246,7 @@ jobs:
         SETUPTOOLS_USE_DISTUTILS: stdlib
       run: >
         cmake -S . -B build
+        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DCMAKE_BUILD_TYPE=Debug
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
@@ -307,6 +311,7 @@ jobs:
       shell: bash
       run: >
         cmake -S . -B build
+        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DCMAKE_CXX_STANDARD=${{ matrix.std }}
@@ -339,7 +344,7 @@ jobs:
       run: apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y cmake git python3-dev python3-pytest python3-numpy
 
     - name: Configure
-      run: cmake -S . -B build -DPYBIND11_CUDA_TESTS=ON -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON
+      run: cmake -S . -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DPYBIND11_CUDA_TESTS=ON -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON
 
     - name: Build
       run: cmake --build build -j2 --verbose
@@ -377,7 +382,7 @@ jobs:
 #      run: |
 #        source /etc/profile.d/modules.sh
 #        module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/20.11
-#        cmake -S . -B build -DDOWNLOAD_CATCH=ON -DCMAKE_CXX_STANDARD=14 -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
+#        cmake -S . -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DDOWNLOAD_CATCH=ON -DCMAKE_CXX_STANDARD=14 -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 #
 #    - name: Build
 #      run: cmake --build build -j 2 --verbose
@@ -475,6 +480,7 @@ jobs:
       shell: bash
       run: >
         cmake -S . -B build
+        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DCMAKE_CXX_STANDARD=${{ matrix.std }}
@@ -529,6 +535,7 @@ jobs:
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake -S . -B build-11     \
+        -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
@@ -561,6 +568,7 @@ jobs:
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake -S . -B build-17     \
+        -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
@@ -627,6 +635,7 @@ jobs:
       shell: bash
       run: >
         cmake -S . -B build
+        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DCMAKE_BUILD_TYPE=MinSizeRel
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
@@ -774,6 +783,7 @@ jobs:
       run: >
         cmake -S . -B build
         -G "Visual Studio 16 2019" -A Win32
+        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
@@ -827,6 +837,7 @@ jobs:
       run: >
         cmake -S . -B build
         -G "Visual Studio 16 2019" -A Win32
+        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DCMAKE_BUILD_TYPE=Debug
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
@@ -867,6 +878,7 @@ jobs:
     - name: Configure C++20
       run: >
         cmake -S . -B build
+        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
@henryiii @Skylion007 I didn't really expect the added `-DCMAKE_VERBOSE_MAKEFILE=ON` to work everywhere, but it does!

The size difference in logs_*.zip is:

```
$ ls -l logs_25759.zip logs_25892.zip
3.9M Dec 12 02:47 logs_25759.zip
5.2M Dec 12 11:05 logs_25892.zip
```

I'm thinking, relative to all the binaries getting generated, that's probably a tiny increase, but it makes the difference between day a night for questions like we want to answer here. E.g. I see that `-Wodr` isn't actually specified explicitly on any command line, and I can now systematically mine the logs for clues what linker options (`-O3`, `-flto`?) trigger the ODR warnings.

I.e. I think it'll be great to merge this PR.

________

To obtain full command lines related to `-Wodr`.

https://github.com/pybind/pybind11/pull/4395#issuecomment-1346191424

https://github.com/pybind/pybind11/actions/runs/3659994679/jobs/6186623695

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
