### PR TITLE
Fix multi-context new Python linking mode

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -9,7 +9,7 @@ if(CMAKE_VERSION VERSION_LESS 3.12)
   message(FATAL_ERROR "You cannot use the new FindPython module with CMake < 3.12")
 endif()
 
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 
 get_property(
   is_config


### PR DESCRIPTION
## Description

Allow CMake find_package() from multiple directories.

Fixes https://github.com/pybind/pybind11/issues/4400


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Allow calling ``find_package(pybind11 CONFIG)`` multiple times from separate
  directories in the same CMake project and properly link Python (new mode).
```
