### PR TITLE
IPO/LTO support for ICX (IntelLLVM) compiler

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -311,10 +311,22 @@ function(_pybind11_generate_lto target prefer_thin_lto)
         HAS_FLTO "-flto${cxx_append}" "-flto${linker_append}" PYBIND11_LTO_CXX_FLAGS
         PYBIND11_LTO_LINKER_FLAGS)
     endif()
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
+    # IntelLLVM equivalent to LTO is called IPO; also IntelLLVM is WIN32/UNIX
+    if(WIN32)
+      _pybind11_return_if_cxx_and_linker_flags_work(
+        HAS_INTEL_IPO "-Qipo" "-Qipo"
+        PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
+    else()
+      _pybind11_return_if_cxx_and_linker_flags_work(
+        HAS_INTEL_IPO "-ipo" "-ipo"
+        PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
+    endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     # Intel equivalent to LTO is called IPO
-    _pybind11_return_if_cxx_and_linker_flags_work(HAS_INTEL_IPO "-ipo" "-ipo"
-                                                  PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
+    _pybind11_return_if_cxx_and_linker_flags_work(
+      HAS_INTEL_IPO "-ipo" "-ipo"
+      PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
   elseif(MSVC)
     # cmake only interprets libraries as linker flags when they start with a - (otherwise it
     # converts /LTCG to \LTCG as if it was a Windows path).  Luckily MSVC supports passing flags

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -315,18 +315,15 @@ function(_pybind11_generate_lto target prefer_thin_lto)
     # IntelLLVM equivalent to LTO is called IPO; also IntelLLVM is WIN32/UNIX
     if(WIN32)
       _pybind11_return_if_cxx_and_linker_flags_work(
-        HAS_INTEL_IPO "-Qipo" "-Qipo"
-        PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
+        HAS_INTEL_IPO "-Qipo" "-Qipo" PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
     else()
       _pybind11_return_if_cxx_and_linker_flags_work(
-        HAS_INTEL_IPO "-ipo" "-ipo"
-        PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
+        HAS_INTEL_IPO "-ipo" "-ipo" PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
     endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     # Intel equivalent to LTO is called IPO
-    _pybind11_return_if_cxx_and_linker_flags_work(
-      HAS_INTEL_IPO "-ipo" "-ipo"
-      PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
+    _pybind11_return_if_cxx_and_linker_flags_work(HAS_INTEL_IPO "-ipo" "-ipo"
+                                                  PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
   elseif(MSVC)
     # cmake only interprets libraries as linker flags when they start with a - (otherwise it
     # converts /LTCG to \LTCG as if it was a Windows path).  Luckily MSVC supports passing flags

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -313,6 +313,7 @@ function(_pybind11_generate_lto target prefer_thin_lto)
     endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
     # IntelLLVM equivalent to LTO is called IPO; also IntelLLVM is WIN32/UNIX
+    # WARNING/HELP WANTED: This block of code is currently not covered by pybind11 GitHub Actions!
     if(WIN32)
       _pybind11_return_if_cxx_and_linker_flags_work(
         HAS_INTEL_IPO "-Qipo" "-Qipo" PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)


### PR DESCRIPTION
## Description

Fixes https://github.com/pybind/pybind11/issues/4080

## Suggested changelog entry:

```rst
* Extend IPO/LTO detection for ICX (a.k.a IntelLLVM) compiler.
```

