### PR TITLE
Set `env: VERBOSE: 1` as suggested by @henryiii

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,6 @@ jobs:
     - name: Configure C++11 ${{ matrix.args }}
       run: >
         cmake -S . -B .
-        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DPYBIND11_SIMPLE_GIL_MANAGEMENT=ON
         -DDOWNLOAD_CATCH=ON
@@ -136,7 +135,6 @@ jobs:
     - name: Configure C++17
       run: >
         cmake -S . -B build2
-        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF
         -DDOWNLOAD_CATCH=ON
@@ -159,7 +157,6 @@ jobs:
     - name: Configure (unstable ABI)
       run: >
         cmake -S . -B build3
-        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
@@ -246,7 +243,6 @@ jobs:
         SETUPTOOLS_USE_DISTUTILS: stdlib
       run: >
         cmake -S . -B build
-        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DCMAKE_BUILD_TYPE=Debug
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
@@ -311,7 +307,6 @@ jobs:
       shell: bash
       run: >
         cmake -S . -B build
-        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DCMAKE_CXX_STANDARD=${{ matrix.std }}
@@ -344,7 +339,7 @@ jobs:
       run: apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y cmake git python3-dev python3-pytest python3-numpy
 
     - name: Configure
-      run: cmake -S . -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DPYBIND11_CUDA_TESTS=ON -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON
+      run: cmake -S . -B build -DPYBIND11_CUDA_TESTS=ON -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON
 
     - name: Build
       run: cmake --build build -j2 --verbose
@@ -382,7 +377,7 @@ jobs:
 #      run: |
 #        source /etc/profile.d/modules.sh
 #        module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/20.11
-#        cmake -S . -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DDOWNLOAD_CATCH=ON -DCMAKE_CXX_STANDARD=14 -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
+#        cmake -S . -B build -DDOWNLOAD_CATCH=ON -DCMAKE_CXX_STANDARD=14 -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 #
 #    - name: Build
 #      run: cmake --build build -j 2 --verbose
@@ -480,7 +475,6 @@ jobs:
       shell: bash
       run: >
         cmake -S . -B build
-        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DCMAKE_CXX_STANDARD=${{ matrix.std }}
@@ -535,7 +529,6 @@ jobs:
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake -S . -B build-11     \
-        -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
@@ -568,7 +561,6 @@ jobs:
       run: |
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         cmake -S . -B build-17     \
-        -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DPYBIND11_WERROR=ON    \
         -DDOWNLOAD_CATCH=ON     \
         -DDOWNLOAD_EIGEN=OFF    \
@@ -635,7 +627,6 @@ jobs:
       shell: bash
       run: >
         cmake -S . -B build
-        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DCMAKE_BUILD_TYPE=MinSizeRel
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
@@ -783,7 +774,6 @@ jobs:
       run: >
         cmake -S . -B build
         -G "Visual Studio 16 2019" -A Win32
-        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON
@@ -837,7 +827,6 @@ jobs:
       run: >
         cmake -S . -B build
         -G "Visual Studio 16 2019" -A Win32
-        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DCMAKE_BUILD_TYPE=Debug
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
@@ -878,7 +867,6 @@ jobs:
     - name: Configure C++20
       run: >
         cmake -S . -B build
-        -DCMAKE_VERBOSE_MAKEFILE=ON
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DDOWNLOAD_EIGEN=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ env:
   PIP_ONLY_BINARY: numpy
   FORCE_COLOR: 3
   PYTEST_TIMEOUT: 300
+  # For cmake:
+  VERBOSE: 1
 
 jobs:
   # This is the "main" test suite, which tests a large number of different
@@ -918,7 +920,7 @@ jobs:
     - name: Configure C++11
       # LTO leads to many undefined reference like
       # `pybind11::detail::function_call::function_call(pybind11::detail::function_call&&)
-      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=11 -DCMAKE_VERBOSE_MAKEFILE=ON -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build
+      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=11 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build
 
     - name: Build C++11
       run: cmake --build build -j 2
@@ -936,7 +938,7 @@ jobs:
       run: git clean -fdx
 
     - name: Configure C++14
-      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=14 -DCMAKE_VERBOSE_MAKEFILE=ON -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build2
+      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=14 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build2
 
     - name: Build C++14
       run: cmake --build build2 -j 2
@@ -954,7 +956,7 @@ jobs:
       run: git clean -fdx
 
     - name: Configure C++17
-      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=17 -DCMAKE_VERBOSE_MAKEFILE=ON -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build3
+      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=17 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build3
 
     - name: Build C++17
       run: cmake --build build3 -j 2
@@ -1015,7 +1017,6 @@ jobs:
       - name: Configure Clang
         run: >
           cmake -G Ninja -S . -B .
-          -DCMAKE_VERBOSE_MAKEFILE=ON
           -DPYBIND11_WERROR=OFF
           -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF
           -DDOWNLOAD_CATCH=ON
@@ -1081,7 +1082,6 @@ jobs:
       - name: CMake Configure
         run: >
           cmake -S . -B .
-          -DCMAKE_VERBOSE_MAKEFILE=ON
           -DPYBIND11_WERROR=ON
           -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF
           -DDOWNLOAD_CATCH=ON

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -9,6 +9,10 @@ on:
       - stable
       - v*
 
+env:
+  # For cmake:
+  VERBOSE: 1
+
 jobs:
   # This tests various versions of CMake in various combinations, to make sure
   # the configure step passes.

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,6 +14,8 @@ on:
 
 env:
   FORCE_COLOR: 3
+  # For cmake:
+  VERBOSE: 1
 
 jobs:
   pre-commit:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -11,6 +11,8 @@ concurrency:
 
 env:
   PIP_ONLY_BINARY: numpy
+  # For cmake:
+  VERBOSE: 1
 
 jobs:
   standard:


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Improve on #4398 in two ways:

1. Set `env: VERBOSE: 1` in ci.yml as suggested by @henryiii.
2. Also apply this to all other .yml files using cmake.

To make it easy to see what the net changes are, compared to the state **before** #4398:

* commit 5136cb502a745428fa7b5fcfbbcf1853de7792ec rolls back `#4398`.
* commit 6abc64271ef66d5159115476a38a3476fbea95b4 brings back the functional equivalent of `#4398`, but instead of adding many `-DCMAKE_VERBOSE_MAKEFILE=ON` it removes a few.
* commit b939e13013c62d0f3087f49137fbd6c0d7914f07 applies the `env: VERBOSE: 1` to all other .yml files using cmake.

The CI logs were inspected manually to verify that this PR is working as intended.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
