### PR TITLE
Fix ODR violations in our Eigen Tensor tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -294,7 +294,7 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
     message(STATUS "Building tests with Eigen v${EIGEN3_VERSION}")
 
     if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0))
-      tests_extra_targets("test_eigen_tensor.py" "test_eigen_tensor_avoid_stl_array")
+      tests_extra_targets("test_eigen_tensor.py" "eigen_tensor_avoid_stl_array")
     endif()
 
   else()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -293,7 +293,10 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
     endif()
     message(STATUS "Building tests with Eigen v${EIGEN3_VERSION}")
 
-    tests_extra_targets("test_eigen_tensor.py" "test_eigen_tensor_avoid_stl_array")
+    if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0))
+      tests_extra_targets("test_eigen_tensor.py" "test_eigen_tensor_avoid_stl_array")
+    endif()
+
   else()
     list(FIND PYBIND11_TEST_FILES test_eigen_matrix.cpp PYBIND11_TEST_FILES_EIGEN_I)
     if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,7 +130,6 @@ set(PYBIND11_TEST_FILES
     test_docstring_options
     test_eigen_matrix
     test_eigen_tensor
-    test_eigen_tensor_avoid_stl_array.cpp
     test_enum
     test_eval
     test_exceptions
@@ -293,6 +292,8 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
       set(EIGEN3_VERSION ${EIGEN3_VERSION_STRING})
     endif()
     message(STATUS "Building tests with Eigen v${EIGEN3_VERSION}")
+
+    tests_extra_targets("test_eigen_tensor.py" "test_eigen_tensor_avoid_stl_array")
   else()
     list(FIND PYBIND11_TEST_FILES test_eigen_matrix.cpp PYBIND11_TEST_FILES_EIGEN_I)
     if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
@@ -300,11 +301,6 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
     endif()
 
     list(FIND PYBIND11_TEST_FILES test_eigen_tensor.cpp PYBIND11_TEST_FILES_EIGEN_I)
-    if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
-      list(REMOVE_AT PYBIND11_TEST_FILES ${PYBIND11_TEST_FILES_EIGEN_I})
-    endif()
-    list(FIND PYBIND11_TEST_FILES test_eigen_tensor_avoid_stl_array.cpp
-         PYBIND11_TEST_FILES_EIGEN_I)
     if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
       list(REMOVE_AT PYBIND11_TEST_FILES ${PYBIND11_TEST_FILES_EIGEN_I})
     endif()
@@ -316,10 +312,6 @@ endif()
 # Some code doesn't support gcc 4
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
   list(FIND PYBIND11_TEST_FILES test_eigen_tensor.cpp PYBIND11_TEST_FILES_EIGEN_I)
-  if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
-    list(REMOVE_AT PYBIND11_TEST_FILES ${PYBIND11_TEST_FILES_EIGEN_I})
-  endif()
-  list(FIND PYBIND11_TEST_FILES test_eigen_tensor_avoid_stl_array.cpp PYBIND11_TEST_FILES_EIGEN_I)
   if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
     list(REMOVE_AT PYBIND11_TEST_FILES ${PYBIND11_TEST_FILES_EIGEN_I})
   endif()

--- a/tests/eigen_tensor_avoid_stl_array.cpp
+++ b/tests/eigen_tensor_avoid_stl_array.cpp
@@ -11,4 +11,4 @@
 
 #include "test_eigen_tensor.inl"
 
-PYBIND11_MODULE(test_eigen_tensor_avoid_stl_array, m) { test_module(m); }
+PYBIND11_MODULE(eigen_tensor_avoid_stl_array, m) { eigen_tensor_test::test_module(m); }

--- a/tests/test_eigen_tensor.cpp
+++ b/tests/test_eigen_tensor.cpp
@@ -5,8 +5,6 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-constexpr const char *test_eigen_tensor_module_name = "eigen_tensor";
-
 #define PYBIND11_TEST_EIGEN_TENSOR_NAMESPACE eigen_tensor
 
 #ifdef EIGEN_AVOID_STL_ARRAY
@@ -14,3 +12,7 @@ constexpr const char *test_eigen_tensor_module_name = "eigen_tensor";
 #endif
 
 #include "test_eigen_tensor.inl"
+
+#include "pybind11_tests.h"
+
+test_initializer name("eigen_tensor", test_module);

--- a/tests/test_eigen_tensor.cpp
+++ b/tests/test_eigen_tensor.cpp
@@ -15,4 +15,4 @@
 
 #include "pybind11_tests.h"
 
-test_initializer name("eigen_tensor", test_module);
+test_initializer egien_tensor("eigen_tensor", eigen_tensor_test::test_module);

--- a/tests/test_eigen_tensor.inl
+++ b/tests/test_eigen_tensor.inl
@@ -7,9 +7,7 @@
 
 #include <pybind11/eigen/tensor.h>
 
-#include "pybind11_tests.h"
-
-PYBIND11_NAMESPACE_BEGIN(PYBIND11_TEST_EIGEN_TENSOR_NAMESPACE)
+namespace py = pybind11;
 
 PYBIND11_WARNING_DISABLE_MSVC(4127)
 
@@ -108,7 +106,7 @@ void init_tensor_module(pybind11::module &m) {
         return check_tensor(get_tensor<Options>()) && check_tensor(get_fixed_tensor<Options>());
     });
 
-    py::class_<CustomExample<Options>>(m, "CustomExample")
+    py::class_<CustomExample<Options>>(m, "CustomExample", py::module_local())
         .def(py::init<>())
         .def_readonly(
             "member", &CustomExample<Options>::member, py::return_value_policy::reference_internal)
@@ -322,8 +320,6 @@ void init_tensor_module(pybind11::module &m) {
         py::return_value_policy::reference);
 }
 
-void test_module(py::module_ &);
-test_initializer name(test_eigen_tensor_module_name, test_module);
 void test_module(py::module_ &m) {
     auto f_style = m.def_submodule("f_style");
     auto c_style = m.def_submodule("c_style");
@@ -331,5 +327,3 @@ void test_module(py::module_ &m) {
     init_tensor_module<Eigen::ColMajor>(f_style);
     init_tensor_module<Eigen::RowMajor>(c_style);
 }
-
-PYBIND11_NAMESPACE_END(PYBIND11_TEST_EIGEN_TENSOR_NAMESPACE)

--- a/tests/test_eigen_tensor.inl
+++ b/tests/test_eigen_tensor.inl
@@ -7,6 +7,8 @@
 
 #include <pybind11/eigen/tensor.h>
 
+PYBIND11_NAMESPACE_BEGIN(eigen_tensor_test)
+
 namespace py = pybind11;
 
 PYBIND11_WARNING_DISABLE_MSVC(4127)
@@ -327,3 +329,5 @@ void test_module(py::module_ &m) {
     init_tensor_module<Eigen::ColMajor>(f_style);
     init_tensor_module<Eigen::RowMajor>(c_style);
 }
+
+PYBIND11_NAMESPACE_END(eigen_tensor_test)

--- a/tests/test_eigen_tensor.py
+++ b/tests/test_eigen_tensor.py
@@ -6,17 +6,17 @@ np = pytest.importorskip("numpy")
 eigen_tensor = pytest.importorskip("pybind11_tests.eigen_tensor")
 submodules = [eigen_tensor.c_style, eigen_tensor.f_style]
 try:
-    import test_eigen_tensor_avoid_stl_array as avoid
+    import eigen_tensor_avoid_stl_array as avoid
 
     submodules += [avoid.c_style, avoid.f_style]
 except ImportError as e:
     # Ensure config, build, toolchain, etc. issues are not masked here:
     raise RuntimeError(
-        "import pybind11_tests.eigen_tensor_avoid_stl_array FAILED, while "
+        "import eigen_tensor_avoid_stl_array FAILED, while "
         "import pybind11_tests.eigen_tensor succeeded. "
         "Please ensure that "
         "test_eigen_tensor.cpp & "
-        "test_eigen_tensor_avoid_stl_array.cpp "
+        "eigen_tensor_avoid_stl_array.cpp "
         "are built together (or both are not built if Eigen is not available)."
     ) from e
 
@@ -42,7 +42,7 @@ def cleanup():
 
 
 def test_import_avoid_stl_array():
-    pytest.importorskip("test_eigen_tensor_avoid_stl_array")
+    pytest.importorskip("eigen_tensor_avoid_stl_array")
     assert len(submodules) == 4
 
 

--- a/tests/test_eigen_tensor.py
+++ b/tests/test_eigen_tensor.py
@@ -6,7 +6,7 @@ np = pytest.importorskip("numpy")
 eigen_tensor = pytest.importorskip("pybind11_tests.eigen_tensor")
 submodules = [eigen_tensor.c_style, eigen_tensor.f_style]
 try:
-    from pybind11_tests import eigen_tensor_avoid_stl_array as avoid
+    import test_eigen_tensor_avoid_stl_array as avoid
 
     submodules += [avoid.c_style, avoid.f_style]
 except ImportError as e:
@@ -42,7 +42,7 @@ def cleanup():
 
 
 def test_import_avoid_stl_array():
-    pytest.importorskip("pybind11_tests.eigen_tensor_avoid_stl_array")
+    pytest.importorskip("test_eigen_tensor_avoid_stl_array")
     assert len(submodules) == 4
 
 

--- a/tests/test_eigen_tensor_avoid_stl_array.cpp
+++ b/tests/test_eigen_tensor_avoid_stl_array.cpp
@@ -5,12 +5,10 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-constexpr const char *test_eigen_tensor_module_name = "eigen_tensor_avoid_stl_array";
-
 #ifndef EIGEN_AVOID_STL_ARRAY
 #    define EIGEN_AVOID_STL_ARRAY
 #endif
 
-#define PYBIND11_TEST_EIGEN_TENSOR_NAMESPACE eigen_tensor_avoid_stl_array
-
 #include "test_eigen_tensor.inl"
+
+PYBIND11_MODULE(test_eigen_tensor_avoid_stl_array, m) { test_module(m); }


### PR DESCRIPTION
## Description

The current way we are doing unit tests with Eigen unintentionally triggers ODR violations due to testing both with and without std::array.

This fixes those ODR violations by updating our build scripts.
