### PR TITLE
Improve the error reporting for inc_ref GIL failures

### DIFF
--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -118,6 +118,29 @@ The ``call_go`` wrapper can also be simplified using the ``call_guard`` policy
     m.def("call_go", &call_go, py::call_guard<py::gil_scoped_release>());
 
 
+Common Sources Of Global Interpreter Lock Errors
+==================================================================
+
+Failing to properly hold the Global Interpreter Lock (GIL) is one of the
+more common sources of bugs within code that uses pybind11. If you are
+running into GIL related errors, we highly recommend you consult the
+following checklist.
+
+- [ ] Do you have any global variables that are pybind11 objects or invoke
+pybind11 functions in either their constructor or destructor? You are generally
+not allowed to invoke any Python function in a global static context. We recommend
+using lazy initialization and then intentionally leaking at the end of the program.
+
+- [ ] Do you have any pybind11 objects that are members of other C++ structures? One
+common overlooked requirement is that pybind11 objects have to increase their reference count
+whenever their copy constructor is called. Thus, you need to be holding the GIL to invoke
+the copy constructor of any C++ class that has a pybind11 member. This can sometimes be very
+tricky to track for complicated programs Think carefully when you make a pybind11 object a member in another struct.
+
+- [ ] C++ destructors that invoke Python functions are a particular troublesome setting as
+destructors can sometimes get invoked in weird and unexpected circumstances.
+
+
 Binding sequence data types, iterators, the slicing protocol, etc.
 ==================================================================
 

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -142,6 +142,8 @@ following checklist.
   destructors can sometimes get invoked in weird and unexpected circumstances as a result
   of exceptions.
 
+- You should try running your code in a debug build. That will enable additional assertions
+  within pybind11 that can throw exceptions on some GIL errors, in particular during reference counting operations.
 
 Binding sequence data types, iterators, the slicing protocol, etc.
 ==================================================================

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -143,7 +143,8 @@ following checklist.
   of exceptions.
 
 - You should try running your code in a debug build. That will enable additional assertions
-  within pybind11 that can throw exceptions on some GIL errors, in particular during reference counting operations.
+  within pybind11 that will throw exceptions on certain GIL handling errors
+  (reference counting operations).
 
 Binding sequence data types, iterators, the slicing protocol, etc.
 ==================================================================

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -126,19 +126,21 @@ more common sources of bugs within code that uses pybind11. If you are
 running into GIL related errors, we highly recommend you consult the
 following checklist.
 
-- [ ] Do you have any global variables that are pybind11 objects or invoke
-pybind11 functions in either their constructor or destructor? You are generally
-not allowed to invoke any Python function in a global static context. We recommend
-using lazy initialization and then intentionally leaking at the end of the program.
+- Do you have any global variables that are pybind11 objects or invoke
+  pybind11 functions in either their constructor or destructor? You are generally
+  not allowed to invoke any Python function in a global static context. We recommend
+  using lazy initialization and then intentionally leaking at the end of the program.
 
-- [ ] Do you have any pybind11 objects that are members of other C++ structures? One
-common overlooked requirement is that pybind11 objects have to increase their reference count
-whenever their copy constructor is called. Thus, you need to be holding the GIL to invoke
-the copy constructor of any C++ class that has a pybind11 member. This can sometimes be very
-tricky to track for complicated programs Think carefully when you make a pybind11 object a member in another struct.
+- Do you have any pybind11 objects that are members of other C++ structures? One
+  commonly overlooked requirement is that pybind11 objects have to increase their reference count
+  whenever their copy constructor is called. Thus, you need to be holding the GIL to invoke
+  the copy constructor of any C++ class that has a pybind11 member. This can sometimes be very
+  tricky to track for complicated programs Think carefully when you make a pybind11 object
+  a member in another struct.
 
-- [ ] C++ destructors that invoke Python functions are a particular troublesome setting as
-destructors can sometimes get invoked in weird and unexpected circumstances.
+- C++ destructors that invoke Python functions can be particularly troublesome as
+  destructors can sometimes get invoked in weird and unexpected circumstances as a result
+  of exceptions.
 
 
 Binding sequence data types, iterators, the slicing protocol, etc.

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -250,7 +250,7 @@ public:
 #ifdef PYBIND11_HANDLE_REF_DEBUG
         inc_ref_counter(1);
 #endif
-#if defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
+#ifdef PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
         if (m_ptr != nullptr && !PyGILState_Check()) {
             throw_gilstate_error("pybind11::handle::inc_ref()");
         }
@@ -265,7 +265,7 @@ public:
         this function automatically. Returns a reference to itself.
     \endrst */
     const handle &dec_ref() const & {
-#if defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
+#ifdef PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
         if (m_ptr != nullptr && !PyGILState_Check()) {
             throw_gilstate_error("pybind11::handle::dec_ref()");
         }
@@ -296,24 +296,27 @@ public:
 protected:
     PyObject *m_ptr = nullptr;
 
-#ifdef PYBIND11_HANDLE_REF_DEBUG
 private:
+#ifdef PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
     void throw_gilstate_error(const std::string &function_name) const {
         fprintf(stderr,
-                "%s is being called while PyGILState_Check() is failing. "
-                "This usually indicates that you are calling pybind11 functions without holding "
-                "the GIL or before "
-                "Python (and/or this Python module) is finished initializing.\n",
+                "%s is being called while the GIL is either not held or invalid. Please see "
+                "https://pybind11.readthedocs.io/en/stable/advanced/"
+                "misc.html#global-interpreter-lock-gil for debugging advice.\n",
                 function_name.c_str());
+        fflush(stderr);
         if (Py_TYPE(m_ptr)->tp_name != nullptr) {
             fprintf(stderr,
                     "The failing %s call was triggered on a %s object.\n",
                     function_name.c_str(),
                     Py_TYPE(m_ptr)->tp_name);
+            fflush(stderr);
         }
         throw std::runtime_error(function_name + " PyGILState_Check() failure.");
     }
+#endif
 
+#ifdef PYBIND11_HANDLE_REF_DEBUG
     static std::size_t inc_ref_counter(std::size_t add) {
         thread_local std::size_t counter = 0;
         counter += add;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -299,11 +299,12 @@ protected:
 private:
 #ifdef PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
     void throw_gilstate_error(const std::string &function_name) const {
-        fprintf(stderr,
-                "%s is being called while the GIL is either not held or invalid. Please see "
-                "https://pybind11.readthedocs.io/en/stable/advanced/"
-                "misc.html#global-interpreter-lock-gil for debugging advice.\n",
-                function_name.c_str());
+        fprintf(
+            stderr,
+            "%s is being called while the GIL is either not held or invalid. Please see "
+            "https://pybind11.readthedocs.io/en/stable/advanced/"
+            "misc.html#common-sources-of-global-interpreter-lock-errors for debugging advice.\n",
+            function_name.c_str());
         fflush(stderr);
         if (Py_TYPE(m_ptr)->tp_name != nullptr) {
             fprintf(stderr,


### PR DESCRIPTION
## Description

In 2.10.2, we added a new feature to catch UB when inc_ref or dec_ref are called without the GIL. This functionality works great, but the error reporting via an exception is very suboptimal as those exceptions get called in weird environments, triggering weird crashes.

This PR adds some good old-fashioned fprintf statements to help users understand what is going on. I want to use fprintf here because that's generally the most reliable method in all sorts of environments (especially when iostream might not be initialized properly).

Closes #4426


<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Improved error messages when inc_ref/dec_ref are called with an invalid GIL state.
```