### PR TITLE
[v2.10] Revert the addition of the GIL check feature

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -329,7 +329,8 @@ PYBIND11_WARNING_POP
          && defined(_MSC_VER)) /* PyPy Windows: pytest hangs indefinitely at the end of the       \
                                   process (see PR #4268) */                                       \
     && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
-#    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
+// TODO: Actually enable the following define in the 2.11 release
+// define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif
 
 // #define PYBIND11_STR_LEGACY_PERMISSIVE

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -329,7 +329,7 @@ PYBIND11_WARNING_POP
          && defined(_MSC_VER)) /* PyPy Windows: pytest hangs indefinitely at the end of the       \
                                   process (see PR #4268) */                                       \
     && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
-// TODO: Actually enable the following define in the 2.11 release
+// The following define will be enabled by default in the 2.11 release
 // define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif
 


### PR DESCRIPTION
## Description

We added some additional GIL status assertion in 2.10.2 (https://github.com/pybind/pybind11/pull/4246).

This change seems fine, but is probably too big for a bugfix release and causing a lot of problems for our users.

This disables those assertions by default. Users can always manually opt-in with PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF.

Helps with https://github.com/pybind/pybind11/issues/4420

## Suggested changelog entry:

```rst
Temporarily disabled our GIL status assertions to be re-enabled later.
```