### PR TITLE
Fix `detail::obj_class_name()` to work correctly for meta classes.

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -463,7 +463,7 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 
 // Equivalent to obj.__class__.__name__ (or obj.__name__ if obj is a class).
 inline const char *obj_class_name(PyObject *obj) {
-    if (Py_TYPE(obj) == &PyType_Type) {
+    if (PyType_Check(obj)) {
         return reinterpret_cast<PyTypeObject *>(obj)->tp_name;
     }
     return Py_TYPE(obj)->tp_name;

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -55,6 +55,8 @@ void bind_empty0(py::module_ &m) {
 } // namespace test_class
 
 TEST_SUBMODULE(class_, m) {
+    m.def("obj_class_name", [](py::handle obj) { return py::detail::obj_class_name(obj.ptr()); });
+
     // test_instance
     struct NoConstructor {
         NoConstructor() = default;

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,13 +1,17 @@
 import pytest
 
-import env  # noqa: F401
+import env
 from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import class_ as m
 
 
 def test_obj_class_name():
-    assert m.obj_class_name(UserType(1)) == "pybind11_tests.UserType"
-    assert m.obj_class_name(UserType) == "pybind11_tests.UserType"
+    if env.PYPY:
+        expected_name = "UserType"
+    else:
+        expected_name = "pybind11_tests.UserType"
+    assert m.obj_class_name(UserType(1)) == expected_name
+    assert m.obj_class_name(UserType) == expected_name
 
 
 def test_repr():

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -5,6 +5,11 @@ from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import class_ as m
 
 
+def test_obj_class_name():
+    assert m.obj_class_name(UserType(1)) == "pybind11_tests.UserType"
+    assert m.obj_class_name(UserType) == "pybind11_tests.UserType"
+
+
 def test_repr():
     assert "pybind11_type" in repr(type(UserType))
     assert "UserType" in repr(UserType)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -99,6 +99,8 @@ void m_defs(py::module_ &m) {
 } // namespace handle_from_move_only_type_with_operator_PyObject
 
 TEST_SUBMODULE(pytypes, m) {
+    m.def("obj_class_name", [](py::handle obj) { return py::detail::obj_class_name(obj.ptr()); });
+
     handle_from_move_only_type_with_operator_PyObject::m_defs(m);
 
     // test_bool

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -9,6 +9,12 @@ from pybind11_tests import detailed_error_messages_enabled
 from pybind11_tests import pytypes as m
 
 
+def test_obj_class_name():
+    assert m.obj_class_name(None) == "NoneType"
+    assert m.obj_class_name(list) == "list"
+    assert m.obj_class_name([]) == "list"
+
+
 def test_handle_from_move_only_type_with_operator_PyObject():  # noqa: N802
     assert m.handle_from_move_only_type_with_operator_PyObject_ncnst()
     assert m.handle_from_move_only_type_with_operator_PyObject_const()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Port of fix here: https://github.com/google/clif/commit/ef64abf9854471d99f663b14e3449b9914d1567f

The fix was suggested by @Lalaland (https://github.com/pybind/pybind11/pull/4427#discussion_r1057970764) and confirmed to be correct by @yhg1s.

Note that the new test in test_class.py fails without this change.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
