### PR TITLE
Expose a few ArrayDescriptor properties and option for mutable flags

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -25,6 +25,15 @@
 #include <typeindex>
 #include <utility>
 #include <vector>
+#include <iostream>
+
+
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
+typedef SSIZE_T ssize_t;
+#endif
+
 
 /* This will be true on all flat address space platforms and allows us to reduce the
    whole npy_intp / ssize_t / Py_intptr_t business down to just ssize_t for all size
@@ -622,6 +631,15 @@ public:
     /// Flags for the array descriptor
     char flags() const { return detail::array_descriptor_proxy(m_ptr)->flags; }
 
+    /// NumPy array type char
+    char type() const { return detail::array_descriptor_proxy(m_ptr)->type; }
+
+    /// NumPy array type num
+    int type_num() const { return detail::array_descriptor_proxy(m_ptr)->type_num; }
+
+    /// NumPy array element size
+    int elsize() const { return detail::array_descriptor_proxy(m_ptr)->elsize; }
+
 private:
     static object _dtype_from_pep3118() {
         static PyObject *obj = module_::import("numpy.core._internal")
@@ -823,6 +841,9 @@ public:
 
     /// Return the NumPy array flags
     int flags() const { return detail::array_proxy(m_ptr)->flags; }
+
+    /// Mutable NumPy array flags
+    int& flags() { return detail::array_proxy(m_ptr)->flags; }
 
     /// If set, the array is writeable (otherwise the buffer is read-only)
     bool writeable() const {


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This change exposes a few elements in the `PyArrayDescr` struct which I am using in another project.

It also exposes a mutable version of `flags()` in `pybind11::array()`, which is useful when you need to steal the memory from a numpy array accross python calls.

