### PR TITLE
Make sure to properly untrack gc objects before freeing them

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -445,9 +445,15 @@ inline void clear_instance(PyObject *self) {
 /// Instance destructor function for all pybind11 types. It calls `type_info.dealloc`
 /// to destroy the C++ object itself, while the rest is Python bookkeeping.
 extern "C" inline void pybind11_object_dealloc(PyObject *self) {
+    auto *type = Py_TYPE(self);
+
+    // If this is a GC tracked object, untrack it first
+    if(PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC)) {
+        PyObject_GC_UnTrack(self);
+    }
+
     clear_instance(self);
 
-    auto *type = Py_TYPE(self);
     type->tp_free(self);
 
 #if PY_VERSION_HEX < 0x03080000

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -448,7 +448,7 @@ extern "C" inline void pybind11_object_dealloc(PyObject *self) {
     auto *type = Py_TYPE(self);
 
     // If this is a GC tracked object, untrack it first
-    if(PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC)) {
+    if (PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC)) {
         PyObject_GC_UnTrack(self);
     }
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -448,7 +448,7 @@ extern "C" inline void pybind11_object_dealloc(PyObject *self) {
     auto *type = Py_TYPE(self);
 
     // If this is a GC tracked object, untrack it first
-    if (PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC)) {
+    if (PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC) != 0) {
         PyObject_GC_UnTrack(self);
     }
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -448,6 +448,8 @@ extern "C" inline void pybind11_object_dealloc(PyObject *self) {
     auto *type = Py_TYPE(self);
 
     // If this is a GC tracked object, untrack it first
+    // Note that the track call is implicitly done by the
+    // default tp_alloc, which we never override.
     if (PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC) != 0) {
         PyObject_GC_UnTrack(self);
     }


### PR DESCRIPTION
## Description

There is no issue for this as the problem is hard to describe without showing code.
The problem is that this dealloc function is sometimes associated with GC objects but it doesn't properly call PyObject_GC_UnTrack as required by https://docs.python.org/3/c-api/gcsupport.html (note that the track call is implicitly done by the default tp_alloc which we never override).

This was detected because the latest 3.11 release now raises a warning for this when pydebug is enabled.
This warning is being raised in particular for this class in PyTorch: https://github.com/pytorch/pytorch/blob/764f79f6804a57a75d9d4da97824b4f57b638ef5/torch/csrc/jit/python/script_init.cpp#L1454
Since similar warnings for some of our custom python objects do lead to hard crash, I think it is important to fix it (details https://github.com/pytorch/pytorch/issues/91161 )

There is no test in this PR as I don't know how to test this. The warning is only raised in python debug builds (and is a weird warning that cannot be turned into an error). If you have an idea on how to test this, I am happy to do it!
