### PR TITLE
Use PyConfig_InitPythonConfig instead of PyConfig_InitIsolatedConfig

### DIFF
--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -198,9 +198,10 @@ inline void initialize_interpreter(bool init_signal_handlers = true,
         init_signal_handlers, argc, argv, add_program_dir_to_path);
 #else
     PyConfig config;
-    PyConfig_InitIsolatedConfig(&config);
-    config.isolated = 0;
-    config.use_environment = 1;
+    PyConfig_InitPythonConfig(&config);
+    // See PR #4473 for background
+    config.parse_argv = 0;
+
     config.install_signal_handlers = init_signal_handlers ? 1 : 0;
     initialize_interpreter(&config, argc, argv, add_program_dir_to_path);
 #endif


### PR DESCRIPTION
## Description

Attempts to address #4471 

`initialize_interpreter` initializes an isolated configuration via `PyConfig_InitIsolatedConfig`. The [docs](https://docs.python.org/3/c-api/init_config.html#isolated-configuration) on this config say:

> This configuration ignores global configuration variables, environment variables, command line arguments ([PyConfig.argv](https://docs.python.org/3/c-api/init_config.html#c.PyConfig.argv) is not parsed) and user site directory. The C standard streams (ex: stdout) and the LC_CTYPE locale are left unchanged. Signal handlers are not installed.

After initializing this config, the function then sets `config.isolated` to false, `config.use_environment` to true, and `config.install_signal_handlers` to the parameter passed to `initialize_interpreter`, which undoes most of the characteristics that make this an isolated config.

The isolated configuration also says it ignores command line arguments, yet we pass them along anyway.

On top of that, this configuration ignores the user site directory, which means the interpreter won't be able to find any modules installed there (`matplotlib` is an example of a module that usually defaults to the user site directory)

It seems that `PyConfig_InitPythonConfig` makes _much_ more sense here, as the [docs](https://docs.python.org/3/c-api/init_config.html#python-configuration) for this configuration say:

> Environments variables and command line arguments are used to configure Python, whereas global configuration variables are ignored.

This seems much more consistent with what we actually want.

**Note**:

I can see this was brought up in the discussion for #4119, specifically [here](https://github.com/pybind/pybind11/pull/4119#issuecomment-1215953618), though I'm a bit confused as to what the reasoning was behind sticking with the isolated config. Seems like maybe it was just that a unit test was failing. If that test still fails with this MR I may have time to play around and figure out why.

**UPDATE**: 

After some digging, it seems that the necessary change that was missing in #4119 is setting `config.parse_argv` to 0, which is the value used for the isolated configuration.  If we just set this to 0, `PyConfig_InitPythonConfig` seems to work.

## Suggested changelog entry:

```rst
Initialize interpreter with python configuration instead of isolated configuration.
```