### PR TITLE
Bump pre-commit isort version to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
 
 # Nicely sort includes
 - repo: https://github.com/PyCQA/isort
-  rev: "5.11.4"
+  rev: "5.12.0"
   hooks:
   - id: isort
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
As recommended by @henryiii here: https://github.com/pybind/pybind11/pull/4473#issuecomment-1411284106

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
