### PR TITLE
bugfix: Keep registered types until after Py_Finalize(). Fix #4459

### DIFF
--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -259,7 +259,8 @@ inline void finalize_interpreter() {
 
     // Local internals contains data managed by the current interpreter, so we must clear them to
     // avoid undefined behaviors when initializing another interpreter
-    // Must be cleared after Py_Finalize() so atexit and other hooks can use registered_types
+    // Must be cleared only after Py_Finalize() so atexit and other hooks can still use
+    // registered_types
     detail::get_local_internals().registered_types_cpp.clear();
     detail::get_local_internals().registered_exception_translators.clear();
 

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -254,12 +254,14 @@ inline void finalize_interpreter() {
     if (builtins.contains(id) && isinstance<capsule>(builtins[id])) {
         internals_ptr_ptr = capsule(builtins[id]);
     }
-    // Local internals contains data managed by the current interpreter, so we must clear them to
-    // avoid undefined behaviors when initializing another interpreter
-    detail::get_local_internals().registered_types_cpp.clear();
-    detail::get_local_internals().registered_exception_translators.clear();
 
     Py_Finalize();
+
+    // Local internals contains data managed by the current interpreter, so we must clear them to
+    // avoid undefined behaviors when initializing another interpreter
+    // Must be cleared after Py_Finalize() so atexit and other hooks can use registered_types
+    detail::get_local_internals().registered_types_cpp.clear();
+    detail::get_local_internals().registered_exception_translators.clear();
 
     if (internals_ptr_ptr) {
         delete *internals_ptr_ptr;


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Fix #4459 . Keep types registered until after atexit is called.

TODO / help wanted: unit test exercising the atexit situation.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fix bug where cpptypes were unregistered before atexit was called.
```

<!-- If the upgrade guide needs updating, note that here too -->
