### PR TITLE
bugfix: delete proper ctors in gil.h

### DIFF
--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -152,8 +152,8 @@ public:
         }
     }
 
-    gil_scoped_release(const gil_scoped_acquire &) = delete;
-    gil_scoped_release &operator=(const gil_scoped_acquire &) = delete;
+    gil_scoped_release(const gil_scoped_release &) = delete;
+    gil_scoped_release &operator=(const gil_scoped_release &) = delete;
 
     /// This method will disable the PyThreadState_DeleteCurrent call and the
     /// GIL won't be acquired. This method should be used if the interpreter
@@ -203,7 +203,7 @@ class gil_scoped_release {
 public:
     gil_scoped_release() : state{PyEval_SaveThread()} {}
     gil_scoped_release(const gil_scoped_release &) = delete;
-    gil_scoped_release &operator=(const gil_scoped_acquire &) = delete;
+    gil_scoped_release &operator=(const gil_scoped_release &) = delete;
     ~gil_scoped_release() { PyEval_RestoreThread(state); }
     void disarm() {}
 };
@@ -230,7 +230,7 @@ public:
         (void) (this != (this + 1));
     }
     gil_scoped_release(const gil_scoped_release &) = delete;
-    gil_scoped_release &operator=(const gil_scoped_acquire &) = delete;
+    gil_scoped_release &operator=(const gil_scoped_release &) = delete;
     void disarm() {}
 };
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Fix #4484 . A copy paste bug resulted in a non-existent ctor being deleted.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* bugfix: ensure gil_scoped_release RAII is non-copyable.
```

<!-- If the upgrade guide needs updating, note that here too -->
