### PR TITLE
Go back to CMake 3.25.2 to resolve macos-latest FindCatch "Could not download" errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
 
     - name: Update CMake
       uses: jwlawson/actions-setup-cmake@v1.13
+      # TEMPORARILY pin version because 3.26.0-rc1 is failing under macOS:
+      with:
+        cmake-version: '3.25.2'
 
     - name: Cache wheels
       if: runner.os == 'macOS'
@@ -1071,6 +1074,9 @@ jobs:
 
       - name: Update CMake
         uses: jwlawson/actions-setup-cmake@v1.13
+        # TEMPORARILY pin version because 3.26.0-rc1 is failing under macOS:
+        with:
+          cmake-version: '3.25.2'
 
       - name: Run pip installs
         run: |


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
I took a close look at a pair of CI logs (Python 3.11 macos-latest):
* last to succeed (2023-02-02T18:18:14.2041233Z)
* first to fail (2023-02-02T22:57:24.3630240Z)

This diff looked like a smoking gun:
```diff
- -- CMake 3.25.2
+ -- CMake 3.26.0-rc1
```
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
