### PR TITLE
WIP Pip ubuntu-latest issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
 
     - name: Update CMake
       uses: jwlawson/actions-setup-cmake@v1.13
+      # TEMPORARILY pin version because 3.26.0-rc1 is failing under macOS:
+      with:
+        cmake-version: '3.25.2'
 
     - name: Cache wheels
       if: runner.os == 'macOS'
@@ -1071,6 +1074,9 @@ jobs:
 
       - name: Update CMake
         uses: jwlawson/actions-setup-cmake@v1.13
+        # TEMPORARILY pin version because 3.26.0-rc1 is failing under macOS:
+        with:
+          cmake-version: '3.25.2'
 
       - name: Run pip installs
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
 
 # PyLint has native support - not always usable, but works for us
 - repo: https://github.com/PyCQA/pylint
-  rev: "v2.16.1"
+  rev: "v2.16.0"
   hooks:
   - id: pylint
     files: ^pybind11


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The Pip workflow under ubuntu-latest started failing with PR #4495, although it isn't clear if it was that PR or some other change in the environment.

* Last to succeed: 2023-02-06T21:08:12.5159143Z
* First to fail: 2023-02-07T05:52:47.6325927Z

Could it be that the test directory is added to the package when it shouldn't?

https://github.com/pybind/pybind11/actions/runs/4110964186/jobs/7094265355

Any ideas why?

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
