### PR TITLE
Show segfault in embed scoped_interpreter test

### DIFF
--- a/tests/test_embed/catch.cpp
+++ b/tests/test_embed/catch.cpp
@@ -35,6 +35,7 @@ int main(int argc, char *argv[]) {
     setenv("PYTHONPATH", updated_pythonpath.c_str(), /*replace=*/1);
 #endif
 
+    { py::scoped_interpreter guard; }
     py::scoped_interpreter guard{};
 
     auto result = Catch::Session().run(argc, argv);


### PR DESCRIPTION
Hey, we've noticed we're getting a segfault in the destructor of the scoped_interpreter.

I've updated a test of yours to force a full lifecycle of the scoped_interpreter class before anything else.

I've run this on my own fork and it does [segfault](https://github.com/PhilipDeegan/pybind11/actions/runs/4118780267/jobs/7111717816#step:8:50). 

It's possible I have misunderstood something so please let me know if this is not a smart thing to be doing.