### PR TITLE
Revert "Go back to CMake 3.25.2 (#4496)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,6 @@ jobs:
 
     - name: Update CMake
       uses: jwlawson/actions-setup-cmake@v1.13
-      # TEMPORARILY pin version because 3.26.0-rc1 is failing under macOS:
-      with:
-        cmake-version: '3.25.2'
 
     - name: Cache wheels
       if: runner.os == 'macOS'
@@ -1074,9 +1071,6 @@ jobs:
 
       - name: Update CMake
         uses: jwlawson/actions-setup-cmake@v1.13
-        # TEMPORARILY pin version because 3.26.0-rc1 is failing under macOS:
-        with:
-          cmake-version: '3.25.2'
 
       - name: Run pip installs
         run: |

--- a/tools/FindCatch.cmake
+++ b/tools/FindCatch.cmake
@@ -36,10 +36,14 @@ endfunction()
 function(_download_catch version destination_dir)
   message(STATUS "Downloading catch v${version}...")
   set(url https://github.com/philsquared/Catch/releases/download/v${version}/catch.hpp)
-  file(DOWNLOAD ${url} "${destination_dir}/catch.hpp" STATUS status)
+  file(
+    DOWNLOAD ${url} "${destination_dir}/catch.hpp"
+    STATUS status
+    LOG log)
   list(GET status 0 error)
   if(error)
-    message(FATAL_ERROR "Could not download ${url}")
+    string(REPLACE "\n" "\n  " log "  ${log}")
+    message(FATAL_ERROR "Could not download URL:\n" "  ${url}\n" "Log:\n" "${log}")
   endif()
   set(CATCH_INCLUDE_DIR
       "${destination_dir}"


### PR DESCRIPTION
This reverts PR #4496 (b8f28551cc3a98ea9fbfc15c05b513c8f2d23e84).

CMake bug report (suspected regression): https://gitlab.kitware.com/cmake/cmake/-/issues/24398

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
