### PR TITLE
Fix #4459 (cpp atexit callbacks) without segfault (#4500)

### DIFF
--- a/tests/test_embed/catch.cpp
+++ b/tests/test_embed/catch.cpp
@@ -34,7 +34,8 @@ int main(int argc, char *argv[]) {
 #else
     setenv("PYTHONPATH", updated_pythonpath.c_str(), /*replace=*/1);
 #endif
-
+    // Below is a test case for a potential segfault. See PR #4500.
+    { py::scoped_interpreter guard; }
     py::scoped_interpreter guard{};
 
     auto result = Catch::Session().run(argc, argv);


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Fix #4459 without introducing the segfault discovered in #4500. This is a nasty hotfix, but it should support both use cases without crashing.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:
<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fix regression that prevented using atexit callbacks with cpp registered types in an embedded interpreter.
```

<!-- If the upgrade guide needs updating, note that here too -->
