### PR TITLE
fix: tests dir has started to show up in packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+prune tests
 recursive-include pybind11/include/pybind11 *.h
 recursive-include pybind11 *.py
 recursive-include pybind11 py.typed


### PR DESCRIPTION
Tests have been failing due to a change (I think in setuptools) that has started including the tests folder in the SDist. We can't run the tests from outside the repo as far as I know, so let's restore the old behavior.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


<!-- If the upgrade guide needs updating, note that here too -->
