### PR TITLE
add --version option to pybind11-config

### DIFF
--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 import sysconfig
 
+from ._version import __version__
 from .commands import get_cmake_dir, get_include, get_pkgconfig_dir
 
 
@@ -25,6 +26,12 @@ def print_includes() -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=__version__,
+        help="Print the version and exit.",
+    )
     parser.add_argument(
         "--includes",
         action="store_true",


### PR DESCRIPTION
Without this, it's impossible to get feature parity between detection mechanisms. Both the pkg-config file and the cmake config set their versions, but the python probe script didn't provide an option for this.

So you could print the compiler flags for using it, but you could not check what you got.