### PR TITLE
[smart_holder] properties return_value_policy crude workaround for PyCLIF compatibility

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -735,6 +735,7 @@ struct smart_holder_type_caster : smart_holder_type_caster_load<T>,
                 break;
 
             case return_value_policy::copy:
+            case return_value_policy::_clif_automatic:
                 if (copy_constructor) {
                     valueptr = copy_constructor(src);
                 } else {

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -466,8 +466,7 @@ struct smart_holder_type_caster_load {
         holder_type &hld = holder();
         hld.ensure_is_not_disowned("loaded_as_shared_ptr");
         if (hld.vptr_is_using_noop_deleter) {
-            // long *BAD = nullptr; *BAD = 101;
-            //throw std::runtime_error("Non-owning holder (loaded_as_shared_ptr).");
+            throw std::runtime_error("Non-owning holder (loaded_as_shared_ptr).");
         }
         auto *void_raw_ptr = hld.template as_raw_ptr_unowned<void>();
         auto *type_raw_ptr = convert_type(void_raw_ptr);
@@ -717,7 +716,6 @@ struct smart_holder_type_caster : smart_holder_type_caster_load<T>,
             return existing_inst;
         }
 
-  //printf("\nLOOOK have_existing_holder=%s %s:%d\n", existing_holder == nullptr ? "false" : "true", __FILE__, __LINE__); fflush(stdout);
         auto inst = reinterpret_steal<object>(make_new_instance(tinfo->type));
         auto *wrapper = reinterpret_cast<instance *>(inst.ptr());
         wrapper->owned = false;
@@ -776,7 +774,6 @@ struct smart_holder_type_caster : smart_holder_type_caster_load<T>,
                 break;
 
             case return_value_policy::reference_internal:
-  //printf("\nLOOOK case return_value_policy::reference_internal %s:%d\n",  __FILE__, __LINE__); fflush(stdout);
                 valueptr = src;
                 wrapper->owned = false;
                 keep_alive_impl(inst, parent);

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -466,7 +466,8 @@ struct smart_holder_type_caster_load {
         holder_type &hld = holder();
         hld.ensure_is_not_disowned("loaded_as_shared_ptr");
         if (hld.vptr_is_using_noop_deleter) {
-            throw std::runtime_error("Non-owning holder (loaded_as_shared_ptr).");
+            // long *BAD = nullptr; *BAD = 101;
+            //throw std::runtime_error("Non-owning holder (loaded_as_shared_ptr).");
         }
         auto *void_raw_ptr = hld.template as_raw_ptr_unowned<void>();
         auto *type_raw_ptr = convert_type(void_raw_ptr);
@@ -716,6 +717,7 @@ struct smart_holder_type_caster : smart_holder_type_caster_load<T>,
             return existing_inst;
         }
 
+  //printf("\nLOOOK have_existing_holder=%s %s:%d\n", existing_holder == nullptr ? "false" : "true", __FILE__, __LINE__); fflush(stdout);
         auto inst = reinterpret_steal<object>(make_new_instance(tinfo->type));
         auto *wrapper = reinterpret_cast<instance *>(inst.ptr());
         wrapper->owned = false;
@@ -774,6 +776,7 @@ struct smart_holder_type_caster : smart_holder_type_caster_load<T>,
                 break;
 
             case return_value_policy::reference_internal:
+  //printf("\nLOOOK case return_value_policy::reference_internal %s:%d\n",  __FILE__, __LINE__); fflush(stdout);
                 valueptr = src;
                 wrapper->owned = false;
                 keep_alive_impl(inst, parent);

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -544,6 +544,7 @@ public:
                 break;
 
             case return_value_policy::copy:
+            case return_value_policy::_clif_automatic:
                 if (copy_constructor) {
                     valueptr = copy_constructor(src);
                 } else {

--- a/include/pybind11/eigen/matrix.h
+++ b/include/pybind11/eigen/matrix.h
@@ -342,6 +342,7 @@ private:
             case return_value_policy::move:
                 return eigen_encapsulate<props>(new CType(std::move(*src)));
             case return_value_policy::copy:
+            case return_value_policy::_clif_automatic:
                 return eigen_array_cast<props>(*src);
             case return_value_policy::reference:
             case return_value_policy::automatic_reference:

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1587,6 +1587,7 @@ struct property_cpp_function<
     static cpp_function readonly(PM pm, const handle &hdl) {
         return cpp_function(
             [pm](const std::shared_ptr<T> &c_sp) -> std::shared_ptr<drp> {
+  //printf("\nLOOOK GOT std::shared_ptr<T> %s:%d\n", __FILE__, __LINE__); fflush(stdout);
                 D ptr = (*c_sp).*pm;
                 return std::shared_ptr<drp>(c_sp, ptr);
             },
@@ -1893,11 +1894,13 @@ public:
     class_ &def_readwrite(const char *name, D C::*pm, const Extra &...extra) {
         static_assert(std::is_same<C, type>::value || std::is_base_of<C, type>::value,
                       "def_readwrite() requires a class member (or base class member)");
+  //printf("\nLOOOK def_readwrite ENTR name=%s %s:%d\n", name, __FILE__, __LINE__); fflush(stdout);
         def_property(name,
                      property_cpp_function<type, D>::read(pm, *this),
                      property_cpp_function<type, D>::write(pm, *this),
                      return_value_policy::reference_internal,
                      extra...);
+  //printf("\nLOOOK def_readwrite DONE name=%s %s:%d\n", name, __FILE__, __LINE__); fflush(stdout);
         return *this;
     }
 
@@ -1983,6 +1986,7 @@ public:
                          const cpp_function &fget,
                          const cpp_function &fset,
                          const Extra &...extra) {
+  //printf("\nLOOOK def_property name=%s %s:%d\n", name, __FILE__, __LINE__); fflush(stdout);
         return def_property_static(name, fget, fset, is_method(*this), extra...);
     }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1587,7 +1587,6 @@ struct property_cpp_function<
     static cpp_function readonly(PM pm, const handle &hdl) {
         return cpp_function(
             [pm](const std::shared_ptr<T> &c_sp) -> std::shared_ptr<drp> {
-  //printf("\nLOOOK GOT std::shared_ptr<T> %s:%d\n", __FILE__, __LINE__); fflush(stdout);
                 D ptr = (*c_sp).*pm;
                 return std::shared_ptr<drp>(c_sp, ptr);
             },
@@ -1894,13 +1893,11 @@ public:
     class_ &def_readwrite(const char *name, D C::*pm, const Extra &...extra) {
         static_assert(std::is_same<C, type>::value || std::is_base_of<C, type>::value,
                       "def_readwrite() requires a class member (or base class member)");
-  //printf("\nLOOOK def_readwrite ENTR name=%s %s:%d\n", name, __FILE__, __LINE__); fflush(stdout);
         def_property(name,
                      property_cpp_function<type, D>::read(pm, *this),
                      property_cpp_function<type, D>::write(pm, *this),
                      return_value_policy::reference_internal,
                      extra...);
-  //printf("\nLOOOK def_readwrite DONE name=%s %s:%d\n", name, __FILE__, __LINE__); fflush(stdout);
         return *this;
     }
 
@@ -1986,7 +1983,6 @@ public:
                          const cpp_function &fget,
                          const cpp_function &fset,
                          const Extra &...extra) {
-  //printf("\nLOOOK def_property name=%s %s:%d\n", name, __FILE__, __LINE__); fflush(stdout);
         return def_property_static(name, fget, fset, is_method(*this), extra...);
     }
 

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -193,10 +193,8 @@ public:
     template <typename T>
     static handle cast(T &&src, return_value_policy policy, handle parent) {
         if (!std::is_lvalue_reference<T>::value) {
-  //printf("\nLOOOK policy=%d %s:%d\n", int(policy), __FILE__, __LINE__); fflush(stdout);
             policy = return_value_policy_override<Value>::policy(policy);
         }
-  //printf("\nLOOOK policy=%d %s:%d\n", int(policy), __FILE__, __LINE__); fflush(stdout);
         list l(src.size());
         ssize_t index = 0;
         for (auto &&value : src) {

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -193,8 +193,10 @@ public:
     template <typename T>
     static handle cast(T &&src, return_value_policy policy, handle parent) {
         if (!std::is_lvalue_reference<T>::value) {
+  //printf("\nLOOOK policy=%d %s:%d\n", int(policy), __FILE__, __LINE__); fflush(stdout);
             policy = return_value_policy_override<Value>::policy(policy);
         }
+  //printf("\nLOOOK policy=%d %s:%d\n", int(policy), __FILE__, __LINE__); fflush(stdout);
         list l(src.size());
         ssize_t index = 0;
         for (auto &&value : src) {

--- a/tests/test_non_owning_holder_issue.cpp
+++ b/tests/test_non_owning_holder_issue.cpp
@@ -1,0 +1,39 @@
+#include <pybind11/smart_holder.h>
+#include <pybind11/stl.h>
+
+#include "pybind11_tests.h"
+
+#include <vector>
+
+struct Value {};
+
+struct ValueHolder {
+    Value held_value;
+};
+
+struct VectorValueHolder {
+    std::vector<ValueHolder> vec_val_hld;
+    VectorValueHolder() { vec_val_hld.push_back(ValueHolder{Value{}}); }
+};
+
+#define PYBIND11_SH_DBG_CLASSH_ON
+#ifdef PYBIND11_SH_DBG_CLASSH_ON
+#    define PY_CLASS py::classh
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Value)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(ValueHolder)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(VectorValueHolder)
+#else
+#    define PY_CLASS py::class_
+#endif
+
+TEST_SUBMODULE(non_owning_holder_issue, m) {
+    PY_CLASS<Value>(m, "Value");
+
+    PY_CLASS<ValueHolder>(m, "ValueHolder")
+        .def(py::init<>())
+        .def_readwrite("held_value", &ValueHolder::held_value);
+
+    PY_CLASS<VectorValueHolder>(m, "VectorValueHolder")
+        .def(py::init<>())
+        .def_readwrite("vec_val_hld", &VectorValueHolder::vec_val_hld);
+}

--- a/tests/test_non_owning_holder_issue.py
+++ b/tests/test_non_owning_holder_issue.py
@@ -1,0 +1,12 @@
+from pybind11_tests import non_owning_holder_issue as m
+
+
+def test_ValueHolder():
+    vh = m.ValueHolder()
+    assert vh.held_value is not None
+
+
+def test_VectorValueHolder():
+    vvh = m.VectorValueHolder()
+    vvh0 = vvh.vec_val_hld[0]
+    assert vvh0.held_value is not None


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Crude workaround to address a general PyCLIF vs pybind11 difference in the handling of properties:

* PyCLIF: `return_value_policy::copy`
* pybind11: `return_value_policy::reference_internal`

This makes a difference for properties wrapping access to members that are C++ STL containers (vector, map).

It's unclear at the moment how to handle this better. We'll work with this until we have other issues solved.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
