### PR TITLE
test_modules.py Python 3.12 compatibility

### DIFF
--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -63,7 +63,6 @@ def test_importing():
     from pybind11_tests.modules import OD
 
     assert OD is OrderedDict
-    assert str(OD([(1, "a"), (2, "b")])) == "OrderedDict([(1, 'a'), (2, 'b')])"
 
 
 def test_pydoc():


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Remove test code that does not exercise anything in pybind11, but breaks between Python 3.12alpha3 (still working) and 3.12alpha6 (broken):

```
str(OrderedDict([(1, "a"), (2, "b")]))
```

Old:
```
OrderedDict([(1, 'a'), (2, 'b')])
```

New:
```
OrderedDict({1: 'a', 2: 'b'})
```

See also: https://github.com/python/cpython/issues/101446

Note:

* Change back-ported here from google/pywrapcc#30006

* Testing with Python 3.12alpha6 there: https://github.com/google/pywrapcc/actions/runs/4378273367/jobs/7662807505

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
