### PR TITLE
Change `always_forkserver_on_unix()` to `use_multiprocessing_forkserver_on_linux()`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,8 @@ import contextlib
 import difflib
 import gc
 import multiprocessing
-import os
 import re
+import sys
 import textwrap
 import traceback
 
@@ -25,8 +25,9 @@ except Exception:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def always_forkserver_on_unix():
-    if os.name == "nt":
+def use_multiprocessing_forkserver_on_linux():
+    if sys.platform != "linux":
+        # The default on Windows and macOS is "spawn": If it's not broken, don't fix it.
         return
 
     # Full background: https://github.com/pybind/pybind11/issues/4105#issuecomment-1301004592
@@ -34,8 +35,6 @@ def always_forkserver_on_unix():
     # It is actually a well-known pitfall, unfortunately without guard rails.
     # "forkserver" is more performant than "spawn" (~9s vs ~13s for tests/test_gil_scoped.py,
     # visit the issuecomment link above for details).
-    # Windows does not have fork() and the associated pitfall, therefore it is best left
-    # running with defaults.
     multiprocessing.set_start_method("forkserver")
 
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
To be completely honest, I missed that [`"spawn"` is the default under macOS](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods) while working on PR #4216 & #4306.

In the meantime,

* I noticed in passing,
* and all DEADLOCKs tracked under #4373 occurred under macos-latest.

This PR overrides the multiprocessing default only when we're sure the default is broken.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
