### PR TITLE
Disable LTO only with MINGW+GCC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -890,7 +890,7 @@ jobs:
       run: cmake --build build --target test_cmake_build
 
   mingw:
-    name: "🐍 3 • windows-latest • ${{ matrix.sys }}"
+    name: "🐍 3 • windows-latest • ${{ matrix.msystem }}"
     runs-on: windows-latest
     defaults:
       run:
@@ -917,7 +917,7 @@ jobs:
           catch:p
     - name: Install scipy
       if: ${{ matrix.msystem != 'CLANG64' }}
-      run: pacboy -S python-scipy:p
+      run: pacboy -S python-scipy:p --noconfirm
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,25 +898,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { sys: mingw64, env: x86_64 }
-          - { sys: mingw32, env: i686 }
+        msystem: [MINGW32, MINGW64, UCRT64, CLANG64]
     steps:
     - uses: msys2/setup-msys2@v2
       with:
-        msystem: ${{matrix.sys}}
+        msystem: ${{matrix.msystem}}
         install: >-
           git
-          mingw-w64-${{matrix.env}}-gcc
-          mingw-w64-${{matrix.env}}-python-pip
-          mingw-w64-${{matrix.env}}-python-numpy
-          mingw-w64-${{matrix.env}}-python-scipy
-          mingw-w64-${{matrix.env}}-cmake
-          mingw-w64-${{matrix.env}}-make
-          mingw-w64-${{matrix.env}}-python-pytest
-          mingw-w64-${{matrix.env}}-eigen3
-          mingw-w64-${{matrix.env}}-boost
-          mingw-w64-${{matrix.env}}-catch
+        pacboy: >-
+          cc:p
+          pip:p
+          python-numpy:p
+          cmake:p
+          make:p
+          python-pytest:p
+          eigen3:p
+          boost:p
+          catch:p
+    - name: Install scipy
+      if: ${{ matrix.msystem != CLANG64 }}
+      run: pacboy -S python-scipy:p
 
     - uses: actions/checkout@v3
 
@@ -932,10 +933,10 @@ jobs:
       run: cmake --build build --target pytest -j 2
 
     - name: C++11 tests
-      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build --target cpptest -j 2
+      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build --target cpptest -j 2
 
     - name: Interface test C++11
-      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build --target test_cmake_build
+      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build --target test_cmake_build
 
     - name: Clean directory
       run: git clean -fdx
@@ -950,10 +951,10 @@ jobs:
       run: cmake --build build2 --target pytest -j 2
 
     - name: C++14 tests
-      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build2 --target cpptest -j 2
+      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build2 --target cpptest -j 2
 
     - name: Interface test C++14
-      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build2 --target test_cmake_build
+      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build2 --target test_cmake_build
 
     - name: Clean directory
       run: git clean -fdx
@@ -968,10 +969,10 @@ jobs:
       run: cmake --build build3 --target pytest -j 2
 
     - name: C++17 tests
-      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build3 --target cpptest -j 2
+      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build3 --target cpptest -j 2
 
     - name: Interface test C++17
-      run: PYTHONHOME=/${{matrix.sys}} PYTHONPATH=/${{matrix.sys}} cmake --build build3 --target test_cmake_build
+      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build3 --target test_cmake_build
 
   windows_clang:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -907,7 +907,7 @@ jobs:
           git
         pacboy: >-
           cc:p
-          pip:p
+          python-pip:p
           python-numpy:p
           cmake:p
           make:p

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -924,16 +924,16 @@ jobs:
     - name: Configure C++11
       # LTO leads to many undefined reference like
       # `pybind11::detail::function_call::function_call(pybind11::detail::function_call&&)
-      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=11 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build
+      run: cmake -GNinja -DCMAKE_CXX_STANDARD=11 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build
 
     - name: Build C++11
-      run: cmake --build build -j 2
+      run: cmake --build build
 
     - name: Python tests C++11
-      run: cmake --build build --target pytest -j 2
+      run: cmake --build build --target pytest
 
     - name: C++11 tests
-      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build --target cpptest -j 2
+      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build --target cpptest
 
     - name: Interface test C++11
       run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build --target test_cmake_build
@@ -942,16 +942,16 @@ jobs:
       run: git clean -fdx
 
     - name: Configure C++14
-      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=14 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build2
+      run: cmake -GNinja -DCMAKE_CXX_STANDARD=14 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build2
 
     - name: Build C++14
-      run: cmake --build build2 -j 2
+      run: cmake --build build2
 
     - name: Python tests C++14
-      run: cmake --build build2 --target pytest -j 2
+      run: cmake --build build2 --target pytest
 
     - name: C++14 tests
-      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build2 --target cpptest -j 2
+      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build2 --target cpptest
 
     - name: Interface test C++14
       run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build2 --target test_cmake_build
@@ -960,16 +960,16 @@ jobs:
       run: git clean -fdx
 
     - name: Configure C++17
-      run: cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=17 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build3
+      run: cmake -GNinja -DCMAKE_CXX_STANDARD=17 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -S . -B build3
 
     - name: Build C++17
-      run: cmake --build build3 -j 2
+      run: cmake --build build3
 
     - name: Python tests C++17
-      run: cmake --build build3 --target pytest -j 2
+      run: cmake --build build3 --target pytest
 
     - name: C++17 tests
-      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build3 --target cpptest -j 2
+      run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build3 --target cpptest
 
     - name: Interface test C++17
       run: PYTHONHOME=${MINGW_PREFIX} PYTHONPATH=${MINGW_PREFIX} cmake --build build3 --target test_cmake_build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -916,7 +916,7 @@ jobs:
           boost:p
           catch:p
     - name: Install scipy
-      if: ${{ matrix.msystem != CLANG64 }}
+      if: ${{ matrix.msystem != 'CLANG64' }}
       run: pacboy -S python-scipy:p
 
     - uses: actions/checkout@v3

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -277,8 +277,8 @@ function(_pybind11_return_if_cxx_and_linker_flags_work result cxxflags linkerfla
 endfunction()
 
 function(_pybind11_generate_lto target prefer_thin_lto)
-  if(MINGW)
-    message(STATUS "${target} disabled (problems with undefined symbols for MinGW for now)")
+  if(MINGW AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    message(STATUS "${target} disabled (problems with undefined symbols for MinGW+GCC for now)")
     return()
   endif()
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

MINGW+Clang doesn't have the issue of undefined symbols


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Enable LTO with MINGW+Clang

```

<!-- If the upgrade guide needs updating, note that here too -->
