### PR TITLE
Get rid of recursive template instantiations for concatenating type signatures on C++17 and higher

### DIFF
--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -143,11 +143,24 @@ constexpr descr<N, Ts...> concat(const descr<N, Ts...> &descr) {
     return descr;
 }
 
+#if defined(PYBIND11_CPP17)
+template <size_t N1, size_t N2, typename... Ts1, typename... Ts2>
+constexpr descr<N1 + N2 + 2, Ts1..., Ts2...> operator,(const descr<N1, Ts1...> &a,
+                                                       const descr<N2, Ts2...> &b) {
+    return a + const_name(", ") + b;
+}
+
+template <size_t N, typename... Ts, typename... Args>
+constexpr auto concat(const descr<N, Ts...> &d, const Args &...args) {
+    return (d, ..., args);
+}
+#else
 template <size_t N, typename... Ts, typename... Args>
 constexpr auto concat(const descr<N, Ts...> &d, const Args &...args)
     -> decltype(std::declval<descr<N + 2, Ts...>>() + concat(args...)) {
     return d + const_name(", ") + concat(args...);
 }
+#endif
 
 template <size_t N, typename... Ts>
 constexpr descr<N + 2, Ts...> type_descr(const descr<N, Ts...> &descr) {


### PR DESCRIPTION
## Description
I have had the same error as #1828 when tried to compile big class with a lot of properties and methods with a big number of arguments. I had this issue compiling C++17 standard on MSVC. Unlike GCCs(-ftemplate-depth), for example, MSVC does not have the ability to configure the depth of template instantiation, and on large and complex classes, the compiler's limit can be reached. Since C++17 recursive implementation of `concat` function can be replaced with fold expression. This change has helped me in my case.

## Suggested changelog entry:
```rst
* Get rid of recursive template instantiations for concatenating type signatures on C++17 and higher.
```
