### PR TITLE
Demo: `return_value_policy::copy` ignored

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,7 @@ set(PYBIND11_TEST_FILES
     test_opaque_types
     test_operator_overloading
     test_pickling
+    test_property_stl
     test_pytypes
     test_sequences_and_iterators
     test_smart_ptr

--- a/tests/test_property_stl.cpp
+++ b/tests/test_property_stl.cpp
@@ -1,0 +1,51 @@
+#include <pybind11/smart_holder.h>
+#include <pybind11/stl.h>
+
+#include "pybind11_tests.h"
+
+#include <cstddef>
+#include <vector>
+
+namespace test_class_sh_property_stl {
+
+struct Field {
+    explicit Field(int wrapped_int) : wrapped_int{wrapped_int} {}
+    int wrapped_int = 100;
+};
+
+struct FieldHolder {
+    explicit FieldHolder(const Field &fld) : fld{fld} {}
+    Field fld = Field{200};
+};
+
+struct VectorFieldHolder {
+    std::vector<FieldHolder> vec_fld_hld;
+    VectorFieldHolder() { vec_fld_hld.push_back(FieldHolder{Field{300}}); }
+    void reset_at(std::size_t index, int wrapped_int) {
+        if (index < vec_fld_hld.size()) {
+            vec_fld_hld[index].fld.wrapped_int = wrapped_int;
+        }
+    }
+};
+
+} // namespace test_class_sh_property_stl
+
+using namespace test_class_sh_property_stl;
+
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Field)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(FieldHolder)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(VectorFieldHolder)
+
+TEST_SUBMODULE(class_sh_property_stl, m) {
+    py::classh<Field>(m, "Field").def_readwrite("wrapped_int", &Field::wrapped_int);
+
+    py::classh<FieldHolder>(m, "FieldHolder").def_readwrite("fld", &FieldHolder::fld);
+
+    py::classh<VectorFieldHolder>(m, "VectorFieldHolder")
+        .def(py::init<>())
+        .def("reset_at", &VectorFieldHolder::reset_at)
+        .def_readwrite("vec_fld_hld_ref", &VectorFieldHolder::vec_fld_hld)
+        .def_readwrite("vec_fld_hld_cpy",
+                       &VectorFieldHolder::vec_fld_hld,
+                       py::return_value_policy::_clif_automatic);
+}

--- a/tests/test_property_stl.cpp
+++ b/tests/test_property_stl.cpp
@@ -1,4 +1,3 @@
-#include <pybind11/smart_holder.h>
 #include <pybind11/stl.h>
 
 #include "pybind11_tests.h"
@@ -6,7 +5,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace test_class_sh_property_stl {
+namespace test_property_stl {
 
 struct Field {
     explicit Field(int wrapped_int) : wrapped_int{wrapped_int} {}
@@ -28,24 +27,19 @@ struct VectorFieldHolder {
     }
 };
 
-} // namespace test_class_sh_property_stl
+} // namespace test_property_stl
 
-using namespace test_class_sh_property_stl;
+TEST_SUBMODULE(property_stl, m) {
+    using namespace test_property_stl;
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(Field)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(FieldHolder)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(VectorFieldHolder)
+    py::class_<Field>(m, "Field").def_readwrite("wrapped_int", &Field::wrapped_int);
 
-TEST_SUBMODULE(class_sh_property_stl, m) {
-    py::classh<Field>(m, "Field").def_readwrite("wrapped_int", &Field::wrapped_int);
+    py::class_<FieldHolder>(m, "FieldHolder").def_readwrite("fld", &FieldHolder::fld);
 
-    py::classh<FieldHolder>(m, "FieldHolder").def_readwrite("fld", &FieldHolder::fld);
-
-    py::classh<VectorFieldHolder>(m, "VectorFieldHolder")
+    py::class_<VectorFieldHolder>(m, "VectorFieldHolder")
         .def(py::init<>())
         .def("reset_at", &VectorFieldHolder::reset_at)
         .def_readwrite("vec_fld_hld_ref", &VectorFieldHolder::vec_fld_hld)
-        .def_readwrite("vec_fld_hld_cpy",
-                       &VectorFieldHolder::vec_fld_hld,
-                       py::return_value_policy::_clif_automatic);
+        .def_readwrite(
+            "vec_fld_hld_cpy", &VectorFieldHolder::vec_fld_hld, py::return_value_policy::copy);
 }

--- a/tests/test_property_stl.py
+++ b/tests/test_property_stl.py
@@ -1,4 +1,4 @@
-from pybind11_tests import class_sh_property_stl as m
+from pybind11_tests import property_stl as m
 
 
 def test_cpy_after_ref():

--- a/tests/test_property_stl.py
+++ b/tests/test_property_stl.py
@@ -1,0 +1,31 @@
+from pybind11_tests import class_sh_property_stl as m
+
+
+def test_cpy_after_ref():
+    h = m.VectorFieldHolder()
+    c1 = h.vec_fld_hld_cpy
+    c2 = h.vec_fld_hld_cpy
+    assert repr(c2) != repr(c1)
+    r1 = h.vec_fld_hld_ref
+    assert repr(r1) != repr(c2)
+    assert repr(r1) != repr(c1)
+    r2 = h.vec_fld_hld_ref
+    assert repr(r2) == repr(r1)
+    c3 = h.vec_fld_hld_cpy
+    assert repr(c3) == repr(r1)  # SURPRISE!
+
+
+def test_persistent_holder():
+    h = m.VectorFieldHolder()
+    c0 = h.vec_fld_hld_cpy[0]  # Must be first. See test_cpy_after_ref().
+    r0 = h.vec_fld_hld_ref[0]  # Must be second.
+    assert c0.fld.wrapped_int == 300
+    assert r0.fld.wrapped_int == 300
+    h.reset_at(0, 400)
+    assert c0.fld.wrapped_int == 300
+    assert r0.fld.wrapped_int == 400
+
+
+def test_temporary_holder_keep_alive():
+    r0 = m.VectorFieldHolder().vec_fld_hld_ref[0]
+    assert r0.fld.wrapped_int == 300


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Demo: `return_value_policy::copy` ignored after `return_value_policy::reference_internal` already created a Python object. Back-ported from pywrapcc test_class_sh_property_stl.cpp,py

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
