### PR TITLE
chore: make #4587 use fold expr cpp17 feature macro

### DIFF
--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -143,7 +143,7 @@ constexpr descr<N, Ts...> concat(const descr<N, Ts...> &descr) {
     return descr;
 }
 
-#if defined(PYBIND11_CPP17)
+#ifdef __cpp_fold_expressions
 template <size_t N1, size_t N2, typename... Ts1, typename... Ts2>
 constexpr descr<N1 + N2 + 2, Ts1..., Ts2...> operator,(const descr<N1, Ts1...> &a,
                                                        const descr<N2, Ts2...> &b) {


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Updates #4587 to use more consistent cpp feature macro to determine if the fold expression feature is available. This will also allow the feature to be used on older compilers that support it, but may not have full CPP17 codebase or allow the fold expression feature to be enabled if desired.

<!-- Include relevant issues or PRs here, describe what changed and why -->