### PR TITLE
bugfix: allow noexcept lambdas in C++17. Fix #4565

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -754,7 +754,16 @@ template <typename C, typename R, typename... A>
 struct remove_class<R (C::*)(A...) const> {
     using type = R(A...);
 };
-
+#ifdef __cpp_noexcept_function_type
+template <typename C, typename R, typename... A>
+struct remove_class<R (C::*)(A...) noexcept> {
+    using type = R(A...);
+};
+template <typename C, typename R, typename... A>
+struct remove_class<R (C::*)(A...) const noexcept> {
+    using type = R(A...);
+};
+#endif
 /// Helper template to strip away type modifiers
 template <typename T>
 struct intrinsic_type {

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -149,6 +149,6 @@ TEST_SUBMODULE(constants_and_functions, m) {
             py::arg_v("z", default_value));
     });
 
-    // test noexcept(true) lambda
+    // test noexcept(true) lambda (#4565)
     m.def("l1", []() noexcept(true) { return 0; });
 }

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -150,12 +150,5 @@ TEST_SUBMODULE(constants_and_functions, m) {
     });
 
     // test noexcept(true) lambda
-    m.def("l1", [](void) noexcept(true) {
-        try {
-        } catch (py::error_already_set &eas) {
-            eas.discard_as_unraisable(__func__);
-        } catch (const std::exception &e) {
-        }
-        return 0;
-    });
+    m.def("l1", [](void) noexcept(true) { return 0; });
 }

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -150,5 +150,5 @@ TEST_SUBMODULE(constants_and_functions, m) {
     });
 
     // test noexcept(true) lambda
-    m.def("l1", [](void) noexcept(true) { return 0; });
+    m.def("l1", []() noexcept(true) { return 0; });
 }

--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -148,4 +148,14 @@ TEST_SUBMODULE(constants_and_functions, m) {
             py::arg_v("y", 42, "<the answer>"),
             py::arg_v("z", default_value));
     });
+
+    // test noexcept(true) lambda
+    m.def("l1", [](void) noexcept(true) {
+        try {
+        } catch (py::error_already_set &eas) {
+            eas.discard_as_unraisable(__func__);
+        } catch (const std::exception &e) {
+        }
+        return 0;
+    });
 }

--- a/tests/test_constants_and_functions.py
+++ b/tests/test_constants_and_functions.py
@@ -50,3 +50,7 @@ def test_function_record_leaks():
         m.register_large_capture_with_invalid_arguments(m)
     with pytest.raises(RuntimeError):
         m.register_with_raising_repr(m, RaisingRepr())
+
+
+def test_noexcept_lambda():
+    assert m.l1() == 0


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Allows lambda specified to function defs to be `noexcept(true)` in C++17. This ended up being a rather quick fix compared to more general case which would require some extensive meta-templating to do this properly in C++17.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Allow lambda specified to function definition to be noexcept(true) in C++17
```

<!-- If the upgrade guide needs updating, note that here too -->
