### PR TITLE
Add `type_caster<PyObject>`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,8 @@ set(PYBIND11_HEADERS
     include/pybind11/pytypes.h
     include/pybind11/stl.h
     include/pybind11/stl_bind.h
-    include/pybind11/stl/filesystem.h)
+    include/pybind11/stl/filesystem.h
+    include/pybind11/type_caster_pyobject_ptr.h)
 
 # Compare with grep and warn if mismatched
 if(PYBIND11_MASTER_PROJECT AND NOT CMAKE_VERSION VERSION_LESS 3.12)

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1041,7 +1041,10 @@ make_caster<T> load_type(const handle &handle) {
 PYBIND11_NAMESPACE_END(detail)
 
 // pytype -> C++ type
-template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
+template <
+    typename T,
+    detail::enable_if_t<!detail::is_pyobject<T>::value && !std::is_same<T, PyObject *>::value, int>
+    = 0>
 T cast(const handle &handle) {
     using namespace detail;
     static_assert(!cast_is_temporary_value_reference<T>::value,
@@ -1053,6 +1056,12 @@ T cast(const handle &handle) {
 template <typename T, detail::enable_if_t<detail::is_pyobject<T>::value, int> = 0>
 T cast(const handle &handle) {
     return T(reinterpret_borrow<object>(handle));
+}
+
+template <typename T,
+          detail::enable_if_t<std::is_same<detail::remove_cvref_t<T>, PyObject *>::value, int> = 0>
+T cast(const handle &handle) {
+    return handle.ptr();
 }
 
 // C++ type -> py::object

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1041,10 +1041,11 @@ make_caster<T> load_type(const handle &handle) {
 PYBIND11_NAMESPACE_END(detail)
 
 // pytype -> C++ type
-template <
-    typename T,
-    detail::enable_if_t<!detail::is_pyobject<T>::value && !std::is_same<T, PyObject *>::value, int>
-    = 0>
+template <typename T,
+          detail::enable_if_t<!detail::is_pyobject<T>::value
+                                  && !detail::is_same_ignoring_cvref<T, PyObject *>::value,
+                              int>
+          = 0>
 T cast(const handle &handle) {
     using namespace detail;
     static_assert(!cast_is_temporary_value_reference<T>::value,
@@ -1059,7 +1060,7 @@ T cast(const handle &handle) {
 }
 
 template <typename T,
-          detail::enable_if_t<std::is_same<detail::remove_cvref_t<T>, PyObject *>::value, int> = 0>
+          detail::enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value, int> = 0>
 T cast(const handle &handle) {
     return handle.ptr();
 }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1062,7 +1062,7 @@ T cast(const handle &handle) {
 template <typename T,
           detail::enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value, int> = 0>
 T cast(const handle &handle) {
-    return handle.ptr();
+    return handle.inc_ref().ptr();
 }
 
 // C++ type -> py::object

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1060,7 +1060,11 @@ T cast(const handle &handle) {
 }
 
 // Note that `cast<PyObject *>(obj)` increments the reference count of `obj`.
-// This is necessary for the case that `obj` is a temporary.
+// This is necessary for the case that `obj` is a temporary, and could
+// not possibly be different, given
+// 1. the established convention that the passed `handle` is borrowed, and
+// 2. we don't want to force all generic code using `cast<T>()` to special-case
+//    handling of `T` = `PyObject *` (to increment the reference count there).
 // It is the responsibility of the caller to ensure that the reference count
 // is decremented.
 template <typename T,

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1068,9 +1068,23 @@ T cast(const handle &handle) {
 // It is the responsibility of the caller to ensure that the reference count
 // is decremented.
 template <typename T,
-          detail::enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value, int> = 0>
-T cast(const handle &handle) {
+          typename Handle,
+          detail::enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value
+                                  && detail::is_same_ignoring_cvref<Handle, handle>::value,
+                              int>
+          = 0>
+T cast(Handle &&handle) {
     return handle.inc_ref().ptr();
+}
+// To optimize way an inc_ref/dec_ref cycle:
+template <typename T,
+          typename Object,
+          detail::enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value
+                                  && detail::is_same_ignoring_cvref<Object, object>::value,
+                              int>
+          = 0>
+T cast(Object &&obj) {
+    return obj.release().ptr();
 }
 
 // C++ type -> py::object

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1059,6 +1059,10 @@ T cast(const handle &handle) {
     return T(reinterpret_borrow<object>(handle));
 }
 
+// Note that `cast<PyObject *>(obj)` increments the reference count of `obj`.
+// This is necessary for the case that `obj` is a temporary.
+// It is the responsibility of the caller to ensure that the reference count
+// is decremented.
 template <typename T,
           detail::enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value, int> = 0>
 T cast(const handle &handle) {

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -661,6 +661,10 @@ template <class T>
 using remove_cvref_t = typename remove_cvref<T>::type;
 #endif
 
+/// Example usage: is_same_ignoring_cvref<T, PyObject *>
+template <typename T, typename U>
+using is_same_ignoring_cvref = std::is_same<detail::remove_cvref_t<T>, U>;
+
 /// Index sequences
 #if defined(PYBIND11_CPP14)
 using std::index_sequence;

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -661,7 +661,7 @@ template <class T>
 using remove_cvref_t = typename remove_cvref<T>::type;
 #endif
 
-/// Example usage: is_same_ignoring_cvref<T, PyObject *>
+/// Example usage: is_same_ignoring_cvref<T, PyObject *>::value
 template <typename T, typename U>
 using is_same_ignoring_cvref = std::is_same<detail::remove_cvref_t<T>, U>;
 

--- a/include/pybind11/type_caster_pyobject_ptr.h
+++ b/include/pybind11/type_caster_pyobject_ptr.h
@@ -35,8 +35,12 @@ public:
         if (policy == return_value_policy::take_ownership) {
             return src;
         }
-        Py_INCREF(src);
-        return src;
+        if (policy == return_value_policy::reference
+            || policy == return_value_policy::automatic_reference) {
+            return handle(src).inc_ref();
+        }
+        pybind11_fail("type_caster<PyObject>::cast(): unsupported return_value_policy: "
+                      + std::to_string(static_cast<int>(policy)));
     }
 
     bool load(handle src, bool) {

--- a/include/pybind11/type_caster_pyobject_ptr.h
+++ b/include/pybind11/type_caster_pyobject_ptr.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2023 The pybind Community.
+
+#pragma once
+
+#include "detail/common.h"
+#include "detail/descr.h"
+#include "cast.h"
+#include "pytypes.h"
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+template <>
+class type_caster<PyObject> {
+public:
+    static constexpr auto name = const_name("PyObject *");
+
+    // This overload is purely to guard against accidents.
+    template <typename T,
+              detail::enable_if_t<!is_same_ignoring_cvref<T, PyObject *>::value, int> = 0>
+    static handle cast(T &&, return_value_policy, handle /*parent*/) {
+        static_assert(is_same_ignoring_cvref<T, PyObject *>::value,
+                      "Invalid C++ type T for to-Python conversion (type_caster<PyObject>).");
+        return nullptr; // Unreachable.
+    }
+
+    static handle cast(PyObject *src, return_value_policy policy, handle /*parent*/) {
+        if (src == nullptr) {
+            throw error_already_set();
+        }
+        if (PyErr_Occurred()) {
+            raise_from(PyExc_SystemError, "src != nullptr but PyErr_Occurred()");
+            throw error_already_set();
+        }
+        if (policy == return_value_policy::take_ownership) {
+            return src;
+        }
+        Py_INCREF(src);
+        return src;
+    }
+
+    bool load(handle src, bool) {
+        value = reinterpret_borrow<object>(src);
+        return true;
+    }
+
+    template <typename T>
+    using cast_op_type = PyObject *;
+
+    explicit operator PyObject *() { return value.ptr(); }
+
+private:
+    object value;
+};
+
+PYBIND11_NAMESPACE_END(detail)
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/type_caster_pyobject_ptr.h
+++ b/include/pybind11/type_caster_pyobject_ptr.h
@@ -13,7 +13,7 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 template <>
 class type_caster<PyObject> {
 public:
-    static constexpr auto name = const_name("PyObject *");
+    static constexpr auto name = const_name("object"); // See discussion under PR #4601.
 
     // This overload is purely to guard against accidents.
     template <typename T,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,6 +154,7 @@ set(PYBIND11_TEST_FILES
     test_stl_binders
     test_tagbased_polymorphic
     test_thread
+    test_type_caster_pyobject_ptr
     test_union
     test_virtual_functions)
 

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -43,6 +43,7 @@ main_headers = {
     "include/pybind11/pytypes.h",
     "include/pybind11/stl.h",
     "include/pybind11/stl_bind.h",
+    "include/pybind11/type_caster_pyobject_ptr.h",
 }
 
 detail_headers = {

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -23,11 +23,9 @@ public:
 
     static handle cast(PyObject *src, return_value_policy policy, handle parent) {
         if (src == nullptr) {
-            // NEEDS TEST
             throw error_already_set();
         }
         if (PyErr_Occurred()) {
-            // NEEDS TEST
             raise_from(PyExc_SystemError, "src != nullptr but PyErr_Occurred()");
         }
         if (policy == return_value_policy::take_ownership) {
@@ -84,6 +82,14 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
           [](const std::function<PyObject *(int mode)> &cb, int mode) { return cb(mode); });
     m.def("call_callback_with_PyObject_ptr_arg",
           [](const std::function<bool(PyObject *)> &cb, py::handle obj) { return cb(obj.ptr()); });
+
+    m.def("cast_nullptr", [](bool set_error) {
+        if (set_error) {
+            PyErr_SetString(PyExc_RuntimeError, "As in functioning error handling.");
+        }
+        PyObject *ptr = nullptr;
+        py::cast(ptr);
+    });
 
 #ifdef PYBIND11_NO_COMPILE_SECTION // Change to ifndef for manual testing.
     {

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -21,14 +21,16 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
     m.def("pass_pyobject_ptr", [](PyObject *obj) { return bool(PyTuple_CheckExact(obj)); });
 
     m.def("call_callback_with_object_return",
-          [](const std::function<py::object(int mode)> &cb, int mode) { return cb(mode); });
-    m.def("call_callback_with_handle_return",
-          [](const std::function<py::handle(int mode)> &cb, int mode) { return cb(mode); });
-    //
-    m.def("call_callback_with_pyobject_ptr_return",
-          [](const std::function<PyObject *(int mode)> &cb, int mode) { return cb(mode); });
-    m.def("call_callback_with_pyobject_ptr_arg",
-          [](const std::function<bool(PyObject *)> &cb, py::handle obj) { return cb(obj.ptr()); });
+          [](const std::function<py::object(int)> &cb, int value) { return cb(value); });
+    m.def(
+        "call_callback_with_pyobject_ptr_return",
+        [](const std::function<PyObject *(int)> &cb, int value) { return cb(value); },
+        py::return_value_policy::take_ownership);
+    m.def(
+        "call_callback_with_pyobject_ptr_arg",
+        [](const std::function<bool(PyObject *)> &cb, py::handle obj) { return cb(obj.ptr()); },
+        py::arg("cb"), // This triggers return_value_policy::automatic_reference
+        py::arg("obj"));
 
     m.def("cast_to_pyobject_ptr_nullptr", [](bool set_error) {
         if (set_error) {

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -28,6 +28,7 @@ public:
         }
         if (PyErr_Occurred()) {
             raise_from(PyExc_SystemError, "src != nullptr but PyErr_Occurred()");
+            throw error_already_set();
         }
         if (policy == return_value_policy::take_ownership) {
             return src;
@@ -54,38 +55,43 @@ private:
 } // namespace pybind11
 
 TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
-    m.def("cast_from_PyObject_ptr", []() {
+    m.def("cast_from_pyobject_ptr", []() {
         PyObject *ptr = PyLong_FromLongLong(6758L);
         py::object retval = py::cast(ptr, py::return_value_policy::take_ownership);
         return retval;
     });
-    m.def("cast_to_PyObject_ptr", [](py::handle obj) {
+    m.def("cast_to_pyobject_ptr", [](py::handle obj) {
         auto *ptr = py::cast<PyObject *>(obj);
         return bool(PyTuple_CheckExact(ptr));
     });
 
     m.def(
-        "return_PyObject_ptr",
+        "return_pyobject_ptr",
         []() { return PyLong_FromLongLong(2314L); },
         py::return_value_policy::take_ownership);
-    m.def("pass_PyObject_ptr", [](PyObject *obj) { return bool(PyTuple_CheckExact(obj)); });
+    m.def("pass_pyobject_ptr", [](PyObject *obj) { return bool(PyTuple_CheckExact(obj)); });
 
     m.def("call_callback_with_object_return",
           [](const std::function<py::object(int mode)> &cb, int mode) { return cb(mode); });
     m.def("call_callback_with_handle_return",
           [](const std::function<py::handle(int mode)> &cb, int mode) { return cb(mode); });
     //
-    m.def("call_callback_with_PyObject_ptr_return",
+    m.def("call_callback_with_pyobject_ptr_return",
           [](const std::function<PyObject *(int mode)> &cb, int mode) { return cb(mode); });
-    m.def("call_callback_with_PyObject_ptr_arg",
+    m.def("call_callback_with_pyobject_ptr_arg",
           [](const std::function<bool(PyObject *)> &cb, py::handle obj) { return cb(obj.ptr()); });
 
-    m.def("cast_nullptr", [](bool set_error) {
+    m.def("cast_to_pyobject_ptr_nullptr", [](bool set_error) {
         if (set_error) {
-            PyErr_SetString(PyExc_RuntimeError, "As in functioning error handling.");
+            PyErr_SetString(PyExc_RuntimeError, "Reflective of healthy error handling.");
         }
         PyObject *ptr = nullptr;
         py::cast(ptr);
+    });
+
+    m.def("cast_to_pyobject_ptr_non_nullptr_with_error_set", []() {
+        PyErr_SetString(PyExc_RuntimeError, "Reflective of unhealthy error handling.");
+        py::cast(Py_None);
     });
 
 #ifdef PYBIND11_NO_COMPILE_SECTION // Change to ifndef for manual testing.

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -25,7 +25,7 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
         PyObject *ptr = PyLong_FromLongLong(6758L);
         return py::cast(ptr, py::return_value_policy::take_ownership);
     });
-    m.def("cast_to_pyobject_ptr", [](py::handle obj) {
+    m.def("cast_handle_to_pyobject_ptr", [](py::handle obj) {
         auto rc1 = obj.ref_count();
         auto *ptr = py::cast<PyObject *>(obj);
         auto rc2 = obj.ref_count();
@@ -33,6 +33,27 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
             return -1;
         }
         return 100 - py::reinterpret_steal<py::object>(ptr).attr("value").cast<int>();
+    });
+    m.def("cast_object_to_pyobject_ptr", [](py::object obj) {
+        py::handle hdl = obj;
+        auto rc1 = hdl.ref_count();
+        auto *ptr = py::cast<PyObject *>(std::move(obj));
+        auto rc2 = hdl.ref_count();
+        if (rc2 != rc1) {
+            return -1;
+        }
+        return 300 - py::reinterpret_steal<py::object>(ptr).attr("value").cast<int>();
+    });
+    m.def("cast_list_to_pyobject_ptr", [](py::list lst) {
+        // This is to cover types implicitly convertible to object.
+        py::handle hdl = lst;
+        auto rc1 = hdl.ref_count();
+        auto *ptr = py::cast<PyObject *>(std::move(lst));
+        auto rc2 = hdl.ref_count();
+        if (rc2 != rc1) {
+            return -1;
+        }
+        return 400 - static_cast<int>(py::len(py::reinterpret_steal<py::list>(ptr)));
     });
 
     m.def(

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -1,0 +1,76 @@
+#include <pybind11/functional.h>
+
+#include "pybind11_tests.h"
+
+namespace pybind11 {
+namespace detail {
+
+template <>
+class type_caster<PyObject> {
+public:
+    static constexpr auto name = const_name("PyObject *");
+
+    static handle cast(PyObject *src, return_value_policy policy, handle parent) {
+        if (src == nullptr) {
+            // NEEDS TEST
+            throw error_already_set();
+        }
+        if (PyErr_Occurred()) {
+            // NEEDS TEST
+            raise_from(PyExc_SystemError, "src != nullptr but PyErr_Occurred()");
+        }
+        if (policy == return_value_policy::take_ownership) {
+            return src;
+        }
+        if (policy == return_value_policy::reference_internal) {
+            // NEEDS TEST
+            keep_alive_impl(src, parent);
+        }
+        Py_INCREF(src);
+        return src;
+    }
+
+    bool load(handle src, bool) {
+        value = reinterpret_borrow<object>(src);
+        return true;
+    }
+
+    template <typename T>
+    using cast_op_type = PyObject *;
+
+    explicit operator PyObject *() { return value.ptr(); }
+
+private:
+    object value;
+};
+
+} // namespace detail
+} // namespace pybind11
+
+TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
+    m.def("cast_from_PyObject_ptr", []() {
+        PyObject *ptr = PyLong_FromLongLong(6758L);
+        py::object retval = py::cast(ptr, py::return_value_policy::take_ownership);
+        return retval;
+    });
+    m.def("cast_to_PyObject_ptr", [](py::handle obj) {
+        auto *ptr = py::cast<PyObject *>(obj);
+        return bool(PyTuple_CheckExact(ptr));
+    });
+
+    m.def(
+        "return_PyObject_ptr",
+        []() { return PyLong_FromLongLong(2314L); },
+        py::return_value_policy::take_ownership);
+    m.def("pass_PyObject_ptr", [](const PyObject *obj) { return bool(PyTuple_CheckExact(obj)); });
+
+    m.def("call_callback_with_object_return",
+          [](const std::function<py::object(int mode)> &cb, int mode) { return cb(mode); });
+    m.def("call_callback_with_handle_return",
+          [](const std::function<py::handle(int mode)> &cb, int mode) { return cb(mode); });
+    //
+    m.def("call_callback_with_PyObject_ptr_return",
+          [](const std::function<PyObject *(int mode)> &cb, int mode) { return cb(mode); });
+    m.def("call_callback_with_PyObject_ptr_arg",
+          [](const std::function<bool(PyObject *)> &cb, py::handle obj) { return cb(obj.ptr()); });
+}

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -3,11 +3,10 @@
 #include "pybind11_tests.h"
 
 namespace pybind11 {
+namespace detail {
 
 template <typename T, typename U>
 static constexpr bool is_same_ignoring_cvref = std::is_same<detail::remove_cvref_t<T>, U>::value;
-
-namespace detail {
 
 template <>
 class type_caster<PyObject> {

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -62,7 +62,7 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
         "return_PyObject_ptr",
         []() { return PyLong_FromLongLong(2314L); },
         py::return_value_policy::take_ownership);
-    m.def("pass_PyObject_ptr", [](const PyObject *obj) { return bool(PyTuple_CheckExact(obj)); });
+    m.def("pass_PyObject_ptr", [](PyObject *obj) { return bool(PyTuple_CheckExact(obj)); });
 
     m.def("call_callback_with_object_return",
           [](const std::function<py::object(int mode)> &cb, int mode) { return cb(mode); });

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -22,7 +22,7 @@ public:
         return nullptr; // Unreachable.
     }
 
-    static handle cast(PyObject *src, return_value_policy policy, handle parent) {
+    static handle cast(PyObject *src, return_value_policy policy, handle /*parent*/) {
         if (src == nullptr) {
             throw error_already_set();
         }
@@ -31,10 +31,6 @@ public:
         }
         if (policy == return_value_policy::take_ownership) {
             return src;
-        }
-        if (policy == return_value_policy::reference_internal) {
-            // NEEDS TEST
-            keep_alive_impl(src, parent);
         }
         Py_INCREF(src);
         return src;

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -90,8 +90,8 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
         std::size_t i = 0;
         for (; i < vec_obj.size(); i++) {
             py::handle h(vec_obj[i]);
-            if (static_cast<std::size_t>(h.ref_count()) < i) {
-                break;
+            if (static_cast<std::size_t>(h.ref_count()) < 2) {
+                break; // Something is badly wrong.
             }
             h.dec_ref();
         }

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -98,6 +98,8 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
         return i;
     });
 
+    m.def("pass_pyobject_ptr_and_int", [](PyObject *, int) {});
+
 #ifdef PYBIND11_NO_COMPILE_SECTION // Change to ifndef for manual testing.
     {
         PyObject *ptr = nullptr;

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -6,7 +6,7 @@ namespace pybind11 {
 namespace detail {
 
 template <typename T, typename U>
-static constexpr bool is_same_ignoring_cvref = std::is_same<detail::remove_cvref_t<T>, U>::value;
+using is_same_ignoring_cvref = std::is_same<detail::remove_cvref_t<T>, U>;
 
 template <>
 class type_caster<PyObject> {
@@ -14,9 +14,10 @@ public:
     static constexpr auto name = const_name("PyObject *");
 
     // This overload is purely to guard against accidents.
-    template <typename T, detail::enable_if_t<!is_same_ignoring_cvref<T, PyObject *>, int> = 0>
+    template <typename T,
+              detail::enable_if_t<!is_same_ignoring_cvref<T, PyObject *>::value, int> = 0>
     static handle cast(T &&, return_value_policy, handle /*parent*/) {
-        static_assert(is_same_ignoring_cvref<T, PyObject *>,
+        static_assert(is_same_ignoring_cvref<T, PyObject *>::value,
                       "Invalid C++ type T for to-Python conversion (type_caster<PyObject>).");
         return nullptr; // Unreachable.
     }

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -13,8 +13,16 @@ def test_cast_from_pyobject_ptr():
     assert m.cast_from_pyobject_ptr() == 6758
 
 
-def test_cast_to_pyobject_ptr():
-    assert m.cast_to_pyobject_ptr(ValueHolder(24)) == 76
+def test_cast_handle_to_pyobject_ptr():
+    assert m.cast_handle_to_pyobject_ptr(ValueHolder(24)) == 76
+
+
+def test_cast_object_to_pyobject_ptr():
+    assert m.cast_object_to_pyobject_ptr(ValueHolder(43)) == 257
+
+
+def test_cast_list_to_pyobject_ptr():
+    assert m.cast_list_to_pyobject_ptr([1, 2, 3, 4, 5]) == 395
 
 
 def test_return_pyobject_ptr():

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -69,3 +69,23 @@ def test_cast_to_python_non_nullptr_with_error_set():
         m.cast_to_pyobject_ptr_non_nullptr_with_error_set()
     assert str(excinfo.value) == "src != nullptr but PyErr_Occurred()"
     assert str(excinfo.value.__cause__) == "Reflective of unhealthy error handling."
+
+
+def test_pass_list_pyobject_ptr():
+    acc = m.pass_list_pyobject_ptr([ValueHolder(842), ValueHolder(452)])
+    assert acc == 842452
+
+
+def test_return_list_pyobject_ptr_take_ownership():
+    vec_obj = m.return_list_pyobject_ptr_take_ownership(ValueHolder)
+    assert [e.value for e in vec_obj] == [93, 186]
+
+
+def test_return_list_pyobject_ptr_reference():
+    vec_obj = m.return_list_pyobject_ptr_reference(ValueHolder)
+    assert [e.value for e in vec_obj] == [93, 186]
+    # Commenting out the next `assert` will leak the Python references.
+    # An easy way to see evidence of the leaks:
+    # Insert `while True:` as the first line of this function and monitor the
+    # process RES (Resident Memory Size) with the Unix top command.
+    assert m.dec_ref_each_pyobject_ptr(vec_obj) == 2

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -89,3 +89,8 @@ def test_return_list_pyobject_ptr_reference():
     # Insert `while True:` as the first line of this function and monitor the
     # process RES (Resident Memory Size) with the Unix top command.
     assert m.dec_ref_each_pyobject_ptr(vec_obj) == 2
+
+
+def test_type_caster_name_via_incompatible_function_arguments_type_error():
+    with pytest.raises(TypeError, match=r"1\. \(arg0: object, arg1: int\) -> None"):
+        m.pass_pyobject_ptr_and_int(ValueHolder(101), ValueHolder(202))

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -3,13 +3,18 @@ import pytest
 from pybind11_tests import type_caster_pyobject_ptr as m
 
 
+# For use as a temporary user-defined object, to maximize sensitivity of the tests below.
+class ValueHolder:
+    def __init__(self, value):
+        self.value = value
+
+
 def test_cast_from_pyobject_ptr():
     assert m.cast_from_pyobject_ptr() == 6758
 
 
 def test_cast_to_pyobject_ptr():
-    assert m.cast_to_pyobject_ptr(())
-    assert not m.cast_to_pyobject_ptr({})
+    assert m.cast_to_pyobject_ptr(ValueHolder(24)) == 76
 
 
 def test_return_pyobject_ptr():
@@ -17,13 +22,7 @@ def test_return_pyobject_ptr():
 
 
 def test_pass_pyobject_ptr():
-    assert m.pass_pyobject_ptr(())
-    assert not m.pass_pyobject_ptr({})
-
-
-class ValueHolder:
-    def __init__(self, value):
-        self.value = value
+    assert m.pass_pyobject_ptr(ValueHolder(82)) == 118
 
 
 @pytest.mark.parametrize(
@@ -37,7 +36,6 @@ def test_call_callback_with_object_return(call_callback):
     def cb(value):
         if value < 0:
             raise ValueError("Raised from cb")
-        # Return a temporary user-defined object, to maximize sensitivity of this test.
         return ValueHolder(1000 - value)
 
     assert call_callback(cb, 287).value == 713
@@ -48,10 +46,9 @@ def test_call_callback_with_object_return(call_callback):
 
 def test_call_callback_with_pyobject_ptr_arg():
     def cb(obj):
-        return isinstance(obj, tuple)
+        return 300 - obj.value
 
-    assert m.call_callback_with_pyobject_ptr_arg(cb, ())
-    assert not m.call_callback_with_pyobject_ptr_arg(cb, {})
+    assert m.call_callback_with_pyobject_ptr_arg(cb, ValueHolder(39)) == 261
 
 
 @pytest.mark.parametrize("set_error", [True, False])

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -49,3 +49,16 @@ def test_call_callback_with_PyObject_ptr_arg():
 
     assert m.call_callback_with_PyObject_ptr_arg(cb, ())
     assert not m.call_callback_with_PyObject_ptr_arg(cb, {})
+
+
+@pytest.mark.parametrize("set_error", [True, False])
+def test_cast_nullptr(set_error):
+    expected = {
+        True: r"As in functioning error handling\.",
+        False: (
+            r"Internal error: pybind11::error_already_set called "
+            r"while Python error indicator not set\."
+        ),
+    }[set_error]
+    with pytest.raises(RuntimeError, match=expected):
+        m.cast_nullptr(set_error)

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -1,0 +1,51 @@
+import pytest
+
+from pybind11_tests import type_caster_pyobject_ptr as m
+
+
+def test_cast_from_PyObject_ptr():
+    assert m.cast_from_PyObject_ptr() == 6758
+
+
+def test_cast_to_PyObject_ptr():
+    assert m.cast_to_PyObject_ptr(())
+    assert not m.cast_to_PyObject_ptr({})
+
+
+def test_return_PyObject_ptr():
+    assert m.return_PyObject_ptr() == 2314
+
+
+def test_pass_PyObject_ptr():
+    assert m.pass_PyObject_ptr(())
+    assert not m.pass_PyObject_ptr({})
+
+
+@pytest.mark.parametrize(
+    "call_callback",
+    [
+        m.call_callback_with_object_return,
+        m.call_callback_with_handle_return,
+        m.call_callback_with_PyObject_ptr_return,
+    ],
+)
+def test_call_callback_with_object_return(call_callback):
+    def cb(mode):
+        if mode == 0:
+            return 10
+        if mode == 1:
+            return "One"
+        raise NotImplementedError(f"Unknown mode: {mode}")
+
+    assert call_callback(cb, 0) == 10
+    assert call_callback(cb, 1) == "One"
+    with pytest.raises(NotImplementedError, match="Unknown mode: 2"):
+        call_callback(cb, 2)
+
+
+def test_call_callback_with_PyObject_ptr_arg():
+    def cb(obj):
+        return isinstance(obj, tuple)
+
+    assert m.call_callback_with_PyObject_ptr_arg(cb, ())
+    assert not m.call_callback_with_PyObject_ptr_arg(cb, {})

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -3,22 +3,22 @@ import pytest
 from pybind11_tests import type_caster_pyobject_ptr as m
 
 
-def test_cast_from_PyObject_ptr():
-    assert m.cast_from_PyObject_ptr() == 6758
+def test_cast_from_pyobject_ptr():
+    assert m.cast_from_pyobject_ptr() == 6758
 
 
-def test_cast_to_PyObject_ptr():
-    assert m.cast_to_PyObject_ptr(())
-    assert not m.cast_to_PyObject_ptr({})
+def test_cast_to_pyobject_ptr():
+    assert m.cast_to_pyobject_ptr(())
+    assert not m.cast_to_pyobject_ptr({})
 
 
-def test_return_PyObject_ptr():
-    assert m.return_PyObject_ptr() == 2314
+def test_return_pyobject_ptr():
+    assert m.return_pyobject_ptr() == 2314
 
 
-def test_pass_PyObject_ptr():
-    assert m.pass_PyObject_ptr(())
-    assert not m.pass_PyObject_ptr({})
+def test_pass_pyobject_ptr():
+    assert m.pass_pyobject_ptr(())
+    assert not m.pass_pyobject_ptr({})
 
 
 @pytest.mark.parametrize(
@@ -26,7 +26,7 @@ def test_pass_PyObject_ptr():
     [
         m.call_callback_with_object_return,
         m.call_callback_with_handle_return,
-        m.call_callback_with_PyObject_ptr_return,
+        m.call_callback_with_pyobject_ptr_return,
     ],
 )
 def test_call_callback_with_object_return(call_callback):
@@ -43,22 +43,29 @@ def test_call_callback_with_object_return(call_callback):
         call_callback(cb, 2)
 
 
-def test_call_callback_with_PyObject_ptr_arg():
+def test_call_callback_with_pyobject_ptr_arg():
     def cb(obj):
         return isinstance(obj, tuple)
 
-    assert m.call_callback_with_PyObject_ptr_arg(cb, ())
-    assert not m.call_callback_with_PyObject_ptr_arg(cb, {})
+    assert m.call_callback_with_pyobject_ptr_arg(cb, ())
+    assert not m.call_callback_with_pyobject_ptr_arg(cb, {})
 
 
 @pytest.mark.parametrize("set_error", [True, False])
-def test_cast_nullptr(set_error):
+def test_cast_to_python_nullptr(set_error):
     expected = {
-        True: r"As in functioning error handling\.",
+        True: r"^Reflective of healthy error handling\.$",
         False: (
-            r"Internal error: pybind11::error_already_set called "
-            r"while Python error indicator not set\."
+            r"^Internal error: pybind11::error_already_set called "
+            r"while Python error indicator not set\.$"
         ),
     }[set_error]
     with pytest.raises(RuntimeError, match=expected):
-        m.cast_nullptr(set_error)
+        m.cast_to_pyobject_ptr_nullptr(set_error)
+
+
+def test_cast_to_python_non_nullptr_with_error_set():
+    with pytest.raises(SystemError) as excinfo:
+        m.cast_to_pyobject_ptr_non_nullptr_with_error_set()
+    assert str(excinfo.value) == "src != nullptr but PyErr_Occurred()"
+    assert str(excinfo.value.__cause__) == "Reflective of unhealthy error handling."


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This is to support automatic wrapping of APIs that make use of `PyObject *`. It is impractical to rewrite all such APIs to use `py::handle` or `py::object` (although that would of course be ideal).

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
