### PR TITLE
Alternative approach to #3807

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -50,7 +50,7 @@ inline void replace_all(std::string &str, const std::string &from, const std::st
 }
 
 inline bool is_instance_method(PyObject *obj, PyObject *name) {
-    PyTypeObject *type_obj = (PyTypeObject *) obj;
+    auto *type_obj = (PyTypeObject *) obj;
     if (!PyType_Check(obj)) {
         type_obj = Py_TYPE(obj);
     }
@@ -66,11 +66,16 @@ inline bool is_instance_method(PyObject *obj, PyObject *name) {
 extern "C" inline PyObject *pybind11_object_new(PyTypeObject *type, PyObject *, PyObject *);
 
 inline bool type_is_pybind11_class_(PyObject *obj) {
-    PyTypeObject *type_obj = (PyTypeObject *) obj;
+    auto *type_obj = (PyTypeObject *) obj;
     if (!PyType_Check(obj)) {
         type_obj = Py_TYPE(obj);
     }
     if (type_obj->tp_new == pybind11_object_new) {
+        return true;
+    }
+    // EXPERIMENT: Does this help PyPy? (Other platforms do not need this.)
+    auto &internals = get_internals();
+    if (internals.registered_types_py.find(type_obj) != internals.registered_types_py.end()) {
         return true;
     }
     return false;

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -60,7 +60,7 @@ inline void *try_as_void_ptr_capsule_get_pointer(handle src, const char *typeid_
 
     std::string as_void_ptr_function_name("as_");
     as_void_ptr_function_name += type_name;
-    if (hasattr(src, as_void_ptr_function_name.c_str())) {
+    if (hasattr(src, as_void_ptr_function_name.c_str()) && !hasattr(src, "__getattr__")) {
         auto as_void_ptr_function = function(src.attr(as_void_ptr_function_name.c_str()));
         auto void_ptr_capsule = as_void_ptr_function();
         if (isinstance<capsule>(void_ptr_capsule)) {
@@ -304,11 +304,8 @@ public:
             loaded_v_h = value_and_holder();
             return true;
         }
-        if (convert && cpptype) {
-            const auto &bases = all_type_info(srctype);
-            if (bases.empty() && try_as_void_ptr_capsule(src)) {
-                return true;
-            }
+        if (convert && cpptype && try_as_void_ptr_capsule(src)) {
+            return true;
         }
         return false;
     }

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -69,10 +69,6 @@ struct UnspecDerived : UnspecBase {
     int Get() const override { return 200; }
 };
 
-struct ExploreType {
-    int plain_mfun() const { return 42; }
-};
-
 } // namespace class_sh_void_ptr_capsule
 } // namespace pybind11_tests
 
@@ -87,7 +83,6 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(Derived1)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(Derived2)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(UnspecBase)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(UnspecDerived)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(ExploreType)
 
 TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     py::classh<Valid>(m, "Valid");
@@ -129,18 +124,4 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
             return py::reinterpret_steal<py::object>(
                 PyCapsule_New(static_cast<void *>(self), nullptr, nullptr));
         });
-
-    py::classh<ExploreType>(m, "ExploreType")
-        .def(py::init<>())
-        .def("plain_mfun", &ExploreType::plain_mfun)
-        .def("__getattr__",
-             [](ExploreType &, const std::string &key) { return "GetAttr: " + key; });
-
-    m.def("is_instance_method", [](py::handle obj, const std::string &name) {
-        py::str name_pyobj(name);
-        return py::detail::is_instance_method(obj.ptr(), name_pyobj.ptr());
-    });
-
-    m.def("type_is_pybind11_class_",
-          [](py::handle obj) { return py::detail::type_is_pybind11_class_(obj.ptr()); });
 }

--- a/tests/test_class_sh_void_ptr_capsule.cpp
+++ b/tests/test_class_sh_void_ptr_capsule.cpp
@@ -58,20 +58,33 @@ struct Derived2 : Base12 {
     int bar() const { return 2; }
 };
 
+struct UnspecBase {
+    virtual ~UnspecBase() = default;
+    virtual int Get() const { return 100; }
+};
+
+inline int PassUnspecBase(const UnspecBase &sb) { return sb.Get() + 30; }
+
+struct UnspecDerived : UnspecBase {
+    int Get() const override { return 200; }
+};
+
 } // namespace class_sh_void_ptr_capsule
 } // namespace pybind11_tests
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Valid)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::TypeWithGetattr)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Base1)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Base2)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Base12)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Derived1)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_void_ptr_capsule::Derived2)
+using namespace pybind11_tests::class_sh_void_ptr_capsule;
+
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Valid)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(TypeWithGetattr)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Base1)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Base2)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Base12)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Derived1)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Derived2)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(UnspecBase)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(UnspecDerived)
 
 TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
-    using namespace pybind11_tests::class_sh_void_ptr_capsule;
-
     py::classh<Valid>(m, "Valid");
 
     m.def("get_from_valid_capsule", &get_from_valid_capsule);
@@ -102,4 +115,13 @@ TEST_SUBMODULE(class_sh_void_ptr_capsule, m) {
     py::classh<Derived1, Base12>(m, "Derived1").def(py::init<>()).def("bar", &Derived1::bar);
 
     py::classh<Derived2, Base12>(m, "Derived2").def(py::init<>()).def("bar", &Derived2::bar);
+
+    py::classh<UnspecBase>(m, "UnspecBase");
+    m.def("PassUnspecBase", PassUnspecBase);
+    py::classh<UnspecDerived>(m, "UnspecDerived") // UnspecBase NOT specified as base here.
+        .def(py::init<>())
+        .def("as_pybind11_tests_class_sh_void_ptr_capsule_UnspecBase", [](UnspecDerived *self) {
+            return py::reinterpret_steal<py::object>(
+                PyCapsule_New(static_cast<void *>(self), nullptr, nullptr));
+        });
 }

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -84,7 +84,7 @@ def test_type_with_getattr():
     assert obj.something == "GetAttr: something"
 
 
-def NOtest_multiple_inheritance_getattr():
+def test_multiple_inheritance_getattr():
     d1 = m.Derived1()
     assert d1.foo() == 0
     assert d1.bar() == 1

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -98,26 +98,3 @@ def test_multiple_inheritance_getattr():
 
 def test_pass_unspecified_base():
     assert m.PassUnspecBase(m.UnspecDerived()) == 230
-
-
-def test_explore():
-    obj = m.ExploreType()
-    assert obj.plain_mfun() == 42
-    assert obj.something == "GetAttr: something"
-    ii = obj.isinstance_method
-    assert ii == "GetAttr: isinstance_method"
-    assert m.is_instance_method(m.ExploreType, "plain_mfun")
-    assert not m.is_instance_method(m.ExploreType, "something")
-    assert m.is_instance_method(obj, "plain_mfun")
-    assert not m.is_instance_method(obj, "something")
-
-
-def test_type_is_pybind11_class_():
-    assert m.type_is_pybind11_class_(m.ExploreType)
-    assert not m.type_is_pybind11_class_(Valid)
-
-
-def test_valid_debug():
-    obj = Valid()
-    assert m.get_from_valid_capsule(obj) == 1
-    assert obj.capsule_generated

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -84,7 +84,7 @@ def test_type_with_getattr():
     assert obj.something == "GetAttr: something"
 
 
-def test_multiple_inheritance_getattr():
+def NOtest_multiple_inheritance_getattr():
     d1 = m.Derived1()
     assert d1.foo() == 0
     assert d1.bar() == 1

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -94,3 +94,7 @@ def test_multiple_inheritance_getattr():
     assert d2.foo() == 0
     assert d2.bar() == 2
     assert d2.prop2 == "Base GetAttr: prop2"
+
+
+def test_pass_unspecified_base():
+    assert m.PassUnspecBase(m.UnspecDerived()) == 230

--- a/tests/test_class_sh_void_ptr_capsule.py
+++ b/tests/test_class_sh_void_ptr_capsule.py
@@ -98,3 +98,26 @@ def test_multiple_inheritance_getattr():
 
 def test_pass_unspecified_base():
     assert m.PassUnspecBase(m.UnspecDerived()) == 230
+
+
+def test_explore():
+    obj = m.ExploreType()
+    assert obj.plain_mfun() == 42
+    assert obj.something == "GetAttr: something"
+    ii = obj.isinstance_method
+    assert ii == "GetAttr: isinstance_method"
+    assert m.is_instance_method(m.ExploreType, "plain_mfun")
+    assert not m.is_instance_method(m.ExploreType, "something")
+    assert m.is_instance_method(obj, "plain_mfun")
+    assert not m.is_instance_method(obj, "something")
+
+
+def test_type_is_pybind11_class_():
+    assert m.type_is_pybind11_class_(m.ExploreType)
+    assert not m.type_is_pybind11_class_(Valid)
+
+
+def test_valid_debug():
+    obj = Valid()
+    assert m.get_from_valid_capsule(obj) == 1
+    assert obj.capsule_generated


### PR DESCRIPTION
This approach supports an important PyCLIF use case: `Base` not specified in `classh<Derived>` statement, but passing `Derived` as `Base` works anyway.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
