### PR TITLE
Introduce recursive_container_traits

### DIFF
--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -822,56 +822,173 @@ using movable_cast_op_type
                                   typename std::add_rvalue_reference<intrinsic_t<T>>::type,
                                   typename std::add_lvalue_reference<intrinsic_t<T>>::type>>;
 
-// True if Container has a dependent type mapped_type that is equivalent
-// to Container itself
-// Actual implementation in the SFINAE specialization below
-template <typename Container, typename MappedType = Container>
-struct is_container_with_recursive_mapped_type : std::false_type {};
+template <bool Condition, typename Then, typename Else>
+struct if_then_else {};
 
-// This specialization is only valid if both conditions are fulfilled:
-// 1) The mapped_type exists
-// 2) And it is equivalent to Container
-template <typename Container>
-struct is_container_with_recursive_mapped_type<Container, typename Container::mapped_type>
-    : std::true_type {};
+template <typename Then, typename Else>
+struct if_then_else<true, Then, Else> {
+    using type = Then;
+};
 
-// True if Container has a dependent type value_type that is equivalent
-// to Container itself
-// Actual implementation in the SFINAE specialization below
-template <typename Container, typename MappedType = Container>
-struct is_container_with_recursive_value_type : std::false_type {};
+template <typename Then, typename Else>
+struct if_then_else<false, Then, Else> {
+    using type = Else;
+};
 
-// This specialization is only valid if both conditions are fulfilled:
-// 1) The value_type exists
-// 2) And it is equivalent to Container
-template <typename Container>
-struct is_container_with_recursive_value_type<Container, typename Container::value_type>
-    : std::true_type {};
-
-// True constant if the type contains itself recursively.
-// By default, this will check the mapped_type and value_type dependent types.
-// In more complex recursion patterns, users can specialize this struct.
-// The second template parameter SFINAE=void is for use of std::enable_if in specializations.
-// An example is found in tests/test_stl_binders.cpp.
+// Does the container have a mapped type and is it recursive?
+// Implemented by specializations below.
 template <typename Container, typename SFINAE = void>
-struct is_recursive_container : any_of<is_container_with_recursive_value_type<Container>,
-                                       is_container_with_recursive_mapped_type<Container>> {};
+struct container_mapped_type_traits {
+    static constexpr bool has_mapped_type = false;
+    static constexpr bool has_recursive_mapped_type = false;
+};
 
-template <typename T, typename SFINAE = void>
-struct is_move_constructible : std::is_move_constructible<T> {};
-
-// Specialization for types that appear to be move constructible but also look like stl containers
-// (we specifically check for: has `value_type` and `reference` with `reference = value_type&`): if
-// so, move constructability depends on whether the value_type is move constructible.
 template <typename Container>
-struct is_move_constructible<
+struct container_mapped_type_traits<
     Container,
-    enable_if_t<
-        all_of<std::is_move_constructible<Container>,
-               std::is_same<typename Container::value_type &, typename Container::reference>,
-               // Avoid infinite recursion
-               negation<is_recursive_container<Container>>>::value>>
-    : is_move_constructible<typename Container::value_type> {};
+    typename std::enable_if<
+        std::is_same<typename Container::mapped_type, Container>::value>::type> {
+    static constexpr bool has_mapped_type = true;
+    static constexpr bool has_recursive_mapped_type = true;
+};
+
+template <typename Container>
+struct container_mapped_type_traits<
+    Container,
+    typename std::enable_if<
+        negation<std::is_same<typename Container::mapped_type, Container>>::value>::type> {
+    static constexpr bool has_mapped_type = true;
+    static constexpr bool has_recursive_mapped_type = false;
+};
+
+// Does the container have a value type and is it recursive?
+// Implemented by specializations below.
+template <typename Container, typename SFINAE = void>
+struct container_value_type_traits : std::false_type {
+    static constexpr bool has_value_type = false;
+    static constexpr bool has_recursive_value_type = false;
+};
+
+template <typename Container>
+struct container_value_type_traits<
+    Container,
+    typename std::enable_if<
+        std::is_same<typename Container::value_type, Container>::value>::type> {
+    static constexpr bool has_value_type = true;
+    static constexpr bool has_recursive_value_type = true;
+};
+
+template <typename Container>
+struct container_value_type_traits<
+    Container,
+    typename std::enable_if<
+        negation<std::is_same<typename Container::value_type, Container>>::value>::type> {
+    static constexpr bool has_value_type = true;
+    static constexpr bool has_recursive_value_type = false;
+};
+
+/*
+ * Tag to be used for representing the bottom of recursively defined types.
+ * Define this tag so we don't have to use void.
+ */
+struct recursive_bottom {};
+
+/*
+ * Implementation detail of `recursive_container_traits` below.
+ * `T` is the `value_type` of the container, which might need to be modified to
+ * avoid recursive types and const types.
+ */
+template <typename T, bool is_this_a_map>
+struct impl_type_to_check_recursively {
+    /*
+     * If the container is recursive, then no further recursion should be done.
+     */
+    using if_recursive = recursive_bottom;
+    /*
+     * Otherwise yield `T` unchanged.
+     */
+    using if_not_recursive = T;
+};
+
+/*
+ * For pairs - only as value type of a map -, the first type should remove the `const`.
+ * Also, if the map is recursive, then the recursive checking should consider
+ * the first type only.
+ */
+template <typename A, typename B>
+struct impl_type_to_check_recursively<std::pair<A, B>, /* is_this_a_map = */ true> {
+    using if_recursive = typename std::remove_const<A>::type;
+    using if_not_recursive = std::pair<typename std::remove_const<A>::type, B>;
+};
+
+/*
+ * Implementation of `recursive_container_traits` below.
+ */
+template <typename Container, typename SFINAE = void>
+struct impl_recursive_container_traits {
+    using type_to_check_recursively = recursive_bottom;
+};
+
+template <typename Container>
+struct impl_recursive_container_traits<
+    Container,
+    typename std::enable_if<container_value_type_traits<Container>::has_value_type>::type> {
+    static constexpr bool is_recursive
+        = container_mapped_type_traits<Container>::has_recursive_mapped_type
+          || container_value_type_traits<Container>::has_recursive_value_type;
+    /*
+     * This member dictates which type Pybind11 should check recursively in traits
+     * such as `is_move_constructible`, `is_copy_constructible`, `is_move_assignable`, ...
+     * Direct access to `value_type` should be avoided:
+     * 1. `value_type` might recursively contain the type again
+     * 2. `value_type` of STL map types is `std::pair<A const, B>`, the `const`
+     *    should be removed.
+     *
+     */
+    using type_to_check_recursively = typename if_then_else<
+        is_recursive,
+        typename impl_type_to_check_recursively<
+            typename Container::value_type,
+            container_mapped_type_traits<Container>::has_mapped_type>::if_recursive,
+        typename impl_type_to_check_recursively<
+            typename Container::value_type,
+            container_mapped_type_traits<Container>::has_mapped_type>::if_not_recursive>::type;
+};
+
+/*
+ * This trait defines the `type_to_check_recursively` which is needed to properly
+ * handle recursively defined traits such as `is_move_constructible` without going
+ * into an infinite recursion.
+ * Should be used instead of directly accessing the `value_type`.
+ * It cancels the recursion by returning the `recursive_bottom` tag.
+ *
+ * The default definition of `type_to_check_recursively` is as follows:
+ *
+ * 1. By default, it is `recursive_bottom`, so that the recursion is canceled.
+ * 2. If the type is non-recursive and defines a `value_type`, then the `value_type` is used.
+ *    If the `value_type` is a pair and a `mapped_type` is defined,
+ *    then the `const` is removed from the first type.
+ * 3. If the type is recursive and `value_type` is not a pair, then `recursive_bottom` is returned.
+ * 4. If the type is recursive and `value_type` is a pair and a `mapped_type` is defined,
+ *    then `const` is removed from the first type and the first type is returned.
+ *
+ * This behavior can be extended by the user as seen in test_stl_binders.cpp.
+ *
+ * This struct is exactly the same as impl_recursive_container_traits.
+ * The duplication achieves that user-defined specializations don't compete
+ * with internal specializations, but take precedence.
+ */
+template <typename Container, typename SFINAE = void>
+struct recursive_container_traits : impl_recursive_container_traits<Container> {};
+
+template <typename T>
+struct is_move_constructible
+    : all_of<std::is_move_constructible<T>,
+             is_move_constructible<
+                 typename recursive_container_traits<T>::type_to_check_recursively>> {};
+
+template <>
+struct is_move_constructible<recursive_bottom> : std::true_type {};
 
 // Likewise for std::pair
 // (after C++17 it is mandatory that the move constructor not exist when the two types aren't
@@ -883,21 +1000,14 @@ struct is_move_constructible<std::pair<T1, T2>>
 
 // std::is_copy_constructible isn't quite enough: it lets std::vector<T> (and similar) through when
 // T is non-copyable, but code containing such a copy constructor fails to actually compile.
-template <typename T, typename SFINAE = void>
-struct is_copy_constructible : std::is_copy_constructible<T> {};
+template <typename T>
+struct is_copy_constructible
+    : all_of<std::is_copy_constructible<T>,
+             is_copy_constructible<
+                 typename recursive_container_traits<T>::type_to_check_recursively>> {};
 
-// Specialization for types that appear to be copy constructible but also look like stl containers
-// (we specifically check for: has `value_type` and `reference` with `reference = value_type&`): if
-// so, copy constructability depends on whether the value_type is copy constructible.
-template <typename Container>
-struct is_copy_constructible<
-    Container,
-    enable_if_t<
-        all_of<std::is_copy_constructible<Container>,
-               std::is_same<typename Container::value_type &, typename Container::reference>,
-               // Avoid infinite recursion
-               negation<is_recursive_container<Container>>>::value>>
-    : is_copy_constructible<typename Container::value_type> {};
+template <>
+struct is_copy_constructible<recursive_bottom> : std::true_type {};
 
 // Likewise for std::pair
 // (after C++17 it is mandatory that the copy constructor not exist when the two types aren't
@@ -908,24 +1018,19 @@ struct is_copy_constructible<std::pair<T1, T2>>
     : all_of<is_copy_constructible<T1>, is_copy_constructible<T2>> {};
 
 // The same problems arise with std::is_copy_assignable, so we use the same workaround.
-template <typename T, typename SFINAE = void>
-struct is_copy_assignable : std::is_copy_assignable<T> {};
-template <typename Container>
-struct is_copy_assignable<
-    Container,
-    enable_if_t<
-        all_of<std::is_copy_assignable<Container>,
-               std::is_same<typename Container::value_type &, typename Container::reference>,
-               // Avoid infinite recursion
-               negation<is_recursive_container<Container>>>::value>>
-    : is_copy_assignable<typename Container::value_type> {};
+template <typename T>
+struct is_copy_assignable
+    : all_of<
+          std::is_copy_assignable<T>,
+          is_copy_assignable<typename recursive_container_traits<T>::type_to_check_recursively>> {
+};
+
+template <>
+struct is_copy_assignable<recursive_bottom> : std::true_type {};
+
 template <typename T1, typename T2>
 struct is_copy_assignable<std::pair<T1, T2>>
-    /*
-     * Need to remove the const qualifier from T1 here since the value_type in
-     * STL map types is std::pair<const Key, T>, and const types are never assignable
-     */
-    : all_of<is_copy_assignable<typename std::remove_const<T1>::type>, is_copy_assignable<T2>> {};
+    : all_of<is_copy_assignable<T1>, is_copy_assignable<T2>> {};
 
 PYBIND11_NAMESPACE_END(detail)
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -830,6 +830,20 @@ struct is_copy_constructible : std::is_copy_constructible<T> {};
 template <typename T, typename SFINAE = void>
 struct is_move_constructible : std::is_move_constructible<T> {};
 
+// True if Container has a dependent type mapped_type that is equivalent
+// to Container itself
+template<typename Container, typename MappedType = Container>
+struct map_self_referential
+{
+    constexpr static bool value = false;
+};
+
+template<typename Container>
+struct map_self_referential<Container, typename Container::mapped_type>
+{
+    constexpr static bool value = true;
+};
+
 // Specialization for types that appear to be copy constructible but also look like stl containers
 // (we specifically check for: has `value_type` and `reference` with `reference = value_type&`): if
 // so, copy constructability depends on whether the value_type is copy constructible.
@@ -839,8 +853,10 @@ struct is_copy_constructible<
     enable_if_t<
         all_of<std::is_copy_constructible<Container>,
                std::is_same<typename Container::value_type &, typename Container::reference>,
-               // Avoid infinite recursion
-               negation<std::is_same<Container, typename Container::value_type>>>::value>>
+               // Avoid infinite recursion (list types)
+               negation<std::is_same<Container, typename Container::value_type>>,
+               // Avoid infinite recursion (map types)
+               negation<map_self_referential<Container>>>::value>>
     : is_copy_constructible<typename Container::value_type> {};
 
 // Likewise for std::pair
@@ -858,7 +874,11 @@ template <typename Container>
 struct is_copy_assignable<Container,
                           enable_if_t<all_of<std::is_copy_assignable<Container>,
                                              std::is_same<typename Container::value_type &,
-                                                          typename Container::reference>>::value>>
+                                                          typename Container::reference>,
+                                            // Avoid infinite recursion (list types)
+                                            negation<std::is_same<Container, typename Container::value_type>>,
+                                            // Avoid infinite recursion (map types)
+                                            negation<map_self_referential<Container>>>::value>>
     : is_copy_assignable<typename Container::value_type> {};
 template <typename T1, typename T2>
 struct is_copy_assignable<std::pair<T1, T2>>

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -822,19 +822,6 @@ using movable_cast_op_type
                                   typename std::add_rvalue_reference<intrinsic_t<T>>::type,
                                   typename std::add_lvalue_reference<intrinsic_t<T>>::type>>;
 
-template <bool Condition, typename Then, typename Else>
-struct if_then_else {};
-
-template <typename Then, typename Else>
-struct if_then_else<true, Then, Else> {
-    using type = Then;
-};
-
-template <typename Then, typename Else>
-struct if_then_else<false, Then, Else> {
-    using type = Else;
-};
-
 // Does the container have a mapped type and is it recursive?
 // Implemented by specializations below.
 template <typename Container, typename SFINAE = void>
@@ -945,7 +932,7 @@ struct impl_recursive_container_traits<
      *    should be removed.
      *
      */
-    using type_to_check_recursively = typename if_then_else<
+    using type_to_check_recursively = typename std::conditional<
         is_recursive,
         typename impl_type_to_check_recursively<
             typename Container::value_type,

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -822,14 +822,6 @@ using movable_cast_op_type
                                   typename std::add_rvalue_reference<intrinsic_t<T>>::type,
                                   typename std::add_lvalue_reference<intrinsic_t<T>>::type>>;
 
-// std::is_copy_constructible isn't quite enough: it lets std::vector<T> (and similar) through when
-// T is non-copyable, but code containing such a copy constructor fails to actually compile.
-template <typename T, typename SFINAE = void>
-struct is_copy_constructible : std::is_copy_constructible<T> {};
-
-template <typename T, typename SFINAE = void>
-struct is_move_constructible : std::is_move_constructible<T> {};
-
 // True if Container has a dependent type mapped_type that is equivalent
 // to Container itself
 // Actual implementation in the SFINAE specialization below
@@ -864,6 +856,14 @@ struct is_container_with_recursive_value_type<Container, typename Container::val
 template <typename Container, typename SFINAE = void>
 struct is_recursive_container : any_of<is_container_with_recursive_value_type<Container>,
                                        is_container_with_recursive_mapped_type<Container>> {};
+
+template <typename T, typename SFINAE = void>
+struct is_move_constructible : std::is_move_constructible<T> {};
+
+// std::is_copy_constructible isn't quite enough: it lets std::vector<T> (and similar) through when
+// T is non-copyable, but code containing such a copy constructor fails to actually compile.
+template <typename T, typename SFINAE = void>
+struct is_copy_constructible : std::is_copy_constructible<T> {};
 
 // Specialization for types that appear to be copy constructible but also look like stl containers
 // (we specifically check for: has `value_type` and `reference` with `reference = value_type&`): if

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -921,7 +921,11 @@ struct is_copy_assignable<
     : is_copy_assignable<typename Container::value_type> {};
 template <typename T1, typename T2>
 struct is_copy_assignable<std::pair<T1, T2>>
-    : all_of<is_copy_assignable<T1>, is_copy_assignable<T2>> {};
+    /*
+     * Need to remove the const qualifier from T1 here since the value_type in
+     * STL map types is std::pair<const Key, T>, and const types are never assignable
+     */
+    : all_of<is_copy_assignable<typename std::remove_const<T1>::type>, is_copy_assignable<T2>> {};
 
 PYBIND11_NAMESPACE_END(detail)
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -832,15 +832,13 @@ struct is_move_constructible : std::is_move_constructible<T> {};
 
 // True if Container has a dependent type mapped_type that is equivalent
 // to Container itself
-template<typename Container, typename MappedType = Container>
-struct map_self_referential
-{
+template <typename Container, typename MappedType = Container>
+struct map_self_referential {
     constexpr static bool value = false;
 };
 
-template<typename Container>
-struct map_self_referential<Container, typename Container::mapped_type>
-{
+template <typename Container>
+struct map_self_referential<Container, typename Container::mapped_type> {
     constexpr static bool value = true;
 };
 
@@ -871,14 +869,15 @@ struct is_copy_constructible<std::pair<T1, T2>>
 template <typename T, typename SFINAE = void>
 struct is_copy_assignable : std::is_copy_assignable<T> {};
 template <typename Container>
-struct is_copy_assignable<Container,
-                          enable_if_t<all_of<std::is_copy_assignable<Container>,
-                                             std::is_same<typename Container::value_type &,
-                                                          typename Container::reference>,
-                                            // Avoid infinite recursion (list types)
-                                            negation<std::is_same<Container, typename Container::value_type>>,
-                                            // Avoid infinite recursion (map types)
-                                            negation<map_self_referential<Container>>>::value>>
+struct is_copy_assignable<
+    Container,
+    enable_if_t<
+        all_of<std::is_copy_assignable<Container>,
+               std::is_same<typename Container::value_type &, typename Container::reference>,
+               // Avoid infinite recursion (list types)
+               negation<std::is_same<Container, typename Container::value_type>>,
+               // Avoid infinite recursion (map types)
+               negation<map_self_referential<Container>>>::value>>
     : is_copy_assignable<typename Container::value_type> {};
 template <typename T1, typename T2>
 struct is_copy_assignable<std::pair<T1, T2>>

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -68,12 +68,13 @@ struct is_comparable<T,
     static constexpr const bool value = is_comparable<typename T::value_type>::value;
 };
 
+/* Skip the recursion if the type itself is recursive */
 template <typename T>
 struct is_comparable<T,
                      enable_if_t<container_traits<T>::is_vector &&
                                  // Special case: The vector type is recursive
-                                 std::is_same<T, typename T::value_type>::value>> {
-    static constexpr const bool value = true;
+                                 is_recursive_container<T>::value>> {
+    static constexpr const bool value = container_traits<T>::is_comparable;
 };
 
 /* For pairs, recursively check the two data types */

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -61,8 +61,19 @@ struct is_comparable<
 /* For a vector/map data structure, recursively check the value type
    (which is std::pair for maps) */
 template <typename T>
-struct is_comparable<T, enable_if_t<container_traits<T>::is_vector>> {
+struct is_comparable<T,
+                     enable_if_t<container_traits<T>::is_vector &&
+                                 // Avoid this instantiation if the type is recursive
+                                 negation<std::is_same<T, typename T::value_type>>::value>> {
     static constexpr const bool value = is_comparable<typename T::value_type>::value;
+};
+
+template <typename T>
+struct is_comparable<T,
+                     enable_if_t<container_traits<T>::is_vector &&
+                                 // Special case: The vector type is recursive
+                                 std::is_same<T, typename T::value_type>::value>> {
+    static constexpr const bool value = true;
 };
 
 /* For pairs, recursively check the two data types */

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -61,11 +61,10 @@ struct is_comparable<
 /* For a vector/map data structure, recursively check the value type
    (which is std::pair for maps) */
 template <typename T>
-struct is_comparable<
-    T,
-    enable_if_t<container_traits<T>::is_vector &&
-                // Avoid this instantiation if the type is recursive
-                negation<is_container_with_self_referential_mapped_type<T>>::value>> {
+struct is_comparable<T,
+                     enable_if_t<container_traits<T>::is_vector &&
+                                 // Avoid this instantiation if the type is recursive
+                                 negation<is_recursive_container<T>>::value>> {
     static constexpr const bool value = is_comparable<typename T::value_type>::value;
 };
 

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -61,21 +61,11 @@ struct is_comparable<
 /* For a vector/map data structure, recursively check the value type
    (which is std::pair for maps) */
 template <typename T>
-struct is_comparable<T,
-                     enable_if_t<container_traits<T>::is_vector &&
-                                 // Avoid this instantiation if the type is recursive
-                                 negation<is_recursive_container<T>>::value>> {
-    static constexpr const bool value = is_comparable<typename T::value_type>::value;
-};
+struct is_comparable<T, enable_if_t<container_traits<T>::is_vector>>
+    : is_comparable<typename recursive_container_traits<T>::type_to_check_recursively> {};
 
-/* Skip the recursion if the type itself is recursive */
-template <typename T>
-struct is_comparable<T,
-                     enable_if_t<container_traits<T>::is_vector &&
-                                 // Special case: The vector type is recursive
-                                 is_recursive_container<T>::value>> {
-    static constexpr const bool value = container_traits<T>::is_comparable;
-};
+template <>
+struct is_comparable<recursive_bottom> : std::true_type {};
 
 /* For pairs, recursively check the two data types */
 template <typename T>

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -61,10 +61,11 @@ struct is_comparable<
 /* For a vector/map data structure, recursively check the value type
    (which is std::pair for maps) */
 template <typename T>
-struct is_comparable<T,
-                     enable_if_t<container_traits<T>::is_vector &&
-                                 // Avoid this instantiation if the type is recursive
-                                 negation<std::is_same<T, typename T::value_type>>::value>> {
+struct is_comparable<
+    T,
+    enable_if_t<container_traits<T>::is_vector &&
+                // Avoid this instantiation if the type is recursive
+                negation<is_container_with_self_referential_mapped_type<T>>::value>> {
     static constexpr const bool value = is_comparable<typename T::value_type>::value;
 };
 

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -298,7 +298,7 @@ TEST_SUBMODULE(copy_move_policies, m) {
 
 /*
  * Rest of the file:
- * static_assert based tests for pybind11 adaptations of of
+ * static_assert based tests for pybind11 adaptations of
  * std::is_move_constructible, std::is_copy_constructible and
  * std::is_copy_assignable (no adaptation of std::is_move_assignable).
  * Difference between pybind11 and std traits: pybind11 traits will also check

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -13,6 +13,8 @@
 #include "constructor_stats.h"
 #include "pybind11_tests.h"
 
+#include <type_traits>
+
 template <typename derived>
 struct empty {
     static const derived &get_one() { return instance_; }
@@ -293,3 +295,239 @@ TEST_SUBMODULE(copy_move_policies, m) {
     // Make sure that cast from pytype rvalue to other pytype works
     m.def("get_pytype_rvalue_castissue", [](double i) { return py::float_(i).cast<py::int_>(); });
 }
+
+/*
+ * Rest of the file:
+ * static_assert based tests for pybind11 adaptations of of
+ * std::is_move_constructible, std::is_copy_constructible and
+ * std::is_copy_assignable (no adaptation of std::is_move_assignable).
+ * Difference between pybind11 and std traits: pybind11 traits will also check
+ * the contained value_types.
+ */
+
+struct NotMovable {
+    NotMovable() = default;
+    NotMovable(NotMovable const &) = default;
+    NotMovable(NotMovable &&) = delete;
+    NotMovable &operator=(NotMovable const &) = default;
+    NotMovable &operator=(NotMovable &&) = delete;
+};
+static_assert(!std::is_move_constructible<NotMovable>::value,
+              "!std::is_move_constructible<NotMovable>::value");
+static_assert(std::is_copy_constructible<NotMovable>::value,
+              "std::is_copy_constructible<NotMovable>::value");
+static_assert(!pybind11::detail::is_move_constructible<NotMovable>::value,
+              "!pybind11::detail::is_move_constructible<NotMovable>::value");
+static_assert(pybind11::detail::is_copy_constructible<NotMovable>::value,
+              "pybind11::detail::is_copy_constructible<NotMovable>::value");
+static_assert(!std::is_move_assignable<NotMovable>::value,
+              "!std::is_move_assignable<NotMovable>::value");
+static_assert(std::is_copy_assignable<NotMovable>::value,
+              "std::is_copy_assignable<NotMovable>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<NotMovable>::value,
+//               "!pybind11::detail::is_move_assignable<NotMovable>::value");
+static_assert(pybind11::detail::is_copy_assignable<NotMovable>::value,
+              "pybind11::detail::is_copy_assignable<NotMovable>::value");
+
+struct NotCopyable {
+    NotCopyable() = default;
+    NotCopyable(NotCopyable const &) = delete;
+    NotCopyable(NotCopyable &&) = default;
+    NotCopyable &operator=(NotCopyable const &) = delete;
+    NotCopyable &operator=(NotCopyable &&) = default;
+};
+static_assert(std::is_move_constructible<NotCopyable>::value,
+              "std::is_move_constructible<NotCopyable>::value");
+static_assert(!std::is_copy_constructible<NotCopyable>::value,
+              "!std::is_copy_constructible<NotCopyable>::value");
+static_assert(pybind11::detail::is_move_constructible<NotCopyable>::value,
+              "pybind11::detail::is_move_constructible<NotCopyable>::value");
+static_assert(!pybind11::detail::is_copy_constructible<NotCopyable>::value,
+              "!pybind11::detail::is_copy_constructible<NotCopyable>::value");
+static_assert(std::is_move_assignable<NotCopyable>::value,
+              "std::is_move_assignable<NotCopyable>::value");
+static_assert(!std::is_copy_assignable<NotCopyable>::value,
+              "!std::is_copy_assignable<NotCopyable>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<NotCopyable>::value,
+//               "!pybind11::detail::is_move_assignable<NotCopyable>::value");
+static_assert(!pybind11::detail::is_copy_assignable<NotCopyable>::value,
+              "!pybind11::detail::is_copy_assignable<NotCopyable>::value");
+
+struct NotCopyableNotMovable {
+    NotCopyableNotMovable() = default;
+    NotCopyableNotMovable(NotCopyableNotMovable const &) = delete;
+    NotCopyableNotMovable(NotCopyableNotMovable &&) = delete;
+    NotCopyableNotMovable &operator=(NotCopyableNotMovable const &) = delete;
+    NotCopyableNotMovable &operator=(NotCopyableNotMovable &&) = delete;
+};
+static_assert(!std::is_move_constructible<NotCopyableNotMovable>::value,
+              "!std::is_move_constructible<NotCopyableNotMovable>::value");
+static_assert(!std::is_copy_constructible<NotCopyableNotMovable>::value,
+              "!std::is_copy_constructible<NotCopyableNotMovable>::value");
+static_assert(!pybind11::detail::is_move_constructible<NotCopyableNotMovable>::value,
+              "!pybind11::detail::is_move_constructible<NotCopyableNotMovable>::value");
+static_assert(!pybind11::detail::is_copy_constructible<NotCopyableNotMovable>::value,
+              "!pybind11::detail::is_copy_constructible<NotCopyableNotMovable>::value");
+static_assert(!std::is_move_assignable<NotCopyableNotMovable>::value,
+              "!std::is_move_assignable<NotCopyableNotMovable>::value");
+static_assert(!std::is_copy_assignable<NotCopyableNotMovable>::value,
+              "!std::is_copy_assignable<NotCopyableNotMovable>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<NotCopyableNotMovable>::value,
+//               "!pybind11::detail::is_move_assignable<NotCopyableNotMovable>::value");
+static_assert(!pybind11::detail::is_copy_assignable<NotCopyableNotMovable>::value,
+              "!pybind11::detail::is_copy_assignable<NotCopyableNotMovable>::value");
+
+struct NotMovableVector : std::vector<NotMovable> {};
+static_assert(std::is_move_constructible<NotMovableVector>::value,
+              "std::is_move_constructible<NotMovableVector>::value");
+static_assert(std::is_copy_constructible<NotMovableVector>::value,
+              "std::is_copy_constructible<NotMovableVector>::value");
+static_assert(!pybind11::detail::is_move_constructible<NotMovableVector>::value,
+              "!pybind11::detail::is_move_constructible<NotMovableVector>::value");
+static_assert(pybind11::detail::is_copy_constructible<NotMovableVector>::value,
+              "pybind11::detail::is_copy_constructible<NotMovableVector>::value");
+static_assert(std::is_move_assignable<NotMovableVector>::value,
+              "std::is_move_assignable<NotMovableVector>::value");
+static_assert(std::is_copy_assignable<NotMovableVector>::value,
+              "std::is_copy_assignable<NotMovableVector>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<NotMovableVector>::value,
+//               "!pybind11::detail::is_move_assignable<NotMovableVector>::value");
+static_assert(pybind11::detail::is_copy_assignable<NotMovableVector>::value,
+              "pybind11::detail::is_copy_assignable<NotMovableVector>::value");
+
+struct NotCopyableVector : std::vector<NotCopyable> {};
+static_assert(std::is_move_constructible<NotCopyableVector>::value,
+              "std::is_move_constructible<NotCopyableVector>::value");
+static_assert(std::is_copy_constructible<NotCopyableVector>::value,
+              "std::is_copy_constructible<NotCopyableVector>::value");
+static_assert(pybind11::detail::is_move_constructible<NotCopyableVector>::value,
+              "pybind11::detail::is_move_constructible<NotCopyableVector>::value");
+static_assert(!pybind11::detail::is_copy_constructible<NotCopyableVector>::value,
+              "!pybind11::detail::is_copy_constructible<NotCopyableVector>::value");
+static_assert(std::is_move_assignable<NotCopyableVector>::value,
+              "std::is_move_assignable<NotCopyableVector>::value");
+static_assert(std::is_copy_assignable<NotCopyableVector>::value,
+              "std::is_copy_assignable<NotCopyableVector>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<NotCopyableVector>::value,
+//               "!pybind11::detail::is_move_assignable<NotCopyableVector>::value");
+static_assert(!pybind11::detail::is_copy_assignable<NotCopyableVector>::value,
+              "!pybind11::detail::is_copy_assignable<NotCopyableVector>::value");
+
+struct NotCopyableNotMovableVector : std::vector<NotCopyableNotMovable> {};
+static_assert(std::is_move_constructible<NotCopyableNotMovableVector>::value,
+              "std::is_move_constructible<NotCopyableNotMovableVector>::value");
+static_assert(std::is_copy_constructible<NotCopyableNotMovableVector>::value,
+              "std::is_copy_constructible<NotCopyableNotMovableVector>::value");
+static_assert(!pybind11::detail::is_move_constructible<NotCopyableNotMovableVector>::value,
+              "!pybind11::detail::is_move_constructible<NotCopyableNotMovableVector>::value");
+static_assert(!pybind11::detail::is_copy_constructible<NotCopyableNotMovableVector>::value,
+              "!pybind11::detail::is_copy_constructible<NotCopyableNotMovableVector>::value");
+static_assert(std::is_move_assignable<NotCopyableNotMovableVector>::value,
+              "std::is_move_assignable<NotCopyableNotMovableVector>::value");
+static_assert(std::is_copy_assignable<NotCopyableNotMovableVector>::value,
+              "std::is_copy_assignable<NotCopyableNotMovableVector>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<NotCopyableNotMovableVector>::value,
+//               "!pybind11::detail::is_move_assignable<NotCopyableNotMovableVector>::value");
+static_assert(!pybind11::detail::is_copy_assignable<NotCopyableNotMovableVector>::value,
+              "!pybind11::detail::is_copy_assignable<NotCopyableNotMovableVector>::value");
+
+struct NotMovableMap : std::map<int, NotMovable> {};
+static_assert(std::is_move_constructible<NotMovableMap>::value,
+              "std::is_move_constructible<NotMovableMap>::value");
+static_assert(std::is_copy_constructible<NotMovableMap>::value,
+              "std::is_copy_constructible<NotMovableMap>::value");
+static_assert(!pybind11::detail::is_move_constructible<NotMovableMap>::value,
+              "!pybind11::detail::is_move_constructible<NotMovableMap>::value");
+static_assert(pybind11::detail::is_copy_constructible<NotMovableMap>::value,
+              "pybind11::detail::is_copy_constructible<NotMovableMap>::value");
+static_assert(std::is_move_assignable<NotMovableMap>::value,
+              "std::is_move_assignable<NotMovableMap>::value");
+static_assert(std::is_copy_assignable<NotMovableMap>::value,
+              "std::is_copy_assignable<NotMovableMap>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<NotMovableMap>::value,
+//               "!pybind11::detail::is_move_assignable<NotMovableMap>::value");
+static_assert(pybind11::detail::is_copy_assignable<NotMovableMap>::value,
+              "pybind11::detail::is_copy_assignable<NotMovableMap>::value");
+
+struct NotCopyableMap : std::map<int, NotCopyable> {};
+static_assert(std::is_move_constructible<NotCopyableMap>::value,
+              "std::is_move_constructible<NotCopyableMap>::value");
+static_assert(std::is_copy_constructible<NotCopyableMap>::value,
+              "std::is_copy_constructible<NotCopyableMap>::value");
+static_assert(pybind11::detail::is_move_constructible<NotCopyableMap>::value,
+              "pybind11::detail::is_move_constructible<NotCopyableMap>::value");
+static_assert(!pybind11::detail::is_copy_constructible<NotCopyableMap>::value,
+              "!pybind11::detail::is_copy_constructible<NotCopyableMap>::value");
+static_assert(std::is_move_assignable<NotCopyableMap>::value,
+              "std::is_move_assignable<NotCopyableMap>::value");
+static_assert(std::is_copy_assignable<NotCopyableMap>::value,
+              "std::is_copy_assignable<NotCopyableMap>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<NotCopyableMap>::value,
+//               "!pybind11::detail::is_move_assignable<NotCopyableMap>::value");
+static_assert(!pybind11::detail::is_copy_assignable<NotCopyableMap>::value,
+              "!pybind11::detail::is_copy_assignable<NotCopyableMap>::value");
+
+struct NotCopyableNotMovableMap : std::map<int, NotCopyableNotMovable> {};
+static_assert(std::is_move_constructible<NotCopyableNotMovableMap>::value,
+              "std::is_move_constructible<NotCopyableNotMovableMap>::value");
+static_assert(std::is_copy_constructible<NotCopyableNotMovableMap>::value,
+              "std::is_copy_constructible<NotCopyableNotMovableMap>::value");
+static_assert(!pybind11::detail::is_move_constructible<NotCopyableNotMovableMap>::value,
+              "!pybind11::detail::is_move_constructible<NotCopyableNotMovableMap>::value");
+static_assert(!pybind11::detail::is_copy_constructible<NotCopyableNotMovableMap>::value,
+              "!pybind11::detail::is_copy_constructible<NotCopyableNotMovableMap>::value");
+static_assert(std::is_move_assignable<NotCopyableNotMovableMap>::value,
+              "std::is_move_assignable<NotCopyableNotMovableMap>::value");
+static_assert(std::is_copy_assignable<NotCopyableNotMovableMap>::value,
+              "std::is_copy_assignable<NotCopyableNotMovableMap>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<NotCopyableNotMovableMap>::value,
+//               "!pybind11::detail::is_move_assignable<NotCopyableNotMovableMap>::value");
+static_assert(!pybind11::detail::is_copy_assignable<NotCopyableNotMovableMap>::value,
+              "!pybind11::detail::is_copy_assignable<NotCopyableNotMovableMap>::value");
+
+struct RecursiveVector : std::vector<RecursiveVector> {};
+static_assert(std::is_move_constructible<RecursiveVector>::value,
+              "std::is_move_constructible<RecursiveVector>::value");
+static_assert(std::is_copy_constructible<RecursiveVector>::value,
+              "std::is_copy_constructible<RecursiveVector>::value");
+static_assert(pybind11::detail::is_move_constructible<RecursiveVector>::value,
+              "pybind11::detail::is_move_constructible<RecursiveVector>::value");
+static_assert(pybind11::detail::is_copy_constructible<RecursiveVector>::value,
+              "pybind11::detail::is_copy_constructible<RecursiveVector>::value");
+static_assert(std::is_move_assignable<RecursiveVector>::value,
+              "std::is_move_assignable<RecursiveVector>::value");
+static_assert(std::is_copy_assignable<RecursiveVector>::value,
+              "std::is_copy_assignable<RecursiveVector>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<RecursiveVector>::value,
+//               "!pybind11::detail::is_move_assignable<RecursiveVector>::value");
+static_assert(pybind11::detail::is_copy_assignable<RecursiveVector>::value,
+              "pybind11::detail::is_copy_assignable<RecursiveVector>::value");
+
+struct RecursiveMap : std::map<int, RecursiveMap> {};
+static_assert(std::is_move_constructible<RecursiveMap>::value,
+              "std::is_move_constructible<RecursiveMap>::value");
+static_assert(std::is_copy_constructible<RecursiveMap>::value,
+              "std::is_copy_constructible<RecursiveMap>::value");
+static_assert(pybind11::detail::is_move_constructible<RecursiveMap>::value,
+              "pybind11::detail::is_move_constructible<RecursiveMap>::value");
+static_assert(pybind11::detail::is_copy_constructible<RecursiveMap>::value,
+              "pybind11::detail::is_copy_constructible<RecursiveMap>::value");
+static_assert(std::is_move_assignable<RecursiveMap>::value,
+              "std::is_move_assignable<RecursiveMap>::value");
+static_assert(std::is_copy_assignable<RecursiveMap>::value,
+              "std::is_copy_assignable<RecursiveMap>::value");
+// pybind11 does not have this
+// static_assert(!pybind11::detail::is_move_assignable<RecursiveMap>::value,
+//               "!pybind11::detail::is_move_assignable<RecursiveMap>::value");
+static_assert(pybind11::detail::is_copy_assignable<RecursiveMap>::value,
+              "pybind11::detail::is_copy_assignable<RecursiveMap>::value");

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -10,7 +10,6 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl_bind.h>
 
-#include "pybind11/detail/type_caster_base.h"
 #include "pybind11_tests.h"
 
 #include <deque>

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -97,15 +97,9 @@ struct MutuallyRecursiveVector : std::vector<MutuallyRecursiveMap> {};
 namespace pybind11 {
 namespace detail {
 template <>
-struct is_comparable<MutuallyRecursiveVector, void> : std::true_type {};
+struct is_container_with_self_referential_mapped_type<MutuallyRecursiveVector> : std::true_type {};
 template <>
-struct is_copy_assignable<MutuallyRecursiveVector, void> : std::true_type {};
-template <>
-struct is_copy_assignable<MutuallyRecursiveMap, void> : std::true_type {};
-template <>
-struct is_copy_constructible<MutuallyRecursiveVector, void> : std::true_type {};
-template <>
-struct is_copy_constructible<MutuallyRecursiveMap, void> : std::true_type {};
+struct is_container_with_self_referential_mapped_type<MutuallyRecursiveMap> : std::true_type {};
 } // namespace detail
 } // namespace pybind11
 

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -70,6 +70,19 @@ NestMap *times_hundred(int n) {
     return m;
 }
 
+/*
+ * Recursive data structures as test for issue #4623
+ */
+struct RecursiveVector : std::vector<RecursiveVector> {
+    using Parent = std::vector<RecursiveVector>;
+    using Parent::Parent;
+};
+
+struct RecursiveMap : std::map<int, RecursiveMap> {
+    using Parent = std::map<int, RecursiveMap>;
+    using Parent::Parent;
+};
+
 TEST_SUBMODULE(stl_binders, m) {
     // test_vector_int
     py::bind_vector<std::vector<unsigned int>>(m, "VectorInt", py::buffer_protocol());
@@ -149,4 +162,7 @@ TEST_SUBMODULE(stl_binders, m) {
     m.def("get_vectorstruct", [] {
         return std::vector<VStruct>{{false, 5, 3.0, true}, {true, 30, -1e4, false}};
     });
+
+    py::bind_vector<RecursiveVector>(m, "RecursiveVector");
+    py::bind_map<RecursiveMap>(m, "RecursiveMap");
 }

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -86,9 +86,8 @@ struct RecursiveMap : std::map<int, RecursiveMap> {
 /*
  * Pybind11 does not catch more complicated recursion schemes, such as mutual
  * recursion.
- * In that case, an alternative is to add a custom specialization to
- * pybind11::detail::is_container_with_self_referential_mapped_type, thus
- * manually telling pybind11 about the recursion.
+ * In that case custom is_recursive_container specializations need to be added,
+ * thus manually telling pybind11 about the recursion.
  */
 struct MutuallyRecursiveContainerPairMV;
 struct MutuallyRecursiveContainerPairVM;

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -168,6 +168,12 @@ TEST_SUBMODULE(stl_binders, m) {
             m, "VectorUndeclStruct", py::buffer_protocol());
     });
 
+    // Bind recursive container types
+    py::bind_vector<RecursiveVector>(m, "RecursiveVector");
+    py::bind_map<RecursiveMap>(m, "RecursiveMap");
+    py::bind_map<MutuallyRecursiveMap>(m, "MutuallyRecursiveMap");
+    py::bind_vector<MutuallyRecursiveVector>(m, "MutuallyRecursiveVector");
+
     // The rest depends on numpy:
     try {
         py::module_::import("numpy");
@@ -188,9 +194,4 @@ TEST_SUBMODULE(stl_binders, m) {
     m.def("get_vectorstruct", [] {
         return std::vector<VStruct>{{false, 5, 3.0, true}, {true, 30, -1e4, false}};
     });
-
-    py::bind_vector<RecursiveVector>(m, "RecursiveVector");
-    py::bind_map<RecursiveMap>(m, "RecursiveMap");
-    py::bind_map<MutuallyRecursiveMap>(m, "MutuallyRecursiveMap");
-    py::bind_vector<MutuallyRecursiveVector>(m, "MutuallyRecursiveVector");
 }

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -10,6 +10,7 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl_bind.h>
 
+#include "pybind11/detail/type_caster_base.h"
 #include "pybind11_tests.h"
 
 #include <deque>
@@ -86,7 +87,7 @@ struct RecursiveMap : std::map<int, RecursiveMap> {
 /*
  * Pybind11 does not catch more complicated recursion schemes, such as mutual
  * recursion.
- * In that case custom is_recursive_container specializations need to be added,
+ * In that case custom recursive_container_traits specializations need to be added,
  * thus manually telling pybind11 about the recursion.
  */
 struct MutuallyRecursiveContainerPairMV;
@@ -98,9 +99,13 @@ struct MutuallyRecursiveContainerPairVM : std::vector<MutuallyRecursiveContainer
 namespace pybind11 {
 namespace detail {
 template <typename SFINAE>
-struct is_recursive_container<MutuallyRecursiveContainerPairMV, SFINAE> : std::true_type {};
+struct recursive_container_traits<MutuallyRecursiveContainerPairMV, SFINAE> {
+    using type_to_check_recursively = recursive_bottom;
+};
 template <typename SFINAE>
-struct is_recursive_container<MutuallyRecursiveContainerPairVM, SFINAE> : std::true_type {};
+struct recursive_container_traits<MutuallyRecursiveContainerPairVM, SFINAE> {
+    using type_to_check_recursively = recursive_bottom;
+};
 } // namespace detail
 } // namespace pybind11
 

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -90,20 +90,18 @@ struct RecursiveMap : std::map<int, RecursiveMap> {
  * pybind11::detail::is_container_with_self_referential_mapped_type, thus
  * manually telling pybind11 about the recursion.
  */
-struct MutuallyRecursiveContainerPairA;
-struct MutuallyRecursiveContainerPairB;
+struct MutuallyRecursiveContainerPairMV;
+struct MutuallyRecursiveContainerPairVM;
 
-struct MutuallyRecursiveContainerPairA : std::map<int, MutuallyRecursiveContainerPairB> {};
-struct MutuallyRecursiveContainerPairB : std::vector<MutuallyRecursiveContainerPairA> {};
+struct MutuallyRecursiveContainerPairMV : std::map<int, MutuallyRecursiveContainerPairVM> {};
+struct MutuallyRecursiveContainerPairVM : std::vector<MutuallyRecursiveContainerPairMV> {};
 
 namespace pybind11 {
 namespace detail {
-template <>
-struct is_container_with_self_referential_mapped_type<MutuallyRecursiveContainerPairB>
-    : std::true_type {};
-template <>
-struct is_container_with_self_referential_mapped_type<MutuallyRecursiveContainerPairA>
-    : std::true_type {};
+template <typename SFINAE>
+struct is_recursive_container<MutuallyRecursiveContainerPairMV, SFINAE> : std::true_type {};
+template <typename SFINAE>
+struct is_recursive_container<MutuallyRecursiveContainerPairVM, SFINAE> : std::true_type {};
 } // namespace detail
 } // namespace pybind11
 
@@ -169,8 +167,8 @@ TEST_SUBMODULE(stl_binders, m) {
     // Bind recursive container types
     py::bind_vector<RecursiveVector>(m, "RecursiveVector");
     py::bind_map<RecursiveMap>(m, "RecursiveMap");
-    py::bind_map<MutuallyRecursiveContainerPairA>(m, "MutuallyRecursiveContainerPairA");
-    py::bind_vector<MutuallyRecursiveContainerPairB>(m, "MutuallyRecursiveContainerPairB");
+    py::bind_map<MutuallyRecursiveContainerPairMV>(m, "MutuallyRecursiveContainerPairMV");
+    py::bind_vector<MutuallyRecursiveContainerPairVM>(m, "MutuallyRecursiveContainerPairVM");
 
     // The rest depends on numpy:
     try {

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -337,19 +337,19 @@ def test_map_view_types():
     assert type(unordered_map_string_double_const.items()) is items_type
 
 
-def test_recursive_containers():
+def test_recursive_vector():
     recursive_vector = m.RecursiveVector()
     recursive_vector.append(m.RecursiveVector())
     recursive_vector[0].append(m.RecursiveVector())
-    recursive_vector[0][0].append(m.RecursiveVector())
-    recursive_vector[0][0].append(m.RecursiveVector())
+    recursive_vector[0].append(m.RecursiveVector())
     # Can't use len() since test_stl_binders.cpp does not include stl.h,
     # so the necessary conversion is missing
-    assert recursive_vector[0][0].count(m.RecursiveVector()) == 2
+    assert recursive_vector[0].count(m.RecursiveVector()) == 2
 
+
+def test_recursive_map():
     recursive_map = m.RecursiveMap()
-    recursive_map[1] = m.RecursiveMap()
-    recursive_map[1][1] = m.RecursiveMap()
-    recursive_map[1][1][1] = m.RecursiveMap()
-    recursive_map[1][1][2] = m.RecursiveMap()
-    assert list(recursive_map[1][1].keys()) == [1, 2]
+    recursive_map[100] = m.RecursiveMap()
+    recursive_map[100][101] = m.RecursiveMap()
+    recursive_map[100][102] = m.RecursiveMap()
+    assert list(recursive_map[100].keys()) == [101, 102]

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -335,3 +335,21 @@ def test_map_view_types():
     assert type(unordered_map_string_double.items()) is items_type
     assert type(map_string_double_const.items()) is items_type
     assert type(unordered_map_string_double_const.items()) is items_type
+
+
+def test_recursive_containers():
+    recursive_vector = m.RecursiveVector()
+    recursive_vector.append(m.RecursiveVector())
+    recursive_vector[0].append(m.RecursiveVector())
+    recursive_vector[0][0].append(m.RecursiveVector())
+    recursive_vector[0][0].append(m.RecursiveVector())
+    # Can't use len() since test_stl_binders.cpp does not include stl.h,
+    # so the necessary conversion is missing
+    assert recursive_vector[0][0].count(m.RecursiveVector()) == 2
+
+    recursive_map = m.RecursiveMap()
+    recursive_map[1] = m.RecursiveMap()
+    recursive_map[1][1] = m.RecursiveMap()
+    recursive_map[1][1][1] = m.RecursiveMap()
+    recursive_map[1][1][2] = m.RecursiveMap()
+    assert list(recursive_map[1][1].keys()) == [1, 2]


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

This fix is necessary when trying to bind recursive map types such as:

```cpp
struct RecursiveMap : std::map<int, RecursiveMap> {}
```

The old check (`negation<std::is_same<Container, typename Container::value_type>>`) is insufficient here, as `Container::value_type` is `std::pair<int, RecursiveMap>`. The check needs to additionally consider `Container::mapped_type`.
Since `mapped_type` does not exist for all container-like types, this uses SFINAE in the helper struct `map_self_referential`.

More complicated self-referential patterns (such as mutually referential lists and maps) are not considered by this PR.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Introduce recursive_container_traits

```

<!-- If the upgrade guide needs updating, note that here too -->
