### PR TITLE
fix: remove -stdlib=libc++ from setup helpers, not needed on modern Pythons

### DIFF
--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -266,41 +266,21 @@ def auto_cpp_level(compiler: Any) -> Union[str, int]:
     raise RuntimeError(msg)
 
 
-@lru_cache()
-def has_stdlib_libc(compiler: Any) -> bool:
-    """
-    Return whether the flag "-stdlib=libc++" is supported by the compiler.
-    On macOS, this flag is required for clang but is invalid for GCC.
-    """
-    return has_flag(compiler, "-stdlib=libc++")
-
-
 class build_ext(_build_ext):  # type: ignore[misc] # noqa: N801
     """
     Customized build_ext that allows an auto-search for the highest supported
-    C++ level on all systems for Pybind11Extensions, and also auto-determine
-    whether "-stdlib=libc++" should be used on macOS. This is only needed for
-    these two auto-detections for now, and is completely optional otherwise.
+    C++ level for Pybind11Extension. This is only needed for the auto-search
+    for now, and is completely optional otherwise.
     """
 
     def build_extensions(self) -> None:
         """
-        Build extensions, injecting C++ std (and stdlib=libc++ on macOS) for
-        Pybind11Extension if needed.
+        Build extensions, injecting C++ std for Pybind11Extension if needed.
         """
 
         for ext in self.extensions:
             if hasattr(ext, "_cxx_level") and ext._cxx_level == 0:
                 ext.cxx_std = auto_cpp_level(self.compiler)
-
-            if (
-                MACOS
-                and hasattr(ext, "_add_cflags")
-                and hasattr(ext, "_add_ldflags")
-                and has_stdlib_libc(self.compiler)
-            ):
-                ext._add_cflags(["-stdlib=libc++"])
-                ext._add_ldflags(["-stdlib=libc++"])
 
         super().build_extensions()
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
On macOS, by default, pybind11 currently unconditionally set the compiler flag `-stdlib=libc++` in `Pybind11Extension.__init__()`, regardless of which compiler is used. This flag is required for clang, but is invalid for GCC. If GCC is used, it causes compilation failures in all Python projects that use pybind11, with the error message:

    arm64-apple-darwin22-gcc: error: unrecognized command-line option -stdlib=libc++.

This commit uses has_flag() to detect whether `-stdlib=libc++` on macOS, and injects this flag from build_ext.build_extensions(), rather than setting it unconditionally.

This PR resolves Issue #4637.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
No longer inject -stdlib=libc++, not needed for modern Pythons (macOS 10.9+)
```

<!-- If the upgrade guide needs updating, note that here too -->
