### PR TITLE
Fix: Set minimal permissions to github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - stable
       - v*
 
+permissions:
+  contents: read
+
 concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ on:
       - stable
       - v*
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   group: test-${{ github.ref }}

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -9,6 +9,9 @@ on:
       - stable
       - v*
 
+permissions:
+  contents: read
+
 env:
   # For cmake:
   VERBOSE: 1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,6 +12,9 @@ on:
     - stable
     - "v*"
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 3
   # For cmake:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,10 +3,15 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}
+
 jobs:
   label:
     name: Labeler
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
 
     - uses: actions/labeler@main

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
 
     - uses: actions/labeler@main
-#       if: >
-#         github.event.pull_request.merged == true &&
-#         !startsWith(github.event.pull_request.title, 'chore(deps):') &&
-#         !startsWith(github.event.pull_request.title, 'ci(fix):') &&
-#         !startsWith(github.event.pull_request.title, 'docs(changelog):')
+      if: >
+        github.event.pull_request.merged == true &&
+        !startsWith(github.event.pull_request.title, 'chore(deps):') &&
+        !startsWith(github.event.pull_request.title, 'ci(fix):') &&
+        !startsWith(github.event.pull_request.title, 'docs(changelog):')
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         configuration-path: .github/labeler_merged.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
 
     - uses: actions/labeler@main
-      if: >
-        github.event.pull_request.merged == true &&
-        !startsWith(github.event.pull_request.title, 'chore(deps):') &&
-        !startsWith(github.event.pull_request.title, 'ci(fix):') &&
-        !startsWith(github.event.pull_request.title, 'docs(changelog):')
+#       if: >
+#         github.event.pull_request.merged == true &&
+#         !startsWith(github.event.pull_request.title, 'chore(deps):') &&
+#         !startsWith(github.event.pull_request.title, 'ci(fix):') &&
+#         !startsWith(github.event.pull_request.title, 'docs(changelog):')
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         configuration-path: .github/labeler_merged.yml

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -12,6 +12,9 @@ on:
     types:
     - published
 
+permissions:
+  contents: read
+
 env:
   PIP_ONLY_BINARY: numpy
 

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: upstream-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Closes #4567 

Run tests:
- CI (ci.yml): [success example](https://github.com/joycebrum/pybind11/actions/runs/4948449656)
- Config (configure.yml): [success example](https://github.com/joycebrum/pybind11/actions/runs/4938469409)
- Format (format.yml): [success example](https://github.com/joycebrum/pybind11/actions/runs/4938455257)
- Labeler (labeler.yml): [success example](https://github.com/joycebrum/pybind11/actions/runs/4948451571); [PR labeled](https://github.com/joycebrum/pybind11/pull/1) (I’ve tested without the if clause just to simplify the test case)
- Pip (pip.yml): [success example](https://github.com/joycebrum/pybind11/actions/runs/4938453918). It skipped the Upload to PyPi step which does not seems to need any more github permission than contents: read
- Upstream (upstream.yml): [succes example](https://github.com/joycebrum/pybind11/actions/runs/4940975803)

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Set minimal permission to GitHub Workflows
```

<!-- If the upgrade guide needs updating, note that here too -->
