### PR TITLE
Python 3.11+: Add `__notes__` to `error_already_set::what()` output.

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,4 +1,3 @@
-
 name: Upstream
 
 on:
@@ -65,8 +64,8 @@ jobs:
     - name: Python tests C++11
       run: cmake --build build11 --target pytest -j 2
 
-    # - name: C++11 tests
-    #   run: cmake --build build11  --target cpptest -j 2
+    - name: C++11 tests
+      run: cmake --build build11  --target cpptest -j 2
 
     - name: Interface test C++11
       run: cmake --build build11 --target test_cmake_build
@@ -86,8 +85,8 @@ jobs:
     - name: Python tests
       run: cmake --build build17 --target pytest
 
-    # - name: C++ tests
-    #   run: cmake --build build17 --target cpptest
+    - name: C++ tests
+      run: cmake --build build17 --target cpptest
 
     # Third build - C++17 mode with unstable ABI
     - name: Configure (unstable ABI)

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,3 +1,4 @@
+
 name: Upstream
 
 on:
@@ -64,8 +65,8 @@ jobs:
     - name: Python tests C++11
       run: cmake --build build11 --target pytest -j 2
 
-    - name: C++11 tests
-      run: cmake --build build11  --target cpptest -j 2
+    # - name: C++11 tests
+    #   run: cmake --build build11  --target cpptest -j 2
 
     - name: Interface test C++11
       run: cmake --build build11 --target test_cmake_build
@@ -85,8 +86,8 @@ jobs:
     - name: Python tests
       run: cmake --build build17 --target pytest
 
-    - name: C++ tests
-      run: cmake --build build17 --target cpptest
+    # - name: C++ tests
+    #   run: cmake --build build17 --target cpptest
 
     # Third build - C++17 mode with unstable ABI
     - name: Configure (unstable ABI)

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -471,6 +471,14 @@ inline const char *obj_class_name(PyObject *obj) {
 
 std::string error_string();
 
+// The code in this struct is very unusual, to minimize the chances of
+// masking bugs (elsewhere) by errors during the error handling (here).
+// This is meant to be a lifeline for troubleshooting long-running processes
+// that crash under conditions that are virtually impossible to reproduce.
+// Low-level implementation alternatives are preferred to higher-level ones
+// that might raise cascading exceptions. Last-ditch-kind-of attempts are made
+// to report as much of the original error as possible, even if there are
+// secondary issues obtaining some of the details.
 struct error_fetch_and_normalize {
     // This comment only applies to Python <= 3.11:
     //     Immediate normalization is long-established behavior (starting with

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -331,7 +331,9 @@ def _test_flaky_exception_failure_point_init_before_py_3_12():
     # Checking the first two lines of the traceback as formatted in error_string():
     assert "test_exceptions.py(" in lines[3]
     assert lines[3].endswith("): __init__")
-    assert lines[4].endswith("): test_flaky_exception_failure_point_init")
+    assert lines[4].endswith(
+        "): _test_flaky_exception_failure_point_init_before_py_3_12"
+    )
 
 
 def _test_flaky_exception_failure_point_init_py_3_12():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -317,13 +317,7 @@ def test_error_already_set_what_with_happy_exceptions(
     assert what == expected_what
 
 
-@pytest.mark.skipif(
-    # Intentionally very specific:
-    "sys.version_info == (3, 12, 0, 'alpha', 7)",
-    reason="WIP: https://github.com/python/cpython/issues/102594",
-)
-@pytest.mark.skipif("env.PYPY", reason="PyErr_NormalizeException Segmentation fault")
-def test_flaky_exception_failure_point_init():
+def _test_flaky_exception_failure_point_init_before_py_3_12():
     with pytest.raises(RuntimeError) as excinfo:
         m.error_already_set_what(FlakyException, ("failure_point_init",))
     lines = str(excinfo.value).splitlines()
@@ -338,6 +332,30 @@ def test_flaky_exception_failure_point_init():
     assert "test_exceptions.py(" in lines[3]
     assert lines[3].endswith("): __init__")
     assert lines[4].endswith("): test_flaky_exception_failure_point_init")
+
+
+def _test_flaky_exception_failure_point_init_py_3_12():
+    # Behavior change in Python 3.12: https://github.com/python/cpython/issues/102594
+    what, py_err_set_after_what = m.error_already_set_what(
+        FlakyException, ("failure_point_init",)
+    )
+    assert not py_err_set_after_what
+    lines = what.splitlines()
+    assert lines[0].endswith("ValueError[WITH __notes__]: triggered_failure_point_init")
+    assert lines[1] == "__notes__ (len=1):"
+    assert "Normalization failed:" in lines[2]
+    assert "FlakyException" in lines[2]
+
+
+@pytest.mark.skipif(
+    "env.PYPY and sys.version_info[:2] < (3, 12)",
+    reason="PyErr_NormalizeException Segmentation fault",
+)
+def test_flaky_exception_failure_point_init():
+    if sys.version_info[:2] < (3, 12):
+        _test_flaky_exception_failure_point_init_before_py_3_12()
+    else:
+        _test_flaky_exception_failure_point_init_py_3_12()
 
 
 def test_flaky_exception_failure_point_str():


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The original motivation for this PR was to account for a a fairly major behavior change in Python 3.12:

* https://github.com/python/cpython/issues/102594

Python 3.12 `PyErr_Fetch()` normalizes exceptions immediately and tracks any normalization errors under `__notes__`:

* https://github.com/python/cpython/pull/102675/files

`__notes__` were introduced already with Python 3.11, but this was not reflected in pybind11 until now. Adding them to the `error_already_set::what()` output therefore catches up with Python developments in general, and ensures that exception normalization errors continue to be obvious.

A highly technical detail for completeness:

The `FAILURE obtaining` and `FAILURE formatting` conditions are impractical to exercise in the usual way via unit tests, but a manual pass was made exercising them with temporary tweaks.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Python exception ``__notes__`` (introduced with Python 3.11) are now added to the ``error_already_set::what()`` output.
```

<!-- If the upgrade guide needs updating, note that here too -->
