### PR TITLE
Use annotated for array

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -276,8 +276,8 @@ public:
                          const_name<Resizable>(const_name(""), const_name("Annotated["))
                              + const_name("List[") + value_conv::name + const_name("]")
                              + const_name<Resizable>(const_name(""),
-                                                     const_name(", ") + const_name<Size>()
-                                                         + const_name("]")));
+                                                     const_name(", FixedSize(") + const_name<Size>()
+                                                         + const_name(")]")));
 };
 
 template <typename Type, size_t Size>

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -276,8 +276,8 @@ public:
                          const_name<Resizable>(const_name(""), const_name("Annotated["))
                              + const_name("List[") + value_conv::name + const_name("]")
                              + const_name<Resizable>(const_name(""),
-                                                     const_name(", FixedSize(") + const_name<Size>()
-                                                         + const_name(")]")));
+                                                     const_name(", FixedSize(")
+                                                         + const_name<Size>() + const_name(")]")));
 };
 
 template <typename Type, size_t Size>

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -276,7 +276,8 @@ public:
                          const_name<Resizable>(const_name(""), const_name("Annotated["))
                              + const_name("List[") + value_conv::name + const_name("]")
                              + const_name<Resizable>(const_name(""),
-                                                     const_name(", ") + const_name<Size>() + const_name("]")));
+                                                     const_name(", ") + const_name<Size>()
+                                                         + const_name("]")));
 };
 
 template <typename Type, size_t Size>

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -273,11 +273,10 @@ public:
     }
 
     PYBIND11_TYPE_CASTER(ArrayType,
-                         const_name("List[") + value_conv::name
+                         const_name("Annotated[List[") + value_conv::name
                              + const_name<Resizable>(const_name(""),
-                                                     const_name("[") + const_name<Size>()
-                                                         + const_name("]"))
-                             + const_name("]"));
+                                                     const_name("], ") + const_name<Size>()
+                                                         + const_name("]")));
 };
 
 template <typename Type, size_t Size>

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -273,10 +273,10 @@ public:
     }
 
     PYBIND11_TYPE_CASTER(ArrayType,
-                         const_name("Annotated[List[") + value_conv::name
+                         const_name<Resizable>(const_name(""), const_name("Annotated["))
+                             + const_name("List[") + value_conv::name + const_name("]")
                              + const_name<Resizable>(const_name(""),
-                                                     const_name("], ") + const_name<Size>()
-                                                         + const_name("]")));
+                                                     const_name(", ") + const_name<Size>() + const_name("]")));
 };
 
 template <typename Type, size_t Size>

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -39,8 +39,8 @@ def test_array(doc):
     assert m.load_array(lst)
     assert m.load_array(tuple(lst))
 
-    assert doc(m.cast_array) == "cast_array() -> Annotated[List[int], 2]"
-    assert doc(m.load_array) == "load_array(arg0: Annotated[List[int], 2]) -> bool"
+    assert doc(m.cast_array) == "cast_array() -> Annotated[List[int], FixedSize(2)]"
+    assert doc(m.load_array) == "load_array(arg0: Annotated[List[int], FixedSize(2)]) -> bool"
 
 
 def test_valarray(doc):

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -39,8 +39,8 @@ def test_array(doc):
     assert m.load_array(lst)
     assert m.load_array(tuple(lst))
 
-    assert doc(m.cast_array) == "cast_array() -> List[int[2]]"
-    assert doc(m.load_array) == "load_array(arg0: List[int[2]]) -> bool"
+    assert doc(m.cast_array) == "cast_array() -> Annotated[List, 2]"
+    assert doc(m.load_array) == "load_array(arg0: Annotated[List, 2]) -> bool"
 
 
 def test_valarray(doc):

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -51,7 +51,9 @@ def test_valarray(doc):
     assert m.load_valarray(tuple(lst))
 
     assert doc(m.cast_valarray) == "cast_valarray() -> Annotated[List[int], 3]"
-    assert doc(m.load_valarray) == "load_valarray(arg0: Annotated[List[int], 3]) -> bool"
+    assert (
+        doc(m.load_valarray) == "load_valarray(arg0: Annotated[List[int], 3]) -> bool"
+    )
 
 
 def test_map(doc):

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -39,8 +39,8 @@ def test_array(doc):
     assert m.load_array(lst)
     assert m.load_array(tuple(lst))
 
-    assert doc(m.cast_array) == "cast_array() -> Annotated[List, 2]"
-    assert doc(m.load_array) == "load_array(arg0: Annotated[List, 2]) -> bool"
+    assert doc(m.cast_array) == "cast_array() -> Annotated[List[int], 2]"
+    assert doc(m.load_array) == "load_array(arg0: Annotated[List[int], 2]) -> bool"
 
 
 def test_valarray(doc):
@@ -50,8 +50,8 @@ def test_valarray(doc):
     assert m.load_valarray(lst)
     assert m.load_valarray(tuple(lst))
 
-    assert doc(m.cast_valarray) == "cast_valarray() -> List[int]"
-    assert doc(m.load_valarray) == "load_valarray(arg0: List[int]) -> bool"
+    assert doc(m.cast_valarray) == "cast_valarray() -> Annotated[List[int], 3]"
+    assert doc(m.load_valarray) == "load_valarray(arg0: Annotated[List[int], 3]) -> bool"
 
 
 def test_map(doc):

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -40,7 +40,10 @@ def test_array(doc):
     assert m.load_array(tuple(lst))
 
     assert doc(m.cast_array) == "cast_array() -> Annotated[List[int], FixedSize(2)]"
-    assert doc(m.load_array) == "load_array(arg0: Annotated[List[int], FixedSize(2)]) -> bool"
+    assert (
+        doc(m.load_array)
+        == "load_array(arg0: Annotated[List[int], FixedSize(2)]) -> bool"
+    )
 
 
 def test_valarray(doc):

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -50,10 +50,8 @@ def test_valarray(doc):
     assert m.load_valarray(lst)
     assert m.load_valarray(tuple(lst))
 
-    assert doc(m.cast_valarray) == "cast_valarray() -> Annotated[List[int], 3]"
-    assert (
-        doc(m.load_valarray) == "load_valarray(arg0: Annotated[List[int], 3]) -> bool"
-    )
+    assert doc(m.cast_valarray) == "cast_valarray() -> List[int]"
+    assert doc(m.load_valarray) == "load_valarray(arg0: List[int]) -> bool"
 
 
 def test_map(doc):


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Addressed https://github.com/pybind/pybind11/pull/3916#discussion_r1001030269 Fixes #3912 


## Suggested changelog entry:

```rst
* Fixes docstring generation for ``std::array``-list caster. Previously, signatures included the size of the list in a non-standard, non-spec compliant way. The new format conforms to PEP 593. **Tooling for processing the docstrings may need to be updated accordingly.**
```

(oh I copy-pasted 3916)

<!-- If the upgrade guide needs updating, note that here too -->

----

/cc @Skylion007 
/cc @felixvd