### PR TITLE
Tiny Proof Of Concept: `type_fingerprint()` to support safely passing C++ pointers between Python extensions.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,6 +155,7 @@ set(PYBIND11_TEST_FILES
     test_tagbased_polymorphic
     test_thread
     test_type_caster_pyobject_ptr
+    test_type_fingerprint
     test_union
     test_unnamed_namespace_a
     test_unnamed_namespace_b

--- a/tests/test_type_fingerprint.cpp
+++ b/tests/test_type_fingerprint.cpp
@@ -1,0 +1,17 @@
+#include "pybind11_tests.h"
+
+#define PYBIND11_PLATFORM_ABI_KEY                                                                 \
+    PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI PYBIND11_BUILD_TYPE
+
+namespace {
+namespace poc {
+
+template <typename T>
+std::string type_fingerprint() {
+    return std::string(typeid(T).name()) + " " PYBIND11_PLATFORM_ABI_KEY;
+}
+
+} // namespace poc
+} // namespace
+
+TEST_SUBMODULE(type_fingerprint, m) { m.def("std_string", poc::type_fingerprint<std::string>); }

--- a/tests/test_type_fingerprint.py
+++ b/tests/test_type_fingerprint.py
@@ -1,0 +1,7 @@
+import pytest
+
+from pybind11_tests import type_fingerprint as m
+
+
+def test_std_string():
+    pytest.skip(f"SHOW: {m.std_string()}")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This PR is only to have a public record of the simple idea.
 
High-level idea: Pass C++ pointers via Python capsules between **any** wrapping system (SWIG, pybind11, nanobind, ..., manually written).

All those systems would have to standardize on

* the same "finger print",

* names for methods to request a Python capsule (e.g. `__cpp_raw_ptr__`, `__cpp_unique_ptr__`, `__cpp_shared_ptr__`).

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
