### PR TITLE
Systematically add `PIP_BREAK_SYSTEM_PACKAGES` to all .yml files from which pip is called.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,17 +455,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        container_suffix:
+          - ""
         include:
           - { gcc: 7, std: 11 }
           - { gcc: 7, std: 17 }
           - { gcc: 8, std: 14 }
           - { gcc: 8, std: 17 }
-          - { gcc: 10, std: 17 }
+          - { gcc: 10, std: 17, container_suffix: "-bullseye" }
           - { gcc: 11, std: 20 }
           - { gcc: 12, std: 20 }
 
     name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }}• x64"
-    container: "gcc:${{ matrix.gcc }}"
+    container: "gcc:${{ matrix.gcc }}${{ matrix.container_suffix }}"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
   PIP_ONLY_BINARY: numpy
   FORCE_COLOR: 3
   PYTEST_TIMEOUT: 300

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,16 +455,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container_suffix:
-          - ""
         include:
-          - { gcc: 7, std: 11 }
-          - { gcc: 7, std: 17 }
-          - { gcc: 8, std: 14 }
-          - { gcc: 8, std: 17 }
+          - { gcc: 7, std: 11, container_suffix: "" }
+          - { gcc: 7, std: 17, container_suffix: "" }
+          - { gcc: 8, std: 14, container_suffix: "" }
+          - { gcc: 8, std: 17, container_suffix: "" }
           - { gcc: 10, std: 17, container_suffix: "-bullseye" }
-          - { gcc: 11, std: 20 }
-          - { gcc: 12, std: 20 }
+          - { gcc: 11, std: 20, container_suffix: "" }
+          - { gcc: 12, std: 20, container_suffix: "" }
 
     name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }}• x64"
     container: "gcc:${{ matrix.gcc }}${{ matrix.container_suffix }}"

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -13,6 +13,7 @@ permissions:
   contents: read
 
 env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
   # For cmake:
   VERBOSE: 1
 

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
 
 env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
   PIP_ONLY_BINARY: numpy
 
 jobs:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
   PIP_ONLY_BINARY: ":all:"
   # For cmake:
   VERBOSE: 1


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
See e.g. https://veronneau.org/python-311-pip-and-breaking-system-packages.html for background.

Currently `PIP_BREAK_SYSTEM_PACKAGES` is really only needed in ci.yml, but pro-actively setting it everywhere pip is called, so we don't have to come back here repeatedly in the future.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
