### PR TITLE
chore: 3.12 + cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
+        - '3.12'
         - 'pypy-3.7'
         - 'pypy-3.8'
         - 'pypy-3.9'
@@ -74,6 +75,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
+        allow-prereleases: true
 
     - name: Setup Boost (Linux)
       # Can't use boost + define _

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,7 @@ repos:
     - markdown-it-py<3 # Drop this together with dropping Python 3.7 support.
     - nox
     - rich
+    - types-setuptools
 
 # CMake formatting
 - repo: https://github.com/cheshirekow/cmake-format-precommit

--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -66,8 +66,8 @@ try:
     from setuptools import Extension as _Extension
     from setuptools.command.build_ext import build_ext as _build_ext
 except ImportError:
-    from distutils.command.build_ext import build_ext as _build_ext
-    from distutils.extension import Extension as _Extension
+    from distutils.command.build_ext import build_ext as _build_ext  # type: ignore[assignment]
+    from distutils.extension import Extension as _Extension  # type: ignore[assignment]
 
 import distutils.ccompiler
 import distutils.errors
@@ -84,7 +84,7 @@ STD_TMPL = "/std:c++{}" if WIN else "-std=c++{}"
 # directory into your path if it sits beside your setup.py.
 
 
-class Pybind11Extension(_Extension):  # type: ignore[misc]
+class Pybind11Extension(_Extension):
     """
     Build a C++11+ Extension module with pybind11. This automatically adds the
     recommended flags when you init the extension and assumes C++ sources - you
@@ -266,7 +266,7 @@ def auto_cpp_level(compiler: Any) -> Union[str, int]:
     raise RuntimeError(msg)
 
 
-class build_ext(_build_ext):  # type: ignore[misc] # noqa: N801
+class build_ext(_build_ext):  # noqa: N801
     """
     Customized build_ext that allows an auto-search for the highest supported
     C++ level for Pybind11Extension. This is only needed for the auto-search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = ["setuptools>=42", "cmake>=3.18", "ninja"]
 build-backend = "setuptools.build_meta"
 
+
 [tool.check-manifest]
 ignore = [
     "tests/**",
@@ -15,6 +16,7 @@ ignore = [
     "noxfile.py",
 ]
 
+
 [tool.mypy]
 files = ["pybind11"]
 python_version = "3.6"
@@ -24,7 +26,7 @@ enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 
 [[tool.mypy.overrides]]
-module = ["ghapi.*", "setuptools.*"]
+module = ["ghapi.*"]
 ignore_missing_imports = true
 
 
@@ -55,10 +57,11 @@ messages_control.disable = [
   "unused-argument",  # covered by Ruff ARG
 ]
 
+
 [tool.ruff]
 select = [
   "E", "F", "W", # flake8
-  "B",  "B904",  # flake8-bugbear
+  "B",           # flake8-bugbear
   "I",           # isort
   "N",           # pep8-naming
   "ARG",         # flake8-unused-arguments
@@ -77,14 +80,13 @@ select = [
   "YTT",         # flake8-2020
 ]
 ignore = [
-  "PLR",   # Design related pylint
-  "E501",  # Line too long (Black is enough)
-  "PT011", # Too broad with raises in pytest
-  "PT004", # Fixture that doesn't return needs underscore (no, it is fine)
-  "SIM118",# iter(x) is not always the same as iter(x.keys())
+  "PLR",    # Design related pylint
+  "E501",   # Line too long (Black is enough)
+  "PT011",  # Too broad with raises in pytest
+  "PT004",  # Fixture that doesn't return needs underscore (no, it is fine)
+  "SIM118", # iter(x) is not always the same as iter(x.keys())
 ]
 target-version = "py37"
-typing-modules = ["scikit_build_core._compat.typing"]
 src = ["src"]
 unfixable = ["T20"]
 exclude = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: Implementation :: PyPy
     Programming Language :: Python :: Implementation :: CPython

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ def get_and_replace(
 
 # Use our input files instead when making the SDist (and anything that depends
 # on it, like a wheel)
-class SDist(setuptools.command.sdist.sdist):  # type: ignore[misc]
+class SDist(setuptools.command.sdist.sdist):
     def make_release_tree(self, base_dir: str, files: List[str]) -> None:
         super().make_release_tree(base_dir, files)
 


### PR DESCRIPTION
Signed-off-by: Henry Schreiner <henryschreineriii@gmail.com>

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Some cleanup and adding Python 3.12 to our normal test suite & classifiers.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Test on Python 3.12's betas
```

<!-- If the upgrade guide needs updating, note that here too -->
