### PR TITLE
Undo ci.yml gcc10 workaround after docker-library/gcc#95 was resolved.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,16 +458,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { gcc: 7, std: 11, container_suffix: "" }
-          - { gcc: 7, std: 17, container_suffix: "" }
-          - { gcc: 8, std: 14, container_suffix: "" }
-          - { gcc: 8, std: 17, container_suffix: "" }
-          - { gcc: 10, std: 17, container_suffix: "-bullseye" }
-          - { gcc: 11, std: 20, container_suffix: "" }
-          - { gcc: 12, std: 20, container_suffix: "" }
+          - { gcc: 7, std: 11 }
+          - { gcc: 7, std: 17 }
+          - { gcc: 8, std: 14 }
+          - { gcc: 8, std: 17 }
+          - { gcc: 10, std: 17 }
+          - { gcc: 11, std: 20 }
+          - { gcc: 12, std: 20 }
 
     name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }}• x64"
-    container: "gcc:${{ matrix.gcc }}${{ matrix.container_suffix }}"
+    container: "gcc:${{ matrix.gcc }}"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The gcc10 workaround was introduced with PR #4705.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
