### PR TITLE
Trivial refactoring to make the capsule API more user friendly.

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -508,8 +508,8 @@ protected:
             rec->def->ml_flags = METH_VARARGS | METH_KEYWORDS;
 
             capsule rec_capsule(unique_rec.release(),
+                                detail::get_function_record_capsule_name(),
                                 [](void *ptr) { destruct((detail::function_record *) ptr); });
-            rec_capsule.set_name(detail::get_function_record_capsule_name());
             guarded_strdup.release();
 
             object scope_module;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -260,6 +260,15 @@ TEST_SUBMODULE(pytypes, m) {
         });
     });
 
+    m.def("return_capsule_with_destructor_3", []() {
+        py::print("creating capsule");
+        auto cap = py::capsule((void *) 1233, "oname", [](void *ptr) {
+            py::print("destructing capsule: {}"_s.format((size_t) ptr));
+        });
+        py::print("original name: {}"_s.format(cap.name()));
+        return cap;
+    });
+
     m.def("return_renamed_capsule_with_destructor_2", []() {
         py::print("creating capsule");
         auto cap = py::capsule((void *) 1234, [](void *ptr) {

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -320,6 +320,19 @@ def test_capsule(capture):
     )
 
     with capture:
+        a = m.return_capsule_with_destructor_3()
+        del a
+        pytest.gc_collect()
+    assert (
+        capture.unordered
+        == """
+        creating capsule
+        destructing capsule: 1233
+        original name: oname
+    """
+    )
+
+    with capture:
         a = m.return_renamed_capsule_with_destructor_2()
         del a
         pytest.gc_collect()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Enable
```
return py::capsule(ptr, "name", dtor);
```
vs
```
py::capsule cap(ptr, dtor);
cap.set_name("name");
return cap;
```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
The ``capsule`` API gained a user-friendly constructor (``py::capsule(ptr, "name", dtor)``).
```

<!-- If the upgrade guide needs updating, note that here too -->
