### PR TITLE
array_t: overload `operator()` for multi-dim indexing

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1110,6 +1110,20 @@ public:
                  + byte_offset(ssize_t(index)...) / itemsize());
     }
 
+    // const-reference to element at a given index without bounds checking
+    template <typename... Ix>
+    const T &operator()(Ix... index) const {
+        return *(static_cast<const T *>(array::data())
+                 + byte_offset(ssize_t(index)...) / itemsize());
+    }
+
+    // mutable reference to element at a given index without bounds checking
+    template <typename... Ix>
+    T &operator()(Ix... index) {
+        return *(static_cast<T *>(array::mutable_data())
+                 + byte_offset(ssize_t(index)...) / itemsize());
+    }
+
     /**
      * Returns a proxy object that provides access to the array's data without bounds or
      * dimensionality checking.  Will throw if the array is missing the `writeable` flag.  Use with


### PR DESCRIPTION
## Description

Currently, the class `array_t` supports direct subscripting via:
```cpp
template<typename... Ix> const T& at(Ix... index) const;
template<typename... Ix>       T& mutable_at(Ix... index); 
```
both of these check bounds and have a specific name. 

This PR proposes to overload `operator()`:
```cpp
template<typename... Ix>  const T& operator()(Ix... index) const;
template<typename... Ix>        T& operator()(Ix... index);
```

This would make it easier to write generic functions like this:
```cpp

template<class T>
void foo(T & matrix){
  matrix(0,1) = 454.;
}

void caller_cpp(){
  Eigen::MatrixXd A(10,11);
  foo(A);
}

using eigen_mat_layleft_t = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
using eigen_ref_mat_layleft_t = Eigen::Ref<eigen_mat_layleft_t>;

void caller_py(eigen_ref_mat_layleft_t & mat){
  foo(mat);
}
```


## Suggested changelog entry:

```rst
TBD
```