### PR TITLE
Warning on comparing wrapper enums with is

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -549,3 +549,7 @@ The ``name`` property returns the name of the enum value as a unicode string.
            ...
 
     By default, these are omitted to conserve space.
+
+.. warning::
+
+    Contrary to Python customs, enum values from the wrappers should not be compared using "is", but with "==".

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -552,4 +552,4 @@ The ``name`` property returns the name of the enum value as a unicode string.
 
 .. warning::
 
-    Contrary to Python customs, enum values from the wrappers should not be compared using "is", but with "==".
+    Contrary to Python customs, enum values from the wrappers should not be compared using ``is``, but with ``==`` (see `#1177 <https://github.com/pybind/pybind11/issues/1177>`_ for background).


### PR DESCRIPTION
Added warning to docs on comparing wrapped enums with "is", which is customary in Python.