### PR TITLE
Remove newlines from docstring signature

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -74,8 +74,9 @@ inline std::string replace_newlines_and_squash(const char *text) {
 
     // Strip leading and trailing whitespaces
     const size_t str_begin = result.find_first_not_of(whitespaces);
-    if (str_begin == std::string::npos)
+    if (str_begin == std::string::npos) {
         return "";
+    }
 
     const size_t str_end = result.find_last_not_of(whitespaces);
     const size_t str_range = str_end - str_begin + 1;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -54,12 +54,20 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 
 inline std::string replace_newlines_and_squash(const char *text) {
     const char *whitespaces = " \t\n\r\f\v";
-    std::string result;
+    std::string result(text);
     bool previous_is_whitespace = false;
+
+    // Do not modify string representations
+    char first_char = result[0];
+    char last_char = result[result.size() - 1];
+    if (first_char == last_char && first_char == '\'') {
+        return result;
+    }
+    result.clear();
 
     // Replace characters in whitespaces array with spaces and squash consecutive spaces
     while (*text != '\0') {
-        if (strchr(whitespaces, *text)) {
+        if (std::strchr(whitespaces, *text)) {
             if (!previous_is_whitespace) {
                 result += ' ';
                 previous_is_whitespace = true;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -52,9 +52,8 @@ PYBIND11_WARNING_DISABLE_MSVC(4127)
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-constexpr const char *whitespaces = " \t\n\r\f\v";
-
 inline std::string replace_newlines_and_squash(const char *text) {
+    const char *whitespaces = " \t\n\r\f\v";
     std::string result;
     bool previous_is_whitespace = false;
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -56,7 +56,7 @@ inline std::string replaceNewlinesAndSquash(const char *text) {
     std::string result;
 
     // Replace newlines with spaces and squash consecutive spaces
-    while (*text) {
+    while (*text != '\0') {
         if (*text == '\n') {
             result += ' ';
             while (*(text + 1) == ' ') {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -462,6 +462,7 @@ protected:
             pybind11_fail("Internal error while parsing type signature (2)");
         }
 
+        signature.erase(std::remove(signature.begin(), signature.end(), '\n'), signature.end());
         rec->signature = guarded_strdup(signature.c_str());
         rec->args.shrink_to_fit();
         rec->nargs = (std::uint16_t) args;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -68,15 +68,23 @@ inline std::string replaceNewlinesAndSquash(const char *text) {
         ++text;
     }
 
-    // Strip leading and trailing spaces
-    result.erase(result.begin(), std::find_if(result.begin(), result.end(), [](unsigned char ch) {
-                     return !std::isspace(ch);
-                 }));
-    result.erase(std::find_if(result.rbegin(),
-                              result.rend(),
-                              [](unsigned char ch) { return !std::isspace(ch); })
-                     .base(),
-                 result.end());
+    // Strip leading spaces
+    size_t firstNonSpace = result.find_first_not_of(" \t\n\r\f\v");
+
+    if (firstNonSpace != std::string::npos) {
+        result.erase(0, firstNonSpace);
+    } else {
+        result.clear();
+    }
+
+    // Strip trailing spaces
+    size_t lastNonSpace = result.find_last_not_of(" \t\n\r\f\v");
+
+    if (lastNonSpace != std::string::npos) {
+        result.erase(lastNonSpace + 1);
+    } else {
+        result.clear();
+    }
 
     return result;
 }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -52,7 +52,7 @@ PYBIND11_WARNING_DISABLE_MSVC(4127)
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-inline std::string replaceNewlinesAndSquash(const char* text) {
+inline std::string replaceNewlinesAndSquash(const char *text) {
     std::string result;
 
     // Replace newlines with spaces and squash consecutive spaces
@@ -70,11 +70,13 @@ inline std::string replaceNewlinesAndSquash(const char* text) {
 
     // Strip leading and trailing spaces
     result.erase(result.begin(), std::find_if(result.begin(), result.end(), [](unsigned char ch) {
-        return !std::isspace(ch);
-    }));
-    result.erase(std::find_if(result.rbegin(), result.rend(), [](unsigned char ch) {
-        return !std::isspace(ch);
-    }).base(), result.end());
+                     return !std::isspace(ch);
+                 }));
+    result.erase(std::find_if(result.rbegin(),
+                              result.rend(),
+                              [](unsigned char ch) { return !std::isspace(ch); })
+                     .base(),
+                 result.end());
 
     return result;
 }

--- a/tests/test_eigen_matrix.cpp
+++ b/tests/test_eigen_matrix.cpp
@@ -340,7 +340,7 @@ TEST_SUBMODULE(eigen_matrix, m) {
         Eigen::VectorXd defaultVector = Eigen::VectorXd::Ones(32);
         m.def(
             "defaults_vec", [](const Eigen::VectorXd &) {}, py::arg("vec") = defaultMatrix);
-    } catch (const py::error_already_set &ex) {
+    } catch (const py::error_already_set&) {
     }
     // test_sparse, test_sparse_signature
     m.def("sparse_r", [mat]() -> SparseMatrixR {

--- a/tests/test_eigen_matrix.cpp
+++ b/tests/test_eigen_matrix.cpp
@@ -331,7 +331,13 @@ TEST_SUBMODULE(eigen_matrix, m) {
     m.def("dense_copy_r", [](const DenseMatrixR &m) -> DenseMatrixR { return m; });
     m.def("dense_copy_c", [](const DenseMatrixC &m) -> DenseMatrixC { return m; });
     // test_defaults
+    bool have_numpy = true;
     try {
+        py::module_::import("numpy");
+    } catch (const py::error_already_set &) {
+        have_numpy = false;
+    }
+    if (have_numpy) {
         py::module_::import("numpy");
         Eigen::Matrix<double, 3, 3> defaultMatrix = Eigen::Matrix3d::Identity();
         m.def(
@@ -340,7 +346,6 @@ TEST_SUBMODULE(eigen_matrix, m) {
         Eigen::VectorXd defaultVector = Eigen::VectorXd::Ones(32);
         m.def(
             "defaults_vec", [](const Eigen::VectorXd &) {}, py::arg("vec") = defaultMatrix);
-    } catch (const py::error_already_set &) {
     }
     // test_sparse, test_sparse_signature
     m.def("sparse_r", [mat]() -> SparseMatrixR {

--- a/tests/test_eigen_matrix.cpp
+++ b/tests/test_eigen_matrix.cpp
@@ -340,7 +340,7 @@ TEST_SUBMODULE(eigen_matrix, m) {
         Eigen::VectorXd defaultVector = Eigen::VectorXd::Ones(32);
         m.def(
             "defaults_vec", [](const Eigen::VectorXd &) {}, py::arg("vec") = defaultMatrix);
-    } catch (const py::error_already_set&) {
+    } catch (const py::error_already_set &) {
     }
     // test_sparse, test_sparse_signature
     m.def("sparse_r", [mat]() -> SparseMatrixR {

--- a/tests/test_eigen_matrix.cpp
+++ b/tests/test_eigen_matrix.cpp
@@ -330,6 +330,16 @@ TEST_SUBMODULE(eigen_matrix, m) {
     m.def("dense_c", [mat]() -> DenseMatrixC { return DenseMatrixC(mat); });
     m.def("dense_copy_r", [](const DenseMatrixR &m) -> DenseMatrixR { return m; });
     m.def("dense_copy_c", [](const DenseMatrixC &m) -> DenseMatrixC { return m; });
+    // test_defaults
+    Eigen::Matrix<double, 3, 3> defaultMatrix = Eigen::Matrix3d::Identity();
+    m.def(
+        "defaults_mat", [](const Eigen::Matrix3d&) {},
+        py::arg("mat") = defaultMatrix);
+
+    Eigen::VectorXd defaultVector = Eigen::VectorXd::Ones(32);
+    m.def(
+        "defaults_vec", [](const Eigen::VectorXd&) {},
+        py::arg("vec") = defaultVector);
     // test_sparse, test_sparse_signature
     m.def("sparse_r", [mat]() -> SparseMatrixR {
         // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)

--- a/tests/test_eigen_matrix.cpp
+++ b/tests/test_eigen_matrix.cpp
@@ -333,13 +333,11 @@ TEST_SUBMODULE(eigen_matrix, m) {
     // test_defaults
     Eigen::Matrix<double, 3, 3> defaultMatrix = Eigen::Matrix3d::Identity();
     m.def(
-        "defaults_mat", [](const Eigen::Matrix3d&) {},
-        py::arg("mat") = defaultMatrix);
+        "defaults_mat", [](const Eigen::Matrix3d &) {}, py::arg("mat") = defaultMatrix);
 
     Eigen::VectorXd defaultVector = Eigen::VectorXd::Ones(32);
     m.def(
-        "defaults_vec", [](const Eigen::VectorXd&) {},
-        py::arg("vec") = defaultVector);
+        "defaults_vec", [](const Eigen::VectorXd &) {}, py::arg("vec") = defaultVector);
     // test_sparse, test_sparse_signature
     m.def("sparse_r", [mat]() -> SparseMatrixR {
         // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)

--- a/tests/test_eigen_matrix.cpp
+++ b/tests/test_eigen_matrix.cpp
@@ -331,13 +331,17 @@ TEST_SUBMODULE(eigen_matrix, m) {
     m.def("dense_copy_r", [](const DenseMatrixR &m) -> DenseMatrixR { return m; });
     m.def("dense_copy_c", [](const DenseMatrixC &m) -> DenseMatrixC { return m; });
     // test_defaults
-    Eigen::Matrix<double, 3, 3> defaultMatrix = Eigen::Matrix3d::Identity();
-    m.def(
-        "defaults_mat", [](const Eigen::Matrix3d &) {}, py::arg("mat") = defaultMatrix);
+    try {
+        py::module_::import("numpy");
+        Eigen::Matrix<double, 3, 3> defaultMatrix = Eigen::Matrix3d::Identity();
+        m.def(
+            "defaults_mat", [](const Eigen::Matrix3d &) {}, py::arg("mat") = defaultMatrix);
 
-    Eigen::VectorXd defaultVector = Eigen::VectorXd::Ones(32);
-    m.def(
-        "defaults_vec", [](const Eigen::VectorXd &) {}, py::arg("vec") = defaultVector);
+        Eigen::VectorXd defaultVector = Eigen::VectorXd::Ones(32);
+        m.def(
+            "defaults_vec", [](const Eigen::VectorXd &) {}, py::arg("vec") = defaultMatrix);
+    } catch (const py::error_already_set &ex) {
+    }
     // test_sparse, test_sparse_signature
     m.def("sparse_r", [mat]() -> SparseMatrixR {
         // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)

--- a/tests/test_eigen_matrix.py
+++ b/tests/test_eigen_matrix.py
@@ -716,6 +716,15 @@ def test_dense_signature(doc):
     )
 
 
+def test_defaults(doc):
+    assert (
+        '\n' not in str(doc(m.defaults_mat))
+    )
+    assert (
+        '\n' not in str(doc(m.defaults_vec))
+    )
+
+
 def test_named_arguments():
     a = np.array([[1.0, 2], [3, 4], [5, 6]])
     b = np.ones((2, 1))

--- a/tests/test_eigen_matrix.py
+++ b/tests/test_eigen_matrix.py
@@ -717,12 +717,8 @@ def test_dense_signature(doc):
 
 
 def test_defaults(doc):
-    assert (
-        '\n' not in str(doc(m.defaults_mat))
-    )
-    assert (
-        '\n' not in str(doc(m.defaults_vec))
-    )
+    assert "\n" not in str(doc(m.defaults_mat))
+    assert "\n" not in str(doc(m.defaults_vec))
 
 
 def test_named_arguments():

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -51,24 +51,34 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
         std::string __repr__() const { return repr_string; }
     };
 
-    py::class_<CustomRepr>(m, "CustomRepr").def(py::init<const std::string &>())
+    py::class_<CustomRepr>(m, "CustomRepr")
+        .def(py::init<const std::string &>())
         .def("__repr__", &CustomRepr::__repr__);
 
     m.def(
-        "kw_lb_func0", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("  Hello World!  "));
+        "kw_lb_func0",
+        [](const CustomRepr &) {},
+        py::arg("custom") = CustomRepr("  Hello World!  "));
     m.def(
-        "kw_lb_func1", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("  Hello\nWorld!  "));
+        "kw_lb_func1",
+        [](const CustomRepr &) {},
+        py::arg("custom") = CustomRepr("  Hello\nWorld!  "));
     m.def(
-        "kw_lb_func2", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("\n   Hello World!"));
+        "kw_lb_func2",
+        [](const CustomRepr &) {},
+        py::arg("custom") = CustomRepr("\n   Hello World!"));
     m.def(
-        "kw_lb_func3", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("Hello World!   \n"));
+        "kw_lb_func3",
+        [](const CustomRepr &) {},
+        py::arg("custom") = CustomRepr("Hello World!   \n"));
     m.def(
-        "kw_lb_func4", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("Hello\n\nWorld!"));
+        "kw_lb_func4",
+        [](const CustomRepr &) {},
+        py::arg("custom") = CustomRepr("Hello\n\nWorld!"));
     m.def(
         "kw_lb_func5", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("Hello  World!"));
     m.def(
         "kw_lb_func6", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr(" \t "));
-
 
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -81,6 +81,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
         py::arg("custom") = CustomRepr("array([[A, B],  [C, D]])"));
     m.def(
         "kw_lb_func6", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr(" \t "));
+    m.def("kw_lb_func7", [](const std::string &) {}, py::arg("str_arg") = "First line.\nSecond line.");
 
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -66,25 +66,25 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     m.def(
         "kw_lb_func2",
         [](const CustomRepr &) {},
-        py::arg("custom") = CustomRepr("\n   array([[A, B], [C, D]])"));
+        py::arg("custom") = CustomRepr("\v\n   array([[A, B], [C, D]])"));
     m.def(
         "kw_lb_func3",
         [](const CustomRepr &) {},
-        py::arg("custom") = CustomRepr("array([[A, B], [C, D]])   \n"));
+        py::arg("custom") = CustomRepr("array([[A, B], [C, D]])   \f\n"));
     m.def(
         "kw_lb_func4",
         [](const CustomRepr &) {},
-        py::arg("custom") = CustomRepr("array([[A, B],\n\n[C, D]])"));
+        py::arg("custom") = CustomRepr("array([[A, B],\n\f\n[C, D]])"));
     m.def(
         "kw_lb_func5",
         [](const CustomRepr &) {},
-        py::arg("custom") = CustomRepr("array([[A, B],  [C, D]])"));
+        py::arg("custom") = CustomRepr("array([[A, B],\r  [C, D]])"));
     m.def(
-        "kw_lb_func6", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr(" \t "));
+        "kw_lb_func6", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr(" \v\t "));
     m.def(
         "kw_lb_func7",
         [](const std::string &) {},
-        py::arg("str_arg") = "First line.\nSecond line.");
+        py::arg("str_arg") = "First line.\n  Second line.");
 
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -7,7 +7,6 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include <pybind11/eigen/matrix.h>
 #include <pybind11/stl.h>
 
 #include "constructor_stats.h"
@@ -54,6 +53,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     m.def(
         "kw_lb_func0", [](const CustomRepr &) {}, py::arg("custom") = defaultCustomRepr);
 
+<<<<<<< HEAD
     Eigen::Matrix<double, 3, 3> defaultMatrix = Eigen::Matrix3d::Identity();
     m.def(
         "kw_lb_func1", [](const Eigen::Matrix3d &) {}, py::arg("mat") = defaultMatrix);
@@ -62,6 +62,8 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     m.def(
         "kw_lb_func2", [](const Eigen::VectorXd &) {}, py::arg("vec") = defaultVector);
 
+=======
+>>>>>>> fea352cb (Separate Eigen tests)
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {
         PYBIND11_WARNING_PUSH

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -46,7 +46,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     struct CustomRepr {
         std::string repr_string;
 
-        CustomRepr(const std::string &repr) : repr_string(repr) {}
+        explicit CustomRepr(const std::string &repr) : repr_string(repr) {}
 
         std::string __repr__() const { return repr_string; }
     };
@@ -58,25 +58,27 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     m.def(
         "kw_lb_func0",
         [](const CustomRepr &) {},
-        py::arg("custom") = CustomRepr("  Hello World!  "));
+        py::arg("custom") = CustomRepr("  array([[A, B], [C, D]])  "));
     m.def(
         "kw_lb_func1",
         [](const CustomRepr &) {},
-        py::arg("custom") = CustomRepr("  Hello\nWorld!  "));
+        py::arg("custom") = CustomRepr("  array([[A, B],\n[C, D]])  "));
     m.def(
         "kw_lb_func2",
         [](const CustomRepr &) {},
-        py::arg("custom") = CustomRepr("\n   Hello World!"));
+        py::arg("custom") = CustomRepr("\n   array([[A, B], [C, D]])"));
     m.def(
         "kw_lb_func3",
         [](const CustomRepr &) {},
-        py::arg("custom") = CustomRepr("Hello World!   \n"));
+        py::arg("custom") = CustomRepr("array([[A, B], [C, D]])   \n"));
     m.def(
         "kw_lb_func4",
         [](const CustomRepr &) {},
-        py::arg("custom") = CustomRepr("Hello\n\nWorld!"));
+        py::arg("custom") = CustomRepr("array([[A, B],\n\n[C, D]])"));
     m.def(
-        "kw_lb_func5", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("Hello  World!"));
+        "kw_lb_func5",
+        [](const CustomRepr &) {},
+        py::arg("custom") = CustomRepr("array([[A, B],  [C, D]])"));
     m.def(
         "kw_lb_func6", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr(" \t "));
 

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -7,8 +7,8 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
-#include <pybind11/stl.h>
 #include <pybind11/eigen/matrix.h>
+#include <pybind11/stl.h>
 
 #include "constructor_stats.h"
 #include "pybind11_tests.h"
@@ -48,23 +48,19 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
         std::string __repr__() { return "line\nbreak"; }
     };
 
-    py::class_<CustomRepr>(m, "CustomRepr")
-        .def("__repr__", &CustomRepr::__repr__);
+    py::class_<CustomRepr>(m, "CustomRepr").def("__repr__", &CustomRepr::__repr__);
 
     CustomRepr defaultCustomRepr{};
     m.def(
-        "kw_lb_func0", [](const CustomRepr&) {},
-        py::arg("custom") = defaultCustomRepr);
+        "kw_lb_func0", [](const CustomRepr &) {}, py::arg("custom") = defaultCustomRepr);
 
     Eigen::Matrix<double, 3, 3> defaultMatrix = Eigen::Matrix3d::Identity();
     m.def(
-        "kw_lb_func1", [](const Eigen::Matrix3d&) {},
-        py::arg("mat") = defaultMatrix);
+        "kw_lb_func1", [](const Eigen::Matrix3d &) {}, py::arg("mat") = defaultMatrix);
 
     Eigen::VectorXd defaultVector = Eigen::VectorXd::Ones(32);
     m.def(
-        "kw_lb_func2", [](const Eigen::VectorXd&) {},
-        py::arg("vec") = defaultVector);
+        "kw_lb_func2", [](const Eigen::VectorXd &) {}, py::arg("vec") = defaultVector);
 
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -44,14 +44,31 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
 
     // test line breaks in default argument representation
     struct CustomRepr {
-        std::string __repr__() { return "line\nbreak"; }
+        std::string repr_string;
+
+        CustomRepr(const std::string &repr) : repr_string(repr) {}
+
+        std::string __repr__() const { return repr_string; }
     };
 
-    py::class_<CustomRepr>(m, "CustomRepr").def("__repr__", &CustomRepr::__repr__);
+    py::class_<CustomRepr>(m, "CustomRepr").def(py::init<const std::string &>())
+        .def("__repr__", &CustomRepr::__repr__);
 
-    CustomRepr defaultCustomRepr{};
     m.def(
-        "kw_lb_func0", [](const CustomRepr &) {}, py::arg("custom") = defaultCustomRepr);
+        "kw_lb_func0", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("  Hello World!  "));
+    m.def(
+        "kw_lb_func1", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("  Hello\nWorld!  "));
+    m.def(
+        "kw_lb_func2", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("\n   Hello World!"));
+    m.def(
+        "kw_lb_func3", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("Hello World!   \n"));
+    m.def(
+        "kw_lb_func4", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("Hello\n\nWorld!"));
+    m.def(
+        "kw_lb_func5", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr("Hello  World!"));
+    m.def(
+        "kw_lb_func6", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr(" \t "));
+
 
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -81,7 +81,10 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
         py::arg("custom") = CustomRepr("array([[A, B],  [C, D]])"));
     m.def(
         "kw_lb_func6", [](const CustomRepr &) {}, py::arg("custom") = CustomRepr(" \t "));
-    m.def("kw_lb_func7", [](const std::string &) {}, py::arg("str_arg") = "First line.\nSecond line.");
+    m.def(
+        "kw_lb_func7",
+        [](const std::string &) {},
+        py::arg("str_arg") = "First line.\nSecond line.");
 
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -53,17 +53,6 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     m.def(
         "kw_lb_func0", [](const CustomRepr &) {}, py::arg("custom") = defaultCustomRepr);
 
-<<<<<<< HEAD
-    Eigen::Matrix<double, 3, 3> defaultMatrix = Eigen::Matrix3d::Identity();
-    m.def(
-        "kw_lb_func1", [](const Eigen::Matrix3d &) {}, py::arg("mat") = defaultMatrix);
-
-    Eigen::VectorXd defaultVector = Eigen::VectorXd::Ones(32);
-    m.def(
-        "kw_lb_func2", [](const Eigen::VectorXd &) {}, py::arg("vec") = defaultVector);
-
-=======
->>>>>>> fea352cb (Separate Eigen tests)
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {
         PYBIND11_WARNING_PUSH

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <pybind11/stl.h>
+#include <pybind11/eigen/matrix.h>
 
 #include "constructor_stats.h"
 #include "pybind11_tests.h"
@@ -41,6 +42,29 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
 
     m.def("kw_func_udl", kw_func, "x"_a, "y"_a = 300);
     m.def("kw_func_udl_z", kw_func, "x"_a, "y"_a = 0);
+
+    // test line breaks in default argument representation
+    struct CustomRepr {
+        std::string __repr__() { return "line\nbreak"; }
+    };
+
+    py::class_<CustomRepr>(m, "CustomRepr")
+        .def("__repr__", &CustomRepr::__repr__);
+
+    CustomRepr defaultCustomRepr{};
+    m.def(
+        "kw_lb_func0", [](const CustomRepr&) {},
+        py::arg("custom") = defaultCustomRepr);
+
+    Eigen::Matrix<double, 3, 3> defaultMatrix = Eigen::Matrix3d::Identity();
+    m.def(
+        "kw_lb_func1", [](const Eigen::Matrix3d&) {},
+        py::arg("mat") = defaultMatrix);
+
+    Eigen::VectorXd defaultVector = Eigen::VectorXd::Ones(32);
+    m.def(
+        "kw_lb_func2", [](const Eigen::VectorXd&) {},
+        py::arg("vec") = defaultVector);
 
     // test_args_and_kwargs
     m.def("args_function", [](py::args args) -> py::tuple {

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -27,12 +27,9 @@ def test_function_signatures(doc):
         doc(m.kw_lb_func0)
         == "kw_lb_func0(custom: m.kwargs_and_defaults.CustomRepr = line break) -> None"
     )
-    assert (
-        '\n' not in str(doc(m.kw_lb_func1))
-    )
-    assert (
-        '\n' not in str(doc(m.kw_lb_func2))
-    )
+    assert "\n" not in str(doc(m.kw_lb_func1))
+    assert "\n" not in str(doc(m.kw_lb_func2))
+
 
 def test_named_arguments():
     assert m.kw_func0(5, 10) == "x=5, y=10"

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -25,27 +25,27 @@ def test_function_signatures(doc):
     )
     assert (
         doc(m.kw_lb_func0)
-        == "kw_lb_func0(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+        == "kw_lb_func0(custom: m.kwargs_and_defaults.CustomRepr = array([[A, B], [C, D]])) -> None"
     )
     assert (
         doc(m.kw_lb_func1)
-        == "kw_lb_func1(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+        == "kw_lb_func1(custom: m.kwargs_and_defaults.CustomRepr = array([[A, B], [C, D]])) -> None"
     )
     assert (
         doc(m.kw_lb_func2)
-        == "kw_lb_func2(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+        == "kw_lb_func2(custom: m.kwargs_and_defaults.CustomRepr = array([[A, B], [C, D]])) -> None"
     )
     assert (
         doc(m.kw_lb_func3)
-        == "kw_lb_func3(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+        == "kw_lb_func3(custom: m.kwargs_and_defaults.CustomRepr = array([[A, B], [C, D]])) -> None"
     )
     assert (
         doc(m.kw_lb_func4)
-        == "kw_lb_func4(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+        == "kw_lb_func4(custom: m.kwargs_and_defaults.CustomRepr = array([[A, B], [C, D]])) -> None"
     )
     assert (
         doc(m.kw_lb_func5)
-        == "kw_lb_func5(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+        == "kw_lb_func5(custom: m.kwargs_and_defaults.CustomRepr = array([[A, B], [C, D]])) -> None"
     )
     assert (
         doc(m.kw_lb_func6)

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -25,9 +25,32 @@ def test_function_signatures(doc):
     )
     assert (
         doc(m.kw_lb_func0)
-        == "kw_lb_func0(custom: m.kwargs_and_defaults.CustomRepr = line break) -> None"
+        == "kw_lb_func0(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
     )
-
+    assert (
+        doc(m.kw_lb_func1)
+        == "kw_lb_func1(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+    )
+    assert (
+        doc(m.kw_lb_func2)
+        == "kw_lb_func2(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+    )
+    assert (
+        doc(m.kw_lb_func3)
+        == "kw_lb_func3(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+    )
+    assert (
+        doc(m.kw_lb_func4)
+        == "kw_lb_func4(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+    )
+    assert (
+        doc(m.kw_lb_func5)
+        == "kw_lb_func5(custom: m.kwargs_and_defaults.CustomRepr = Hello World!) -> None"
+    )
+    assert (
+        doc(m.kw_lb_func6)
+        == "kw_lb_func6(custom: m.kwargs_and_defaults.CustomRepr = ) -> None"
+    )
 
 def test_named_arguments():
     assert m.kw_func0(5, 10) == "x=5, y=10"

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -23,7 +23,16 @@ def test_function_signatures(doc):
         doc(m.KWClass.foo1)
         == "foo1(self: m.kwargs_and_defaults.KWClass, x: int, y: float) -> None"
     )
-
+    assert (
+        doc(m.kw_lb_func0)
+        == "kw_lb_func0(custom: m.kwargs_and_defaults.CustomRepr = line break) -> None"
+    )
+    assert (
+        '\n' not in str(doc(m.kw_lb_func1))
+    )
+    assert (
+        '\n' not in str(doc(m.kw_lb_func2))
+    )
 
 def test_named_arguments():
     assert m.kw_func0(5, 10) == "x=5, y=10"

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -52,6 +52,7 @@ def test_function_signatures(doc):
         == "kw_lb_func6(custom: m.kwargs_and_defaults.CustomRepr = ) -> None"
     )
 
+
 def test_named_arguments():
     assert m.kw_func0(5, 10) == "x=5, y=10"
 

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -28,6 +28,7 @@ def test_function_signatures(doc):
         == "kw_lb_func0(custom: m.kwargs_and_defaults.CustomRepr = line break) -> None"
     )
 
+
 def test_named_arguments():
     assert m.kw_func0(5, 10) == "x=5, y=10"
 

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -53,7 +53,7 @@ def test_function_signatures(doc):
     )
     assert (
         doc(m.kw_lb_func7)
-        == "kw_lb_func7(str_arg: str = 'First line.\\nSecond line.') -> None"
+        == "kw_lb_func7(str_arg: str = 'First line.\\n  Second line.') -> None"
     )
 
 

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -27,9 +27,6 @@ def test_function_signatures(doc):
         doc(m.kw_lb_func0)
         == "kw_lb_func0(custom: m.kwargs_and_defaults.CustomRepr = line break) -> None"
     )
-    assert "\n" not in str(doc(m.kw_lb_func1))
-    assert "\n" not in str(doc(m.kw_lb_func2))
-
 
 def test_named_arguments():
     assert m.kw_func0(5, 10) == "x=5, y=10"

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -51,6 +51,10 @@ def test_function_signatures(doc):
         doc(m.kw_lb_func6)
         == "kw_lb_func6(custom: m.kwargs_and_defaults.CustomRepr = ) -> None"
     )
+    assert (
+        doc(m.kw_lb_func7)
+        == "kw_lb_func7(str_arg: str = 'First line.\\nSecond line.') -> None"
+    )
 
 
 def test_named_arguments():


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Addresses issue https://github.com/pybind/pybind11/issues/4734 by removing all newlines from function signature docstring.
<!-- Include relevant issues or PRs here, describe what changed and why -->



## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Enforce single line docstring signatures.
```

<!-- If the upgrade guide needs updating, note that here too -->
