### PR TITLE
Disable `PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF` generally for PyPy

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -324,10 +324,7 @@ PYBIND11_WARNING_POP
 #endif
 
 // See description of PR #4246:
-#if !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF)                                \
-    && !(defined(PYPY_VERSION)                                                                    \
-         && defined(_MSC_VER)) /* PyPy Windows: pytest hangs indefinitely at the end of the       \
-                                  process (see PR #4268) */                                       \
+#if !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(PYPY_VERSION)      \
     && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This is to resolve #4748.

Note that we have this since Apr 2021:

* https://github.com/pybind/pybind11/pull/2919/files

That suggests generally `PyGILState_Check()` is working as intended with PyPy, but maybe PyPy's teardown it not GIL clean?

Answering this is left for another day.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
``PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF`` was disabled for PyPy in general (not just PyPy Windows). This is to resolve #4748.
```

<!-- If the upgrade guide needs updating, note that here too -->
