### PR TITLE
Provide `PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF` as an option

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -324,7 +324,7 @@ PYBIND11_WARNING_POP
 #endif
 
 // See description of PR #4246:
-#if !defined(PYBIND11_NO_GIL_CHECKS) && !defined(NDEBUG)                                          \
+#if !defined(PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(NDEBUG)                                          \
     && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(PYPY_VERSION)                       \
     && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -325,8 +325,7 @@ PYBIND11_WARNING_POP
 
 // See description of PR #4246:
 #if !defined(PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(NDEBUG)                       \
-    && !defined(PYPY_VERSION)                       \
-    && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
+    && !defined(PYPY_VERSION) && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -323,6 +323,12 @@ PYBIND11_WARNING_POP
 #    define PYBIND11_HAS_U8STRING
 #endif
 
+// See description of PR #4246:
+#if !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(PYPY_VERSION)      \
+    && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
+#    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
+#endif
+
 // #define PYBIND11_STR_LEGACY_PERMISSIVE
 // If DEFINED, pybind11::str can hold PyUnicodeObject or PyBytesObject
 //             (probably surprising and never documented, but this was the

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -324,7 +324,8 @@ PYBIND11_WARNING_POP
 #endif
 
 // See description of PR #4246:
-#if !defined(PYBIND11_NO_GIL_CHECKS) && !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(PYPY_VERSION)      \
+#if !defined(PYBIND11_NO_GIL_CHECKS) && !defined(NDEBUG)                                          \
+    && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(PYPY_VERSION)                       \
     && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -323,12 +323,6 @@ PYBIND11_WARNING_POP
 #    define PYBIND11_HAS_U8STRING
 #endif
 
-// See description of PR #4246:
-#if !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(PYPY_VERSION)      \
-    && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
-#    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
-#endif
-
 // #define PYBIND11_STR_LEGACY_PERMISSIVE
 // If DEFINED, pybind11::str can hold PyUnicodeObject or PyBytesObject
 //             (probably surprising and never documented, but this was the

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -324,7 +324,7 @@ PYBIND11_WARNING_POP
 #endif
 
 // See description of PR #4246:
-#if !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(PYPY_VERSION)      \
+#if !defined(PYBIND11_NO_GIL_CHECKS) && !defined(NDEBUG) && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(PYPY_VERSION)      \
     && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -324,7 +324,7 @@ PYBIND11_WARNING_POP
 #endif
 
 // See description of PR #4246:
-#if !defined(PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(NDEBUG)                                          \
+#if !defined(PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(NDEBUG)                       \
     && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(PYPY_VERSION)                       \
     && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -325,7 +325,7 @@ PYBIND11_WARNING_POP
 
 // See description of PR #4246:
 #if !defined(PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(NDEBUG)                       \
-    && !defined(PY_ASSERT_GIL_HELD_INCREF_DECREF) && !defined(PYPY_VERSION)                       \
+    && !defined(PYPY_VERSION)                       \
     && !defined(PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF)
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -304,8 +304,11 @@ private:
             "%s is being called while the GIL is either not held or invalid. Please see "
             "https://pybind11.readthedocs.io/en/stable/advanced/"
             "misc.html#common-sources-of-global-interpreter-lock-errors for debugging advice.\n"
-            "If you are convinced there is no bug in your code, you can #define PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF"
-            "to disable this check. In that case you have to ensure this #define is consistently used for all translation units linked into a given pybind11 extension, otherwise there will be ODR violations.",
+            "If you are convinced there is no bug in your code, you can #define "
+            "PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF"
+            "to disable this check. In that case you have to ensure this #define is consistently "
+            "used for all translation units linked into a given pybind11 extension, otherwise "
+            "there will be ODR violations.",
             function_name.c_str());
         fflush(stderr);
         if (Py_TYPE(m_ptr)->tp_name != nullptr) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -304,7 +304,8 @@ private:
             "%s is being called while the GIL is either not held or invalid. Please see "
             "https://pybind11.readthedocs.io/en/stable/advanced/"
             "misc.html#common-sources-of-global-interpreter-lock-errors for debugging advice.\n"
-            "If you are absolutely sure there is no bug, you can #define PYBIND11_NO_GIL_CHECKS to disable this check.",
+            "If you are absolutely sure there is no bug, you can #define PYBIND11_NO_GIL_CHECKS "
+            "to disable this check.",
             function_name.c_str());
         fflush(stderr);
         if (Py_TYPE(m_ptr)->tp_name != nullptr) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -304,8 +304,8 @@ private:
             "%s is being called while the GIL is either not held or invalid. Please see "
             "https://pybind11.readthedocs.io/en/stable/advanced/"
             "misc.html#common-sources-of-global-interpreter-lock-errors for debugging advice.\n"
-            "If you are absolutely sure there is no bug, you can #define PYBIND11_NO_GIL_CHECKS "
-            "to disable this check.",
+            "If you are convinced there is no bug in your code, you can #define PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF"
+            "to disable this check. In that case you have to ensure this #define is consistently used for all translation units linked into a given pybind11 extension, otherwise there will be ODR violations.",
             function_name.c_str());
         fflush(stderr);
         if (Py_TYPE(m_ptr)->tp_name != nullptr) {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -303,7 +303,8 @@ private:
             stderr,
             "%s is being called while the GIL is either not held or invalid. Please see "
             "https://pybind11.readthedocs.io/en/stable/advanced/"
-            "misc.html#common-sources-of-global-interpreter-lock-errors for debugging advice.\n",
+            "misc.html#common-sources-of-global-interpreter-lock-errors for debugging advice.\n"
+            "If you are absolutely sure there is no bug, you can #define PYBIND11_NO_GIL_CHECKS to disable this check.",
             function_name.c_str());
         fflush(stderr);
         if (Py_TYPE(m_ptr)->tp_name != nullptr) {


### PR DESCRIPTION
Pybind11 recently added a feature to help detect GIL errors during inc_ref and dec_ref. As far as we can tell, theses checks do work correctly in cpython, but some projects want to disable these as a temporary measure while they debug further.

This flag will allow temporary disabling of these checks.