### PR TITLE
Add command to check for vX.Y.Z tag vs pybind11/_version.py consistency.

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -47,9 +47,8 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
 - Update tags (optional; if you skip this, the GitHub release makes a
     non-annotated tag for you)
     - ``git tag -a vX.Y.Z -m 'vX.Y.Z release'``.
-    - To visually double-check that the new tag is consistent with the version
-      number in the sources, run this command:
-          - ``grep ^__version__ pybind11/_version.py``
+    - ``grep ^__version__ pybind11/_version.py``
+          - Last-minute consistency check: same as tag?
     - ``git push --tags``.
 - Update stable
     - ``git checkout stable``

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -33,8 +33,7 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
     - Run ``nox -s tests_packaging`` to ensure this was done correctly.
     - Ensure that all the information in ``setup.cfg`` is up-to-date, like
       supported Python versions.
-    - Add release date in ``docs/changelog.rst`` and integrate the output of
-      ``nox -s make_changelog``.
+    - Add release date in ``docs/changelog.rst`` and integrate the output of ``nox -s make_changelog``.
           - Note that the ``make_changelog`` command inspects
             `needs changelog <https://github.com/pybind/pybind11/pulls?q=is%3Apr+is%3Aclosed+label%3A%22needs+changelog%22>`_.
           - Manually clear the ``needs changelog`` labels using the GitHub web
@@ -44,8 +43,7 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
 - Add a release branch if this is a new MINOR version, or update the existing release branch if it is a patch version
     - New branch: ``git checkout -b vX.Y``, ``git push -u origin vX.Y``
     - Update branch: ``git checkout vX.Y``, ``git merge <release branch>``, ``git push``
-- Update tags (optional; if you skip this, the GitHub release makes a
-  non-annotated tag for you)
+- Update tags (optional; if you skip this, the GitHub release makes a non-annotated tag for you)
     - ``git tag -a vX.Y.Z -m 'vX.Y.Z release'``
     - ``grep ^__version__ pybind11/_version.py``
           - Last-minute consistency check: same as tag?
@@ -56,10 +54,7 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
     - ``git diff vX.Y.Z``
     - Carefully review and reconcile any diffs. There should be none.
     - ``git push``
-- Make a GitHub release (this shows up in the UI, sends new release
-  notifications to users watching releases, and also uploads PyPI packages).
-  (Note: if you do not use an existing tag, this creates a new lightweight tag
-  for you, so you could skip the above step.)
+- Make a GitHub release (this shows up in the UI, sends new release notifications to users watching releases, and also uploads PyPI packages). (Note: if you do not use an existing tag, this creates a new lightweight tag for you, so you could skip the above step.)
     - GUI method: Under `releases <https://github.com/pybind/pybind11/releases>`_
       click "Draft a new release" on the far right, fill in the tag name
       (if you didn't tag above, it will be made here), fill in a release name

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -15,8 +15,8 @@ For example:
 
 For beta, ``PYBIND11_VERSION_PATCH`` should be ``Z.b1``. RC's can be ``Z.rc1``.
 Always include the dot (even though PEP 440 allows it to be dropped). For a
-final release, this must be a simple integer. There is also a HEX version of
-the version just below.
+final release, this must be a simple integer. There is also
+``PYBIND11_VERSION_HEX`` just below that needs to be updated.
 
 
 To release a new version of pybind11:
@@ -26,55 +26,93 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
 ``pipx install nox`` or ``brew install nox`` (Unix).
 
 - Update the version number
-    - Update ``PYBIND11_VERSION_MAJOR`` etc. in
-      ``include/pybind11/detail/common.h``. PATCH should be a simple integer.
-    - Update the version HEX just below, as well.
-    - Update ``pybind11/_version.py`` (match above)
-    - Run ``nox -s tests_packaging`` to ensure this was done correctly.
-    - Ensure that all the information in ``setup.cfg`` is up-to-date, like
-      supported Python versions.
-    - Add release date in ``docs/changelog.rst`` and integrate the output of ``nox -s make_changelog``.
-          - Note that the ``make_changelog`` command inspects
-            `needs changelog <https://github.com/pybind/pybind11/pulls?q=is%3Apr+is%3Aclosed+label%3A%22needs+changelog%22>`_.
-          - Manually clear the ``needs changelog`` labels using the GitHub web
-            interface (very easy: start by clicking the link above).
-    - ``git add`` and ``git commit``, ``git push``. **Ensure CI passes**. (If it
-      fails due to a known flake issue, either ignore or restart CI.)
-- Add a release branch if this is a new MINOR version, or update the existing release branch if it is a patch version
-    - New branch: ``git checkout -b vX.Y``, ``git push -u origin vX.Y``
-    - Update branch: ``git checkout vX.Y``, ``git merge <release branch>``, ``git push``
-- Update tags (optional; if you skip this, the GitHub release makes a non-annotated tag for you)
-    - ``git tag -a vX.Y.Z -m 'vX.Y.Z release'``
-    - ``grep ^__version__ pybind11/_version.py``
-          - Last-minute consistency check: same as tag?
-    - ``git push --tags``
+
+  - Update ``PYBIND11_VERSION_MAJOR`` etc. in
+    ``include/pybind11/detail/common.h``. PATCH should be a simple integer.
+
+  - Update ``PYBIND11_VERSION_HEX`` just below as well.
+
+  - Update ``pybind11/_version.py`` (match above).
+
+  - Run ``nox -s tests_packaging`` to ensure this was done correctly.
+
+  - Ensure that all the information in ``setup.cfg`` is up-to-date, like
+    supported Python versions.
+
+  - Add release date in ``docs/changelog.rst`` and integrate the output of
+    ``nox -s make_changelog``.
+
+    - Note that the ``make_changelog`` command inspects
+      `needs changelog <https://github.com/pybind/pybind11/pulls?q=is%3Apr+is%3Aclosed+label%3A%22needs+changelog%22>`_.
+
+    - Manually clear the ``needs changelog`` labels using the GitHub web
+      interface (very easy: start by clicking the link above).
+
+  - ``git add`` and ``git commit``, ``git push``. **Ensure CI passes**. (If it
+    fails due to a known flake issue, either ignore or restart CI.)
+
+- Add a release branch if this is a new MINOR version, or update the existing
+  release branch if it is a patch version
+
+  - New branch: ``git checkout -b vX.Y``, ``git push -u origin vX.Y``
+
+  - Update branch: ``git checkout vX.Y``, ``git merge <release branch>``, ``git push``
+
+- Update tags (optional; if you skip this, the GitHub release makes a
+  non-annotated tag for you)
+
+  - ``git tag -a vX.Y.Z -m 'vX.Y.Z release'``
+
+  - ``grep ^__version__ pybind11/_version.py``
+
+    - Last-minute consistency check: same as tag?
+
+  - ``git push --tags``
+
 - Update stable
-    - ``git checkout stable``
-    - ``git merge -X theirs vX.Y.Z``
-    - ``git diff vX.Y.Z``
-    - Carefully review and reconcile any diffs. There should be none.
-    - ``git push``
-- Make a GitHub release (this shows up in the UI, sends new release notifications to users watching releases, and also uploads PyPI packages). (Note: if you do not use an existing tag, this creates a new lightweight tag for you, so you could skip the above step.)
-    - GUI method: Under `releases <https://github.com/pybind/pybind11/releases>`_
-      click "Draft a new release" on the far right, fill in the tag name
-      (if you didn't tag above, it will be made here), fill in a release name
-      like "Version X.Y.Z", and copy-and-paste the markdown-formatted (!) changelog
-      into the description. You can use ``cat docs/changelog.rst | pandoc -f rst -t gfm``,
-      then manually remove line breaks and strip links to PRs and issues,
-      e.g. to a bare ``#1234``, without the surrounding ``<...>_`` hyperlink markup.
-      Check "pre-release" if this is a beta/RC.
-    - CLI method: with ``gh`` installed, run ``gh release create vX.Y.Z -t "Version X.Y.Z"``
-      If this is a pre-release, add ``-p``.
+
+  - ``git checkout stable``
+
+  - ``git merge -X theirs vX.Y.Z``
+
+  - ``git diff vX.Y.Z``
+
+  - Carefully review and reconcile any diffs. There should be none.
+
+  - ``git push``
+
+- Make a GitHub release (this shows up in the UI, sends new release
+  notifications to users watching releases, and also uploads PyPI packages).
+  (Note: if you do not use an existing tag, this creates a new lightweight tag
+  for you, so you could skip the above step.)
+
+  - GUI method: Under `releases <https://github.com/pybind/pybind11/releases>`_
+    click "Draft a new release" on the far right, fill in the tag name
+    (if you didn't tag above, it will be made here), fill in a release name
+    like "Version X.Y.Z", and copy-and-paste the markdown-formatted (!) changelog
+    into the description. You can use ``cat docs/changelog.rst | pandoc -f rst -t gfm``,
+    then manually remove line breaks and strip links to PRs and issues,
+    e.g. to a bare ``#1234``, without the surrounding ``<...>_`` hyperlink markup.
+    Check "pre-release" if this is a beta/RC.
+
+  - CLI method: with ``gh`` installed, run ``gh release create vX.Y.Z -t "Version X.Y.Z"``
+    If this is a pre-release, add ``-p``.
 
 - Get back to work
-    - Make sure you are on master, not somewhere else: ``git checkout master``
-    - Update version macros in ``include/pybind11/detail/common.h`` (set PATCH to
-      ``0.dev1`` and increment MINOR).
-    - Update ``pybind11/_version.py`` to match
-    - Run ``nox -s tests_packaging`` to ensure this was done correctly.
-    - If the release was a new MINOR version, add a new `IN DEVELOPMENT`
-      section in ``docs/changelog.rst``.
-    - ``git add``, ``git commit``, ``git push``
+
+  - Make sure you are on master, not somewhere else: ``git checkout master``
+
+  - Update version macros in ``include/pybind11/detail/common.h`` (set PATCH to
+    ``0.dev1`` and increment MINOR).
+
+  - Update ``pybind11/_version.py`` to match.
+
+  - Run ``nox -s tests_packaging`` to ensure this was done correctly.
+
+  - If the release was a new MINOR version, add a new ``IN DEVELOPMENT``
+    section in ``docs/changelog.rst``.
+
+  - ``git add``, ``git commit``, ``git push``
 
 If a version branch is updated, remember to set PATCH to ``1.dev1``.
 
@@ -91,7 +129,11 @@ merge it if there are no issues.
 Manual packaging
 ^^^^^^^^^^^^^^^^
 
-If you need to manually upload releases, you can download the releases from the job artifacts and upload them with twine. You can also make the files locally (not recommended in general, as your local directory is more likely to be "dirty" and SDists love picking up random unrelated/hidden files); this is the procedure:
+If you need to manually upload releases, you can download the releases from
+the job artifacts and upload them with twine. You can also make the files
+locally (not recommended in general, as your local directory is more likely
+to be "dirty" and SDists love picking up random unrelated/hidden files);
+this is the procedure:
 
 .. code-block:: bash
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -45,11 +45,11 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
     - New branch: ``git checkout -b vX.Y``, ``git push -u origin vX.Y``
     - Update branch: ``git checkout vX.Y``, ``git merge <release branch>``, ``git push``
 - Update tags (optional; if you skip this, the GitHub release makes a
-    non-annotated tag for you)
-    - ``git tag -a vX.Y.Z -m 'vX.Y.Z release'``.
+  non-annotated tag for you)
+    - ``git tag -a vX.Y.Z -m 'vX.Y.Z release'``
     - ``grep ^__version__ pybind11/_version.py``
           - Last-minute consistency check: same as tag?
-    - ``git push --tags``.
+    - ``git push --tags``
 - Update stable
     - ``git checkout stable``
     - ``git merge -X theirs vX.Y.Z``

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -47,6 +47,9 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
 - Update tags (optional; if you skip this, the GitHub release makes a
     non-annotated tag for you)
     - ``git tag -a vX.Y.Z -m 'vX.Y.Z release'``.
+    - To ensure the new tag is consistent with the version number in the sources, run this command:
+          - ``git diff "$(grep ^__version__ pybind11/_version.py | cut -d'"' -f2 | sed 's/^/v/')"``
+          - There should be no diff.
     - ``git push --tags``.
 - Update stable
     - ``git checkout stable``
@@ -62,7 +65,9 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
       click "Draft a new release" on the far right, fill in the tag name
       (if you didn't tag above, it will be made here), fill in a release name
       like "Version X.Y.Z", and copy-and-paste the markdown-formatted (!) changelog
-      into the description (usually ``cat docs/changelog.rst | pandoc -f rst -t gfm``).
+      into the description. You can use ``cat docs/changelog.rst | pandoc -f rst -t gfm``,
+      then manually remove line breaks and strip links to PRs and issues,
+      e.g. to a bare ``#1234``, without the surrounding ``<...>_`` hyperlink markup.
       Check "pre-release" if this is a beta/RC.
     - CLI method: with ``gh`` installed, run ``gh release create vX.Y.Z -t "Version X.Y.Z"``
       If this is a pre-release, add ``-p``.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -47,9 +47,9 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
 - Update tags (optional; if you skip this, the GitHub release makes a
     non-annotated tag for you)
     - ``git tag -a vX.Y.Z -m 'vX.Y.Z release'``.
-    - To ensure the new tag is consistent with the version number in the sources, run this command:
-          - ``git diff "$(grep ^__version__ pybind11/_version.py | cut -d'"' -f2 | sed 's/^/v/')"``
-          - There should be no diff.
+    - To visually double-check that the new tag is consistent with the version
+      number in the sources, run this command:
+          - ``grep ^__version__ pybind11/_version.py``
     - ``git push --tags``.
 - Update stable
     - ``git checkout stable``


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Slightly expand instructions based on lesson just learned (see #4756).

Piggy-backing hints for converting changelog to release message.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
