### PR TITLE
Do not check the GIL/decref object if the Python runtime is dead

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -265,12 +265,15 @@ public:
         this function automatically. Returns a reference to itself.
     \endrst */
     const handle &dec_ref() const & {
+        // If python is already dead, leak the wrapped python objects
+        if (Py_IsInitialized()) {
 #ifdef PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
-        if (m_ptr != nullptr && !PyGILState_Check()) {
-            throw_gilstate_error("pybind11::handle::dec_ref()");
-        }
+            if (m_ptr != nullptr && !PyGILState_Check()) {
+                throw_gilstate_error("pybind11::handle::dec_ref()");
+            }
 #endif
-        Py_XDECREF(m_ptr);
+            Py_XDECREF(m_ptr);
+        }
         return *this;
     }
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -266,7 +266,7 @@ public:
     \endrst */
     const handle &dec_ref() const & {
         // If python is already dead, leak the wrapped python objects
-        if (Py_IsInitialized()) {
+        if (Py_IsInitialized() != 0) {
 #ifdef PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
             if (m_ptr != nullptr && !PyGILState_Check()) {
                 throw_gilstate_error("pybind11::handle::dec_ref()");


### PR DESCRIPTION
## Description

This change guards GIL check and decref for objects behind a check that the Python runtime still exists.
This can happen if a static variable outlives the python runtime and is destroyed later. This happens when the user uses the recommended way to create custom exceptions from https://pybind11.readthedocs.io/en/stable/advanced/exceptions.html as `static py::exception<MyCustomException> exc(m, "MyCustomError");
`

In particular, this change fixes the segfault described at https://github.com/pytorch/pytorch/pull/106083 (when working on upgrading PyTorch to 3.12)

## Suggested changelog entry:

Skip calling Python decref when the Python runtime is already dead.