### PR TITLE
docs: Remove upper bound on pybind11 in example pyproject.toml for setuptools

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -143,7 +143,7 @@ Your ``pyproject.toml`` file will likely look something like this:
 .. code-block:: toml
 
     [build-system]
-    requires = ["setuptools>=42", "wheel", "pybind11>=2.6.1"]
+    requires = ["setuptools>=42", "pybind11>=2.6.1"]
     build-backend = "setuptools.build_meta"
 
 .. note::

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -143,7 +143,7 @@ Your ``pyproject.toml`` file will likely look something like this:
 .. code-block:: toml
 
     [build-system]
-    requires = ["setuptools>=42", "wheel", "pybind11~=2.6.1"]
+    requires = ["setuptools>=42", "wheel", "pybind11>=2.6.1"]
     build-backend = "setuptools.build_meta"
 
 .. note::


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

The upper bound set here is incompatible with Python 3.11. I got bit copy and pasting this code block for `pyproject.toml`

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Remove upper bound in example pyproject.toml for setuptools
```

<!-- If the upgrade guide needs updating, note that here too -->
