### PR TITLE
[smart_holder] Make smart holder type caster of `unique_ptr` accept `automatic_reference`

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -965,6 +965,7 @@ struct smart_holder_type_caster<std::unique_ptr<T, D>> : smart_holder_type_caste
 
     static handle cast(std::unique_ptr<T, D> &&src, return_value_policy policy, handle parent) {
         if (policy != return_value_policy::automatic
+            && policy != return_value_policy::automatic_reference
             && policy != return_value_policy::reference_internal
             && policy != return_value_policy::move
             && policy != return_value_policy::_clif_automatic) {

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -160,6 +160,12 @@ TEST_SUBMODULE(class_sh_basic, m) {
     m.def("args_shared_ptr_const", [](std::shared_ptr<atyp const> p) { return p; });
     m.def("args_unique_ptr", [](std::unique_ptr<atyp> p) { return p; });
     m.def("args_unique_ptr_const", [](std::unique_ptr<atyp const> p) { return p; });
+
+    // Make sure unique_ptr type caster accept automatic_reference return value policy.
+    m.def(
+        "rtrn_uq_automatic_reference",
+        []() { return std::make_unique<atyp>("rtrn_uq_automatic_reference"); },
+        pybind11::return_value_policy::automatic_reference);
 }
 
 } // namespace class_sh_basic

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -164,7 +164,7 @@ TEST_SUBMODULE(class_sh_basic, m) {
     // Make sure unique_ptr type caster accept automatic_reference return value policy.
     m.def(
         "rtrn_uq_automatic_reference",
-        []() { return std::make_unique<atyp>("rtrn_uq_automatic_reference"); },
+        []() { return std::unique_ptr<atyp>(new atyp("rtrn_uq_automatic_reference")); },
         pybind11::return_value_policy::automatic_reference);
 }
 

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -1,9 +1,12 @@
+#include <pybind11/functional.h>
 #include <pybind11/smart_holder.h>
 
 #include "pybind11_tests.h"
 
+#include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace pybind11_tests {
@@ -79,6 +82,11 @@ struct SharedPtrStash {
     std::vector<std::shared_ptr<const atyp>> stash;
     void Add(const std::shared_ptr<const atyp> &obj) { stash.push_back(obj); }
 };
+
+std::string pass_uq_cb(const std::function<std::string(std::unique_ptr<atyp>)> &cb) {
+    std::unique_ptr<atyp> ptr = std::make_unique<atyp>("pass_uq_cb");
+    return cb(std::move(ptr));
+}
 
 } // namespace class_sh_basic
 } // namespace pybind11_tests
@@ -160,6 +168,12 @@ TEST_SUBMODULE(class_sh_basic, m) {
     m.def("args_shared_ptr_const", [](std::shared_ptr<atyp const> p) { return p; });
     m.def("args_unique_ptr", [](std::unique_ptr<atyp> p) { return p; });
     m.def("args_unique_ptr_const", [](std::unique_ptr<atyp const> p) { return p; });
+
+    // Make sure unique_ptr type caster accept automatic_reference return value policy.
+    m.def("pass_uq_cb",
+          &pass_uq_cb,
+          pybind11::arg("cb").policies(pybind11::return_value_policy_pack(
+              pybind11::return_value_policy::automatic_reference)));
 }
 
 } // namespace class_sh_basic

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -1,12 +1,9 @@
-#include <pybind11/functional.h>
 #include <pybind11/smart_holder.h>
 
 #include "pybind11_tests.h"
 
-#include <functional>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace pybind11_tests {
@@ -82,11 +79,6 @@ struct SharedPtrStash {
     std::vector<std::shared_ptr<const atyp>> stash;
     void Add(const std::shared_ptr<const atyp> &obj) { stash.push_back(obj); }
 };
-
-std::string pass_uq_cb(const std::function<std::string(std::unique_ptr<atyp>)> &cb) {
-    std::unique_ptr<atyp> ptr = std::make_unique<atyp>("pass_uq_cb");
-    return cb(std::move(ptr));
-}
 
 } // namespace class_sh_basic
 } // namespace pybind11_tests
@@ -168,12 +160,6 @@ TEST_SUBMODULE(class_sh_basic, m) {
     m.def("args_shared_ptr_const", [](std::shared_ptr<atyp const> p) { return p; });
     m.def("args_unique_ptr", [](std::unique_ptr<atyp> p) { return p; });
     m.def("args_unique_ptr_const", [](std::unique_ptr<atyp const> p) { return p; });
-
-    // Make sure unique_ptr type caster accept automatic_reference return value policy.
-    m.def("pass_uq_cb",
-          &pass_uq_cb,
-          pybind11::arg("cb").policies(pybind11::return_value_policy_pack(
-              pybind11::return_value_policy::automatic_reference)));
 }
 
 } // namespace class_sh_basic

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -181,3 +181,10 @@ def test_function_signatures(doc):
         doc(m.args_unique_ptr_const)
         == "args_unique_ptr_const(arg0: m.class_sh_basic.atyp) -> m.class_sh_basic.atyp"
     )
+
+
+def test_unique_ptr_return_value_policy_automatic_reference():
+    def cb(atyp):
+        return m.get_mtxt(atyp)
+
+    assert m.pass_uq_cb(cb) == "pass_uq_cb"

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -181,10 +181,3 @@ def test_function_signatures(doc):
         doc(m.args_unique_ptr_const)
         == "args_unique_ptr_const(arg0: m.class_sh_basic.atyp) -> m.class_sh_basic.atyp"
     )
-
-
-def test_unique_ptr_return_value_policy_automatic_reference():
-    def cb(atyp):
-        return m.get_mtxt(atyp)
-
-    assert m.pass_uq_cb(cb) == "pass_uq_cb"

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -181,3 +181,7 @@ def test_function_signatures(doc):
         doc(m.args_unique_ptr_const)
         == "args_unique_ptr_const(arg0: m.class_sh_basic.atyp) -> m.class_sh_basic.atyp"
     )
+
+
+def test_unique_ptr_return_value_policy_automatic_reference():
+    assert m.get_mtxt(m.rtrn_uq_automatic_reference()) == "rtrn_uq_automatic_reference"


### PR DESCRIPTION
## Description

When calling a Python callback function that consumes `std::unique_ptr` in C++, we see `RuntimeError: Invalid return_value_policy for unique_ptr.` This is because when calling Python functions manually from C++ , we use `return_value_policy::automatic_reference` for function arguments, and the type caster of  `std::unique_ptr` rejects this return value policy.

Pybind11 always override `return_value_policy::automatic` and `return_value_policy::automatic_reference` with `return_value_policy::move` for `std::unique_ptr`: https://github.com/pybind/pybind11/blob/b6444460eeddc2965ab1a49c6c50c83073779489/include/pybind11/cast.h#L1138, so `return_value_policy::automatic` and `return_value_policy::automatic_reference` does not make any difference for `std::unique_ptr`. We should make the type caster accept both.
