### PR TITLE
fix: Different MSVC versions may be ABI incompatible, guard with _MSC_VER (fix #2898)

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -291,9 +291,12 @@ struct type_info {
 #endif
 
 /// On Linux/OSX, changes in __GXX_ABI_VERSION__ indicate ABI incompatibility.
+/// On MSVC, changes in _MSC_VER may indicate ABI incompatibility (#2898).
 #ifndef PYBIND11_BUILD_ABI
 #    if defined(__GXX_ABI_VERSION)
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
+#    elif defined(_MSC_VER)
+#        define PYBIND11_BUILD_ABI "_mscver" PYBIND11_TOSTRING(_MSC_VER)
 #    else
 #        define PYBIND11_BUILD_ABI ""
 #    endif


### PR DESCRIPTION
## Description

Pybind11, currently by default, shares C++ data structures across DLLs built with different MSVC versions, for which there is no documented guarantee for ABI compatibility. This has caused difficult-to-track crashes on several occasions for quite some time now (#1562, #1618, #2898, onnx/onnx#3493, pytorch/pytorch#62090, pytorch/pytorch#84457, NVIDIA/TensorRT#2853, IntelRealSense/librealsense#8570).

This PR aims to mitigate the risk of an ABI mismatch in pybind11-module interaction by guarding against different MSVC compiler/lib/toolchain versions, without causing significant changes for pybind11 (see also discussion in #2898).

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Guard against crashes/corruptions caused by modules built with different MSVC versions
```

<!-- If the upgrade guide needs updating, note that here too -->
