### PR TITLE
Update deprecated FindPython

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,9 @@ else()
   cmake_policy(VERSION 3.26)
 endif()
 
+# Include Python headers from FindPython
+include_directories(${Python_INCLUDE_DIRS})
+
 # Filter out items; print an optional message if any items filtered. This ignores extensions.
 #
 # Usage:

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -95,10 +95,10 @@ if(NOT PythonLibsNew_FIND_VERSION)
   set(PythonLibsNew_FIND_VERSION "3.6")
 endif()
 
-find_package(PythonInterp ${PythonLibsNew_FIND_VERSION} ${_pythonlibs_required}
-             ${_pythonlibs_quiet})
+find_package(Python ${PythonLibsNew_FIND_VERSION} ${_pythonlibs_required}
+             ${_pythonlibs_quiet} COMPONENTS Interpreter Development REQUIRED)
 
-if(NOT PYTHONINTERP_FOUND)
+if(NOT Python_Interpreter_FOUND)
   set(PYTHONLIBS_FOUND FALSE)
   set(PythonLibsNew_FOUND FALSE)
   return()
@@ -112,7 +112,7 @@ endif()
 # VERSION. VERSION will typically be like "2.7" on unix, and "27" on windows.
 execute_process(
   COMMAND
-    "${PYTHON_EXECUTABLE}" "-c" "
+    "${Python_EXECUTABLE}" "-c" "
 import sys;import struct;
 import sysconfig as s
 USE_SYSCONFIG = sys.version_info >= (3, 10)

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -95,8 +95,10 @@ if(NOT PythonLibsNew_FIND_VERSION)
   set(PythonLibsNew_FIND_VERSION "3.6")
 endif()
 
-find_package(Python ${PythonLibsNew_FIND_VERSION} ${_pythonlibs_required}
-             ${_pythonlibs_quiet} COMPONENTS Interpreter Development REQUIRED)
+find_package(
+  Python ${PythonLibsNew_FIND_VERSION} ${_pythonlibs_required} ${_pythonlibs_quiet}
+  COMPONENTS Interpreter Development
+  REQUIRED)
 
 if(NOT Python_Interpreter_FOUND)
   set(PYTHONLIBS_FOUND FALSE)


### PR DESCRIPTION
CMake 2.27 removes support for deprecated FindPython scripts.

In case CMake is custom built/installed in /usr/local, it seems to pick up the version of FindPython from the /usr/share folder. This causes issues when, for example, using a custom built installation of Python in `/usr/local`: if the version is more recent than what's listed in the system CMake script, it's not picked up.

Use the new version of the script, so Python is picked up correctly.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
