### PR TITLE
Migrate to readthedocs configuration file v2¶

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,4 +12,4 @@ sphinx:
 
 python:
   install:
-  - requirements_file: docs/requirements.txt
+  - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,15 @@
+# https://blog.readthedocs.com/migrate-configuration-v2/
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
 python:
-  version: 3
-requirements_file: docs/requirements.txt
+  install:
+  - requirements_file: docs/requirements.txt


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

- https://blog.readthedocs.com/migrate-configuration-v2/#migrate-your-project-to-readthedocs-yaml-configuration-file-v2
- Last successful before enforcement kicked in: https://readthedocs.org/projects/pybind11/builds/21599337/
- First failing: https://readthedocs.org/projects/pybind11/builds/21602133/


<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
