### PR TITLE
Copy nanobind readthedocs config.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  apt_packages:
+    - librsvg2-bin
   tools:
     python: "3.11"
 
@@ -13,3 +15,6 @@ sphinx:
 python:
   install:
   - requirements: docs/requirements.txt
+
+formats:
+  - pdf


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The only diffs to the nanobind readthedocs config are an extra comment at the top (URL) and consistent indentation.

Small follow-on to #4789.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
