### PR TITLE
During exception handling check if it is not null before using

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1168,7 +1168,7 @@ protected:
         if (!result) {
             std::string msg = "Unable to convert function return value to a "
                               "Python type! The signature was\n\t";
-	    msg += (it) ? it->signature : std::string("unavailable");
+            msg += (it) ? it->signature : std::string("unavailable");
             append_note_if_missing_header_is_suspected(msg);
             // Attach additional error info to the exception if supported
             if (PyErr_Occurred()) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1168,7 +1168,7 @@ protected:
         if (!result) {
             std::string msg = "Unable to convert function return value to a "
                               "Python type! The signature was\n\t";
-            msg += it->signature;
+	    msg += (it) ? it->signature : std::string("unavailable");
             append_note_if_missing_header_is_suspected(msg);
             // Attach additional error info to the exception if supported
             if (PyErr_Occurred()) {


### PR DESCRIPTION
## Description

Coverity tool flags use of "it->signature" citing that it could be a `nullptr`.

![image](https://github.com/pybind/pybind11/assets/21087696/9fe80c92-6358-4b21-8acb-7695be67246f)

I suppose the thinking was that exception can only arise within the loop (so `it` is not null per loop termination condition), but perhaps it is better to be safe.


## Suggested changelog entry:

None.