### PR TITLE
Help Coverty avoid generating a false positive.

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1022,7 +1022,6 @@ protected:
                         // would be if we'd encountered this failure in the first-pass loop.
                         if (!result) {
                             curr_overl = &call.func;
-                            assert(curr_overl != nullptr);
                         }
                         break;
                     }
@@ -1169,6 +1168,7 @@ protected:
         if (!result) {
             std::string msg = "Unable to convert function return value to a "
                               "Python type! The signature was\n\t";
+            assert(curr_overl != nullptr);
             msg += curr_overl->signature;
             append_note_if_missing_header_is_suspected(msg);
             // Attach additional error info to the exception if supported

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -719,7 +719,7 @@ protected:
         /* Iterator over the list of potentially admissible overloads */
         const function_record *overloads = reinterpret_cast<function_record *>(
                                   PyCapsule_GetPointer(self, get_function_record_capsule_name())),
-                              *curr_overl = overloads;
+                              *current_overload = overloads;
         assert(overloads != nullptr);
 
         /* Need to know how many arguments + keyword arguments there are to pick the right
@@ -757,9 +757,10 @@ protected:
             std::vector<function_call> second_pass;
 
             // However, if there are no overloads, we can just skip the no-convert pass entirely
-            const bool overloaded = curr_overl != nullptr && curr_overl->next != nullptr;
+            const bool overloaded
+                = current_overload != nullptr && current_overload->next != nullptr;
 
-            for (; curr_overl != nullptr; curr_overl = curr_overl->next) {
+            for (; current_overload != nullptr; current_overload = current_overload->next) {
 
                 /* For each overload:
                    1. Copy all positional arguments we were given, also checking to make sure that
@@ -780,7 +781,7 @@ protected:
                    a result other than PYBIND11_TRY_NEXT_OVERLOAD.
                  */
 
-                const function_record &func = *curr_overl;
+                const function_record &func = *current_overload;
                 size_t num_args = func.nargs; // Number of positional arguments that we need
                 if (func.has_args) {
                     --num_args; // (but don't count py::args
@@ -1018,10 +1019,10 @@ protected:
                     }
 
                     if (result.ptr() != PYBIND11_TRY_NEXT_OVERLOAD) {
-                        // The error reporting logic below expects 'curr_overl' to be valid, as it
-                        // would be if we'd encountered this failure in the first-pass loop.
+                        // The error reporting logic below expects 'current_overload' to be valid,
+                        // as it would be if we'd encountered this failure in the first-pass loop.
                         if (!result) {
-                            curr_overl = &call.func;
+                            current_overload = &call.func;
                         }
                         break;
                     }
@@ -1168,8 +1169,8 @@ protected:
         if (!result) {
             std::string msg = "Unable to convert function return value to a "
                               "Python type! The signature was\n\t";
-            assert(curr_overl != nullptr);
-            msg += curr_overl->signature;
+            assert(current_overload != nullptr);
+            msg += current_overload->signature;
             append_note_if_missing_header_is_suspected(msg);
             // Attach additional error info to the exception if supported
             if (PyErr_Occurred()) {


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Please see #4814 for background.

This PR does not change the pybind11 behavior at all when `NDEBUG` is set.

For Coverty use `-UNDEBUG`.

The variable name change was helpful in determining that we think of the Coverty result as a false positive. The name change could be reverted, but is useful to keep (increases readability).
 
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
An `assert()` was added to help Coverty avoid generating a false positive.
```

<!-- If the upgrade guide needs updating, note that here too -->
