### PR TITLE
Fix enum's `__str__` docstring

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2014,7 +2014,7 @@ struct enum_base {
                 object type_name = type::handle_of(arg).attr("__name__");
                 return pybind11::str("{}.{}").format(std::move(type_name), enum_name(arg));
             },
-            name("name"),
+            name("__str__"),
             is_method(m_base));
 
         if (options::show_enum_members_docstring()) {

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -264,3 +264,8 @@ def test_docstring_signatures():
         for attr in enum_type.__dict__.values():
             # Issue #2623/PR #2637: Add argument names to enum_ methods
             assert "arg0" not in (attr.__doc__ or "")
+
+
+def test_str_signature():
+    for enum_type in [m.ScopedEnum, m.UnscopedEnum]:
+        assert enum_type.__str__.__doc__.startswith("__str__")


### PR DESCRIPTION
## Description

Fix incorrect signature `name(self: handle) -> str\n` in enum's `__str__` docstring.
Introduced in #2637

## Suggested changelog entry:

```rst
   Fixed `base_enum.__str__` docstring
```
