### PR TITLE
fix: Missing typed variants of `iterator` and `iterable`

### DIFF
--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -45,6 +45,16 @@ class Set : public set {
     using set::set;
 };
 
+template <typename T>
+class Iterable : public iterable {
+    using iterable::iterable;
+};
+
+template <typename T>
+class Iterator : public iterator {
+    using iterator::iterator;
+};
+
 template <typename Signature>
 class Callable;
 
@@ -83,6 +93,16 @@ struct handle_type_name<typing::List<T>> {
 template <typename T>
 struct handle_type_name<typing::Set<T>> {
     static constexpr auto name = const_name("set[") + make_caster<T>::name + const_name("]");
+};
+
+template <typename T>
+struct handle_type_name<typing::Iterable<T>> {
+    static constexpr auto name = const_name("Iterable[") + make_caster<T>::name + const_name("]");
+};
+
+template <typename T>
+struct handle_type_name<typing::Iterator<T>> {
+    static constexpr auto name = const_name("Iterator[") + make_caster<T>::name + const_name("]");
 };
 
 template <typename Return, typename... Args>

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -828,6 +828,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_dict_str_int", [](const py::typing::Dict<py::str, int> &) {});
     m.def("annotate_list_int", [](const py::typing::List<int> &) {});
     m.def("annotate_set_str", [](const py::typing::Set<std::string> &) {});
+    m.def("annotate_iterable_str", [](const py::typing::Iterable<std::string> &) {});
+    m.def("annotate_iterator_int", [](const py::typing::Iterator<int> &) {});
     m.def("annotate_fn",
           [](const py::typing::Callable<int(py::typing::List<py::str>, py::str)> &) {});
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -926,6 +926,20 @@ def test_set_annotations(doc):
     assert doc(m.annotate_set_str) == "annotate_set_str(arg0: set[str]) -> None"
 
 
+def test_iterable_annotations(doc):
+    assert (
+        doc(m.annotate_iterable_str)
+        == "annotate_iterable_str(arg0: Iterable[str]) -> None"
+    )
+
+
+def test_iterator_annotations(doc):
+    assert (
+        doc(m.annotate_iterator_int)
+        == "annotate_iterator_int(arg0: Iterator[int]) -> None"
+    )
+
+
 def test_fn_annotations(doc):
     assert (
         doc(m.annotate_fn)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Add missing `Iterator` and `Iterable`.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Added `py::typing::Iterator<T>`, `py::typing::Iterable<T>`
```

<!-- If the upgrade guide needs updating, note that here too -->
