### PR TITLE
fix: Use lowercase builtin collection names

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -661,7 +661,7 @@ public:
     }
 
     static constexpr auto name
-        = const_name("Tuple[") + concat(make_caster<Ts>::name...) + const_name("]");
+        = const_name("tuple[") + concat(make_caster<Ts>::name...) + const_name("]");
 
     template <typename T>
     using cast_op_type = type;

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -100,7 +100,7 @@ public:
         return s.release();
     }
 
-    PYBIND11_TYPE_CASTER(type, const_name("Set[") + key_conv::name + const_name("]"));
+    PYBIND11_TYPE_CASTER(type, const_name("set[") + key_conv::name + const_name("]"));
 };
 
 template <typename Type, typename Key, typename Value>
@@ -157,7 +157,7 @@ public:
     }
 
     PYBIND11_TYPE_CASTER(Type,
-                         const_name("Dict[") + key_conv::name + const_name(", ") + value_conv::name
+                         const_name("dict[") + key_conv::name + const_name(", ") + value_conv::name
                              + const_name("]"));
 };
 
@@ -208,7 +208,7 @@ public:
         return l.release();
     }
 
-    PYBIND11_TYPE_CASTER(Type, const_name("List[") + value_conv::name + const_name("]"));
+    PYBIND11_TYPE_CASTER(Type, const_name("list[") + value_conv::name + const_name("]"));
 };
 
 template <typename Type, typename Alloc>
@@ -274,7 +274,7 @@ public:
 
     PYBIND11_TYPE_CASTER(ArrayType,
                          const_name<Resizable>(const_name(""), const_name("Annotated["))
-                             + const_name("List[") + value_conv::name + const_name("]")
+                             + const_name("list[") + value_conv::name + const_name("]")
                              + const_name<Resizable>(const_name(""),
                                                      const_name(", FixedSize(")
                                                          + const_name<Size>() + const_name(")]")));

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -352,7 +352,7 @@ def test_tuple(doc):
     assert (
         doc(m.pair_passthrough)
         == """
-        pair_passthrough(arg0: Tuple[bool, str]) -> Tuple[str, bool]
+        pair_passthrough(arg0: tuple[bool, str]) -> tuple[str, bool]
 
         Return a pair in reversed order
     """
@@ -360,7 +360,7 @@ def test_tuple(doc):
     assert (
         doc(m.tuple_passthrough)
         == """
-        tuple_passthrough(arg0: Tuple[bool, str, int]) -> Tuple[int, str, bool]
+        tuple_passthrough(arg0: tuple[bool, str, int]) -> tuple[int, str, bool]
 
         Return a triple in reversed order
     """

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -8,7 +8,7 @@ def test_function_signatures(doc):
     assert doc(m.kw_func1) == "kw_func1(x: int, y: int) -> str"
     assert doc(m.kw_func2) == "kw_func2(x: int = 100, y: int = 200) -> str"
     assert doc(m.kw_func3) == "kw_func3(data: str = 'Hello world!') -> None"
-    assert doc(m.kw_func4) == "kw_func4(myList: List[int] = [13, 17]) -> str"
+    assert doc(m.kw_func4) == "kw_func4(myList: list[int] = [13, 17]) -> str"
     assert doc(m.kw_func_udl) == "kw_func_udl(x: int, y: int = 300) -> str"
     assert doc(m.kw_func_udl_z) == "kw_func_udl_z(x: int, y: int = 0) -> str"
     assert doc(m.args_function) == "args_function(*args) -> tuple"

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -16,8 +16,8 @@ def test_vector(doc):
     assert m.load_bool_vector([True, False])
     assert m.load_bool_vector((True, False))
 
-    assert doc(m.cast_vector) == "cast_vector() -> List[int]"
-    assert doc(m.load_vector) == "load_vector(arg0: List[int]) -> bool"
+    assert doc(m.cast_vector) == "cast_vector() -> list[int]"
+    assert doc(m.load_vector) == "load_vector(arg0: list[int]) -> bool"
 
     # Test regression caused by 936: pointers to stl containers weren't castable
     assert m.cast_ptr_vector() == ["lvalue", "lvalue"]
@@ -39,10 +39,10 @@ def test_array(doc):
     assert m.load_array(lst)
     assert m.load_array(tuple(lst))
 
-    assert doc(m.cast_array) == "cast_array() -> Annotated[List[int], FixedSize(2)]"
+    assert doc(m.cast_array) == "cast_array() -> Annotated[list[int], FixedSize(2)]"
     assert (
         doc(m.load_array)
-        == "load_array(arg0: Annotated[List[int], FixedSize(2)]) -> bool"
+        == "load_array(arg0: Annotated[list[int], FixedSize(2)]) -> bool"
     )
 
 
@@ -53,8 +53,8 @@ def test_valarray(doc):
     assert m.load_valarray(lst)
     assert m.load_valarray(tuple(lst))
 
-    assert doc(m.cast_valarray) == "cast_valarray() -> List[int]"
-    assert doc(m.load_valarray) == "load_valarray(arg0: List[int]) -> bool"
+    assert doc(m.cast_valarray) == "cast_valarray() -> list[int]"
+    assert doc(m.load_valarray) == "load_valarray(arg0: list[int]) -> bool"
 
 
 def test_map(doc):
@@ -66,8 +66,8 @@ def test_map(doc):
     assert "key2" in d
     assert m.load_map(d)
 
-    assert doc(m.cast_map) == "cast_map() -> Dict[str, str]"
-    assert doc(m.load_map) == "load_map(arg0: Dict[str, str]) -> bool"
+    assert doc(m.cast_map) == "cast_map() -> dict[str, str]"
+    assert doc(m.load_map) == "load_map(arg0: dict[str, str]) -> bool"
 
 
 def test_set(doc):
@@ -78,8 +78,8 @@ def test_set(doc):
     assert m.load_set(s)
     assert m.load_set(frozenset(s))
 
-    assert doc(m.cast_set) == "cast_set() -> Set[str]"
-    assert doc(m.load_set) == "load_set(arg0: Set[str]) -> bool"
+    assert doc(m.cast_set) == "cast_set() -> set[str]"
+    assert doc(m.load_set) == "load_set(arg0: set[str]) -> bool"
 
 
 def test_recursive_casting():
@@ -303,7 +303,7 @@ def test_stl_pass_by_pointer(msg):
         msg(excinfo.value)
         == """
         stl_pass_by_pointer(): incompatible function arguments. The following argument types are supported:
-            1. (v: List[int] = None) -> List[int]
+            1. (v: list[int] = None) -> list[int]
 
         Invoked with:
     """
@@ -315,7 +315,7 @@ def test_stl_pass_by_pointer(msg):
         msg(excinfo.value)
         == """
         stl_pass_by_pointer(): incompatible function arguments. The following argument types are supported:
-            1. (v: List[int] = None) -> List[int]
+            1. (v: list[int] = None) -> list[int]
 
         Invoked with: None
     """


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

The #4259 introduced lowercase annotations for collections (e.g. `list` for `pybind::typing::List`), while the other parts of the `pybind11` still use uppercase annotations for the same _python_ types. This might lead to a mix of upper/lower case for collections:

```C++
    m.def("mix", [](const std::array<int, 3> &, const py::typing::List<int>&) {});
```

```python
print(demo.mix.__doc__)
# mix(arg0: Annotated[List[int], FixedSize(3)], arg1: list[int]) -> None
#                     ^^^^                            ^^^^
```

This PR fixes this inconsistency, rendering all collection types in lowercase according to [PEP 585](https://peps.python.org/pep-0585/). 

Note: The change is NOT incompatible with Python 3.6, since it alters only docstrings.

Fixes #4828

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Builtins collections names in docstrings are now consistently rendered in lowercase (list, set, dict, tuple), in accordance with PEP 585.
```

<!-- If the upgrade guide needs updating, note that here too -->
