### PR TITLE
feature: Support move-only iterators in `py::make_*iterator`

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2434,7 +2434,7 @@ iterator make_iterator_impl(Iterator first, Sentinel last, Extra &&...extra) {
                 Policy);
     }
 
-    return cast(state{first, last, true});
+    return cast(state{std::forward<Iterator>(first), std::forward<Sentinel>(last), true});
 }
 
 PYBIND11_NAMESPACE_END(detail)
@@ -2451,7 +2451,9 @@ iterator make_iterator(Iterator first, Sentinel last, Extra &&...extra) {
                                       Iterator,
                                       Sentinel,
                                       ValueType,
-                                      Extra...>(first, last, std::forward<Extra>(extra)...);
+                                      Extra...>(std::forward<Iterator>(first),
+                                                std::forward<Sentinel>(last),
+                                                std::forward<Extra>(extra)...);
 }
 
 /// Makes a python iterator over the keys (`.first`) of a iterator over pairs from a
@@ -2467,7 +2469,9 @@ iterator make_key_iterator(Iterator first, Sentinel last, Extra &&...extra) {
                                       Iterator,
                                       Sentinel,
                                       KeyType,
-                                      Extra...>(first, last, std::forward<Extra>(extra)...);
+                                      Extra...>(std::forward<Iterator>(first),
+                                                std::forward<Sentinel>(last),
+                                                std::forward<Extra>(extra)...);
 }
 
 /// Makes a python iterator over the values (`.second`) of a iterator over pairs from a
@@ -2483,7 +2487,9 @@ iterator make_value_iterator(Iterator first, Sentinel last, Extra &&...extra) {
                                       Iterator,
                                       Sentinel,
                                       ValueType,
-                                      Extra...>(first, last, std::forward<Extra>(extra)...);
+                                      Extra...>(std::forward<Iterator>(first),
+                                                std::forward<Sentinel>(last),
+                                                std::forward<Extra>(extra)...);
 }
 
 /// Makes an iterator over values of an stl container or other container supporting

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -100,7 +100,7 @@ public:
 
     private:
         ContainerWithMoveOnlyIterator *container;
-        MoveOnlyIterator(ContainerWithMoveOnlyIterator &c) : container(&c){};
+        explicit MoveOnlyIterator(ContainerWithMoveOnlyIterator &c) : container(&c){};
         friend class ContainerWithMoveOnlyIterator;
     };
 
@@ -109,7 +109,7 @@ public:
     static_assert(!std::is_copy_assignable<MoveOnlyIterator>::value, "");
     static_assert(!std::is_copy_constructible<MoveOnlyIterator>::value, "");
 
-    ContainerWithMoveOnlyIterator(int value) : value(value) {}
+    explicit ContainerWithMoveOnlyIterator(int value) : value(value) {}
     MoveOnlyIterator begin() { return MoveOnlyIterator(*this); };
     Sentinel end() { return Sentinel(); };
 

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -31,9 +31,9 @@ public:
 
     // Make the iterator non-copyable and movable
     NonZeroIterator(const NonZeroIterator &) = delete;
-    NonZeroIterator(NonZeroIterator &&) = default;
+    NonZeroIterator(NonZeroIterator &&) noexcept = default;
     NonZeroIterator &operator=(const NonZeroIterator &) = delete;
-    NonZeroIterator &operator=(NonZeroIterator &&) = default;
+    NonZeroIterator &operator=(NonZeroIterator &&) noexcept = default;
 
     const T &operator*() const { return *ptr_; }
     NonZeroIterator &operator++() {

--- a/tests/test_sequences_and_iterators.cpp
+++ b/tests/test_sequences_and_iterators.cpp
@@ -104,10 +104,10 @@ public:
         friend class ContainerWithMoveOnlyIterator;
     };
 
-    static_assert(std::is_move_assignable<MoveOnlyIterator>::value);
-    static_assert(std::is_move_constructible<MoveOnlyIterator>::value);
-    static_assert(!std::is_copy_assignable<MoveOnlyIterator>::value);
-    static_assert(!std::is_copy_constructible<MoveOnlyIterator>::value);
+    static_assert(std::is_move_assignable<MoveOnlyIterator>::value, "");
+    static_assert(std::is_move_constructible<MoveOnlyIterator>::value, "");
+    static_assert(!std::is_copy_assignable<MoveOnlyIterator>::value, "");
+    static_assert(!std::is_copy_constructible<MoveOnlyIterator>::value, "");
 
     ContainerWithMoveOnlyIterator(int value) : value(value) {}
     MoveOnlyIterator begin() { return MoveOnlyIterator(*this); };

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -250,3 +250,9 @@ def test_carray_iterator():
     arr_h = m.CArrayHolder(*args_gt)
     args = list(arr_h)
     assert args_gt == args
+
+
+def test_move_only_iterator():
+    """#4834: Support move-only iterators"""
+    c = m.ContainerWithMoveOnlyIterator(0)
+    assert list(c) == list(range(10))

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -250,9 +250,3 @@ def test_carray_iterator():
     arr_h = m.CArrayHolder(*args_gt)
     args = list(arr_h)
     assert args_gt == args
-
-
-def test_move_only_iterator():
-    """#4834: Support move-only iterators"""
-    c = m.ContainerWithMoveOnlyIterator(0)
-    assert list(c) == list(range(10))


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Support heavy (move-only) iterators in `py::make_iterator`,  `py::make_key_iterator`,  `py::make_value_iterator`

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Support move-only iterators in `py::make_iterator`, `py::make_key_iterator`, `py::make_value_iterator`
```

<!-- If the upgrade guide needs updating, note that here too -->
