### PR TITLE
MAINT: Include `numpy._core` imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,7 +142,7 @@ repos:
   - id: disallow-caps
     name: Disallow improper capitalization
     language: pygrep
-    entry: PyBind|Numpy|Cmake|CCache|PyTest
+    entry: PyBind|Cmake|CCache|PyTest
     exclude: ^\.pre-commit-config.yaml$
 
 # PyLint has native support - not always usable, but works for us

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,7 +142,7 @@ repos:
   - id: disallow-caps
     name: Disallow improper capitalization
     language: pygrep
-    entry: PyBind|Cmake|CCache|PyTest
+    entry: PyBind|\bNumpy\b|Cmake|CCache|PyTest
     exclude: ^\.pre-commit-config.yaml$
 
 # PyLint has native support - not always usable, but works for us

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -130,11 +130,13 @@ PYBIND11_NOINLINE module_ import_numpy_core_submodule(const char *submodule_name
 
     /* `numpy.core` was renamed to `numpy._core` in NumPy 2.0 as it officially
         became a private module. */
+    std::string numpy_core_path;
     if (major_version >= 2) {
-        return module_::import((std::string("numpy._core.") + submodule_name).c_str());
+        numpy_core_path = std::string("numpy._core");
     } else {
-        return module_::import((std::string("numpy.core.") + submodule_name).c_str());
+        numpy_core_path = std::string("numpy.core");
     }
+    return module_::import((numpy_core_path + "." + submodule_name).c_str());
 }
 
 template <typename T>

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -120,7 +120,7 @@ inline numpy_internals &get_numpy_internals() {
     return *ptr;
 }
 
-PYBIND11_NOINLINE module_ import_numpy_core_submodule(const char * submodule_name) {
+PYBIND11_NOINLINE module_ import_numpy_core_submodule(const char *submodule_name) {
     module_ numpy = module_::import("numpy");
     str version_string = numpy.attr("__version__");
 
@@ -131,13 +131,9 @@ PYBIND11_NOINLINE module_ import_numpy_core_submodule(const char * submodule_nam
     /* `numpy.core` was renamed to `numpy._core` in NumPy 2.0 as it officially
         became a private module. */
     if (major_version >= 2) {
-        return py::module_::import(
-            (std::string("numpy._core.") + submodule_name).c_str()
-        );
+        return py::module_::import((std::string("numpy._core.") + submodule_name).c_str());
     } else {
-        return py::module_::import(
-            (std::string("numpy.core.") + submodule_name).c_str()
-        );
+        return py::module_::import((std::string("numpy.core.") + submodule_name).c_str());
     }
 }
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -120,22 +120,19 @@ inline numpy_internals &get_numpy_internals() {
     return *ptr;
 }
 
-module_ import_numpy_core_submodule(const char * submodule_name) {
+module_ import_numpy_core_submodule(const char *submodule_name) {
     try {
-        return module_::import(
-            (std::string("numpy._core.") + submodule_name).c_str()
-        );
+        return module_::import((std::string("numpy._core.") + submodule_name).c_str());
     } catch (error_already_set &ex) {
-        if (!ex.matches(PyExc_ImportError)) throw;
+        if (!ex.matches(PyExc_ImportError))
+            throw;
         try {
-            return module_::import(
-                (std::string("numpy.core.") + submodule_name).c_str()
-            );
-        } catch(error_already_set &ex) {
-            if (!ex.matches(PyExc_ImportError)) throw;
-            throw import_error(
-                std::string("pybind11 couldn't import ") + submodule_name + " from numpy."
-            );
+            return module_::import((std::string("numpy.core.") + submodule_name).c_str());
+        } catch (error_already_set &ex) {
+            if (!ex.matches(PyExc_ImportError))
+                throw;
+            throw import_error(std::string("pybind11 couldn't import ") + submodule_name
+                               + " from numpy.");
         }
     }
 }
@@ -283,7 +280,7 @@ private:
     };
 
     static npy_api lookup() {
-        module_ m = import_numpy_core_submodule("multiarray");
+        module_ m = detail::import_numpy_core_submodule("multiarray");
         auto c = m.attr("_ARRAY_API");
         void **api_ptr = (void **) PyCapsule_GetPointer(c.ptr(), nullptr);
         npy_api api;
@@ -646,11 +643,8 @@ public:
 
 private:
     static object _dtype_from_pep3118() {
-        module_ m = import_numpy_core_submodule("_internal");
-        static PyObject *obj = m.attr("_dtype_from_pep3118")
-                                   .cast<object>()
-                                   .release()
-                                   .ptr();
+        module_ m = detail::import_numpy_core_submodule("_internal");
+        static PyObject *obj = m.attr("_dtype_from_pep3118").cast<object>().release().ptr();
         return reinterpret_borrow<object>(obj);
     }
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -130,12 +130,7 @@ PYBIND11_NOINLINE module_ import_numpy_core_submodule(const char *submodule_name
 
     /* `numpy.core` was renamed to `numpy._core` in NumPy 2.0 as it officially
         became a private module. */
-    std::string numpy_core_path;
-    if (major_version >= 2) {
-        numpy_core_path = std::string("numpy._core");
-    } else {
-        numpy_core_path = std::string("numpy.core");
-    }
+    std::string numpy_core_path = major_version >= 2 ? "numpy._core" : "numpy.core";
     return module_::import((numpy_core_path + "." + submodule_name).c_str());
 }
 
@@ -287,6 +282,7 @@ private:
         void **api_ptr = (void **) PyCapsule_GetPointer(c.ptr(), nullptr);
         if (api_ptr == nullptr) {
             raise_from(PyExc_SystemError, "FAILURE obtaining numpy _ARRAY_API pointer.");
+            throw error_already_set();
         }
         npy_api api;
 #define DECL_NPY_API(Func) api.Func##_ = (decltype(api.Func##_)) api_ptr[API_##Func];

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -120,17 +120,19 @@ inline numpy_internals &get_numpy_internals() {
     return *ptr;
 }
 
-module_ import_numpy_core_submodule(const char *submodule_name) {
+PYBIND11_NOINLINE module_ import_numpy_core_submodule(const char *submodule_name) {
     try {
         return module_::import((std::string("numpy._core.") + submodule_name).c_str());
     } catch (error_already_set &ex) {
-        if (!ex.matches(PyExc_ImportError))
+        if (!ex.matches(PyExc_ImportError)) {
             throw;
+        }
         try {
             return module_::import((std::string("numpy.core.") + submodule_name).c_str());
         } catch (error_already_set &ex) {
-            if (!ex.matches(PyExc_ImportError))
+            if (!ex.matches(PyExc_ImportError)) {
                 throw;
+            }
             throw import_error(std::string("pybind11 couldn't import ") + submodule_name
                                + " from numpy.");
         }

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -263,7 +263,12 @@ private:
     };
 
     static npy_api lookup() {
-        module_ m = module_::import("numpy.core.multiarray");
+        module_ m;
+        try {
+            m = module_::import("numpy._core.multiarray");
+        } catch (error_already_set&) {
+            m = module_::import("numpy.core.multiarray");
+        }
         auto c = m.attr("_ARRAY_API");
         void **api_ptr = (void **) PyCapsule_GetPointer(c.ptr(), nullptr);
         npy_api api;
@@ -626,8 +631,13 @@ public:
 
 private:
     static object _dtype_from_pep3118() {
-        static PyObject *obj = module_::import("numpy.core._internal")
-                                   .attr("_dtype_from_pep3118")
+        module_ m;
+        try {
+            m = module_::import("numpy._core._internal");
+        } catch (error_already_set&) {
+            m = module_::import("numpy.core._internal");
+        }
+        static PyObject *obj = m.attr("_dtype_from_pep3118")
                                    .cast<object>()
                                    .release()
                                    .ptr();

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -266,7 +266,7 @@ private:
         module_ m;
         try {
             m = module_::import("numpy._core.multiarray");
-        } catch (error_already_set&) {
+        } catch (error_already_set &) {
             m = module_::import("numpy.core.multiarray");
         }
         auto c = m.attr("_ARRAY_API");
@@ -634,13 +634,10 @@ private:
         module_ m;
         try {
             m = module_::import("numpy._core._internal");
-        } catch (error_already_set&) {
+        } catch (error_already_set &) {
             m = module_::import("numpy.core._internal");
         }
-        static PyObject *obj = m.attr("_dtype_from_pep3118")
-                                   .cast<object>()
-                                   .release()
-                                   .ptr();
+        static PyObject *obj = m.attr("_dtype_from_pep3118").cast<object>().release().ptr();
         return reinterpret_borrow<object>(obj);
     }
 


### PR DESCRIPTION
Hi!
`numpy.core` is becoming officially a private module and is being renamed to `numpy._core` in https://github.com/numpy/numpy/pull/24634 PR. 

It's backward and forward compatible change (**in terms of this change only** libraries compiled against 1.x will work with nightly numpy 2.0 installed and the other way around). Only a warning is emitted when accessing `numpy.core.*` with the previous name.

To avoid warnings for downstream libraries that use `pybind11`, such as scipy (such warnings are turned into errors in the CI), I propose this change: 
`pybind11/numpy.h` first tries to import with a new name `_core`. If numpy 1.x is installed it falls back to `core` name, therefore avoids emitting a warning when 2.0 is installed.

Please share your feedback!