### PR TITLE
Avoid copy in iteration by using const auto &

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1142,7 +1142,7 @@ protected:
                     }
                     msg += "kwargs: ";
                     bool first = true;
-                    for (auto kwarg : kwargs) {
+                    for (const auto &kwarg : kwargs) {
                         if (first) {
                             first = false;
                         } else {


### PR DESCRIPTION
## Description

Coverity scan highlights AUTO_CAUSES_COPY issue:

![image](https://github.com/pybind/pybind11/assets/21087696/0e404fa0-9060-4d76-a9f7-fdd9602e89a4)


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

None.


<!-- If the upgrade guide needs updating, note that here too -->
