### PR TITLE
MAINT: Remove `np.int_`

### DIFF
--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -298,7 +298,7 @@ def test_constructors():
     results = m.converting_constructors([1, 2, 3])
     for a in results.values():
         np.testing.assert_array_equal(a, [1, 2, 3])
-    assert results["array"].dtype == np.int_
+    assert results["array"].dtype == np.dtype(int)
     assert results["array_t<int32>"].dtype == np.int32
     assert results["array_t<double>"].dtype == np.float64
 


### PR DESCRIPTION
Hi!
This PR addresses changes that will be shipped in https://github.com/numpy/numpy/pull/24794 - deprecation of `np.int_` and `np.uint`. Instead of `np.int_` an `np.long` is being introduced to match C type names. 

`np.int_` could be potentially replaced by `np.intp` but it would differ on windows 64bit (hopefully it will be solved once [this PR](https://github.com/numpy/numpy/pull/24224) gets merged).

Here I replaced `np.int_` with `np.dtype(int)` as it's backward compatible way for defining a "default" integer dtype. 