### PR TITLE
fix: escape paths with spaces in pybind11-config

### DIFF
--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -18,7 +18,7 @@ except ImportError:
     else:
         # minimal attempt, handling only the most common case (spaces in path)
         def quote(s: str) -> str:
-            return '"' + s + '"' if " " in s else s
+            return f'"{s}"' if " " in s else s
 
 
 def print_includes() -> None:
@@ -34,7 +34,7 @@ def print_includes() -> None:
         if d and d not in unique_dirs:
             unique_dirs.append(d)
 
-    print(" ".join(quote("-I" + d) for d in unique_dirs))
+    print(" ".join(quote(f"-I{d}") for d in unique_dirs))
 
 
 def main() -> None:

--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -25,7 +25,7 @@ elif "nt" in sys.builtin_module_names:
 
         # Paths cannot contain a '"' on Windows, so we don't need to worry
         # about nuanced counting here.
-        return f'"{s}"'
+        return f'"{s}\\"' if s.endswith("\\") else f'"{s}"'
 else:
 
     def quote(s: str) -> str:

--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import shlex
 import sys
 import sysconfig
 
@@ -22,7 +23,7 @@ def print_includes() -> None:
         if d and d not in unique_dirs:
             unique_dirs.append(d)
 
-    print(" ".join("-I" + d for d in unique_dirs))
+    print(" ".join(shlex.quote("-I" + d) for d in unique_dirs))
 
 
 def main() -> None:

--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -2,23 +2,34 @@
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import sysconfig
 
 from ._version import __version__
 from .commands import get_cmake_dir, get_include, get_pkgconfig_dir
 
-try:
-    from oslex import quote
-except ImportError:
-    import os
+# This is the conditional used for os.path being posixpath
+if "posix" in sys.builtin_module_names:
+    from shlex import quote
+elif "nt" in sys.builtin_module_names:
+    # See https://github.com/mesonbuild/meson/blob/db22551ed9d2dd7889abea01cc1c7bba02bf1c75/mesonbuild/utils/universal.py#L1092-L1121
+    # and the original documents:
+    # https://docs.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments and
+    # https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+    UNSAFE = re.compile("[ \t\n\r]")
 
-    if os.name != "nt":
-        from shlex import quote
-    else:
-        # minimal attempt, handling only the most common case (spaces in path)
-        def quote(s: str) -> str:
-            return f'"{s}"' if " " in s else s
+    def quote(s: str) -> str:
+        if s and not UNSAFE.search(s):
+            return s
+
+        # Paths cannot contain a '"' on Windows, so we don't need to worry
+        # about nuanced counting here.
+        return f'"{s}"'
+else:
+
+    def quote(s: str) -> str:
+        return s
 
 
 def print_includes() -> None:
@@ -66,9 +77,9 @@ def main() -> None:
     if args.includes:
         print_includes()
     if args.cmakedir:
-        print(get_cmake_dir())
+        print(quote(get_cmake_dir()))
     if args.pkgconfigdir:
-        print(get_pkgconfig_dir())
+        print(quote(get_pkgconfig_dir()))
 
 
 if __name__ == "__main__":

--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -2,12 +2,23 @@
 from __future__ import annotations
 
 import argparse
-import shlex
 import sys
 import sysconfig
 
 from ._version import __version__
 from .commands import get_cmake_dir, get_include, get_pkgconfig_dir
+
+try:
+    from oslex import quote
+except ImportError:
+    import os
+
+    if os.name != "nt":
+        from shlex import quote
+    else:
+        # minimal attempt, handling only the most common case (spaces in path)
+        def quote(s: str) -> str:
+            return '"' + s + '"' if " " in s else s
 
 
 def print_includes() -> None:
@@ -23,7 +34,7 @@ def print_includes() -> None:
         if d and d not in unique_dirs:
             unique_dirs.append(d)
 
-    print(" ".join(shlex.quote("-I" + d) for d in unique_dirs))
+    print(" ".join(quote("-I" + d) for d in unique_dirs))
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 
 [[tool.mypy.overrides]]
-module = ["ghapi.*", "oslex"]
+module = ["ghapi.*"]
 ignore_missing_imports = true
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 
 [[tool.mypy.overrides]]
-module = ["ghapi.*"]
+module = ["ghapi.*", "oslex"]
 ignore_missing_imports = true
 
 


### PR DESCRIPTION
## Description

tl;dr: `pybind11 --includes` returns invalid arguments when the project's directory contains spaces.

When you build an extension manually, the [docs](https://pybind11.readthedocs.io/en/stable/compiling.html#building-manually) suggest this command: `c++ ... $(python3 -m pybind11 --includes) ...`. 
However, this command fails when the project's directory contains a space in its path. 
The command would then expand to `c++ ... -I/home/user/a b/c -I/python ...`, where `/home/user/a` is a in invalid include directory, and `b/c` is an invalid compiler argument.

Even if no manual build is desired this bug might affect users: for example, we're currently building `clang-tidy` in our project, which requires all include paths. 

To solve this issue, this PR escapes include paths of `pybind11 --includes` before printing. Paths without spaces/special characters are printed as-is, while paths with spaces are wrapped in `''`. Thus, the final command line of custom builds will be valid even if spaces occur: `c++ ... '-I/home/user/a b/c' -I/python ...`



## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->


<!-- If the upgrade guide needs updating, note that here too -->
