### PR TITLE
Update pytest to version 7.2.0 (which removes their dependency on py)

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ numpy==1.21.5; platform_python_implementation=="PyPy" and sys_platform=="linux" 
 numpy==1.19.3; platform_python_implementation!="PyPy" and python_version=="3.6"
 numpy==1.21.5; platform_python_implementation!="PyPy" and python_version>="3.7" and python_version<"3.10"
 numpy==1.22.2; platform_python_implementation!="PyPy" and python_version>="3.10" and python_version<"3.11"
-pytest==7.0.0
+pytest==7.2.0
 pytest-timeout
 scipy==1.5.4; platform_python_implementation!="PyPy" and python_version<"3.10"
 scipy==1.10.0; platform_python_implementation!="PyPy" and python_version=="3.10"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,8 @@ numpy==1.21.5; platform_python_implementation=="PyPy" and sys_platform=="linux" 
 numpy==1.19.3; platform_python_implementation!="PyPy" and python_version=="3.6"
 numpy==1.21.5; platform_python_implementation!="PyPy" and python_version>="3.7" and python_version<"3.10"
 numpy==1.22.2; platform_python_implementation!="PyPy" and python_version>="3.10" and python_version<"3.11"
-pytest==7.2.0
+pytest==7.0.0; platform_python_implementation!="PyPy" and python_version=="3.6"
+pytest==7.2.0; platform_python_implementation!="PyPy" and python_version>="3.7"
 pytest-timeout
 scipy==1.5.4; platform_python_implementation!="PyPy" and python_version<"3.10"
 scipy==1.10.0; platform_python_implementation!="PyPy" and python_version=="3.10"


### PR DESCRIPTION
The py library through 1.11.0 for Python allows remote attackers to conduct a ReDoS (Regular expression Denial of Service) attack via a Subversion repository with crafted info data, because the InfoSvnCommand argument is mishandled.

The particular codepath in question is the regular expression at py._path.svnurl.InfoSvnCommand.lspattern and is only relevant when dealing with subversion (svn) projects. Notably the codepath is not used in the popular pytest project. The developers of the pytest package have released version 7.2.0 which removes their dependency on py. Users of pytest seeing alerts relating to this advisory may update to version 7.2.0 of pytest to resolve this issue. See https://github.com/pytest-dev/py/issues/287#issuecomment-1290407715 for additional context.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
