### PR TITLE
Experimenting: `Annotated[Any, CppTypePybind11("cpp_namespace::UserType")]`

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -874,6 +874,38 @@ struct handle_type_name {
     static constexpr auto name = const_name<T>();
 };
 template <>
+struct handle_type_name<object> {
+    static constexpr auto name = const_name("object");
+};
+template <>
+struct handle_type_name<list> {
+    static constexpr auto name = const_name("list");
+};
+template <>
+struct handle_type_name<dict> {
+    static constexpr auto name = const_name("dict");
+};
+template <>
+struct handle_type_name<set> {
+    static constexpr auto name = const_name("set");
+};
+template <>
+struct handle_type_name<frozenset> {
+    static constexpr auto name = const_name("frozenset");
+};
+template <>
+struct handle_type_name<anyset> {
+    static constexpr auto name = const_name("anyset");
+};
+template <>
+struct handle_type_name<str> {
+    static constexpr auto name = const_name("str");
+};
+template <>
+struct handle_type_name<tuple> {
+    static constexpr auto name = const_name("tuple");
+};
+template <>
 struct handle_type_name<bool_> {
     static constexpr auto name = const_name("bool");
 };

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -888,16 +888,16 @@ struct handle_type_name<dict> {
     static constexpr auto name = const_name("dict");
 };
 template <>
+struct handle_type_name<anyset> {
+    static constexpr auto name = const_name("set");
+};
+template <>
 struct handle_type_name<set> {
     static constexpr auto name = const_name("set");
 };
 template <>
 struct handle_type_name<frozenset> {
     static constexpr auto name = const_name("frozenset");
-};
-template <>
-struct handle_type_name<anyset> {
-    static constexpr auto name = const_name("anyset");
 };
 template <>
 struct handle_type_name<str> {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -952,8 +952,20 @@ struct handle_type_name<sequence> {
     static constexpr auto name = const_name("Sequence");
 };
 template <>
+struct handle_type_name<bytearray> {
+    static constexpr auto name = const_name("bytearray");
+};
+template <>
+struct handle_type_name<memoryview> {
+    static constexpr auto name = const_name("memoryview");
+};
+template <>
 struct handle_type_name<slice> {
     static constexpr auto name = const_name("slice");
+};
+template <>
+struct handle_type_name<type> {
+    static constexpr auto name = const_name("type");
 };
 template <>
 struct handle_type_name<args> {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -889,7 +889,7 @@ struct handle_type_name<dict> {
 };
 template <>
 struct handle_type_name<anyset> {
-    static constexpr auto name = const_name("set | frozenset");
+    static constexpr auto name = const_name("Union[set, frozenset]");
 };
 template <>
 struct handle_type_name<set> {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -876,6 +876,38 @@ struct handle_type_name {
     static constexpr auto name = const_name<T>();
 };
 template <>
+struct handle_type_name<object> {
+    static constexpr auto name = const_name("object");
+};
+template <>
+struct handle_type_name<list> {
+    static constexpr auto name = const_name("list");
+};
+template <>
+struct handle_type_name<dict> {
+    static constexpr auto name = const_name("dict");
+};
+template <>
+struct handle_type_name<set> {
+    static constexpr auto name = const_name("set");
+};
+template <>
+struct handle_type_name<frozenset> {
+    static constexpr auto name = const_name("frozenset");
+};
+template <>
+struct handle_type_name<anyset> {
+    static constexpr auto name = const_name("anyset");
+};
+template <>
+struct handle_type_name<str> {
+    static constexpr auto name = const_name("str");
+};
+template <>
+struct handle_type_name<tuple> {
+    static constexpr auto name = const_name("tuple");
+};
+template <>
 struct handle_type_name<bool_> {
     static constexpr auto name = const_name("bool");
 };

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -952,6 +952,10 @@ struct handle_type_name<sequence> {
     static constexpr auto name = const_name("Sequence");
 };
 template <>
+struct handle_type_name<slice> {
+    static constexpr auto name = const_name("slice");
+};
+template <>
 struct handle_type_name<args> {
     static constexpr auto name = const_name("*args");
 };

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -874,38 +874,6 @@ struct handle_type_name {
     static constexpr auto name = const_name<T>();
 };
 template <>
-struct handle_type_name<object> {
-    static constexpr auto name = const_name("object");
-};
-template <>
-struct handle_type_name<list> {
-    static constexpr auto name = const_name("list");
-};
-template <>
-struct handle_type_name<dict> {
-    static constexpr auto name = const_name("dict");
-};
-template <>
-struct handle_type_name<set> {
-    static constexpr auto name = const_name("set");
-};
-template <>
-struct handle_type_name<frozenset> {
-    static constexpr auto name = const_name("frozenset");
-};
-template <>
-struct handle_type_name<anyset> {
-    static constexpr auto name = const_name("anyset");
-};
-template <>
-struct handle_type_name<str> {
-    static constexpr auto name = const_name("str");
-};
-template <>
-struct handle_type_name<tuple> {
-    static constexpr auto name = const_name("tuple");
-};
-template <>
 struct handle_type_name<bool_> {
     static constexpr auto name = const_name("bool");
 };

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -889,7 +889,7 @@ struct handle_type_name<dict> {
 };
 template <>
 struct handle_type_name<anyset> {
-    static constexpr auto name = const_name("set");
+    static constexpr auto name = const_name("set | frozenset");
 };
 template <>
 struct handle_type_name<set> {

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -41,9 +41,15 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 PYBIND11_WARNING_DISABLE_MSVC(4127)
 
+class dtype; // Forward declaration
 class array; // Forward declaration
 
 PYBIND11_NAMESPACE_BEGIN(detail)
+
+template <>
+struct handle_type_name<dtype> {
+    static constexpr auto name = const_name("numpy.dtype");
+};
 
 template <>
 struct handle_type_name<array> {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -493,7 +493,7 @@ protected:
                 } else {
                     std::string tname(t->name());
                     detail::clean_type_id(tname);
-                    signature += tname;
+                    signature += "Annotated[Any, \"" + tname + "\"]";
                 }
             } else {
                 signature += c;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -493,11 +493,7 @@ protected:
                 } else {
                     std::string tname(t->name());
                     detail::clean_type_id(tname);
-                    if (detail::cpp_name_needs_typing_annotated(tname.c_str())) {
-                        signature += "Annotated[Any, CppTypePybind11(\"" + tname + "\")]";
-                    } else {
-                        signature += tname;
-                    }
+                    signature += "Annotated[Any, CppTypePybind11(\"" + tname + "\")]";
                 }
             } else {
                 signature += c;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -493,7 +493,11 @@ protected:
                 } else {
                     std::string tname(t->name());
                     detail::clean_type_id(tname);
-                    signature += "Annotated[Any, \"" + tname + "\"]";
+                    if (detail::cpp_name_needs_typing_annotated(tname.c_str())) {
+                        signature += "Annotated[Any, \"" + tname + "\"]";
+                    } else {
+                        signature += tname;
+                    }
                 }
             } else {
                 signature += c;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -494,7 +494,7 @@ protected:
                     std::string tname(t->name());
                     detail::clean_type_id(tname);
                     if (detail::cpp_name_needs_typing_annotated(tname.c_str())) {
-                        signature += "Annotated[Any, \"" + tname + "\"]";
+                        signature += "Annotated[Any, CppTypePybind11(\"" + tname + "\")]";
                     } else {
                         signature += tname;
                     }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1318,6 +1318,15 @@ public:
     }
 };
 
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+template <>
+struct handle_type_name<module_> {
+    static constexpr auto name = const_name("module");
+};
+
+PYBIND11_NAMESPACE_END(detail)
+
 // When inside a namespace (or anywhere as long as it's not the first item on a line),
 // C++20 allows "module" to be used. This is provided for backward compatibility, and for
 // simplicity, if someone wants to use py::module for example, that is perfectly safe.

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -113,5 +113,15 @@ struct handle_type_name<typing::Callable<Return(Args...)>> {
                                  + const_name("]");
 };
 
+inline bool cpp_name_needs_typing_annotated(const char *cpp_name) {
+    while (*cpp_name) {
+        char c = *cpp_name++;
+        if (c == ':' || c == '<') { // Assuming valid names, there is no need to check for '>'.
+            return true;
+        }
+    }
+    return false;
+}
+
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -114,7 +114,7 @@ struct handle_type_name<typing::Callable<Return(Args...)>> {
 };
 
 inline bool cpp_name_needs_typing_annotated(const char *cpp_name) {
-    while (*cpp_name) {
+    while (*cpp_name != '\0') {
         char c = *cpp_name++;
         if (c == ':' || c == '<') { // Assuming valid names, there is no need to check for '>'.
             return true;

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -113,15 +113,5 @@ struct handle_type_name<typing::Callable<Return(Args...)>> {
                                  + const_name("]");
 };
 
-inline bool cpp_name_needs_typing_annotated(const char *cpp_name) {
-    while (*cpp_name != '\0') {
-        char c = *cpp_name++;
-        if (c == ':' || c == '<') { // Assuming valid names, there is no need to check for '>'.
-            return true;
-        }
-    }
-    return false;
-}
-
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -382,4 +382,7 @@ TEST_SUBMODULE(exceptions, m) {
         // function returns None instead of int, should give a useful error message
         fn().cast<int>();
     });
+
+    // m.def("pass_exception_void", [](const py::exception<void>&) {}); // Does not compile.
+    m.def("return_exception_void", []() { return py::exception<void>(); });
 }

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -419,3 +419,9 @@ def test_fn_cast_int_exception():
     assert str(excinfo.value).startswith(
         "Unable to cast Python instance of type <class 'NoneType'> to C++ type"
     )
+
+
+def test_return_exception_void():
+    with pytest.raises(TypeError) as excinfo:
+        m.return_exception_void()
+    assert 'Annotated[Any, CppTypePybind11("exception<void>")]' in str(excinfo.value)

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -342,8 +342,8 @@ def test_complex_array():
 
 def test_signature(doc):
     assert (
-        doc(m.create_rec_nested)
-        == "create_rec_nested(arg0: int) -> numpy.ndarray[NestedStruct]"
+        doc(m.create_rec_nested) == "create_rec_nested(arg0: int) "
+        '-> numpy.ndarray[Annotated[Any, CppTypePybind11("NestedStruct")]]'
     )
 
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -121,7 +121,7 @@ def test_set(capture, doc):
     assert m.anyset_contains({"foo"}, "foo")
 
     assert doc(m.get_set) == "get_set() -> set"
-    assert doc(m.print_anyset) == "print_anyset(arg0: set | frozenset) -> None"
+    assert doc(m.print_anyset) == "print_anyset(arg0: Union[set, frozenset]) -> None"
 
 
 def test_frozenset(capture, doc):

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -121,7 +121,7 @@ def test_set(capture, doc):
     assert m.anyset_contains({"foo"}, "foo")
 
     assert doc(m.get_set) == "get_set() -> set"
-    assert doc(m.print_anyset) == "print_anyset(arg0: anyset) -> None"
+    assert doc(m.print_anyset) == "print_anyset(arg0: set) -> None"
 
 
 def test_frozenset(capture, doc):

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -121,7 +121,7 @@ def test_set(capture, doc):
     assert m.anyset_contains({"foo"}, "foo")
 
     assert doc(m.get_set) == "get_set() -> set"
-    assert doc(m.print_anyset) == "print_anyset(arg0: set) -> None"
+    assert doc(m.print_anyset) == "print_anyset(arg0: set | frozenset) -> None"
 
 
 def test_frozenset(capture, doc):


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
For context see https://github.com/pybind/pybind11/pull/4876#issuecomment-1768750707 and surrounding comments.

TODO:

* Wait for feedback: https://github.com/python/mypy/issues/16306

* Add unit tests for `handle_type_name<>` specializations:
    - `module_`
    - `bytearray`, `memoryview`, `slice` `type`
    - `dtype`

* In case this PR is closed without merging, extract pure bug fixes: missing `handle_type_name<>` specializations for `dtype`, `module_`, `anyset`.

* Maybe: Remove the `handle_type_name<T>` fallback to `%`, to enforce at compile time that a specialization exists.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
