### PR TITLE
Workaround NVCC parse failure in `cast_op`

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -48,7 +48,8 @@ typename make_caster<T>::template cast_op_type<T> cast_op(make_caster<T> &caster
 template <typename T>
 typename make_caster<T>::template cast_op_type<typename std::add_rvalue_reference<T>::type>
 cast_op(make_caster<T> &&caster) {
-    using result_t = typename make_caster<T>::template cast_op_type<typename std::add_rvalue_reference<T>::type>;
+    using result_t = typename make_caster<T>::template cast_op_type<
+        typename std::add_rvalue_reference<T>::type>;
     return std::move(caster).operator result_t();
 }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -42,14 +42,14 @@ using make_caster = type_caster<intrinsic_t<type>>;
 // Shortcut for calling a caster's `cast_op_type` cast operator for casting a type_caster to a T
 template <typename T>
 typename make_caster<T>::template cast_op_type<T> cast_op(make_caster<T> &caster) {
-    using result_t = typename make_caster<T>::template cast_op_type<T>;
+    using result_t = typename make_caster<T>::template cast_op_type<T>; // See PR #4893
     return caster.operator result_t();
 }
 template <typename T>
 typename make_caster<T>::template cast_op_type<typename std::add_rvalue_reference<T>::type>
 cast_op(make_caster<T> &&caster) {
     using result_t = typename make_caster<T>::template cast_op_type<
-        typename std::add_rvalue_reference<T>::type>;
+        typename std::add_rvalue_reference<T>::type>; // See PR #4893
     return std::move(caster).operator result_t();
 }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -42,13 +42,14 @@ using make_caster = type_caster<intrinsic_t<type>>;
 // Shortcut for calling a caster's `cast_op_type` cast operator for casting a type_caster to a T
 template <typename T>
 typename make_caster<T>::template cast_op_type<T> cast_op(make_caster<T> &caster) {
-    return caster.operator typename make_caster<T>::template cast_op_type<T>();
+    using result_t = typename make_caster<T>::template cast_op_type<T>;
+    return caster.operator result_t();
 }
 template <typename T>
 typename make_caster<T>::template cast_op_type<typename std::add_rvalue_reference<T>::type>
 cast_op(make_caster<T> &&caster) {
-    return std::move(caster).operator typename make_caster<T>::
-        template cast_op_type<typename std::add_rvalue_reference<T>::type>();
+    using result_t = typename make_caster<T>::template cast_op_type<typename std::add_rvalue_reference<T>::type>;
+    return std::move(caster).operator result_t();
 }
 
 template <typename type>


### PR DESCRIPTION
There is a bug in some CUDA versions (observed in CUDA 12.1 and 11.7 w/ GCC 12.2), that makes `cast_op` fail to compile:
  `cast.h:45:120: error: expected template-name before ‘<’ token`

Defining the nested type as an alias and using it allows this to work without any change in semantics.

Fixes #4606

The alternative using a `static_cast` or similar fails due to ambiguity with the `const Foo&` and `Foo&` operators (one of the tests)

## Suggested changelog entry:

```rst
Improve compatibility with the nvcc compiler (especially CUDA 12.1/12.2)

```
