### PR TITLE
Adapt to changed function name in Python 3.13

### DIFF
--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -486,8 +486,10 @@ PYBIND11_NOINLINE handle get_object_handle(const void *ptr, const detail::type_i
 inline PyThreadState *get_thread_state_unchecked() {
 #if defined(PYPY_VERSION)
     return PyThreadState_GET();
-#else
+#elif PY_VERSION_HEX < 0x030D0000
     return _PyThreadState_UncheckedGet();
+#else
+    return PyThreadState_GetUnchecked();
 #endif
 }
 


### PR DESCRIPTION
## Description

According to https://docs.python.org/3.13/whatsnew/3.13.html:

Add PyThreadState_GetUnchecked() function: similar to PyThreadState_Get(), but don't kill the process with a fatal error if it is NULL. The caller is responsible to check if the result is NULL. Previously, the function was private and known as _PyThreadState_UncheckedGet().

As part of preparing for updating Python to version to 3.13 in Fedora 41 (scheduled for October 2024) rebuilds of existing Python packages are attempted against the current Python 3.13 version in a separate development repository. Currently this is Python 3.13.0a1.

[F41 Change Proposal: Python 3.13 (System-Wide)](https://discussion.fedoraproject.org/t/f41-change-proposal-python-3-13-system-wide/92897)

As a maintainer of packages in Fedora, I got two bugs filed against packages I maintain that failed to build in this rebuiild due to the issue this PR proposes to address:

* [HepMC3 fails to build with Python 3.13: error: ‘_PyThreadState_UncheckedGet’ was not declared in this scope; did you mean ‘PyThreadState_GetUnchecked’?](https://bugzilla.redhat.com/show_bug.cgi?id=2245854)
* [pythia8 fails to build with Python 3.13: error: ‘_PyThreadState_UncheckedGet’ was not declared in this scope](https://bugzilla.redhat.com/show_bug.cgi?id=2245858)

With the proposed change these packages can be built with the Python 3.13.0a1 from the special development repo.
