### PR TITLE
Use newer PyCode API and other fixes

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2751,11 +2751,11 @@ get_type_override(const void *this_ptr, const type_info *this_type, const char *
         if ((std::string) str(f_code->co_name) == name && f_code->co_argcount > 0) {
             PyObject *locals = PyEval_GetLocals();
             if (locals != nullptr) {
-#                if PY_VERSION_HEX >= 0x03110000
+#        if PY_VERSION_HEX >= 0x03110000
                 PyObject *co_varnames = PyCode_GetVarnames(f_code);
-#                else
+#        else
                 PyObject *co_varnames = PyObject_GetAttrString((PyObject *) f_code, "co_varnames");
-#                endif
+#        endif
                 PyObject *self_arg = PyTuple_GET_ITEM(co_varnames, 0);
                 Py_DECREF(co_varnames);
                 PyObject *self_caller = dict_getitem(locals, self_arg);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2759,6 +2759,7 @@ get_type_override(const void *this_ptr, const type_info *this_type, const char *
                 PyObject *self_arg = PyTuple_GET_ITEM(co_varnames, 0);
                 Py_DECREF(co_varnames);
                 PyObject *self_caller = dict_getitem(locals, self_arg);
+                Py_DECREF(locals);
                 if (self_caller == self.ptr()) {
                     Py_DECREF(f_code);
                     Py_DECREF(frame);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2751,7 +2751,7 @@ get_type_override(const void *this_ptr, const type_info *this_type, const char *
         if ((std::string) str(f_code->co_name) == name && f_code->co_argcount > 0) {
             PyObject *locals = PyEval_GetLocals();
             if (locals != nullptr) {
-#        if PY_VERSION_HEX >= 0x03110000
+#        if PY_VERSION_HEX >= 0x030b0000
                 PyObject *co_varnames = PyCode_GetVarnames(f_code);
 #        else
                 PyObject *co_varnames = PyObject_GetAttrString((PyObject *) f_code, "co_varnames");

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2751,7 +2751,11 @@ get_type_override(const void *this_ptr, const type_info *this_type, const char *
         if ((std::string) str(f_code->co_name) == name && f_code->co_argcount > 0) {
             PyObject *locals = PyEval_GetLocals();
             if (locals != nullptr) {
+#                if PY_VERSION_HEX >= 0x03110000
+                PyObject *co_varnames = PyCode_GetVarnames(f_code);
+#                else
                 PyObject *co_varnames = PyObject_GetAttrString((PyObject *) f_code, "co_varnames");
+#                endif
                 PyObject *self_arg = PyTuple_GET_ITEM(co_varnames, 0);
                 Py_DECREF(co_varnames);
                 PyObject *self_caller = dict_getitem(locals, self_arg);


### PR DESCRIPTION
This PR replaces PyObject_GetAttrString with PyCode_GetVarnames which is found by a warning of casting ''_object'' to "PyCodeObject". It also fixes an object leak which was found by code review.