### PR TITLE
[smart_holder] type_caster_odr_guard MSVC 193732825 C++17 windows-2022 is failing for unknown reasons.

### DIFF
--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -39,12 +39,15 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 // violations in binaries that are otherwise already fully tested and assumed to be healthy.
 //
 // * MSVC 2017 does not support __builtin_FILE(), __builtin_LINE().
+// * MSVC 193732825 C++17 windows-2020 is failing for unknown reasons.
 // * Intel 2021.6.0.20220226 (g++ 9.4 mode) __builtin_LINE() is unreliable
 //   (line numbers vary between translation units).
 #if defined(PYBIND11_ENABLE_TYPE_CASTER_ODR_GUARD_IF_AVAILABLE)                                   \
     && !defined(PYBIND11_ENABLE_TYPE_CASTER_ODR_GUARD) && defined(PYBIND11_CPP17)                 \
     && !defined(__INTEL_COMPILER)                                                                 \
-    && (!defined(_MSC_VER) || _MSC_VER >= 1920) // MSVC 2019 or newer.
+    && (!defined(_MSC_VER)                                                                        \
+        || (_MSC_VER >= 1920 /* MSVC 2019 or newer */                                             \
+            && (_MSC_VER != 193732825 || defined(PYBIND11_CPP20))))
 #    define PYBIND11_ENABLE_TYPE_CASTER_ODR_GUARD
 #endif
 

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -47,7 +47,7 @@ PYBIND11_NAMESPACE_BEGIN(detail)
     && !defined(__INTEL_COMPILER)                                                                 \
     && (!defined(_MSC_VER)                                                                        \
         || (_MSC_VER >= 1920 /* MSVC 2019 or newer */                                             \
-            && (_MSC_VER != 193732825 || defined(PYBIND11_CPP20))))
+            && (_MSC_FULL_VER != 193732825 || defined(PYBIND11_CPP20))))
 #    define PYBIND11_ENABLE_TYPE_CASTER_ODR_GUARD
 #endif
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The condition added here is based on close inspection of the GHA logs for https://github.com/pybind/pybind11/pull/4914.

* https://github.com/pybind/pybind11/actions/runs/6725911906

* Download: logs_30786.zip

```
$ python3 what_fails.py *.txt | grep 'MSVC 193732825 C++17'
MSVC 193732825 C++17 False 0___3.10___windows-latest___clang-latest.txt
MSVC 193732825 C++17 True 10___3.10___windows-2022___x64.txt
MSVC 193732825 C++17 True 11___3.11___windows-2022___x64.txt
MSVC 193732825 C++17 True 12___3.12___windows-2022___x64.txt
MSVC 193732825 C++17 True 14___pypy-3.9___windows-2022___x64.txt
```

```
$ python3 what_fails.py *.txt | grep -v 'MSVC 193732825 C++17' | grep MSVC
MSVC 192930152 C++14 False 0___3.6___MSVC_2019___x86.txt
MSVC 192930152 C++17 False 0___3.8___MSVC_2019__Debug____x86_-DCMAKE_CXX_STANDARD=17.txt
MSVC 193732825 C++20 False 0___3.9___MSVC_2022_C++20___x64.txt
MSVC 193732825 C++20 False 0___3.9___MSVC_2022_C++20___x64.txt
MSVC 193732825 C++14 False 10___3.10___windows-2022___x64.txt
MSVC 193732825 C++14 False 11___3.11___windows-2022___x64.txt
MSVC 193732825 C++14 False 12___3.12___windows-2022___x64.txt
MSVC 192930152 C++14 False 1___3.7___MSVC_2019___x86_-DCMAKE_CXX_STANDARD=14.txt
MSVC 192930152 C++20 False 1___3.9___MSVC_2019__Debug____x86_-DCMAKE_CXX_STANDARD=20.txt
MSVC 193532217 C++14 False 13___pypy-3.8___windows-2022___x64.txt
MSVC 193532217 C++17 False 13___pypy-3.8___windows-2022___x64.txt
MSVC 193532217 C++17 False 13___pypy-3.8___windows-2022___x64.txt
MSVC 193732825 C++14 False 14___pypy-3.9___windows-2022___x64.txt
MSVC 193532217 C++14 False 15___pypy-3.10___windows-2022___x64.txt
MSVC 193532217 C++17 False 15___pypy-3.10___windows-2022___x64.txt
MSVC 193532217 C++17 False 15___pypy-3.10___windows-2022___x64.txt
MSVC 192930152 C++17 False 2___3.8___MSVC_2019___x86_-DCMAKE_CXX_STANDARD=17.txt
MSVC 192930152 C++14 False 24___3.6___windows-2019___x64_-DPYBIND11_FINDPYTHON=ON.txt
MSVC 192930152 C++17 False 24___3.6___windows-2019___x64_-DPYBIND11_FINDPYTHON=ON.txt
MSVC 192930152 C++17 False 24___3.6___windows-2019___x64_-DPYBIND11_FINDPYTHON=ON.txt
MSVC 192930152 C++14 False 25___3.9___windows-2019___x64.txt
MSVC 192930152 C++17 False 25___3.9___windows-2019___x64.txt
MSVC 192930152 C++17 False 25___3.9___windows-2019___x64.txt
MSVC 192930152 C++20 False 3___3.9___MSVC_2019___x86_-DCMAKE_CXX_STANDARD=20.txt
MSVC 193532217 C++14 False 8___3.6___windows-2022___x64.txt
MSVC 193532217 C++17 False 8___3.6___windows-2022___x64.txt
MSVC 193532217 C++17 False 8___3.6___windows-2022___x64.txt
MSVC 193532217 C++14 False 9___3.9___windows-2022___x64.txt
```

what_fails.py:

```python
"""."""

import sys


def pin_point(filename):
  """."""
  last_cxx_std = None
  found_failed = None
  def transition():
    if last_cxx_std is None:
      assert found_failed is None
    else:
      assert found_failed is not None
      print(last_cxx_std, found_failed, filename)
  for line in open(filename).read().splitlines():
    pat = " C++ Info: "
    ix = line.find(pat)
    if ix >= 0:
      jx = line.find(" __pybind11_internals_")
      assert jx > ix
      transition()
      last_cxx_std = line[ix + len(pat) : jx].strip()
      found_failed = False
      continue
    ix = line.find("FAILED")
    jx = line.find("test_type_caster_odr_guard_")
    if ix >= 0 and jx > ix:
      found_failed = True
      continue
  transition()


def run(args):
  for filename in args:
    pin_point(filename)


if __name__ == "__main__":
  run(args=sys.argv[1:])
```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
