### PR TITLE
[smart_holder] Unique ptr deleter roundtrip tests and fix

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -1083,7 +1083,7 @@ struct smart_holder_type_caster<std::unique_ptr<T const, D>>
     cast(std::unique_ptr<T const, D> &&src, return_value_policy policy, handle parent) {
         return smart_holder_type_caster<std::unique_ptr<T, D>>::cast(
             std::unique_ptr<T, D>(const_cast<T *>(src.release()),
-                                  std::move(src.get_deleter())),  // Const2Mutbl
+                                  std::move(src.get_deleter())), // Const2Mutbl
             policy,
             parent);
     }

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -464,6 +464,29 @@ struct shared_ptr_trampoline_self_life_support {
     }
 };
 
+template <typename D, bool>
+struct delete_assigner {
+    static void assign(D &, bool, std::function<void(void *)> &, void (*)(void *) &) {
+        // Situation where the deleter cannot be assigned from either del_fun or del_ptr.
+        // This covers the default deleters and the like.
+    }
+};
+
+template <typename D>
+struct delete_assigner<D, true> {
+    static void assign(D &deleter,
+                       bool use_del_fun,
+                       std::function<void(void *)> &del_fun,
+                       void (*del_ptr)(void *) &) {
+        // Situation where D is assignable from del_fun.
+        if (use_del_fun) {
+            deleter = std::move(del_fun);
+        } else {
+            deleter = del_ptr;
+        }
+    }
+};
+
 template <typename T>
 struct smart_holder_type_caster_load {
     using holder_type = pybindit::memory::smart_holder;
@@ -616,13 +639,46 @@ struct smart_holder_type_caster_load {
                               "instance cannot safely be transferred to C++.");
         }
 
+        // Need to extract the deleter from the holder such that it can be passed back to the
+        // unique pointer.
+
+        // Temporary variable to store the extracted deleter in.
+        D extracted_deleter;
+
+        // In smart_holder_poc, the deleter is always stored in a guarded delete.
+        // The guarded delete's std::function<void(void*)> actually points at the custom_deleter
+        // type, so we can verify it is of the custom deleter type and finally extract its deleter.
+        auto *gd = std::get_deleter<pybindit::memory::guarded_delete>(holder().vptr);
+        if (gd) {
+            if (gd->use_del_fun) {
+                using custom_deleter_D = pybindit::memory::custom_deleter<T, D>;
+                const auto &custom_deleter_ptr = gd->del_fun.template target<custom_deleter_D>();
+                if (!custom_deleter_ptr) {
+                    throw cast_error("Deletion function is not stored in custom deleter, cannot \
+                                      extract the deleter correctly.");
+                }
+                // Now that we have confirmed the type of the deleter matches the desired return
+                // value we can extract the function.
+                extracted_deleter = std::move(custom_deleter_ptr->deleter);
+            } else {
+                // The del_ptr attribute of the guarded deleter does not provide any type
+                // information that can be used to confirm it is convertible to D. SFINEA here is
+                // necessary to ensure that if D is not constructible from a void(void*) pointer,
+                // it does not cause compilation failures. If this hits an non-convertible type at
+                // compile time it throws.
+                constexpr bool assignable = std::is_constructible<D, decltype(gd->del_fun)>::value;
+                delete_assigner<D, assignable>::assign(
+                    extracted_deleter, gd->use_del_fun, gd->del_fun, gd->del_ptr);
+            }
+        }
+
         // Critical transfer-of-ownership section. This must stay together.
         if (self_life_support != nullptr) {
             holder().disown();
         } else {
             holder().release_ownership();
         }
-        auto result = std::unique_ptr<T, D>(raw_type_ptr);
+        auto result = std::unique_ptr<T, D>(raw_type_ptr, std::move(extracted_deleter));
         if (self_life_support != nullptr) {
             self_life_support->activate_life_support(load_impl.loaded_v_h);
         } else {

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -468,17 +468,20 @@ template <typename T,
           typename D,
           typename std::enable_if<std::is_default_constructible<D>::value, int>::type = 0>
 inline std::unique_ptr<T, D> unique_with_deleter(T *raw_ptr, std::unique_ptr<D> &&deleter) {
-    if (deleter != nullptr) {
-        return std::unique_ptr<T, D>(raw_ptr, std::move(*deleter));
+    if (deleter == nullptr) {
+        return std::unique_ptr<T, D>(raw_ptr);
     }
-    return std::unique_ptr<T, D>(raw_ptr);
+    return std::unique_ptr<T, D>(raw_ptr, std::move(*deleter));
 }
 
 template <typename T,
           typename D,
           typename std::enable_if<!std::is_default_constructible<D>::value, int>::type = 0>
 inline std::unique_ptr<T, D> unique_with_deleter(T *raw_ptr, std::unique_ptr<D> &&deleter) {
-    assert(deleter != nullptr);
+    if (deleter == nullptr) {
+        pybind11_fail("smart_holder_type_casters: deleter is not default constructible and no"
+                      " instance available to return.");
+    }
     return std::unique_ptr<T, D>(raw_ptr, std::move(*deleter));
 }
 

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -1112,7 +1112,8 @@ struct smart_holder_type_caster<std::unique_ptr<T const, D>>
     static handle
     cast(std::unique_ptr<T const, D> &&src, return_value_policy policy, handle parent) {
         return smart_holder_type_caster<std::unique_ptr<T, D>>::cast(
-            std::unique_ptr<T, D>(const_cast<T *>(src.release())), // Const2Mutbl
+            std::unique_ptr<T, D>(const_cast<T *>(src.release()),
+                                  std::move(src.get_deleter())),  // Const2Mutbl
             policy,
             parent);
     }

--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -637,8 +637,8 @@ struct smart_holder_type_caster_load {
                 extracted_deleter = std::move(custom_deleter_ptr->deleter);
             } else {
                 // Not sure if anything needs to be done here. In general, if the del function is
-                // used a default destructor is used which should be accomodated by the type of the
-                // deleter used in the returned unique ptr.
+                // used a default destructor is used which should be accommodated by the type of
+                // the deleter used in the returned unique ptr.
             }
         }
 

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -67,19 +67,16 @@ std::string pass_udcp(std::unique_ptr<atyp const, sddc> obj) { return "pass_udcp
 
 struct custom_deleter
 {
-  std::string delete_txt;
-  void operator()(atyp* p) const
-  {
-    std::default_delete<atyp>()(p);
-  }
+    std::string delete_txt;
+    void operator()(atyp* p) const
+    {
+        std::default_delete<atyp>()(p);
+    }
 };
 
 std::unique_ptr<atyp,       custom_deleter> rtrn_udmp_del() { return std::unique_ptr<atyp,       custom_deleter>(new atyp{"rtrn_udmp_del"}, custom_deleter{"udmp_deleter"}); }
  
-std::string pass_udmp_del(std::unique_ptr<atyp,       custom_deleter> obj) {
-  const auto d = obj.get_deleter();
-  return "pass_udmp_del:" + obj->mtxt + "," + d.delete_txt;
-}
+std::string pass_udmp_del(std::unique_ptr<atyp,       custom_deleter> obj) { return "pass_udmp_del:" + obj->mtxt + "," + obj.get_deleter().delete_txt; }
 
 // clang-format on
 

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -68,7 +68,7 @@ std::string pass_udcp(std::unique_ptr<atyp const, sddc> obj) { return "pass_udcp
 struct custom_deleter
 {
     std::string delete_txt;
-    custom_deleter() = default;
+    custom_deleter() = delete;
     explicit custom_deleter(const std::string &delete_txt_) : delete_txt(delete_txt_) {}
     void operator()(atyp* p) const
     {

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -72,11 +72,17 @@ struct custom_deleter
     {
         std::default_delete<atyp>()(p);
     }
+    void operator()(const atyp* p) const
+    {
+        std::default_delete<const atyp>()(p);
+    }
 };
 
 std::unique_ptr<atyp,       custom_deleter> rtrn_udmp_del() { return std::unique_ptr<atyp,       custom_deleter>(new atyp{"rtrn_udmp_del"}, custom_deleter{"udmp_deleter"}); }
+std::unique_ptr<atyp const, custom_deleter> rtrn_udcp_del() { return std::unique_ptr<atyp const, custom_deleter>(new atyp{"rtrn_udcp_del"}, custom_deleter{"udcp_deleter"}); }
  
 std::string pass_udmp_del(std::unique_ptr<atyp,       custom_deleter> obj) { return "pass_udmp_del:" + obj->mtxt + "," + obj.get_deleter().delete_txt; }
+std::string pass_udcp_del(std::unique_ptr<atyp const, custom_deleter> obj) { return "pass_udcp_del:" + obj->mtxt + "," + obj.get_deleter().delete_txt; }
 
 // clang-format on
 
@@ -145,7 +151,10 @@ TEST_SUBMODULE(class_sh_basic, m) {
     m.def("pass_udcp", pass_udcp);
 
     m.def("rtrn_udmp_del", rtrn_udmp_del);
+    m.def("rtrn_udcp_del", rtrn_udcp_del);
+
     m.def("pass_udmp_del", pass_udmp_del);
+    m.def("pass_udcp_del", pass_udcp_del);
 
     py::classh<uconsumer>(m, "uconsumer")
         .def(py::init<>())

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -42,12 +42,12 @@ struct custom_deleter {
         return *this;
     }
 
-    custom_deleter(custom_deleter &&other) {
+    custom_deleter(custom_deleter &&other) noexcept {
         trace_txt = other.trace_txt + "_MvCtorTo";
         other.trace_txt += "_MvCtorFrom";
     }
 
-    custom_deleter &operator=(custom_deleter &&rhs) {
+    custom_deleter &operator=(custom_deleter &&rhs) noexcept {
         trace_txt = rhs.trace_txt + "_MvLhs";
         rhs.trace_txt += "_MvRhs";
         return *this;

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -68,6 +68,8 @@ std::string pass_udcp(std::unique_ptr<atyp const, sddc> obj) { return "pass_udcp
 struct custom_deleter
 {
     std::string delete_txt;
+    custom_deleter() = default;
+    explicit custom_deleter(const std::string &delete_txt_) : delete_txt(delete_txt_) {}
     void operator()(atyp* p) const
     {
         std::default_delete<atyp>()(p);
@@ -80,7 +82,7 @@ struct custom_deleter
 
 std::unique_ptr<atyp,       custom_deleter> rtrn_udmp_del() { return std::unique_ptr<atyp,       custom_deleter>(new atyp{"rtrn_udmp_del"}, custom_deleter{"udmp_deleter"}); }
 std::unique_ptr<atyp const, custom_deleter> rtrn_udcp_del() { return std::unique_ptr<atyp const, custom_deleter>(new atyp{"rtrn_udcp_del"}, custom_deleter{"udcp_deleter"}); }
- 
+
 std::string pass_udmp_del(std::unique_ptr<atyp,       custom_deleter> obj) { return "pass_udmp_del:" + obj->mtxt + "," + obj.get_deleter().delete_txt; }
 std::string pass_udcp_del(std::unique_ptr<atyp const, custom_deleter> obj) { return "pass_udcp_del:" + obj->mtxt + "," + obj.get_deleter().delete_txt; }
 

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -64,6 +64,23 @@ std::unique_ptr<atyp const, sddc> rtrn_udcp() { return std::unique_ptr<atyp cons
 std::string pass_udmp(std::unique_ptr<atyp,       sddm> obj) { return "pass_udmp:" + obj->mtxt; }
 std::string pass_udcp(std::unique_ptr<atyp const, sddc> obj) { return "pass_udcp:" + obj->mtxt; }
 
+
+struct custom_deleter
+{
+  std::string delete_txt;
+  void operator()(atyp* p) const
+  {
+    std::default_delete<atyp>()(p);
+  }
+};
+
+std::unique_ptr<atyp,       custom_deleter> rtrn_udmp_del() { return std::unique_ptr<atyp,       custom_deleter>(new atyp{"rtrn_udmp_del"}, custom_deleter{"udmp_deleter"}); }
+ 
+std::string pass_udmp_del(std::unique_ptr<atyp,       custom_deleter> obj) {
+  const auto d = obj.get_deleter();
+  return "pass_udmp_del:" + obj->mtxt + "," + d.delete_txt;
+}
+
 // clang-format on
 
 // Helpers for testing.
@@ -129,6 +146,9 @@ TEST_SUBMODULE(class_sh_basic, m) {
 
     m.def("pass_udmp", pass_udmp);
     m.def("pass_udcp", pass_udcp);
+
+    m.def("rtrn_udmp_del", rtrn_udmp_del);
+    m.def("pass_udmp_del", pass_udmp_del);
 
     py::classh<uconsumer>(m, "uconsumer")
         .def(py::init<>())

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -64,10 +64,15 @@ def test_load_with_mtxt(pass_f, mtxt, expected):
 def test_load_with_rtrn_f(pass_f, rtrn_f, expected):
     assert pass_f(rtrn_f()) == expected
 
-def test_deleter_roundtrip():
-    t = m.rtrn_udmp_del()
-    r = m.pass_udmp_del(t)
-    assert r == "pass_udmp_del:rtrn_udmp_del,udmp_deleter"
+@pytest.mark.parametrize(
+    ("pass_f", "rtrn_f", "expected"),
+    [
+        (m.pass_udmp_del, m.rtrn_udmp_del, "pass_udmp_del:rtrn_udmp_del,udmp_deleter"),
+        (m.pass_udcp_del, m.rtrn_udcp_del, "pass_udcp_del:rtrn_udcp_del,udcp_deleter"),
+    ],
+)
+def test_deleter_roundtrip(pass_f, rtrn_f, expected):
+    assert pass_f(rtrn_f()) == expected
 
 @pytest.mark.parametrize(
     ("pass_f", "rtrn_f", "expected"),

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -66,18 +66,32 @@ def test_load_with_rtrn_f(pass_f, rtrn_f, expected):
 
 
 @pytest.mark.parametrize(
-    ("pass_f", "rtrn_f", "expected"),
+    ("pass_f", "rtrn_f", "regex_expected"),
     [
-        (m.pass_udmp_del, m.rtrn_udmp_del, "pass_udmp_del:rtrn_udmp_del,udmp_deleter_" + "_".join(["MvCtorTo"] * 6)),
-        (m.pass_udcp_del, m.rtrn_udcp_del, "pass_udcp_del:rtrn_udcp_del,udcp_deleter_" + "_".join(["MvCtorTo"] * 8)),
-        (m.pass_udmp_del_nd, m.rtrn_udmp_del_nd,
-            "pass_udmp_del_nd:rtrn_udmp_del_nd,udmp_deleter_nd_" + "_".join(["MvCtorTo"] * 6)),
-        (m.pass_udcp_del_nd, m.rtrn_udcp_del_nd,
-            "pass_udcp_del_nd:rtrn_udcp_del_nd,udcp_deleter_nd_" + "_".join(["MvCtorTo"] * 8)),
+        (
+            m.pass_udmp_del,
+            m.rtrn_udmp_del,
+            "pass_udmp_del:rtrn_udmp_del,udmp_deleter(_MvCtorTo)*_MvCtorTo",
+        ),
+        (
+            m.pass_udcp_del,
+            m.rtrn_udcp_del,
+            "pass_udcp_del:rtrn_udcp_del,udcp_deleter(_MvCtorTo)*_MvCtorTo",
+        ),
+        (
+            m.pass_udmp_del_nd,
+            m.rtrn_udmp_del_nd,
+            "pass_udmp_del_nd:rtrn_udmp_del_nd,udmp_deleter_nd(_MvCtorTo)*_MvCtorTo",
+        ),
+        (
+            m.pass_udcp_del_nd,
+            m.rtrn_udcp_del_nd,
+            "pass_udcp_del_nd:rtrn_udcp_del_nd,udcp_deleter_nd(_MvCtorTo)*_MvCtorTo",
+        ),
     ],
 )
-def test_deleter_roundtrip(pass_f, rtrn_f, expected):
-    assert pass_f(rtrn_f()) == expected
+def test_deleter_roundtrip(pass_f, rtrn_f, regex_expected):
+    assert re.match(regex_expected, pass_f(rtrn_f()))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -64,6 +64,7 @@ def test_load_with_mtxt(pass_f, mtxt, expected):
 def test_load_with_rtrn_f(pass_f, rtrn_f, expected):
     assert pass_f(rtrn_f()) == expected
 
+
 @pytest.mark.parametrize(
     ("pass_f", "rtrn_f", "expected"),
     [
@@ -73,6 +74,7 @@ def test_load_with_rtrn_f(pass_f, rtrn_f, expected):
 )
 def test_deleter_roundtrip(pass_f, rtrn_f, expected):
     assert pass_f(rtrn_f()) == expected
+
 
 @pytest.mark.parametrize(
     ("pass_f", "rtrn_f", "expected"),

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -68,8 +68,12 @@ def test_load_with_rtrn_f(pass_f, rtrn_f, expected):
 @pytest.mark.parametrize(
     ("pass_f", "rtrn_f", "expected"),
     [
-        (m.pass_udmp_del, m.rtrn_udmp_del, "pass_udmp_del:rtrn_udmp_del,udmp_deleter_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo"),
-        (m.pass_udcp_del, m.rtrn_udcp_del, "pass_udcp_del:rtrn_udcp_del,udcp_deleter_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo"),
+        (m.pass_udmp_del, m.rtrn_udmp_del, "pass_udmp_del:rtrn_udmp_del,udmp_deleter_" + "_".join(["MvCtorTo"] * 6)),
+        (m.pass_udcp_del, m.rtrn_udcp_del, "pass_udcp_del:rtrn_udcp_del,udcp_deleter_" + "_".join(["MvCtorTo"] * 8)),
+        (m.pass_udmp_del_nd, m.rtrn_udmp_del_nd,
+            "pass_udmp_del_nd:rtrn_udmp_del_nd,udmp_deleter_nd_" + "_".join(["MvCtorTo"] * 6)),
+        (m.pass_udcp_del_nd, m.rtrn_udcp_del_nd,
+            "pass_udcp_del_nd:rtrn_udcp_del_nd,udcp_deleter_nd_" + "_".join(["MvCtorTo"] * 8)),
     ],
 )
 def test_deleter_roundtrip(pass_f, rtrn_f, expected):

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -64,6 +64,10 @@ def test_load_with_mtxt(pass_f, mtxt, expected):
 def test_load_with_rtrn_f(pass_f, rtrn_f, expected):
     assert pass_f(rtrn_f()) == expected
 
+def test_deleter_roundtrip():
+    t = m.rtrn_udmp_del()
+    r = m.pass_udmp_del(t)
+    assert r == "pass_udmp_del:rtrn_udmp_del,udmp_deleter"
 
 @pytest.mark.parametrize(
     ("pass_f", "rtrn_f", "expected"),

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -68,8 +68,8 @@ def test_load_with_rtrn_f(pass_f, rtrn_f, expected):
 @pytest.mark.parametrize(
     ("pass_f", "rtrn_f", "expected"),
     [
-        (m.pass_udmp_del, m.rtrn_udmp_del, "pass_udmp_del:rtrn_udmp_del,udmp_deleter"),
-        (m.pass_udcp_del, m.rtrn_udcp_del, "pass_udcp_del:rtrn_udcp_del,udcp_deleter"),
+        (m.pass_udmp_del, m.rtrn_udmp_del, "pass_udmp_del:rtrn_udmp_del,udmp_deleter_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo"),
+        (m.pass_udcp_del, m.rtrn_udcp_del, "pass_udcp_del:rtrn_udcp_del,udcp_deleter_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo_MvCtorTo"),
     ],
 )
 def test_deleter_roundtrip(pass_f, rtrn_f, expected):


### PR DESCRIPTION
## Description

@rwgk , as promised;  followup to #4850, this PR ensures custom deleters are propagated correctly and keep their state.


I only saw the note about [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) when I filed this PR, so their descriptions aren't that good, the work is mostly split out though in individual commits;

- 7cc1e1f7f96700a2cf5a7e7e86a9b32ec783d505 a failing unit test was introduced showing the deleter got lost.
- 5b00921098ab97001c602fe07c1a1e781efb17ad subsequently fixes that.
- ad7eaa4310fd8ea8fe67bd8e0f876a55a114aa45 adds a unit test for `std::unique_ptr<atyp const, custom_deleter>`, similar how the other default delete unit tests had that.
- a49a7ce819f88e372af800ec6971eddbe254286f Fixes that new unit test for `const atyp`.
- eb05f97c2144b43099c0707fe25e9c1a17734d7f Removes the assignment in case the 'use_del_fun' is  false, I don't think this is necessary as the code in `smart_holder_poc` guarantees that the `del_fun` is used in case there's anything but the default deleter, and for the default deleters no special handling is necessary.

Unit tests `make check` all pass, I ran clang format 13 on the files I touched, but didn't see a `make format` or anything along those lines, so it wouldn't surprise me if some linters still fail.

Happy to iterate, but feel free to push commits to this branch as you see fit. Filing as draft first before involving other code owners.

## Somewhat related observation
One thing that stood out to me was this line; https://github.com/pybind/pybind11/blob/edfaaed87ea3a869eaa1947f3d40cb62958295ca/include/pybind11/detail/smart_holder_poc.h#L106

I feel that shouldn't be doing a `delete`, but instead do:
```cpp
   std::default_delete<T>{}(raw_ptr);
```

Because the trait system that `std::default_delete` provides can be considered an extension point of the standard library, and calling `delete` would bypass any specializations that are provided.

## Suggested changelog entry:

```rst
Custom deleters in unique_ptrs are stored and extracted correctly from the smart holder.
```

<!-- If the upgrade guide needs updating, note that here too -->
