### PR TITLE
[smart_holder] Smart holder default delete

### DIFF
--- a/include/pybind11/detail/smart_holder_poc.h
+++ b/include/pybind11/detail/smart_holder_poc.h
@@ -103,7 +103,7 @@ struct guarded_delete {
 
 template <typename T, typename std::enable_if<std::is_destructible<T>::value, int>::type = 0>
 inline void builtin_delete_if_destructible(void *raw_ptr) {
-    delete static_cast<T *>(raw_ptr);
+    std::default_delete<T>{}(static_cast<T *>(raw_ptr));
 }
 
 template <typename T, typename std::enable_if<!std::is_destructible<T>::value, int>::type = 0>


### PR DESCRIPTION
@rwgk , as requested in https://github.com/pybind/pybind11/pull/4921#issuecomment-1795497776


Ensures `std::default_delete<T>` is used to look up the deleter for a type instead of `delete` directly.


## Description

The smart holder should use `std::default_delete` for looking up a deleter instead of assuming `delete` is the correct thing.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
```
