### PR TITLE
Inherit weakref from handle

### DIFF
--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -287,7 +287,7 @@ avoids this issue involves weak reference with a cleanup callback:
     );
 
     // Create a weak reference with a cleanup callback and initially leak it
-    (void) py::weakref(m.attr("BaseClass"), cleanup_callback).release();
+    (void) py::weakref(m.attr("BaseClass"), cleanup_callback);
 
 .. note::
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1694,8 +1694,7 @@ public:
         weakref(m_ptr, cpp_function([ptr](handle wr) {
                     delete ptr;
                     wr.dec_ref();
-                }))
-            .release();
+                }));
         return *this;
     }
 
@@ -2290,7 +2289,6 @@ PYBIND11_NOINLINE void keep_alive_impl(handle nurse, handle patient) {
         weakref wr(nurse, disable_lifesupport);
 
         patient.inc_ref(); /* reference patient and leak the weak reference */
-        (void) wr.release();
     }
 }
 
@@ -2338,8 +2336,7 @@ all_type_info_get_cache(PyTypeObject *type) {
                     }
 
                     wr.dec_ref();
-                }))
-            .release();
+                }));
     }
 
     return res;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1863,10 +1863,11 @@ public:
     operator double() const { return (double) PyFloat_AsDouble(m_ptr); }
 };
 
-class weakref : public handle {
+class weakref : public object {
 public:
+    PYBIND11_OBJECT_CVT_DEFAULT(weakref, object, PyWeakref_Check, raw_weakref)
     explicit weakref(handle obj, handle callback = {})
-        : handle(PyWeakref_NewRef(obj.ptr(), callback.ptr())) {
+        : object(PyWeakref_NewRef(obj.ptr(), callback.ptr()), stolen_t{}) {
         if (!m_ptr) {
             if (PyErr_Occurred()) {
                 throw error_already_set();
@@ -1874,6 +1875,7 @@ public:
             pybind11_fail("Could not allocate weak reference!");
         }
     }
+    ~weakref() { release(); }
 
 private:
     static PyObject *raw_weakref(PyObject *o) { return PyWeakref_NewRef(o, nullptr); }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1863,11 +1863,10 @@ public:
     operator double() const { return (double) PyFloat_AsDouble(m_ptr); }
 };
 
-class weakref : public object {
+class weakref : public handle {
 public:
-    PYBIND11_OBJECT_CVT_DEFAULT(weakref, object, PyWeakref_Check, raw_weakref)
     explicit weakref(handle obj, handle callback = {})
-        : object(PyWeakref_NewRef(obj.ptr(), callback.ptr()), stolen_t{}) {
+        : handle(PyWeakref_NewRef(obj.ptr(), callback.ptr())) {
         if (!m_ptr) {
             if (PyErr_Occurred()) {
                 throw error_already_set();


### PR DESCRIPTION
The design and uses of weakref in CPython API and pybind11 show that weakref should be better treated as handle and avoid the intentional release()