### PR TITLE
Fix refcount bug introduced with PR #4916.

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2759,7 +2759,6 @@ get_type_override(const void *this_ptr, const type_info *this_type, const char *
                 PyObject *self_arg = PyTuple_GET_ITEM(co_varnames, 0);
                 Py_DECREF(co_varnames);
                 PyObject *self_caller = dict_getitem(locals, self_arg);
-                Py_DECREF(locals);
                 if (self_caller == self.ptr()) {
                     Py_DECREF(f_code);
                     Py_DECREF(frame);


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
See https://github.com/pybind/pybind11/pull/4916/files#r1387035547.

Error message (Google toolchain):

```
.third_party/python_runtime/v3_10/Modules/gcmodule.c:115: gc_decref: Assertion "gc_get_refs(g) > 0" failed: refcount is too small
```

Same error with more context:
```
==================== Test output for //third_party/pybind11/tests:test_virtual_functions:
============================= test session starts ==============================
platform linux -- Python 3.10.13, pytest-7.2.0, pluggy-0.9.0
C++ Info: Clang google3-trunk (c4ba84d6555148fb7469fd44412a49d9d66eb4cf) C++20 __pybind11_internals_v5_clang_libcpp_cxxabi1002_sh_def__ PYBIND11_SIMPLE_GIL_MANAGEMENT=False
rootdir: /build/work/8b40e68d58b1b0798db67cef36d5d620f31e/google3/runfiles/google3/third_party/pybind11/tests, configfile: pytest.ini
collected 10 items

test_virtual_functions.py ### ExampleVirt @ 0x25baffda9e80 destroyed
### ExampleVirt @ 0x25baffda9ec0 destroyed
### ExampleVirt @ 0x25baffda9f00 destroyed
...### NonCopyable @ 0x25baffc01528 created 4 9
### NonCopyable @ 0x7ffc5d532eb0 created via move constructor
### NonCopyable @ 0x25baffc01528 destroyed
### NonCopyable @ 0x7ffc5d532eb0 destroyed
### Movable @ 0x25baffc003c8 created 4 5
### Movable @ 0x7ffc5d532eb4 created via copy constructor
### Movable @ 0x7ffc5d532eb4 destroyed
### Movable @ 0x25baffc01528 created 7 7
### Movable @ 0x7ffc5d532eb4 created via move constructor
### Movable @ 0x25baffc01528 destroyed
### Movable @ 0x7ffc5d532eb4 destroyed
### NonCopyable @ 0x25baffc01528 created 9 9
### Movable @ 0x25baffc003c8 destroyed
### NonCopyable @ 0x25baffc01528 destroyed
.....1st lock acquired
2nd lock acquired
1st lock acquired
2nd lock acquired
.third_party/python_runtime/v3_10/Modules/gcmodule.c:115: gc_decref: Assertion "gc_get_refs(g) > 0" failed: refcount is too small
Enable tracemalloc to get the memory block allocation traceback

object address  : 0x7ff66bd099c0
object refcount : 1
object type     : 0x556a6075a170
object type name: dict
object repr     : {'nodeid': 'test_virtual_functions.py::test_dispatch_issue', 'location': ('test_virtual_functions.py', 235, 'test_dispatch_issue'), 'keywords': {'test_dispatch_issue': 1, 'test_virtual_functions.py': 1, '__init__.py': 1, 'tests': 1}, 'outcome': 'passed', 'longrepr': None, 'when': 'call', 'user_properties': [], 'sections': [], 'duration': 0.0004472718574106693}

Fatal Python error: _PyObject_AssertFailed: _PyObject_AssertFailed
Python runtime state: initialized
```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
