### PR TITLE
chore: update changelog script for categories

### DIFF
--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import re
 
@@ -29,6 +30,18 @@ issues_pages = ghapi.page.paged(
 )
 issues = (issue for page in issues_pages for issue in page)
 missing = []
+cats_descr = {
+    "feat": "New Features",
+    "fix": "Bug fixes",
+    "fix(types)": "",
+    "fix(cmake)": "",
+    "docs": "Documentation",
+    "tests": "Tests",
+    "ci": "CI",
+    "chore": "Other",
+    "unknown": "Uncategorised",
+}
+cats: dict[str, list[str]] = {c: [] for c in cats_descr}
 
 for issue in issues:
     changelog = ENTRY.findall(issue.body or "")
@@ -36,14 +49,27 @@ for issue in issues:
         missing.append(issue)
     else:
         (msg,) = changelog
+        if msg.startswith("- "):
+            msg = msg[2:]
         if not msg.startswith("* "):
             msg = "* " + msg
         if not msg.endswith("."):
             msg += "."
 
         msg += f"\n  `#{issue.number} <{issue.html_url}>`_"
+        for cat in cats:
+            if issue.title.lower().startswith(f"{cat}:"):
+                cats[cat].append(msg)
+                break
+        else:
+            cats["unknown"].append(msg)
 
-        print(Syntax(msg, "rst", theme="ansi_light", word_wrap=True))
+for cat, msgs in cats.items():
+    if msgs:
+        desc = cats_descr[cat]
+        print(f"[bold]{desc}:\n" if desc else "")
+        for msg in msgs:
+            print(Syntax(msg, "rst", theme="ansi_light", word_wrap=True))
         print()
 
 if missing:


### PR DESCRIPTION
Makes categories for each of the conventionalcommit-named PRs. Small touch ups.

Example output:
![Screenshot 2023-11-15 at 4 02 54 PM](https://github.com/pybind/pybind11/assets/4616906/05970403-2b30-4353-9b66-bda663631394)


