### PR TITLE
fix(stl_bind): Enable `bind_map` with `using` declarations.

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -843,7 +843,8 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args &&
         m.erase(it);
     });
 
-    cl.def("__len__", &Map::size);
+    // Always use a lambda in case of `using` declaration
+    cl.def("__len__", [](const Map& m){ return m.size(); });
 
     return cl;
 }

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -844,7 +844,7 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args &&
     });
 
     // Always use a lambda in case of `using` declaration
-    cl.def("__len__", [](const Map& m){ return m.size(); });
+    cl.def("__len__", [](const Map &m) { return m.size(); });
 
     return cl;
 }

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -525,7 +525,7 @@ class_<Vector, holder_type> bind_vector(handle scope, std::string const &name, A
         [](const Vector &v) -> bool { return !v.empty(); },
         "Check whether the list is nonempty");
 
-    cl.def("__len__", [](const Vector& vec) { return vec.size(); });
+    cl.def("__len__", [](const Vector &vec) { return vec.size(); });
 
 #if 0
     // C++ style functions deprecated, leaving it here as an example

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -525,7 +525,7 @@ class_<Vector, holder_type> bind_vector(handle scope, std::string const &name, A
         [](const Vector &v) -> bool { return !v.empty(); },
         "Check whether the list is nonempty");
 
-    cl.def("__len__", &Vector::size);
+    cl.def("__len__", [](const Vector& vec) { return vec.size(); });
 
 #if 0
     // C++ style functions deprecated, leaving it here as an example

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -15,6 +15,7 @@
 #include <deque>
 #include <map>
 #include <unordered_map>
+#include <vector>
 
 class El {
 public:
@@ -81,6 +82,74 @@ struct RecursiveVector : std::vector<RecursiveVector> {
 struct RecursiveMap : std::map<int, RecursiveMap> {
     using Parent = std::map<int, RecursiveMap>;
     using Parent::Parent;
+};
+
+class UserVectorLike : private std::vector<int> {
+public:
+    using Base = std::vector<int>;
+    using typename Base::value_type;
+    using typename Base::size_type;
+    using typename Base::difference_type;
+    using typename Base::iterator;
+    using typename Base::const_iterator;
+
+    using Base::Base;
+    using Base::begin;
+    using Base::end;
+    using Base::cbegin;
+    using Base::cend;
+    using Base::empty;
+    using Base::clear;
+    using Base::push_back;
+    using Base::insert;
+    using Base::swap;
+    using Base::at;
+    using Base::reserve;
+    using Base::erase;
+    using Base::pop_back;
+    using Base::shrink_to_fit;
+    using Base::front;
+    using Base::back;
+    using Base::operator[];
+    using Base::capacity;
+    using Base::size;
+};
+
+bool operator==(UserVectorLike const& , UserVectorLike const& ) { return true; }
+bool operator!=(UserVectorLike const& , UserVectorLike const& ) { return false; }
+
+class UserMapLike : private std::map<int, int> {
+public:
+
+    using Base = std::map<int, int>;
+    using typename Base::key_type;
+    using typename Base::mapped_type;
+    using typename Base::value_type;
+    using typename Base::size_type;
+    using typename Base::iterator;
+    using typename Base::const_iterator;
+
+    using Base::Base;
+    using Base::begin;
+    using Base::end;
+    using Base::cbegin;
+    using Base::cend;
+    using Base::empty;
+    using Base::max_size;
+    using Base::clear;
+    using Base::insert;
+    using Base::insert_or_assign;
+    using Base::emplace;
+    using Base::emplace_hint;
+    using Base::try_emplace;
+    using Base::erase;
+    using Base::swap;
+    using Base::extract;
+    using Base::merge;
+    using Base::find;
+    using Base::at;
+    using Base::operator[];
+    using Base::size;
 };
 
 /*
@@ -172,6 +241,11 @@ TEST_SUBMODULE(stl_binders, m) {
     py::bind_map<RecursiveMap>(m, "RecursiveMap");
     py::bind_map<MutuallyRecursiveContainerPairMV>(m, "MutuallyRecursiveContainerPairMV");
     py::bind_vector<MutuallyRecursiveContainerPairVM>(m, "MutuallyRecursiveContainerPairVM");
+
+    // Bind with private inheritance + `using` directives.
+    // Feel free to add new `using` directives there.
+    py::bind_vector<UserVectorLike>(m, "UserVectorLike");
+    py::bind_map<UserMapLike>(m, "UserMapLike");
 
     // The rest depends on numpy:
     try {

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -87,67 +87,66 @@ struct RecursiveMap : std::map<int, RecursiveMap> {
 class UserVectorLike : private std::vector<int> {
 public:
     using Base = std::vector<int>;
-    using typename Base::value_type;
-    using typename Base::size_type;
+    using typename Base::const_iterator;
     using typename Base::difference_type;
     using typename Base::iterator;
-    using typename Base::const_iterator;
+    using typename Base::size_type;
+    using typename Base::value_type;
 
+    using Base::at;
+    using Base::back;
     using Base::Base;
     using Base::begin;
-    using Base::end;
     using Base::cbegin;
     using Base::cend;
-    using Base::empty;
     using Base::clear;
-    using Base::push_back;
-    using Base::insert;
-    using Base::swap;
-    using Base::at;
-    using Base::reserve;
+    using Base::empty;
+    using Base::end;
     using Base::erase;
-    using Base::pop_back;
-    using Base::shrink_to_fit;
     using Base::front;
-    using Base::back;
+    using Base::insert;
+    using Base::pop_back;
+    using Base::push_back;
+    using Base::reserve;
+    using Base::shrink_to_fit;
+    using Base::swap;
     using Base::operator[];
     using Base::capacity;
     using Base::size;
 };
 
-bool operator==(UserVectorLike const& , UserVectorLike const& ) { return true; }
-bool operator!=(UserVectorLike const& , UserVectorLike const& ) { return false; }
+bool operator==(UserVectorLike const &, UserVectorLike const &) { return true; }
+bool operator!=(UserVectorLike const &, UserVectorLike const &) { return false; }
 
 class UserMapLike : private std::map<int, int> {
 public:
-
     using Base = std::map<int, int>;
+    using typename Base::const_iterator;
+    using typename Base::iterator;
     using typename Base::key_type;
     using typename Base::mapped_type;
-    using typename Base::value_type;
     using typename Base::size_type;
-    using typename Base::iterator;
-    using typename Base::const_iterator;
+    using typename Base::value_type;
 
+    using Base::at;
     using Base::Base;
     using Base::begin;
-    using Base::end;
     using Base::cbegin;
     using Base::cend;
-    using Base::empty;
-    using Base::max_size;
     using Base::clear;
-    using Base::insert;
-    using Base::insert_or_assign;
     using Base::emplace;
     using Base::emplace_hint;
-    using Base::try_emplace;
+    using Base::empty;
+    using Base::end;
     using Base::erase;
-    using Base::swap;
     using Base::extract;
-    using Base::merge;
     using Base::find;
-    using Base::at;
+    using Base::insert;
+    using Base::insert_or_assign;
+    using Base::max_size;
+    using Base::merge;
+    using Base::swap;
+    using Base::try_emplace;
     using Base::operator[];
     using Base::size;
 };

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -139,14 +139,10 @@ public:
     using Base::empty;
     using Base::end;
     using Base::erase;
-    using Base::extract;
     using Base::find;
     using Base::insert;
-    using Base::insert_or_assign;
     using Base::max_size;
-    using Base::merge;
     using Base::swap;
-    using Base::try_emplace;
     using Base::operator[];
     using Base::size;
 };

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -86,6 +86,7 @@ struct RecursiveMap : std::map<int, RecursiveMap> {
 
 class UserVectorLike : private std::vector<int> {
 public:
+    // This is only a subset of the member functions, as needed at the time.
     using Base = std::vector<int>;
     using typename Base::const_iterator;
     using typename Base::difference_type;
@@ -120,6 +121,7 @@ bool operator!=(UserVectorLike const &, UserVectorLike const &) { return false; 
 
 class UserMapLike : private std::map<int, int> {
 public:
+    // This is only a subset of the member functions, as needed at the time.
     using Base = std::map<int, int>;
     using typename Base::const_iterator;
     using typename Base::iterator;
@@ -238,7 +240,6 @@ TEST_SUBMODULE(stl_binders, m) {
     py::bind_vector<MutuallyRecursiveContainerPairVM>(m, "MutuallyRecursiveContainerPairVM");
 
     // Bind with private inheritance + `using` directives.
-    // Feel free to add new `using` directives there.
     py::bind_vector<UserVectorLike>(m, "UserVectorLike");
     py::bind_map<UserMapLike>(m, "UserMapLike");
 

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -353,3 +353,17 @@ def test_recursive_map():
     recursive_map[100][101] = m.RecursiveMap()
     recursive_map[100][102] = m.RecursiveMap()
     assert list(recursive_map[100].keys()) == [101, 102]
+
+
+def test_user_vector_like():
+    vec = m.UserVectorLike()
+    vec.append(2)
+    assert vec[0] == 2
+    assert len(vec) == 1
+
+
+def test_user_like_map():
+    map = m.UserMapLike()
+    map[33] = 44
+    assert map[33] == 44
+    assert len(map) == 1


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Enable using `py::bind_map` with map-like things that privately inherit from map + `using` declarations.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
- Fix ``bind_map`` with ``using`` declarations.
```

<!-- If the upgrade guide needs updating, note that here too -->
