### PR TITLE
Fix MSVC MT/MD incompatibility in PYBIND11_BUILD_ABI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,11 @@ jobs:
             python: '3.10'
             args: >
               -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL
-          - runs-on: windows-2022
-            python: '3.11'
-            args: >
-              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug
+          # This needs a python built with MTd
+          # - runs-on: windows-2022
+          #   python: '3.11'
+          #   args: >
+          #     -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug
           - runs-on: windows-2022
             python: '3.12'
             args: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,23 @@ jobs:
           # Inject a couple Windows 2019 runs
           - runs-on: windows-2019
             python: '3.9'
+          # Inject a few runs with different runtime libraries
+          - runs-on: windows-2022
+            python: '3.9'
+            args: >
+              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
+          - runs-on: windows-2022
+            python: '3.10'
+            args: >
+              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL
+          - runs-on: windows-2022
+            python: '3.11'
+            args: >
+              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug
+          - runs-on: windows-2022
+            python: '3.12'
+            args: >
+              -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebugDLL
           # Extra ubuntu latest job
           - runs-on: ubuntu-latest
             python: '3.11'

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -329,6 +329,7 @@ struct type_info {
 #            define PYBIND11_BUILD_ABI "_md_mscver22"
 #        else
 #            error "Unknown major version for MSC_VER"
+#        endif
 #    elif defined(_MSC_VER) && defined(_MT)
 #        define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
 #    else

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -323,7 +323,11 @@ struct type_info {
 #        elif defined(_MT) // Corresponding to CL command line options /MT or /MTd.
 #            define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
 #        else
-#            error "Unknown combination of MSVC preprocessor macros: PLEASE REVISE THIS CODE."
+#            if (_MSC_VER) / 100 == 19
+#                define PYBIND11_BUILD_ABI "_none_mscver19"
+#            else
+#                error "Unknown major version for MSC_VER: PLEASE REVISE THIS CODE."
+#            endif
 #        endif
 #    elif defined(__NVCOMPILER)       // NVHPC (PGI-based).
 #        define PYBIND11_BUILD_ABI "" // TODO: What should be here, to prevent UB?

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -311,11 +311,11 @@ struct type_info {
 #endif
 
 /// On Linux/OSX, changes in __GXX_ABI_VERSION__ indicate ABI incompatibility.
-/// On MSVC, changes in _MSC_VER may indicate ABI incompatibility (#2898).
+/// On MSVC, mixing /MT and /MD will result in crashes. See (#4779)
 #ifndef PYBIND11_BUILD_ABI
 #    if defined(__GXX_ABI_VERSION)
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
-#    elif defined(_MSC_VER)
+#    elif defined(_MSC_VER) && defined(_MT)
 #        define PYBIND11_BUILD_ABI "_mscver" PYBIND11_TOSTRING(_MSC_VER)
 #    else
 #        define PYBIND11_BUILD_ABI ""

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -312,11 +312,22 @@ struct type_info {
 
 /// On Linux/OSX, changes in __GXX_ABI_VERSION__ indicate ABI incompatibility.
 /// On MSVC, mixing /MT and /MD will result in crashes. See (#4953)
+/// There is no macro for major version for MSVC, so we check for major version
+/// 19, 20, 21, 22 for now as major version 19 is MSVC 2015-2022 and we future
+/// proof for 3 major versions in the future
 #ifndef PYBIND11_BUILD_ABI
 #    if defined(__GXX_ABI_VERSION)
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
+#    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT) && ((_MSC_VER) / 100 == 19)
+#        define PYBIND11_BUILD_ABI "_md_mscver19"
+#    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT) && ((_MSC_VER) / 100 == 20)
+#        define PYBIND11_BUILD_ABI "_md_mscver20"
+#    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT) && ((_MSC_VER) / 100 == 21)
+#        define PYBIND11_BUILD_ABI "_md_mscver21"
+#    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT) && ((_MSC_VER) / 100 == 22)
+#        define PYBIND11_BUILD_ABI "_md_mscver22"
 #    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT)
-#        define PYBIND11_BUILD_ABI "_md_mscver" PYBIND11_TOSTRING(((int) (_MSC_VER) / 100))
+#        error "Unknown major version for MSC_VER"
 #    elif defined(_MSC_VER) && defined(_MT)
 #        define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
 #    else

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -310,21 +310,25 @@ struct type_info {
 #    endif
 #endif
 
-/// On Linux/OSX, changes in __GXX_ABI_VERSION__ indicate ABI incompatibility.
-/// On MSVC, mixing /MT and /MD will result in crashes. See (#4953)
 #ifndef PYBIND11_BUILD_ABI
-#    if defined(__GXX_ABI_VERSION)
+#    if defined(__GXX_ABI_VERSION) // Linux/OSX.
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
-#    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT)
-#        if ((_MSC_VER) / 100 == 19)
-#            define PYBIND11_BUILD_ABI "_md_mscver19"
+#    elif defined(_MSC_VER) // See PR #4953.
+#        if defined(_MT) && defined(_DLL)
+#            define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
+#        elif defined(_MD)
+#            if (_MSC_VER) / 100 == 19
+#                define PYBIND11_BUILD_ABI "_md_mscver19"
+#            else
+#                error "Unknown major version for MSC_VER: PLEASE REVISE THIS CODE."
+#            endif
 #        else
-#            error "Unknown major version for MSC_VER"
+#            error "Unknown combination of MSVC preprocessor macros: PLEASE REVISE THIS CODE."
 #        endif
-#    elif defined(_MSC_VER) && defined(_MT)
-#        define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
+#    elif defined(__NVCOMPILER)       // NVHPC (PGI-based, outdated).
+#        define PYBIND11_BUILD_ABI "" // This was never properly guarded.
 #    else
-#        define PYBIND11_BUILD_ABI ""
+#        error "Unknown platform or compiler: PLEASE REVISE THIS CODE."
 #    endif
 #endif
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -317,10 +317,8 @@ struct type_info {
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
 #    elif defined(_MSC_VER) && defined(_MT)
 #        define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
-#    elif defined(_MSC_VER) && defined(_MD) && (_MSC_VER >= 1900) && (_MSC_VER < 2000)
-#        define PYBIND11_BUILD_ABI "_md_mscver14"
 #    elif defined(_MSC_VER) && defined(_MD)
-#        define PYBIND11_BUILD_ABI "_md_mscver" PYBIND11_TOSTRING(_MSC_VER)
+#        define PYBIND11_BUILD_ABI "_md_mscver" PYBIND11_TOSTRING(((int) (_MSC_VER) / 100))
 #    else
 #        define PYBIND11_BUILD_ABI ""
 #    endif

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -311,7 +311,7 @@ struct type_info {
 #endif
 
 /// On Linux/OSX, changes in __GXX_ABI_VERSION__ indicate ABI incompatibility.
-/// On MSVC, mixing /MT and /MD will result in crashes. See (#4779)
+/// On MSVC, mixing /MT and /MD will result in crashes. See (#4953)
 #ifndef PYBIND11_BUILD_ABI
 #    if defined(__GXX_ABI_VERSION)
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -316,7 +316,11 @@ struct type_info {
 #    if defined(__GXX_ABI_VERSION)
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
 #    elif defined(_MSC_VER) && defined(_MT)
-#        define PYBIND11_BUILD_ABI "_mscver" PYBIND11_TOSTRING(_MSC_VER)
+#        define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
+#    elif defined(_MSC_VER) && defined(_MD) && (_MSC_VER >= 1900) && (_MSC_VER < 2000)
+#        define PYBIND11_BUILD_ABI "_md_mscver14"
+#    elif defined(_MSC_VER) && defined(_MD)
+#        define PYBIND11_BUILD_ABI "_md_mscver" PYBIND11_TOSTRING(_MSC_VER)
 #    else
 #        define PYBIND11_BUILD_ABI ""
 #    endif

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -314,14 +314,14 @@ struct type_info {
 #    if defined(__GXX_ABI_VERSION) // Linux/OSX.
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
 #    elif defined(_MSC_VER) // See PR #4953.
-#        if defined(_MT)
-#            define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
-#        elif defined(_MD)
+#        if defined(_MT) && defined(_DLL)
 #            if (_MSC_VER) / 100 == 19
 #                define PYBIND11_BUILD_ABI "_md_mscver19"
 #            else
 #                error "Unknown major version for MSC_VER: PLEASE REVISE THIS CODE."
 #            endif
+#        elif defined(_MT)
+#            define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
 #        else
 #            error "Unknown combination of MSVC preprocessor macros: PLEASE REVISE THIS CODE."
 #        endif

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -318,16 +318,17 @@ struct type_info {
 #ifndef PYBIND11_BUILD_ABI
 #    if defined(__GXX_ABI_VERSION)
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
-#    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT) && ((_MSC_VER) / 100 == 19)
-#        define PYBIND11_BUILD_ABI "_md_mscver19"
-#    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT) && ((_MSC_VER) / 100 == 20)
-#        define PYBIND11_BUILD_ABI "_md_mscver20"
-#    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT) && ((_MSC_VER) / 100 == 21)
-#        define PYBIND11_BUILD_ABI "_md_mscver21"
-#    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT) && ((_MSC_VER) / 100 == 22)
-#        define PYBIND11_BUILD_ABI "_md_mscver22"
 #    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT)
-#        error "Unknown major version for MSC_VER"
+#        if ((_MSC_VER) / 100 == 19)
+#            define PYBIND11_BUILD_ABI "_md_mscver19"
+#        elif ((_MSC_VER) / 100 == 20)
+#            define PYBIND11_BUILD_ABI "_md_mscver20"
+#        elif ((_MSC_VER) / 100 == 21)
+#            define PYBIND11_BUILD_ABI "_md_mscver21"
+#        elif ((_MSC_VER) / 100 == 22)
+#            define PYBIND11_BUILD_ABI "_md_mscver22"
+#        else
+#            error "Unknown major version for MSC_VER"
 #    elif defined(_MSC_VER) && defined(_MT)
 #        define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
 #    else

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -314,7 +314,7 @@ struct type_info {
 #    if defined(__GXX_ABI_VERSION) // Linux/OSX.
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
 #    elif defined(_MSC_VER) // See PR #4953.
-#        if defined(_MT) && defined(_DLL)
+#        if defined(_MT)
 #            define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
 #        elif defined(_MD)
 #            if (_MSC_VER) / 100 == 19

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -313,14 +313,14 @@ struct type_info {
 #ifndef PYBIND11_BUILD_ABI
 #    if defined(__GXX_ABI_VERSION) // Linux/OSX.
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
-#    elif defined(_MSC_VER) // See PR #4953.
-#        if defined(_MT) && defined(_DLL)
+#    elif defined(_MSC_VER)               // See PR #4953.
+#        if defined(_MT) && defined(_DLL) // Corresponding to CL command line options /MD or /MDd.
 #            if (_MSC_VER) / 100 == 19
 #                define PYBIND11_BUILD_ABI "_md_mscver19"
 #            else
 #                error "Unknown major version for MSC_VER: PLEASE REVISE THIS CODE."
 #            endif
-#        elif defined(_MT)
+#        elif defined(_MT) // Corresponding to CL command line options /MT or /MTd.
 #            define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
 #        else
 #            error "Unknown combination of MSVC preprocessor macros: PLEASE REVISE THIS CODE."

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -312,21 +312,12 @@ struct type_info {
 
 /// On Linux/OSX, changes in __GXX_ABI_VERSION__ indicate ABI incompatibility.
 /// On MSVC, mixing /MT and /MD will result in crashes. See (#4953)
-/// There is no macro for major version for MSVC, so we check for major version
-/// 19, 20, 21, 22 for now as major version 19 is MSVC 2015-2022 and we future
-/// proof for 3 major versions in the future
 #ifndef PYBIND11_BUILD_ABI
 #    if defined(__GXX_ABI_VERSION)
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
 #    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT)
 #        if ((_MSC_VER) / 100 == 19)
 #            define PYBIND11_BUILD_ABI "_md_mscver19"
-#        elif ((_MSC_VER) / 100 == 20)
-#            define PYBIND11_BUILD_ABI "_md_mscver20"
-#        elif ((_MSC_VER) / 100 == 21)
-#            define PYBIND11_BUILD_ABI "_md_mscver21"
-#        elif ((_MSC_VER) / 100 == 22)
-#            define PYBIND11_BUILD_ABI "_md_mscver22"
 #        else
 #            error "Unknown major version for MSC_VER"
 #        endif

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -325,8 +325,8 @@ struct type_info {
 #        else
 #            error "Unknown combination of MSVC preprocessor macros: PLEASE REVISE THIS CODE."
 #        endif
-#    elif defined(__NVCOMPILER)       // NVHPC (PGI-based, outdated).
-#        define PYBIND11_BUILD_ABI "" // This was never properly guarded.
+#    elif defined(__NVCOMPILER)       // NVHPC (PGI-based).
+#        define PYBIND11_BUILD_ABI "" // TODO: What should be here, to prevent UB?
 #    else
 #        error "Unknown platform or compiler: PLEASE REVISE THIS CODE."
 #    endif

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -315,10 +315,10 @@ struct type_info {
 #ifndef PYBIND11_BUILD_ABI
 #    if defined(__GXX_ABI_VERSION)
 #        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_TOSTRING(__GXX_ABI_VERSION)
+#    elif defined(_MSC_VER) && defined(_DLL) && defined(_MT)
+#        define PYBIND11_BUILD_ABI "_md_mscver" PYBIND11_TOSTRING(((int) (_MSC_VER) / 100))
 #    elif defined(_MSC_VER) && defined(_MT)
 #        define PYBIND11_BUILD_ABI "_mt_mscver" PYBIND11_TOSTRING(_MSC_VER)
-#    elif defined(_MSC_VER) && defined(_MD)
-#        define PYBIND11_BUILD_ABI "_md_mscver" PYBIND11_TOSTRING(((int) (_MSC_VER) / 100))
 #    else
 #        define PYBIND11_BUILD_ABI ""
 #    endif


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

The ABI is compatible between different versions of MSVC 14.* (2015 - 14.0, 2017 - 14.1, 2019 - 14.2, 2022 - 14.3).
However, the internal structures are different between these versions. For eg: the internal details of how C++ structures like maps are implemented might be different. (I'm not saying they are, but how maps are implemented is an implementation detail)

With /MT you are statically linking in the C runtime and when allocating one structure in a DLL created with a different MSVC version, runtime linked statically, and trying to use it in another DLL linked to a different MSVC runtime (static or dynamic) results in crashes. That's why when you link with /MT and is crossing DLL boundaries you need them to have the same version.

However, if you are using /MD you are using only one C runtime and the internal structures are consistent. Therefore you don't need to check MSVC version.

See https://learn.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-170
________

For increased safety, this PR also eliminates the fall-through case leaving `PYBIND11_BUILD_ABI` blank.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
