### PR TITLE
fix: fully qualify usages of concat to protect against ADL

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -663,7 +663,7 @@ public:
     }
 
     static constexpr auto name = const_name("tuple[")
-                                 + pybind11::detail::concat(make_caster<Ts>::name...)
+                                 + ::pybind11::detail::concat(make_caster<Ts>::name...)
                                  + const_name("]");
 
     template <typename T>
@@ -1466,7 +1466,7 @@ public:
                   "py::args cannot be specified more than once");
 
     static constexpr auto arg_names
-        = pybind11::detail::concat(type_descr(make_caster<Args>::name)...);
+        = ::pybind11::detail::concat(type_descr(make_caster<Args>::name)...);
 
     bool load_args(function_call &call) { return load_impl_sequence(call, indices{}); }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -662,8 +662,9 @@ public:
         return cast(*src, policy, parent);
     }
 
-    static constexpr auto name
-        = const_name("tuple[") + concat(make_caster<Ts>::name...) + const_name("]");
+    static constexpr auto name = const_name("tuple[")
+                                 + pybind11::detail::concat(make_caster<Ts>::name...)
+                                 + const_name("]");
 
     template <typename T>
     using cast_op_type = type;
@@ -1464,7 +1465,8 @@ public:
     static_assert(args_pos == -1 || args_pos == constexpr_first<argument_is_args, Args...>(),
                   "py::args cannot be specified more than once");
 
-    static constexpr auto arg_names = concat(type_descr(make_caster<Args>::name)...);
+    static constexpr auto arg_names
+        = pybind11::detail::concat(type_descr(make_caster<Args>::name)...);
 
     bool load_args(function_call &call) { return load_impl_sequence(call, indices{}); }
 

--- a/include/pybind11/eigen/tensor.h
+++ b/include/pybind11/eigen/tensor.h
@@ -70,7 +70,7 @@ struct eigen_tensor_helper<Eigen::Tensor<Scalar_, NumIndices_, Options_, IndexTy
 
     template <size_t... Is>
     struct helper<index_sequence<Is...>> {
-        static constexpr auto value = concat(const_name(((void) Is, "?"))...);
+        static constexpr auto value = ::pybind11::detail::concat(const_name(((void) Is, "?"))...);
     };
 
     static constexpr auto dimensions_descriptor
@@ -104,7 +104,8 @@ struct eigen_tensor_helper<
         return get_shape() == shape;
     }
 
-    static constexpr auto dimensions_descriptor = concat(const_name<Indices>()...);
+    static constexpr auto dimensions_descriptor
+        = ::pybind11::detail::concat(const_name<Indices>()...);
 
     template <typename... Args>
     static Type *alloc(Args &&...args) {

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -128,7 +128,8 @@ public:
     }
 
     PYBIND11_TYPE_CASTER(type,
-                         const_name("Callable[[") + concat(make_caster<Args>::name...)
+                         const_name("Callable[[")
+                             + ::pybind11::detail::concat(make_caster<Args>::name...)
                              + const_name("], ") + make_caster<retval_type>::name
                              + const_name("]"));
 };

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -371,7 +371,7 @@ struct array_info<std::array<T, N>> {
     }
 
     static constexpr auto extents = const_name<array_info<T>::is_array>(
-        concat(const_name<N>(), array_info<T>::extents), const_name<N>());
+        ::pybind11::detail::concat(const_name<N>(), array_info<T>::extents), const_name<N>());
 };
 // For numpy we have special handling for arrays of characters, so we don't include
 // the size in the array extents.

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -421,7 +421,8 @@ struct variant_caster<V<Ts...>> {
 
     using Type = V<Ts...>;
     PYBIND11_TYPE_CASTER(Type,
-                         const_name("Union[") + detail::concat(make_caster<Ts>::name...)
+                         const_name("Union[")
+                             + ::pybind11::detail::concat(make_caster<Ts>::name...)
                              + const_name("]"));
 };
 

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -69,8 +69,9 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 
 template <typename... Types>
 struct handle_type_name<typing::Tuple<Types...>> {
-    static constexpr auto name
-        = const_name("tuple[") + concat(make_caster<Types>::name...) + const_name("]");
+    static constexpr auto name = const_name("tuple[")
+                                 + ::pybind11::detail::concat(make_caster<Types>::name...)
+                                 + const_name("]");
 };
 
 template <>
@@ -108,9 +109,9 @@ struct handle_type_name<typing::Iterator<T>> {
 template <typename Return, typename... Args>
 struct handle_type_name<typing::Callable<Return(Args...)>> {
     using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
-    static constexpr auto name = const_name("Callable[[") + concat(make_caster<Args>::name...)
-                                 + const_name("], ") + make_caster<retval_type>::name
-                                 + const_name("]");
+    static constexpr auto name
+        = const_name("Callable[[") + ::pybind11::detail::concat(make_caster<Args>::name...)
+          + const_name("], ") + make_caster<retval_type>::name + const_name("]");
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/tests/test_custom_type_casters.cpp
+++ b/tests/test_custom_type_casters.cpp
@@ -134,6 +134,16 @@ struct type_caster<other_lib::MyType> : public other_lib::my_caster {};
 } // namespace detail
 } // namespace PYBIND11_NAMESPACE
 
+// This simply is required to compile
+namespace ADL_issue {
+template <typename OutStringType = std::string, typename... Args>
+OutStringType concat(Args &&...) {
+    return OutStringType();
+}
+
+struct test {};
+} // namespace ADL_issue
+
 TEST_SUBMODULE(custom_type_casters, m) {
     // test_custom_type_casters
 
@@ -206,4 +216,6 @@ TEST_SUBMODULE(custom_type_casters, m) {
           py::return_value_policy::reference);
 
     m.def("other_lib_type", [](other_lib::MyType x) { return x; });
+
+    m.def("_adl_issue", [](const ADL_issue::test &) {});
 }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Replaced calls to `concat` by using complete namespace `pybind11::detail::concat` in file `cast.h`.



We encountered issues in our library, because the `concat` function from modernjson was erroneously used instead of the correct one from pybind11:
```
~/stormpy/stormpy/build/temp.macosx-14-arm64-cpython-311/_deps/pybind11-src/include/pybind11/cast.h:1402:39: note: non-constexpr function 'concat<std::string, pybind11::detail::descr<3, nlohmann::basic_json<>>>' cannot be used in a constant expression
    static constexpr auto arg_names = concat(type_descr(make_caster<Args>::name)...);
                                      ^
~/storm/resources/3rdparty/modernjson/include/nlohmann/detail/string_concat.hpp:137:22: note: declared here
inline OutStringType concat(Args && ... args)
```
Adding the namespace in pybind fixed this issue.

See [this issue](https://github.com/moves-rwth/stormpy/issues/140) for details.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->
```rst
* Qualify ``py::detail::concat`` usage to avoid ADL selecting one from somewhere else, such as modernjson's concat.
```
<!-- If the upgrade guide needs updating, note that here too -->