### PR TITLE
Add `py::nullptr_default_arg` (intended for `PyObject *` arguments)

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -491,7 +491,7 @@ struct process_attribute<arg_v> : process_attribute_default<arg_v> {
                 "self", /*descr=*/nullptr, /*parent=*/handle(), /*convert=*/true, /*none=*/false);
         }
 
-        if (!a.value) {
+        if (!a.value && !a.value_is_nullptr) {
 #if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
             std::string descr("'");
             if (a.name) {

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -176,14 +176,21 @@ void keep_alive_impl(size_t Nurse, size_t Patient, function_call &call, handle r
 
 /// Internal data structure which holds metadata about a keyword argument
 struct argument_record {
-    const char *name;  ///< Argument name
-    const char *descr; ///< Human-readable version of the argument value
-    handle value;      ///< Associated Python object
-    bool convert : 1;  ///< True if the argument is allowed to convert when loading
-    bool none : 1;     ///< True if None is allowed when loading
+    const char *name;          ///< Argument name
+    const char *descr;         ///< Human-readable version of the argument value
+    handle value;              ///< Associated Python object
+    bool convert : 1;          ///< True if the argument is allowed to convert when loading
+    bool none : 1;             ///< True if None is allowed when loading
+    bool value_is_nullptr : 1; ///< True if explicit nullptr
 
-    argument_record(const char *name, const char *descr, handle value, bool convert, bool none)
-        : name(name), descr(descr), value(value), convert(convert), none(none) {}
+    argument_record(const char *name,
+                    const char *descr,
+                    handle value,
+                    bool convert,
+                    bool none,
+                    bool value_is_nullptr)
+        : name(name), descr(descr), value(value), convert(convert), none(none),
+          value_is_nullptr(value_is_nullptr) {}
 };
 
 /// Internal data structure which holds metadata about a bound function (signature, overloads,
@@ -467,7 +474,12 @@ inline void check_kw_only_arg(const arg &a, function_record *r) {
 
 inline void append_self_arg_if_needed(function_record *r) {
     if (r->is_method && r->args.empty()) {
-        r->args.emplace_back("self", nullptr, handle(), /*convert=*/true, /*none=*/false);
+        r->args.emplace_back("self",
+                             nullptr,
+                             handle(),
+                             /*convert=*/true,
+                             /*none=*/false,
+                             /*value_is_nullptr=*/false);
     }
 }
 
@@ -476,7 +488,8 @@ template <>
 struct process_attribute<arg> : process_attribute_default<arg> {
     static void init(const arg &a, function_record *r) {
         append_self_arg_if_needed(r);
-        r->args.emplace_back(a.name, nullptr, handle(), !a.flag_noconvert, a.flag_none);
+        r->args.emplace_back(
+            a.name, nullptr, handle(), !a.flag_noconvert, a.flag_none, /*value_is_nullptr=*/false);
 
         check_kw_only_arg(a, r);
     }
@@ -487,8 +500,12 @@ template <>
 struct process_attribute<arg_v> : process_attribute_default<arg_v> {
     static void init(const arg_v &a, function_record *r) {
         if (r->is_method && r->args.empty()) {
-            r->args.emplace_back(
-                "self", /*descr=*/nullptr, /*parent=*/handle(), /*convert=*/true, /*none=*/false);
+            r->args.emplace_back("self",
+                                 /*descr=*/nullptr,
+                                 /*parent=*/handle(),
+                                 /*convert=*/true,
+                                 /*none=*/false,
+                                 /*value_is_nullptr=*/false);
         }
 
         if (!a.value && !a.value_is_nullptr) {
@@ -517,7 +534,12 @@ struct process_attribute<arg_v> : process_attribute_default<arg_v> {
                           "more information.");
 #endif
         }
-        r->args.emplace_back(a.name, a.descr, a.value.inc_ref(), !a.flag_noconvert, a.flag_none);
+        r->args.emplace_back(a.name,
+                             a.descr,
+                             a.value.inc_ref(),
+                             !a.flag_noconvert,
+                             a.flag_none,
+                             a.value_is_nullptr);
 
         check_kw_only_arg(a, r);
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1317,15 +1317,17 @@ struct arg {
     bool flag_none : 1;      ///< If set (the default), allow None to be passed to this argument
 };
 
+struct nullptr_default_arg {};
+
 /// \ingroup annotations
 /// Annotation for arguments with values
 struct arg_v : arg {
 private:
-    arg_v(arg &&base, object x, const char *descr = nullptr)
-        : arg(base), value(x), value_is_nullptr(x.ptr() == nullptr), descr(descr)
+    arg_v(arg &&base, nullptr_default_arg, const char *descr = nullptr)
+        : arg(base), value(), value_is_nullptr(true), descr(descr)
 #if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
           ,
-          type(x.ptr() ? detail::obj_class_name(x.ptr()) : "std::nullptr_t")
+          type("pybind11::nullptr_default_arg")
 #endif
     {
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1321,6 +1321,15 @@ struct arg {
 /// Annotation for arguments with values
 struct arg_v : arg {
 private:
+    arg_v(arg &&base, object x, const char *descr = nullptr)
+        : arg(base), value(x), value_is_nullptr(x.ptr() == nullptr), descr(descr)
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
+          ,
+          type(x.ptr() ? detail::obj_class_name(x.ptr()) : "std::nullptr_t")
+#endif
+    {
+    }
+
     template <typename T>
     arg_v(arg &&base, T &&x, const char *descr = nullptr)
         : arg(base), value(reinterpret_steal<object>(detail::make_caster<T>::cast(
@@ -1364,6 +1373,7 @@ public:
 
     /// The default value
     object value;
+    bool value_is_nullptr = false;
     /// The (optional) description of the default value
     const char *descr;
 #if defined(PYBIND11_DETAILED_ERROR_MESSAGES)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -905,7 +905,7 @@ protected:
                             break;
                         }
 
-                        if (value || (arg_rec.convert && arg_rec.none)) {
+                        if (value || arg_rec.value_is_nullptr) {
                             // If we're at the py::args index then first insert a stub for it to be
                             // replaced later
                             if (func.has_args && call.args.size() == func.nargs_pos) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -905,7 +905,7 @@ protected:
                             break;
                         }
 
-                        if (value) {
+                        if (value || (arg_rec.convert && arg_rec.none)) {
                             // If we're at the py::args index then first insert a stub for it to be
                             // replaced later
                             if (func.has_args && call.args.size() == func.nargs_pos) {

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -127,4 +127,16 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
         (void) py::cast(*ptr);
     }
 #endif
+
+    m.def("pyobject_ptr_from_handle_nullptr", []() {
+        py::handle handle_nullptr;
+        if (handle_nullptr.ptr() != nullptr) {
+            return "UNEXPECTED: handle_nullptr.ptr() != nullptr";
+        }
+        auto *pyobject_ptr_from_handle = py::cast<PyObject *>(handle_nullptr);
+        if (pyobject_ptr_from_handle != nullptr) {
+            return "UNEXPECTED: pyobject_ptr_from_handle != nullptr";
+        }
+        return "SUCCESS";
+    });
 }

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -148,5 +148,5 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
             }
             return py::detail::obj_class_name(ptr);
         },
-        py::arg("ptr") = py::object());
+        py::arg("ptr") = py::nullptr_default_arg());
 }

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -139,4 +139,14 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
         }
         return "SUCCESS";
     });
+
+    m.def(
+        "py_arg_handle_nullptr",
+        [](PyObject *ptr) {
+            if (ptr == nullptr) {
+                return "ptr == nullptr";
+            }
+            return py::detail::obj_class_name(ptr);
+        },
+        py::arg("ptr") = py::object());
 }

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -106,3 +106,9 @@ def test_type_caster_name_via_incompatible_function_arguments_type_error():
 
 def test_pyobject_ptr_from_handle_nullptr():
     assert m.pyobject_ptr_from_handle_nullptr() == "SUCCESS"
+
+
+def test_py_arg_handle_nullptr():
+    assert m.py_arg_handle_nullptr(None) == "NoneType"
+    assert m.py_arg_handle_nullptr([]) == "list"
+    assert m.py_arg_handle_nullptr() == "ptr == nullptr"

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -102,3 +102,7 @@ def test_return_list_pyobject_ptr_reference():
 def test_type_caster_name_via_incompatible_function_arguments_type_error():
     with pytest.raises(TypeError, match=r"1\. \(arg0: object, arg1: int\) -> None"):
         m.pass_pyobject_ptr_and_int(ValueHolder(101), ValueHolder(202))
+
+
+def test_pyobject_ptr_from_handle_nullptr():
+    assert m.pyobject_ptr_from_handle_nullptr() == "SUCCESS"


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Continued under google/pywrapcc#30081

This feature was added mainly to support PyCLIF-pybind11 developments (automatic pybind11 bindings generator). The value for manually written bindings is limited (overloads can be used instead).

Leave a comment here if there is an interest in back-porting the feature to pybind11 master.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
