### PR TITLE
bugfix: ensure different KeysView/ValuesView type names for int16_t/int32_t or float/double. Fix #4529

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -718,18 +718,8 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args &&
     }
 
     Class_ cl(scope, name.c_str(), pybind11::module_local(local), std::forward<Args>(args)...);
-    static constexpr auto key_type_descr = detail::make_caster<KeyType>::name;
-    static constexpr auto mapped_type_descr = detail::make_caster<MappedType>::name;
-    std::string key_type_name(key_type_descr.text), mapped_type_name(mapped_type_descr.text);
-
-    // If key type isn't properly wrapped, fall back to C++ names
-    if (key_type_name == "%") {
-        key_type_name = detail::type_info_description(typeid(KeyType));
-    }
-    // Similarly for value type:
-    if (mapped_type_name == "%") {
-        mapped_type_name = detail::type_info_description(typeid(MappedType));
-    }
+    std::string key_type_name(detail::type_info_description(typeid(KeyType)));
+    std::string mapped_type_name(detail::type_info_description(typeid(MappedType)));
 
     // Wrap KeysView[KeyType] if it wasn't already wrapped
     if (!detail::get_type_info(typeid(KeysView))) {

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -187,14 +187,23 @@ TEST_SUBMODULE(stl_binders, m) {
     py::bind_map<std::map<std::string, double>>(m, "MapStringDouble");
     py::bind_map<std::unordered_map<std::string, double>>(m, "UnorderedMapStringDouble");
 
-    // test_map_string_float
-    py::bind_map<std::map<std::string, float>>(m, "MapStringFloat");
-    py::bind_map<std::unordered_map<std::string, float>>(m, "UnorderedMapStringFloat");
-
     // test_map_string_double_const
     py::bind_map<std::map<std::string, double const>>(m, "MapStringDoubleConst");
     py::bind_map<std::unordered_map<std::string, double const>>(m,
                                                                 "UnorderedMapStringDoubleConst");
+
+    // test_map_view_types
+    py::bind_map<std::map<int, double>>(m, "MapIntDouble");
+    py::bind_map<std::unordered_map<int, double>>(m, "UnorderedMapIntDouble");
+
+    py::bind_map<std::map<int, double const>>(m, "MapIntDoubleConst");
+    py::bind_map<std::unordered_map<int, double const>>(m, "UnorderedMapIntDoubleConst");
+
+    py::bind_map<std::map<int, float>>(m, "MapIntFloat");
+    py::bind_map<std::unordered_map<int, float>>(m, "UnorderedMapIntFloat");
+
+    py::bind_map<std::map<int64_t, double>>(m, "MapInt64Double");
+    py::bind_map<std::map<uint64_t, double>>(m, "MapUInt64Double");
 
     py::class_<E_nc>(m, "ENC").def(py::init<int>()).def_readwrite("value", &E_nc::value);
 

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -187,6 +187,10 @@ TEST_SUBMODULE(stl_binders, m) {
     py::bind_map<std::map<std::string, double>>(m, "MapStringDouble");
     py::bind_map<std::unordered_map<std::string, double>>(m, "UnorderedMapStringDouble");
 
+    // test_map_string_float
+    py::bind_map<std::map<std::string, float>>(m, "MapStringFloat");
+    py::bind_map<std::unordered_map<std::string, float>>(m, "UnorderedMapStringFloat");
+
     // test_map_string_double_const
     py::bind_map<std::map<std::string, double const>>(m, "MapStringDoubleConst");
     py::bind_map<std::unordered_map<std::string, double const>>(m,

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -329,15 +329,15 @@ def test_map_view_types():
     assert map_int_float.values().__class__.__name__ == "ValuesView[float]"
     assert map_int_float.items().__class__.__name__ == "ItemsView[int, float]"
 
-    assert map_int64_double.keys().__class__.__name__ == "KeysView[long]"
+    assert map_int64_double.keys().__class__.__name__ in ["KeysView[long]", "KeysView[long long]", "KeysView[__int64]"]
     assert map_int64_double.values().__class__.__name__ == "ValuesView[double]"
-    assert map_int64_double.items().__class__.__name__ == "ItemsView[long, double]"
+    assert map_int64_double.items().__class__.__name__ in ["ItemsView[long, double]", "ItemsView[long long, double]", "ItemsView[__int64, double]"]
 
-    assert map_uint64_double.keys().__class__.__name__ == "KeysView[unsigned long]"
+    assert map_uint64_double.keys().__class__.__name__ in ["KeysView[unsigned long]", "KeysView[unsigned long long]", "KeysView[unsigned __int64]"]
     assert map_uint64_double.values().__class__.__name__ == "ValuesView[double]"
     assert (
         map_uint64_double.items().__class__.__name__
-        == "ItemsView[unsigned long, double]"
+        in ["ItemsView[unsigned long, double]", "ItemsView[unsigned long long, double]", "ItemsView[unsigned __int64, double]"]
     )
 
     keys_type = type(map_int_double.keys())

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -335,7 +335,10 @@ def test_map_view_types():
 
     assert map_uint64_double.keys().__class__.__name__ == "KeysView[unsigned long]"
     assert map_uint64_double.values().__class__.__name__ == "ValuesView[double]"
-    assert map_uint64_double.items().__class__.__name__ == "ItemsView[unsigned long, double]"
+    assert (
+        map_uint64_double.items().__class__.__name__
+        == "ItemsView[unsigned long, double]"
+    )
 
     keys_type = type(map_int_double.keys())
     assert type(unordered_map_int_double.keys()) is keys_type

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -312,36 +312,51 @@ def test_map_delitem():
 
 
 def test_map_view_types():
-    map_string_double = m.MapStringDouble()
-    unordered_map_string_double = m.UnorderedMapStringDouble()
-    map_string_float = m.MapStringFloat()
-    unordered_map_string_float = m.UnorderedMapStringFloat()
-    map_string_double_const = m.MapStringDoubleConst()
-    unordered_map_string_double_const = m.UnorderedMapStringDoubleConst()
+    map_int_double = m.MapIntDouble()
+    unordered_map_int_double = m.UnorderedMapIntDouble()
+    map_int_double_const = m.MapIntDoubleConst()
+    unordered_map_int_double_const = m.UnorderedMapIntDoubleConst()
+    map_int_float = m.MapIntFloat()
+    unordered_map_int_float = m.UnorderedMapIntFloat()
+    map_int64_double = m.MapInt64Double()
+    map_uint64_double = m.MapUInt64Double()
 
-    assert map_string_double.values().__class__.__name__ == "ValuesView[double]"
-    assert map_string_float.values().__class__.__name__ == "ValuesView[float]"
+    assert map_int_double.keys().__class__.__name__ == "KeysView[int]"
+    assert map_int_double.values().__class__.__name__ == "ValuesView[double]"
+    assert map_int_double.items().__class__.__name__ == "ItemsView[int, double]"
 
-    keys_type = type(map_string_double.keys())
-    assert type(unordered_map_string_double.keys()) is keys_type
-    assert type(map_string_float.keys()) is keys_type
-    assert type(unordered_map_string_float.keys()) is keys_type
-    assert type(map_string_double_const.keys()) is keys_type
-    assert type(unordered_map_string_double_const.keys()) is keys_type
+    assert map_int_float.keys().__class__.__name__ == "KeysView[int]"
+    assert map_int_float.values().__class__.__name__ == "ValuesView[float]"
+    assert map_int_float.items().__class__.__name__ == "ItemsView[int, float]"
 
-    values_type_double = type(map_string_double.values())
-    assert type(unordered_map_string_double.values()) is values_type_double
-    assert type(map_string_double_const.values()) is values_type_double
-    assert type(unordered_map_string_double_const.values()) is values_type_double
+    assert map_int64_double.keys().__class__.__name__ == "KeysView[long]"
+    assert map_int64_double.values().__class__.__name__ == "ValuesView[double]"
+    assert map_int64_double.items().__class__.__name__ == "ItemsView[long, double]"
 
-    values_type_float = type(map_string_float.values())
+    assert map_uint64_double.keys().__class__.__name__ == "KeysView[unsigned long]"
+    assert map_uint64_double.values().__class__.__name__ == "ValuesView[double]"
+    assert map_uint64_double.items().__class__.__name__ == "ItemsView[unsigned long, double]"
+
+    keys_type = type(map_int_double.keys())
+    assert type(unordered_map_int_double.keys()) is keys_type
+    assert type(map_int_float.keys()) is keys_type
+    assert type(unordered_map_int_float.keys()) is keys_type
+    assert type(map_int_double_const.keys()) is keys_type
+    assert type(unordered_map_int_double_const.keys()) is keys_type
+
+    values_type_double = type(map_int_double.values())
+    assert type(unordered_map_int_double.values()) is values_type_double
+    assert type(map_int_double_const.values()) is values_type_double
+    assert type(unordered_map_int_double_const.values()) is values_type_double
+
+    values_type_float = type(map_int_float.values())
     assert values_type_float is not values_type_double
-    assert type(unordered_map_string_float.values()) is values_type_float
+    assert type(unordered_map_int_float.values()) is values_type_float
 
-    items_type = type(map_string_double.items())
-    assert type(unordered_map_string_double.items()) is items_type
-    assert type(map_string_double_const.items()) is items_type
-    assert type(unordered_map_string_double_const.items()) is items_type
+    items_type = type(map_int_double.items())
+    assert type(unordered_map_int_double.items()) is items_type
+    assert type(map_int_double_const.items()) is items_type
+    assert type(unordered_map_int_double_const.items()) is items_type
 
 
 def test_recursive_vector():

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -329,16 +329,29 @@ def test_map_view_types():
     assert map_int_float.values().__class__.__name__ == "ValuesView[float]"
     assert map_int_float.items().__class__.__name__ == "ItemsView[int, float]"
 
-    assert map_int64_double.keys().__class__.__name__ in ["KeysView[long]", "KeysView[long long]", "KeysView[__int64]"]
+    assert map_int64_double.keys().__class__.__name__ in [
+        "KeysView[long]",
+        "KeysView[long long]",
+        "KeysView[__int64]",
+    ]
     assert map_int64_double.values().__class__.__name__ == "ValuesView[double]"
-    assert map_int64_double.items().__class__.__name__ in ["ItemsView[long, double]", "ItemsView[long long, double]", "ItemsView[__int64, double]"]
+    assert map_int64_double.items().__class__.__name__ in [
+        "ItemsView[long, double]",
+        "ItemsView[long long, double]",
+        "ItemsView[__int64, double]",
+    ]
 
-    assert map_uint64_double.keys().__class__.__name__ in ["KeysView[unsigned long]", "KeysView[unsigned long long]", "KeysView[unsigned __int64]"]
+    assert map_uint64_double.keys().__class__.__name__ in [
+        "KeysView[unsigned long]",
+        "KeysView[unsigned long long]",
+        "KeysView[unsigned __int64]",
+    ]
     assert map_uint64_double.values().__class__.__name__ == "ValuesView[double]"
-    assert (
-        map_uint64_double.items().__class__.__name__
-        in ["ItemsView[unsigned long, double]", "ItemsView[unsigned long long, double]", "ItemsView[unsigned __int64, double]"]
-    )
+    assert map_uint64_double.items().__class__.__name__ in [
+        "ItemsView[unsigned long, double]",
+        "ItemsView[unsigned long long, double]",
+        "ItemsView[unsigned __int64, double]",
+    ]
 
     keys_type = type(map_int_double.keys())
     assert type(unordered_map_int_double.keys()) is keys_type

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -314,22 +314,29 @@ def test_map_delitem():
 def test_map_view_types():
     map_string_double = m.MapStringDouble()
     unordered_map_string_double = m.UnorderedMapStringDouble()
+    map_string_float = m.MapStringFloat()
+    unordered_map_string_float = m.UnorderedMapStringFloat()
     map_string_double_const = m.MapStringDoubleConst()
     unordered_map_string_double_const = m.UnorderedMapStringDoubleConst()
 
-    assert map_string_double.keys().__class__.__name__ == "KeysView[str]"
-    assert map_string_double.values().__class__.__name__ == "ValuesView[float]"
-    assert map_string_double.items().__class__.__name__ == "ItemsView[str, float]"
+    assert map_string_double.values().__class__.__name__ == "ValuesView[double]"
+    assert map_string_float.values().__class__.__name__ == "ValuesView[float]"
 
     keys_type = type(map_string_double.keys())
     assert type(unordered_map_string_double.keys()) is keys_type
+    assert type(map_string_float.keys()) is keys_type
+    assert type(unordered_map_string_float.keys()) is keys_type
     assert type(map_string_double_const.keys()) is keys_type
     assert type(unordered_map_string_double_const.keys()) is keys_type
 
-    values_type = type(map_string_double.values())
-    assert type(unordered_map_string_double.values()) is values_type
-    assert type(map_string_double_const.values()) is values_type
-    assert type(unordered_map_string_double_const.values()) is values_type
+    values_type_double = type(map_string_double.values())
+    assert type(unordered_map_string_double.values()) is values_type_double
+    assert type(map_string_double_const.values()) is values_type_double
+    assert type(unordered_map_string_double_const.values()) is values_type_double
+
+    values_type_float = type(map_string_float.values())
+    assert values_type_float is not values_type_double
+    assert type(unordered_map_string_float.values()) is values_type_float
 
     items_type = type(map_string_double.items())
     assert type(unordered_map_string_double.items()) is items_type


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

This PR fixes issue #4529. The problem was introduced in PR #4353.

The problem is the following:

```c++
// leads to ImportError: generic_type: cannot initialize type "KeysView[int]": an object with that name is already defined
py::bind_map<map<int, int>>(m, "map_int_int");
py::bind_map<map<long long int, int>>(m, "map_long_int");
```

Here we want ``type(map_int_int.keys())`` to be ``KeysView[int]`` and ``type(map_long_int.keys())`` to be ``KeysView[long]``. But in after PR #4353 they are all assigned the same type name ``KeysView[int]`` which is caused by the usage of ``detail::make_caster<KeyType>::name`` for determining the type name. It maps all C++ integer types (int16_t, int32_t, ...) to the same python type name ``int`` and C++ float/double types to the same name ``float``, etc.

The solution is to always use the C++ type name in ``KeyView[...]`` and ``ValuesView[...]``.

Note that before PR #4353, the type names were ``KeysView[map_int_int]`` and ``KeysView[map_long_int]`` for the above example (which is okay).

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Fix type name clash in ``KeysView`` and ``ValuesView`` when using multiple ``bind_map`` with different integer key types
```

<!-- If the upgrade guide needs updating, note that here too -->
