### PR TITLE
[smart_holder] Change `throw_if_uninitialized_or_disowned_holder()` to also show C++ type name.

### DIFF
--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -109,7 +109,9 @@ def test_pass_unique_ptr_disowns(pass_f, rtrn_f, expected):
     with pytest.raises(ValueError) as exc_info:
         pass_f(obj)
     assert str(exc_info.value) == (
-        "Missing value for wrapped C++ type: Python instance was disowned."
+        "Missing value for wrapped C++ type"
+        + " `pybind11_tests::class_sh_basic::atyp`:"
+        + " Python instance was disowned."
     )
 
 

--- a/tests/test_class_sh_disowning_mi.py
+++ b/tests/test_class_sh_disowning_mi.py
@@ -20,10 +20,7 @@ def is_disowned(callable_method):
     try:
         callable_method()
     except ValueError as e:
-        assert (  # noqa: PT017
-            str(e)
-            == "Missing value for wrapped C++ type: Python instance was disowned."
-        )
+        assert "Python instance was disowned" in str(e)
         return True
     return False
 

--- a/tests/test_class_sh_disowning_mi.py
+++ b/tests/test_class_sh_disowning_mi.py
@@ -20,7 +20,7 @@ def is_disowned(callable_method):
     try:
         callable_method()
     except ValueError as e:
-        assert "Python instance was disowned" in str(e)
+        assert "Python instance was disowned" in str(e)  # noqa: PT017
         return True
     return False
 

--- a/tests/test_class_sh_mi_thunks.py
+++ b/tests/test_class_sh_mi_thunks.py
@@ -38,7 +38,7 @@ def test_get_vec_size_raw_shared(get_fn, vec_size_fn):
 def test_get_vec_size_unique(get_fn):
     obj = get_fn()
     assert m.vec_size_base0_unique_ptr(obj) == 5
-    with pytest.raises(ValueError, match="Python instance was disowned") as exc_info:
+    with pytest.raises(ValueError, match="Python instance was disowned"):
         m.vec_size_base0_unique_ptr(obj)
 
 

--- a/tests/test_class_sh_mi_thunks.py
+++ b/tests/test_class_sh_mi_thunks.py
@@ -38,12 +38,8 @@ def test_get_vec_size_raw_shared(get_fn, vec_size_fn):
 def test_get_vec_size_unique(get_fn):
     obj = get_fn()
     assert m.vec_size_base0_unique_ptr(obj) == 5
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="Python instance was disowned") as exc_info:
         m.vec_size_base0_unique_ptr(obj)
-    assert (
-        str(exc_info.value)
-        == "Missing value for wrapped C++ type: Python instance was disowned."
-    )
 
 
 def test_get_shared_vec_size_unique():

--- a/tests/test_class_sh_property.py
+++ b/tests/test_class_sh_property.py
@@ -87,7 +87,7 @@ def test_uqp(m_attr_readwrite):
     field_orig = m.Field()
     field_orig.num = 39
     setattr(outer, m_attr_readwrite, field_orig)
-    with pytest.raises(ValueError, match="Python instance was disowned") as excinfo:
+    with pytest.raises(ValueError, match="Python instance was disowned"):
         _ = field_orig.num
     field_retr1 = getattr(outer, m_attr_readwrite)
     assert getattr(outer, m_attr_readwrite) is None

--- a/tests/test_class_sh_unique_ptr_member.py
+++ b/tests/test_class_sh_unique_ptr_member.py
@@ -16,12 +16,8 @@ def test_pointee_and_ptr_owner(give_up_ownership_via):
     obj = m.pointee()
     assert obj.get_int() == 213
     owner = m.ptr_owner(obj)
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="Python instance was disowned") as exc_info:
         obj.get_int()
-    assert (
-        str(exc_info.value)
-        == "Missing value for wrapped C++ type: Python instance was disowned."
-    )
     assert owner.is_owner()
     reclaimed = getattr(owner, give_up_ownership_via)()
     assert not owner.is_owner()

--- a/tests/test_class_sh_unique_ptr_member.py
+++ b/tests/test_class_sh_unique_ptr_member.py
@@ -16,7 +16,7 @@ def test_pointee_and_ptr_owner(give_up_ownership_via):
     obj = m.pointee()
     assert obj.get_int() == 213
     owner = m.ptr_owner(obj)
-    with pytest.raises(ValueError, match="Python instance was disowned") as exc_info:
+    with pytest.raises(ValueError, match="Python instance was disowned"):
         obj.get_int()
     assert owner.is_owner()
     reclaimed = getattr(owner, give_up_ownership_via)()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
To aid debugging.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
