### PR TITLE
bugfix: KeysView/ValuesView/ItemsView using Python types. Fix #4529

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -876,6 +876,10 @@ struct handle_type_name {
     static constexpr auto name = const_name<T>();
 };
 template <>
+struct handle_type_name<object> {
+    static constexpr auto name = const_name("object");
+};
+template <>
 struct handle_type_name<bool_> {
     static constexpr auto name = const_name("bool");
 };

--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -187,6 +187,35 @@ TEST_SUBMODULE(stl_binders, m) {
     py::bind_map<std::map<std::string, double>>(m, "MapStringDouble");
     py::bind_map<std::unordered_map<std::string, double>>(m, "UnorderedMapStringDouble");
 
+    // test_map_view_types
+    py::bind_map<std::map<std::string, float>>(m, "MapStringFloat");
+    py::bind_map<std::unordered_map<std::string, float>>(m, "UnorderedMapStringFloat");
+    py::bind_map<std::map<int16_t, double>>(m, "MapInt16Double");
+    py::bind_map<std::map<int32_t, double>>(m, "MapInt32Double");
+    py::bind_map<std::map<int64_t, double>>(m, "MapInt64Double");
+    py::bind_map<std::map<uint64_t, double>>(m, "MapUInt64Double");
+    py::bind_map<std::map<std::pair<short, short>, double>>(m, "MapPairShortShortDouble");
+    py::bind_map<std::map<std::pair<short, long>, std::complex<float>>>(
+        m, "MapPairShortLongComplexFloat");
+    py::bind_map<std::map<std::pair<long, short>, std::complex<double>>>(
+        m, "MapPairLongShortComplexDouble");
+    py::bind_map<std::map<std::tuple<long, long>, std::complex<double>>>(
+        m, "MapTupleLongLongComplexDouble");
+    py::bind_map<std::map<char, std::function<float(int, float)>>>(m,
+                                                                   "MapCharFunctionFloatIntFloat");
+    py::bind_map<std::map<std::string, std::function<double(long, double)>>>(
+        m, "MapStringFunctionDoubleLongDouble");
+    py::bind_map<std::map<std::string, std::function<void(long, double)>>>(
+        m, "MapStringFunctionVoidLongDouble");
+    py::bind_map<std::map<std::string, std::nullptr_t>>(m, "MapStringNone");
+
+    py::bind_map<std::map<int, std::pair<std::map<int, int>, int>>>(m, "MapIntMapIntIntInt");
+    py::bind_map<std::map<int, std::pair<std::map<int, int>, long>>>(m, "MapIntMapIntIntLong");
+    py::bind_map<std::map<int, std::pair<std::map<long, int>, long>>>(m, "MapIntMapLongIntLong");
+
+    py::bind_map<std::map<pybind11::int_, int>>(m, "MapPyIntInt");
+    py::bind_map<std::map<pybind11::int_, pybind11::int_>>(m, "MapPyIntPyInt");
+
     // test_map_string_double_const
     py::bind_map<std::map<std::string, double const>>(m, "MapStringDoubleConst");
     py::bind_map<std::unordered_map<std::string, double const>>(m,

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -314,6 +314,8 @@ def test_map_delitem():
 def test_map_view_types():
     map_string_double = m.MapStringDouble()
     unordered_map_string_double = m.UnorderedMapStringDouble()
+    map_string_float = m.MapStringFloat()
+    unordered_map_string_float = m.UnorderedMapStringFloat()
     map_string_double_const = m.MapStringDoubleConst()
     unordered_map_string_double_const = m.UnorderedMapStringDoubleConst()
 
@@ -321,20 +323,123 @@ def test_map_view_types():
     assert map_string_double.values().__class__.__name__ == "ValuesView[float]"
     assert map_string_double.items().__class__.__name__ == "ItemsView[str, float]"
 
-    keys_type = type(map_string_double.keys())
-    assert type(unordered_map_string_double.keys()) is keys_type
-    assert type(map_string_double_const.keys()) is keys_type
-    assert type(unordered_map_string_double_const.keys()) is keys_type
+    assert map_string_float.keys().__class__.__name__ == "KeysView[str]"
+    assert map_string_float.values().__class__.__name__ == "ValuesView[float]"
+    assert map_string_float.items().__class__.__name__ == "ItemsView[str, float]"
 
-    values_type = type(map_string_double.values())
-    assert type(unordered_map_string_double.values()) is values_type
-    assert type(map_string_double_const.values()) is values_type
-    assert type(unordered_map_string_double_const.values()) is values_type
+    keys_type = map_string_double.keys().__class__
+    assert unordered_map_string_double.keys().__class__ is keys_type
+    assert map_string_double_const.keys().__class__ is keys_type
+    assert unordered_map_string_double_const.keys().__class__ is keys_type
+    assert map_string_float.keys().__class__ is keys_type
+    assert unordered_map_string_float.keys().__class__ is keys_type
 
-    items_type = type(map_string_double.items())
-    assert type(unordered_map_string_double.items()) is items_type
-    assert type(map_string_double_const.items()) is items_type
-    assert type(unordered_map_string_double_const.items()) is items_type
+    values_type = map_string_double.values().__class__
+    assert unordered_map_string_double.values().__class__ is values_type
+    assert map_string_double_const.values().__class__ is values_type
+    assert unordered_map_string_double_const.values().__class__ is values_type
+    assert map_string_float.values().__class__ is values_type
+    assert unordered_map_string_float.values().__class__ is values_type
+
+    items_type = map_string_double.items().__class__
+    assert unordered_map_string_double.items().__class__ is items_type
+    assert map_string_double_const.items().__class__ is items_type
+    assert unordered_map_string_double_const.items().__class__ is items_type
+    assert map_string_float.items().__class__ is items_type
+    assert unordered_map_string_float.items().__class__ is items_type
+
+    map_int16_double = m.MapInt16Double()
+    map_int32_double = m.MapInt32Double()
+    map_int64_double = m.MapInt64Double()
+    map_uint64_double = m.MapUInt64Double()
+
+    assert map_int16_double.keys().__class__.__name__ == "KeysView[int]"
+    assert map_int16_double.keys().__class__ is map_int32_double.keys().__class__
+    assert map_int16_double.keys().__class__ is map_int64_double.keys().__class__
+    assert map_int16_double.keys().__class__ is map_uint64_double.keys().__class__
+
+    assert (1 << 50) not in map_uint64_double.keys()
+    map_uint64_double[1 << 50] = 1.0
+    assert (1 << 50) in map_uint64_double.keys()
+
+    map_pair_short_short_double = m.MapPairShortShortDouble()
+    map_pair_short_long_complex_float = m.MapPairShortLongComplexFloat()
+    map_pair_long_short_complex_double = m.MapPairLongShortComplexDouble()
+    map_tuple_long_long_complex_double = m.MapTupleLongLongComplexDouble()
+    assert (
+        map_pair_short_long_complex_float.keys().__class__.__name__
+        == "KeysView[tuple[int, int]]"
+    )
+    assert (
+        map_pair_short_long_complex_float.values().__class__.__name__
+        == "ValuesView[complex]"
+    )
+    assert (
+        map_pair_short_long_complex_float.items().__class__.__name__
+        == "ItemsView[tuple[int, int], complex]"
+    )
+    assert (
+        map_pair_short_long_complex_float.keys().__class__
+        is map_pair_short_short_double.keys().__class__
+    )
+    assert (
+        map_pair_short_long_complex_float.keys().__class__
+        is map_pair_long_short_complex_double.keys().__class__
+    )
+    assert (
+        map_pair_short_long_complex_float.keys().__class__
+        is map_tuple_long_long_complex_double.keys().__class__
+    )
+    assert (
+        map_pair_short_long_complex_float.values().__class__
+        is map_pair_long_short_complex_double.values().__class__
+    )
+    assert (
+        map_pair_short_long_complex_float.values().__class__
+        is map_tuple_long_long_complex_double.values().__class__
+    )
+
+    map_char_func_fif = m.MapCharFunctionFloatIntFloat()
+    map_string_func_dld = m.MapStringFunctionDoubleLongDouble()
+    assert map_char_func_fif.keys().__class__.__name__ == "KeysView[str]"
+    assert (
+        map_char_func_fif.values().__class__.__name__
+        == "ValuesView[Callable[[int, float], float]]"
+    )
+    assert (
+        map_char_func_fif.items().__class__.__name__
+        == "ItemsView[str, Callable[[int, float], float]]"
+    )
+    assert map_char_func_fif.keys().__class__ is map_string_func_dld.keys().__class__
+    assert (
+        map_char_func_fif.values().__class__ is map_string_func_dld.values().__class__
+    )
+    assert map_char_func_fif.items().__class__ is map_string_func_dld.items().__class__
+
+    map_string_func_vld = m.MapStringFunctionVoidLongDouble()
+    map_string_none = m.MapStringNone()
+    assert (
+        map_string_func_vld.values().__class__.__name__
+        == "ValuesView[Callable[[int, float], None]]"
+    )
+    assert map_string_none.values().__class__.__name__ == "ValuesView[None]"
+
+    map_int_map_int_int_int = m.MapIntMapIntIntInt()
+    map_int_map_int_int_long = m.MapIntMapIntIntLong()
+    map_int_map_long_int_long = m.MapIntMapLongIntLong()
+    assert (
+        map_int_map_int_int_int.values().__class__
+        is map_int_map_int_int_long.values().__class__
+    )
+    assert (
+        map_int_map_int_int_long.values().__class__
+        is not map_int_map_long_int_long.values().__class__
+    )
+
+    map_pyint_int = m.MapPyIntInt()
+    map_pyint_pyint = m.MapPyIntPyInt()
+    assert map_pyint_int.items().__class__.__name__ == "ItemsView[int, int]"
+    assert map_pyint_int.items().__class__ is map_pyint_pyint.items().__class__
 
 
 def test_recursive_vector():


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

This PR is an alternative to PR #4972. Fixes issue #4529 and #3986. Compatible to #4888.

Here, ``KeysView/ValuesView/ItemsView`` will have python style typing strings, like ``KeysView[int]`` (see #3986). ``KeysView[int]`` will only be registered once for all relevant ``KeyType = int16_t, int32_t, int64_t, ...`` which solves #4529. A mix of C++ and Python types can also be supported.

Note: To achieve the goal of this PR I cannot directly use ``detail::make_caster<KeyType>::name`` for the Python type name. Consider the case when ``KeyType = std::pair<int, std::vector<int>>`` which is a mix of Python and C++ types. ``detail::make_caster<KeyType>::name`` for this case will be ``tuple[int, %]``. The ``%`` appears, since ``detail::make_caster<KeyType>::name`` is a ``constexpr``, which cannot recognize the binding name for ``std::vector<int>``. PR #4353 uses ``if (key_type_name == "%")`` to get rid of "%" and fall back to the C++ type name, but unfortunately this does not work for the nested case ``tuple[int, %]``. With this PR, I introduced ``detail::type_mapper<KeyType>::py_name()`` to construct the correct type name.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Fix type name clash in ``KeysView`` and ``ValuesView`` when using multiple ``bind_map`` with different integer key types
```

<!-- If the upgrade guide needs updating, note that here too -->
