### PR TITLE
Fix mingw32 CI failure: Workaround: Do not install python-scipy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -959,13 +959,20 @@ jobs:
           mingw-w64-${{matrix.env}}-gcc
           mingw-w64-${{matrix.env}}-python-pip
           mingw-w64-${{matrix.env}}-python-numpy
-          mingw-w64-${{matrix.env}}-python-scipy
           mingw-w64-${{matrix.env}}-cmake
           mingw-w64-${{matrix.env}}-make
           mingw-w64-${{matrix.env}}-python-pytest
           mingw-w64-${{matrix.env}}-eigen3
           mingw-w64-${{matrix.env}}-boost
           mingw-w64-${{matrix.env}}-catch
+
+    - uses: msys2/setup-msys2@v2
+      if: matrix.sys == 'mingw64'
+      with:
+        msystem: ${{matrix.sys}}
+        install: >-
+          git
+          mingw-w64-${{matrix.env}}-python-scipy
 
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Affected:

:snake: 3 • windows-latest • mingw32

Last to work: `2024-01-08T13:40:51.1780929Z`

First broken:  `2024-01-13T19:31:58.0408995Z`

Example error:

https://github.com/pybind/pybind11/actions/runs/7514690075/job/20457837110

```
Installing additional packages through pacman...
  C:\Windows\system32\cmd.exe /D /S /C D:\a\_temp\setup-msys2\msys2.cmd -c "'pacman' '--noconfirm' '-S' '--needed' '--overwrite' '*' 'git' 'mingw-w64-i686-gcc' 'mingw-w64-i686-python-pip' 'mingw-w64-i686-python-numpy' 'mingw-w64-i686-python-scipy' 'mingw-w64-i686-cmake' 'mingw-w64-i686-make' 'mingw-w64-i686-python-pytest' 'mingw-w64-i686-eigen3' 'mingw-w64-i686-boost' 'mingw-w64-i686-catch'"
  error: target not found: mingw-w64-i686-python-scipy
  Error: The process 'C:\Windows\system32\cmd.exe' failed with exit code 1
```

**The solution under this PR is to simply not install python-scipy for mingw32.** This is only a very minor loss of test coverage, not worth more effort.

For easy future reference, pytest summaries:

* mingw64:

```
============================= test session starts =============================
platform win32 -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
C++ Info: 13.2.0 C++17 __pybind11_internals_v4_mingw_libstdcpp_cxxabi1018__ PYBIND11_SIMPLE_GIL_MANAGEMENT=False
...
=========================== short test summary info ===========================
SKIPPED [1] ../../tests/test_callbacks.py:213: Current PYBIND11_INTERNALS_VERSION too low
SKIPPED [24] ../../tests/test_chrono.py:78: TZ environment variable only supported on POSIX
SKIPPED [1] ../../tests/test_pytypes.py:416: Not defined: PYBIND11_HANDLE_REF_DEBUG
SKIPPED [1] ../../tests/test_stl.py: no <experimental/optional>
====================== 839 passed, 27 skipped in 28.81s =======================
```

* mingw32:

```
============================= test session starts =============================
platform win32 -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
C++ Info: 13.2.0 C++17 __pybind11_internals_v4_mingw_libstdcpp_cxxabi1018__ PYBIND11_SIMPLE_GIL_MANAGEMENT=False
...
=========================== short test summary info ===========================
SKIPPED [1] ../../tests/test_buffers.py:58: np.float128 does not exist.
SKIPPED [1] ../../tests/test_buffers.py:58: np.complex256 does not exist.
SKIPPED [1] ../../tests/test_callbacks.py:213: Current PYBIND11_INTERNALS_VERSION too low
SKIPPED [24] ../../tests/test_chrono.py:78: TZ environment variable only supported on POSIX
SKIPPED [1] ../../tests/test_eigen_matrix.py:746: could not import 'scipy': No module named 'scipy'
SKIPPED [1] ../../tests/test_eigen_matrix.py:756: could not import 'scipy': No module named 'scipy'
SKIPPED [1] ../../tests/test_pytypes.py:416: Not defined: PYBIND11_HANDLE_REF_DEBUG
SKIPPED [1] ../../tests/test_stl.py:147: no <experimental/optional>
====================== 835 passed, 31 skipped in 28.45s =======================
```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
