### PR TITLE
Enable specifying`py::metaclass(PyType_Type)` without a C/C++ cast.

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -82,6 +82,7 @@ struct dynamic_attr {};
 struct buffer_protocol {};
 
 /// Annotation which requests that a special metaclass is created for a type
+/// NOTE: pybind11's default metaclass is not compatible with abc.ABCMeta
 struct metaclass {
     handle value;
 
@@ -90,6 +91,12 @@ struct metaclass {
 
     /// Override pybind11's default metaclass
     explicit metaclass(handle value) : value(value) {}
+
+    /// Example usage: py::metaclass(PyType_Type)
+    /// PyType_Type is recommended if compatibility with abc.ABCMeta is required.
+    /// The only potential downside is that static properties behave differently
+    //  (see pybind/pybind11#679 for background).
+    explicit metaclass(PyTypeObject &type_obj) : value(reinterpret_cast<PyObject *>(&type_obj)) {}
 };
 
 /// Specifies a custom callback with signature `void (PyHeapTypeObject*)` that

--- a/tests/test_methods_and_attributes.cpp
+++ b/tests/test_methods_and_attributes.cpp
@@ -367,7 +367,7 @@ TEST_SUBMODULE(methods_and_attributes, m) {
 
     // test_metaclass_override
     struct MetaclassOverride {};
-    py::class_<MetaclassOverride>(m, "MetaclassOverride", py::metaclass((PyObject *) &PyType_Type))
+    py::class_<MetaclassOverride>(m, "MetaclassOverride", py::metaclass(PyType_Type))
         .def_property_readonly_static("readonly", [](const py::object &) { return 1; });
 
     // test_overload_ordering

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -1,3 +1,4 @@
+import abc
 import sys
 
 import pytest
@@ -225,6 +226,22 @@ def test_metaclass_override():
     m.MetaclassOverride.readonly = 2
     assert m.MetaclassOverride.readonly == 2
     assert isinstance(m.MetaclassOverride.__dict__["readonly"], int)
+
+
+def test_abc_meta_incompatibility():  # Mostly to clearly expose the behavior.
+    with pytest.raises(TypeError) as exc_info:
+
+        class ExampleMandAABC(m.ExampleMandA, metaclass=abc.ABCMeta):
+            pass
+
+    assert "metaclass conflict" in str(exc_info.value)
+
+
+def test_abc_meta_compatibility():
+    class MetaclassOverrideABC(m.MetaclassOverride, metaclass=abc.ABCMeta):
+        pass
+
+    assert type(MetaclassOverrideABC).__name__ == "ABCMeta"
 
 
 def test_no_mixed_overloads():


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
`py::metaclass(PyType_Type)` is useful to resolve these problems:

* [abc.ABCMeta](https://docs.python.org/3/library/abc.html#abc.ABCMeta) incompatibility: look for `metaclass conflict` in the added tests.
* MATLAB incompatibility: see https://github.com/pybind/cmake_example/pull/164.
* [mox](https://pypi.org/project/mox/) incompatibility (mox is deprecated but still in use; fully eradicating it is expensive.)

This PR makes it possible to simply specify

`py::metaclass(PyType_Type)` instead of

`py::metaclass((PyObject *) &PyType_Type)`.

This PR also adds comments regarding abc.ABCMeta compatibility.

Note for completeness: the added tests are a partial backport from [google/pywrapcc#30094](https://github.com/google/pywrapcc/pull/30094/files#diff-9973fac8af12c04b84a77049b3bd0be619441caac64ec75658d3939add4f0e00).

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
It is now possible to specify ``py::metaclass(PyType_Type)`` without a C/C++ cast.
```

<!-- If the upgrade guide needs updating, note that here too -->
