### PR TITLE
ci: Ignore v1 updates for checkout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: actions/checkout
+        versions:
+          - "<2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,8 +529,6 @@ jobs:
   # Testing on ICC using the oneAPI apt repo
   icc:
     runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
 
     name: "🐍 3 • ICC latest • x64"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,3 +146,10 @@ repos:
   hooks:
   - id: pylint
     files: ^pybind11
+
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.28.0
+  hooks:
+  - id: check-readthedocs
+  - id: check-github-workflows
+  - id: check-dependabot


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


Hoping this will reduce the v1 updates like #5022. It might ignore updating _to_ this value, in which case maybe could just ignore all checkout updates and make them manually.

<!-- If the upgrade guide needs updating, note that here too -->
