### PR TITLE
[smart_holder] Fix `PYBIND11_INTERNALS_SH_DEF` mixup.

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -316,9 +316,9 @@ struct type_info {
 /// Classic / Conservative / Progressive cross-module compatibility
 #ifndef PYBIND11_INTERNALS_SH_DEF
 #    if defined(PYBIND11_USE_SMART_HOLDER_AS_DEFAULT)
-#        define PYBIND11_INTERNALS_SH_DEF ""
-#    else
 #        define PYBIND11_INTERNALS_SH_DEF "_sh_def"
+#    else
+#        define PYBIND11_INTERNALS_SH_DEF ""
 #    endif
 #endif
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
`PYBIND11_INTERNALS_SH_DEF` was defined the wrong way around since pybind/pybind11#3283 (merged 2021-09-20).

This was discovered by chance, in passing. There were no complaints in all this time.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
