### PR TITLE
fix: #3851 allow holder other than `std::shared_ptr` to be used with class inherit from `std::enable_shared_from_this`

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1848,11 +1848,12 @@ public:
     }
 
 private:
-    /// Initialize holder object, variant 1: object derives from enable_shared_from_this
-    template <typename T>
+    /// Initialize holder object, variant 1: holder is shared_ptr and object derives
+    /// from enable_shared_from_this
+    template <typename T, typename U>
     static void init_holder(detail::instance *inst,
                             detail::value_and_holder &v_h,
-                            const holder_type * /* unused */,
+                            const std::shared_ptr<U> * /* dummy */,
                             const std::enable_shared_from_this<T> * /* dummy */) {
 
         auto sh = std::dynamic_pointer_cast<typename holder_type::element_type>(

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -216,8 +216,9 @@ struct SharedFromThisVirt : virtual SharedFromThisVBase {};
 struct SharedFromThisForCustomHolder
     : std::enable_shared_from_this<SharedFromThisForCustomHolder> {
     int value;
+    SharedFromThisForCustomHolder(const SharedFromThisForCustomHolder &) = default;
     explicit SharedFromThisForCustomHolder(int v) : value(v) { print_created(this, toString()); }
-    ~SharedFromThisForCustomHolder() { print_destroyed(this, toString()); }
+    virtual ~SharedFromThisForCustomHolder() { print_destroyed(this, toString()); }
     std::string toString() const {
         return "SharedFromThisForCustomHolder[" + std::to_string(value) + "]";
     }

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -240,6 +240,12 @@ def test_shared_ptr_from_this_and_references():
     assert y is z
 
 
+def test_enable_shared_from_this_with_custom_holder():
+    a = m.SharedFromThisForCustomHolder.make_as_raw_ptr()
+    b = m.SharedFromThisForCustomHolder.make_as_custom_holder()
+    assert a.value == 1
+    assert b.value == 2
+
 def test_move_only_holder():
     a = m.TypeWithMoveOnlyHolder.make()
     b = m.TypeWithMoveOnlyHolder.make_as_object()

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -246,6 +246,7 @@ def test_enable_shared_from_this_with_custom_holder():
     assert a.value == 1
     assert b.value == 2
 
+
 def test_move_only_holder():
     a = m.TypeWithMoveOnlyHolder.make()
     b = m.TypeWithMoveOnlyHolder.make_as_object()


### PR DESCRIPTION
## Description

Hi, this pr is to fix issue #3851. The `variant 1` here should only be executed when the holder type is a `std::shared_ptr`, as explained in the issue page.

https://github.com/pybind/pybind11/blob/8b48ff878c168b51fe5ef7b8c728815b9e1a9857/include/pybind11/pybind11.h#L1851-L1869

https://github.com/pybind/pybind11/blob/8b48ff878c168b51fe5ef7b8c728815b9e1a9857/include/pybind11/pybind11.h#L1885-L1898

A test is also created, which can only be compiled with the bug fixed.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
