### PR TITLE
fix(cmake): allow forcing old FindPython

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -174,11 +174,14 @@ endif()
 if(PYBIND11_NOPYTHON)
   set(_pybind11_nopython ON)
 elseif(
-  _pybind11_missing_old_python STREQUAL "NEW"
-  OR PYBIND11_FINDPYTHON
-  OR Python_FOUND
-  OR Python2_FOUND
-  OR Python3_FOUND)
+  NOT (DEFINED PYBIND11_FINDPYTHON AND NOT PYBIND11_FINDPYTHON)
+  AND (_pybind11_missing_old_python STREQUAL "NEW"
+       OR PYBIND11_FINDPYTHON
+       OR Python_FOUND
+       OR Python2_FOUND
+       OR Python3_FOUND
+      ))
+
   # New mode
   include("${CMAKE_CURRENT_LIST_DIR}/pybind11NewTools.cmake")
 

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -173,12 +173,13 @@ endif()
 # Check to see which Python mode we are in, new, old, or no python
 if(PYBIND11_NOPYTHON)
   set(_pybind11_nopython ON)
+# We won't use new FindPython if PYBIND11_FINDPYTHON is defined and falselike
+# Otherwise, we use if FindPythonLibs is missing or if FindPython was already used
 elseif(
-  NOT (DEFINED PYBIND11_FINDPYTHON AND NOT PYBIND11_FINDPYTHON)
+  (NOT DEFINED PYBIND11_FINDPYTHON OR PYBIND11_FINDPYTHON)
   AND (_pybind11_missing_old_python STREQUAL "NEW"
        OR PYBIND11_FINDPYTHON
        OR Python_FOUND
-       OR Python2_FOUND
        OR Python3_FOUND
       ))
 

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -173,8 +173,8 @@ endif()
 # Check to see which Python mode we are in, new, old, or no python
 if(PYBIND11_NOPYTHON)
   set(_pybind11_nopython ON)
-# We won't use new FindPython if PYBIND11_FINDPYTHON is defined and falselike
-# Otherwise, we use if FindPythonLibs is missing or if FindPython was already used
+  # We won't use new FindPython if PYBIND11_FINDPYTHON is defined and falselike
+  # Otherwise, we use if FindPythonLibs is missing or if FindPython was already used
 elseif(
   (NOT DEFINED PYBIND11_FINDPYTHON OR PYBIND11_FINDPYTHON)
   AND (_pybind11_missing_old_python STREQUAL "NEW"


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Currently, if for some reason the new FindPython triggers, like if Python has been found the new way, you can't get pybind11 to use the old mechanism. If `PYBIND11_FINDPYTHON` is both defined and falsy, let's use that to force it off.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Setting `PYBIND11_FINDPYTHON` to OFF will force the old FindPythonLibs mechanism to be used.
```

<!-- If the upgrade guide needs updating, note that here too -->
