### PR TITLE
Create handle_type_name specialization to type-hint variable length tuples

### DIFF
--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -82,7 +82,8 @@ struct handle_type_name<typing::Tuple<>> {
 template <typename T>
 struct handle_type_name<typing::Tuple<T, ellipsis>> {
     // PEP 484 specifies this syntax for a variable-length tuple
-    static constexpr auto name = const_name("tuple[") + make_caster<T>::name + const_name(", ...]");
+    static constexpr auto name
+        = const_name("tuple[") + make_caster<T>::name + const_name(", ...]");
 };
 
 template <typename K, typename V>

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -79,6 +79,12 @@ struct handle_type_name<typing::Tuple<>> {
     static constexpr auto name = const_name("tuple[()]");
 };
 
+template <typename T>
+struct handle_type_name<typing::Tuple<T, ellipsis>> {
+    // PEP 484 specifies this syntax for a variable-length tuple
+    static constexpr auto name = const_name("tuple[") + make_caster<T>::name + const_name(", ...]");
+};
+
 template <typename K, typename V>
 struct handle_type_name<typing::Dict<K, V>> {
     static constexpr auto name = const_name("dict[") + make_caster<K>::name + const_name(", ")

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -825,6 +825,7 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.def("annotate_tuple_float_str", [](const py::typing::Tuple<py::float_, py::str> &) {});
     m.def("annotate_tuple_empty", [](const py::typing::Tuple<> &) {});
+    m.def("annotate_tuple_variable_length", [](const py::typing::Tuple<py::float_, py::ellipsis> &) {});
     m.def("annotate_dict_str_int", [](const py::typing::Dict<py::str, int> &) {});
     m.def("annotate_list_int", [](const py::typing::List<int> &) {});
     m.def("annotate_set_str", [](const py::typing::Set<std::string> &) {});

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -825,7 +825,8 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.def("annotate_tuple_float_str", [](const py::typing::Tuple<py::float_, py::str> &) {});
     m.def("annotate_tuple_empty", [](const py::typing::Tuple<> &) {});
-    m.def("annotate_tuple_variable_length", [](const py::typing::Tuple<py::float_, py::ellipsis> &) {});
+    m.def("annotate_tuple_variable_length",
+          [](const py::typing::Tuple<py::float_, py::ellipsis> &) {});
     m.def("annotate_dict_str_int", [](const py::typing::Dict<py::str, int> &) {});
     m.def("annotate_list_int", [](const py::typing::List<int> &) {});
     m.def("annotate_set_str", [](const py::typing::Set<std::string> &) {});

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -913,7 +913,8 @@ def test_tuple_empty_annotations(doc):
 
 def test_tuple_variable_length_annotations(doc):
     assert (
-        doc(m.annotate_tuple_variable_length) == "annotate_tuple_variable_length(arg0: tuple[float, ...]) -> None"
+        doc(m.annotate_tuple_variable_length)
+        == "annotate_tuple_variable_length(arg0: tuple[float, ...]) -> None"
     )
 
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -911,6 +911,12 @@ def test_tuple_empty_annotations(doc):
     )
 
 
+def test_tuple_variable_length_annotations(doc):
+    assert (
+        doc(m.annotate_tuple_variable_length) == "annotate_tuple_variable_length(arg0: tuple[float, ...]) -> None"
+    )
+
+
 def test_dict_annotations(doc):
     assert (
         doc(m.annotate_dict_str_int)


### PR DESCRIPTION
## Description

Adds a template specialization for handle_type_name in typing.h to allow the type hinting of a variable-length tuple, resulting in the hint `tuple[Any, ...]`.

## Suggested changelog entry:

```rst
Create handle_type_name specialization to type-hint variable length tuples
```
