### PR TITLE
Limit error message size when a function is invoked with the wrong type(s)

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1122,9 +1122,13 @@ protected:
                 msg += '\n';
             }
             msg += "\nInvoked with: ";
+            constexpr auto max_args_repr_size = 5000u;
+            const auto orig_msg_size = msg.size();
             auto args_ = reinterpret_borrow<tuple>(args_in);
             bool some_args = false;
-            for (size_t ti = overloads->is_constructor ? 1 : 0; ti < args_.size(); ++ti) {
+            for (size_t ti = overloads->is_constructor ? 1 : 0;
+                 ti < args_.size() && msg.size() - orig_msg_size <= max_args_repr_size;
+                 ++ti) {
                 if (!some_args) {
                     some_args = true;
                 } else {
@@ -1136,7 +1140,7 @@ protected:
                     msg += "<repr raised Error>";
                 }
             }
-            if (kwargs_in) {
+            if (kwargs_in && msg.size() - orig_msg_size <= max_args_repr_size) {
                 auto kwargs = reinterpret_borrow<dict>(kwargs_in);
                 if (!kwargs.empty()) {
                     if (some_args) {
@@ -1145,6 +1149,10 @@ protected:
                     msg += "kwargs: ";
                     bool first = true;
                     for (const auto &kwarg : kwargs) {
+                        if (msg.size() - orig_msg_size > max_args_repr_size) {
+                            break;
+                        }
+
                         if (first) {
                             first = false;
                         } else {
@@ -1158,6 +1166,10 @@ protected:
                         }
                     }
                 }
+            }
+
+            if (msg.size() - orig_msg_size > max_args_repr_size) {
+                msg += "...";
             }
 
             append_note_if_missing_header_is_suspected(msg);


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Recently I found myself in a situation where a Jupyter notebook would become unresponsive because of the huge error message generated by pybind11 when an exposed function is invoked with arguments of the wrong type(s). In this specific case, the wrong argument was a very long list of user-defined types, each of which has a string repr that requires hundreds of characters.

This PR is an attempt to limit the size of the error message that is attached to the pybind11 exception thrown when an exposed function is invoked with an argument of the wrong type.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Limit the size of the error message when an exposed function is invoked with arguments of the wrong type.
```

<!-- If the upgrade guide needs updating, note that here too -->
