### PR TITLE
ci: skipping test for Windows Clang failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1054,9 +1054,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
-
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
@@ -1084,7 +1081,7 @@ jobs:
         run: >
           cmake -G Ninja -S . -B .
           -DPYBIND11_WERROR=OFF
-          -DPYBIND11_SIMPLE_GIL_MANAGEMENT=ON
+          -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF
           -DDOWNLOAD_CATCH=ON
           -DDOWNLOAD_EIGEN=ON
           -DCMAKE_CXX_COMPILER=clang++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1084,7 +1084,7 @@ jobs:
         run: >
           cmake -G Ninja -S . -B .
           -DPYBIND11_WERROR=OFF
-          -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF
+          -DPYBIND11_SIMPLE_GIL_MANAGEMENT=ON
           -DDOWNLOAD_CATCH=ON
           -DDOWNLOAD_EIGEN=ON
           -DCMAKE_CXX_COMPILER=clang++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1054,6 +1054,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Clang
+        uses: egor-tensin/setup-clang@v1
+
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
@@ -1086,6 +1089,7 @@ jobs:
           -DDOWNLOAD_EIGEN=ON
           -DCMAKE_CXX_COMPILER=clang++
           -DCMAKE_CXX_STANDARD=17
+          -DPYBIND11_PYTEST_ARGS='-k "not test_throw_nested_exception"'
 
       - name: Build
         run: cmake --build . -j 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1089,7 +1089,6 @@ jobs:
           -DDOWNLOAD_EIGEN=ON
           -DCMAKE_CXX_COMPILER=clang++
           -DCMAKE_CXX_STANDARD=17
-          -DPYBIND11_PYTEST_ARGS='-k "not test_throw_nested_exception"'
 
       - name: Build
         run: cmake --build . -j 2

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -67,9 +67,14 @@ inline PyObject *make_object_base_type(PyTypeObject *metaclass);
 // `Py_LIMITED_API` anyway.
 #    if PYBIND11_INTERNALS_VERSION > 4
 #        define PYBIND11_TLS_KEY_REF Py_tss_t &
-#        if defined(__GNUC__) && !defined(__INTEL_COMPILER)
-// Clang on macOS warns due to `Py_tss_NEEDS_INIT` not specifying an initializer
-// for every field.
+#        if defined(__clang__)
+#            define PYBIND11_TLS_KEY_INIT(var)                                                    \
+                _Pragma("clang diagnostic push")                                         /**/     \
+                    _Pragma("clang diagnostic ignored \"-Wmissing-field-initializers\"") /**/     \
+                    Py_tss_t var                                                                  \
+                    = Py_tss_NEEDS_INIT;                                                          \
+                _Pragma("clang diagnostic pop")
+#        elif defined(__GNUC__) && !defined(__INTEL_COMPILER)
 #            define PYBIND11_TLS_KEY_INIT(var)                                                    \
                 _Pragma("GCC diagnostic push")                                         /**/       \
                     _Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"") /**/       \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -520,11 +520,15 @@ set(PYBIND11_TEST_PREFIX_COMMAND
     ""
     CACHE STRING "Put this before pytest, use for checkers and such")
 
+set(PYBIND11_PYTEST_ARGS
+    ""
+    CACHE STRING "Extra arguments for pytest")
+
 # A single command to compile and run the tests
 add_custom_target(
   pytest
   COMMAND ${PYBIND11_TEST_PREFIX_COMMAND} ${PYTHON_EXECUTABLE} -m pytest
-          ${PYBIND11_ABS_PYTEST_FILES}
+          ${PYBIND11_ABS_PYTEST_FILES} ${PYBIND11_PYTEST_ARGS}
   DEPENDS ${test_targets}
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   USES_TERMINAL)

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -80,10 +80,10 @@ PYBIND11_MODULE(pybind11_tests, m) {
 
     // Intentionally kept minimal to not create a maintenance chore
     // ("just enough" to be conclusive).
-#if defined(_MSC_FULL_VER)
-    m.attr("compiler_info") = "MSVC " PYBIND11_TOSTRING(_MSC_FULL_VER);
-#elif defined(__VERSION__)
+#if defined(__VERSION__)
     m.attr("compiler_info") = __VERSION__;
+#elif defined(_MSC_FULL_VER)
+    m.attr("compiler_info") = "MSVC " PYBIND11_TOSTRING(_MSC_FULL_VER);
 #else
     m.attr("compiler_info") = py::none();
 #endif

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -248,7 +248,7 @@ def test_nested_throws(capture):
     assert str(excinfo.value) == "this is a helper-defined translated exception"
 
 
-# TODO: Investigate this crash
+# TODO: Investigate this crash, see pybind/pybind11#5062 for background
 @pytest.mark.skipif(
     sys.platform.startswith("win32") and "Clang" in pybind11_tests.compiler_info,
     reason="Started sefaulting March 2024",

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,7 +4,7 @@ import pytest
 
 import env
 import pybind11_cross_module_tests as cm
-import pybind11_tests  # noqa: F401
+import pybind11_tests
 from pybind11_tests import exceptions as m
 
 
@@ -248,6 +248,11 @@ def test_nested_throws(capture):
     assert str(excinfo.value) == "this is a helper-defined translated exception"
 
 
+# TODO: Investigate this crash
+@pytest.mark.skipif(
+    sys.platform.startswith("win32") and "Clang" in pybind11_tests.compiler_info,
+    reason="Started sefaulting March 2024",
+)
 def test_throw_nested_exception():
     with pytest.raises(RuntimeError) as excinfo:
         m.throw_nested_exception()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -251,7 +251,7 @@ def test_nested_throws(capture):
 # TODO: Investigate this crash, see pybind/pybind11#5062 for background
 @pytest.mark.skipif(
     sys.platform.startswith("win32") and "Clang" in pybind11_tests.compiler_info,
-    reason="Started sefaulting March 2024",
+    reason="Started segfaulting February 2024",
 )
 def test_throw_nested_exception():
     with pytest.raises(RuntimeError) as excinfo:


### PR DESCRIPTION
## Description

Skipping a test for a Clang failure. Also hiding a warning in Clang that we hide in GCC.

Last successful log: 2024-02-20T21:40:01.6656694Z https://github.com/pybind/pybind11/actions/runs/7980348964/job/21789806071

First failing log: 2024-02-27T17:04:02.7790106Z https://github.com/pybind/pybind11/actions/runs/8067833464/job/22041600407

