### PR TITLE
tests: hide warning on clang

### DIFF
--- a/tests/test_constants_and_functions.cpp
+++ b/tests/test_constants_and_functions.cpp
@@ -54,7 +54,11 @@ int f2(int x) noexcept(true) { return x + 2; }
 int f3(int x) noexcept(false) { return x + 3; }
 PYBIND11_WARNING_PUSH
 PYBIND11_WARNING_DISABLE_GCC("-Wdeprecated")
+#if defined(__clang_major__) && __clang_major__ >= 5
+PYBIND11_WARNING_DISABLE_CLANG("-Wdeprecated-dynamic-exception-spec")
+#else
 PYBIND11_WARNING_DISABLE_CLANG("-Wdeprecated")
+#endif
 // NOLINTNEXTLINE(modernize-use-noexcept)
 int f4(int x) throw() { return x + 4; } // Deprecated equivalent to noexcept(true)
 PYBIND11_WARNING_POP


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Hide a warning in our tests on clang.


Warnings look like this:

```
D:/a/pybind11/pybind11/tests/test_constants_and_functions.cpp:59:15: warning: dynamic exception specifications are deprecated [-Wdeprecated-dynamic-exception-spec]
   59 | int f4(int x) throw() { return x + 4; } // Deprecated equivalent to noexcept(true)
      |               ^~~~~~~
D:/a/pybind11/pybind11/tests/test_constants_and_functions.cpp:59:15: note: use 'noexcept' instead
   59 | int f4(int x) throw() { return x + 4; } // Deprecated equivalent to noexcept(true)
      |               ^~~~~~~
      |               noexcept
D:/a/pybind11/pybind11/tests/test_constants_and_functions.cpp:72:19: warning: dynamic exception specifications are deprecated [-Wdeprecated-dynamic-exception-spec]
   72 |     int m7(int x) throw() { return x - 7; }
      |                   ^~~~~~~
D:/a/pybind11/pybind11/tests/test_constants_and_functions.cpp:72:19: note: use 'noexcept' instead
   72 |     int m7(int x) throw() { return x - 7; }
      |                   ^~~~~~~
      |                   noexcept
D:/a/pybind11/pybind11/tests/test_constants_and_functions.cpp:74:25: warning: dynamic exception specifications are deprecated [-Wdeprecated-dynamic-exception-spec]
   74 |     int m8(int x) const throw() { return x - 8; }
      |                         ^~~~~~~
D:/a/pybind11/pybind11/tests/test_constants_and_functions.cpp:74:25: note: use 'noexcept' instead
   74 |     int m8(int x) const throw() { return x - 8; }
      |                         ^~~~~~~
      |                         noexcept

3 warnings generated.
```
