### PR TITLE
chore: prepare 2.12.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,10 +36,10 @@ with everything stripped away that isn't relevant for binding
 generation. Without comments, the core header files only require ~4K
 lines of code and depend on Python (3.6+, or PyPy) and the C++
 standard library. This compact implementation was possible thanks to
-some of the new C++11 language features (specifically: tuples, lambda
-functions and variadic templates). Since its creation, this library has
-grown beyond Boost.Python in many ways, leading to dramatically simpler
-binding code in many common situations.
+some C++11 language features (specifically: tuples, lambda functions and
+variadic templates). Since its creation, this library has grown beyond
+Boost.Python in many ways, leading to dramatically simpler binding code in many
+common situations.
 
 Tutorial and reference documentation is provided at
 `pybind11.readthedocs.io <https://pybind11.readthedocs.io/en/latest>`_.
@@ -71,6 +71,7 @@ pybind11 can map the following core C++ features to Python:
 - Internal references with correct reference counting
 - C++ classes with virtual (and pure virtual) methods can be extended
   in Python
+- Integrated NumPy support (NumPy 2 requires pybind11 2.12+)
 
 Goodies
 -------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,7 +38,7 @@ New Features:
 
 * Two simple ``py::set_error()`` functions were added and the documentation was
   updated accordingly. In particular, ``py::exception<>::operator()`` was
-  deprecated (use one of the new function instead). The documentation for
+  deprecated (use one of the new functions instead). The documentation for
   ``py::exception<>`` was further updated to not suggest code that may result
   in undefined behavior.
   `#4772 <https://github.com/pybind/pybind11/pull/4772>`_
@@ -52,8 +52,8 @@ Bug fixes:
   `#4893 <https://github.com/pybind/pybind11/pull/4893>`_
 
 * ``pybind11/numpy.h`` now imports NumPy's ``multiarray`` and ``_internal``
-  submodules with paths depending on the version of installed NumPy (handling
-  change in NumPy 2.0).
+  submodules with paths depending on the installed version of NumPy (for
+  compatibility with NumPy 2).
   `#4857 <https://github.com/pybind/pybind11/pull/4857>`_
 
 * Builtins collections names in docstrings are now consistently rendered in
@@ -85,6 +85,7 @@ Bug fixes:
   somewhere else, such as modernjson's concat.
   `#4955 <https://github.com/pybind/pybind11/pull/4955>`_
 
+.. fix(types)
 
 * Render typed iterators for ``make_iterator``, ``make_key_iterator``,
   ``make_value_iterator``.
@@ -107,6 +108,7 @@ Bug fixes:
   list, set, and function.
   `#4259 <https://github.com/pybind/pybind11/pull/4259>`_
 
+.. fix(build)
 
 * Fix FindPython mode exports & avoid ``pkg_resources`` if
   ``importlib.metadata`` available.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -90,6 +90,9 @@ Bug fixes:
   ``make_value_iterator``.
   `#4876 <https://github.com/pybind/pybind11/pull/4876>`_
 
+* Add several missing type name specializations.
+  `#5073 <https://github.com/pybind/pybind11/pull/5073>`_
+
 * Change docstring render for ``py::buffer``, ``py::sequence`` and
   ``py::handle`` (to ``Buffer``, ``Sequence``, ``Any``).
   `#4831 <https://github.com/pybind/pybind11/pull/4831>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,8 @@ IN DEVELOPMENT
 
 Changes will be summarized here periodically.
 
+Version 2.12.0 (March 27, 2025)
+-------------------------------
 
 New Features:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,8 +16,146 @@ IN DEVELOPMENT
 Changes will be summarized here periodically.
 
 
+New Features:
+
+* ``pybind11/gil_safe_call_once.h`` was added (it needs to be included
+  explicitly). The primary use case is GIL-safe initialization of C++
+  ``static`` variables.
+  `#4877 <https://github.com/pybind/pybind11/pull/4877>`_
+
+* Support move-only iterators in ``py::make_iterator``,
+  ``py::make_key_iterator``, ``py::make_value_iterator``.
+  `#4834 <https://github.com/pybind/pybind11/pull/4834>`_
+
+* Two simple ``py::set_error()`` functions were added and the documentation was
+  updated accordingly. In particular, ``py::exception<>::operator()`` was
+  deprecated (use one of the new function instead). The documentation for
+  ``py::exception<>`` was further updated to not suggest code that may result
+  in undefined behavior.
+  `#4772 <https://github.com/pybind/pybind11/pull/4772>`_
+
+Bug fixes:
+
+* ``pybind11`` now supports compiling for NumPy 2.  The required changes are
+  small and should not matter to most projects. However, if you experience
+  issues you can use   ``#define PYBIND11_NUMPY_1_ONLY`` to disable the new
+  support for now.
+  `#5050 <https://github.com/pybind/pybind11/pull/5050>`_
+
+* Removes potential for Undefined Behavior during process teardown.
+  `#4897 <https://github.com/pybind/pybind11/pull/4897>`_
+
+* Improve compatibility with the nvcc compiler (especially CUDA 12.1/12.2).
+  `#4893 <https://github.com/pybind/pybind11/pull/4893>`_
+
+* ``pybind11/numpy.h`` now imports NumPy's ``multiarray`` and ``_internal``
+  submodules with paths depending on the version of installed NumPy (handling
+  change in NumPy 2.0).
+  `#4857 <https://github.com/pybind/pybind11/pull/4857>`_
+
+* Builtins collections names in docstrings are now consistently rendered in
+  lowercase (list, set, dict, tuple), in accordance with PEP 585.
+  `#4833 <https://github.com/pybind/pybind11/pull/4833>`_
+
+* Added ``py::typing::Iterator<T>``, ``py::typing::Iterable<T>``.
+  `#4832 <https://github.com/pybind/pybind11/pull/4832>`_
+
+* Render ``py::function`` as ``Callable`` in docstring.
+  `#4829 <https://github.com/pybind/pybind11/pull/4829>`_
+
+* Also bump ``PYBIND11_INTERNALS_VERSION`` for MSVC, which unlocks two new
+  features without creating additional incompatibilities.
+  `#4819 <https://github.com/pybind/pybind11/pull/4819>`_
+
+* Guard against crashes/corruptions caused by modules built with different MSVC
+  versions.
+  `#4779 <https://github.com/pybind/pybind11/pull/4779>`_
+
+* A long-standing bug in the handling of Python multiple inheritance was fixed.
+  See PR #4762 for the rather complex details.
+  `#4762 <https://github.com/pybind/pybind11/pull/4762>`_
+
+* Fix ``bind_map`` with ``using`` declarations.
+  `#4952 <https://github.com/pybind/pybind11/pull/4952>`_
+
+
+* Render typed iterators for ``make_iterator``, ``make_key_iterator``,
+  ``make_value_iterator``.
+  `#4876 <https://github.com/pybind/pybind11/pull/4876>`_
+
+* Change docstring render for ``py::buffer``, ``py::sequence`` and
+  ``py::handle`` (to ``Buffer``, ``Sequence``, ``Any``).
+  `#4831 <https://github.com/pybind/pybind11/pull/4831>`_
+
+* Fixed ``base_enum.__str__`` docstring.
+  `#4827 <https://github.com/pybind/pybind11/pull/4827>`_
+
+* Enforce single line docstring signatures.
+  `#4735 <https://github.com/pybind/pybind11/pull/4735>`_
+
+* Special 'typed' wrappers now available in typing.h to annotate tuple, dict,
+  list, set, and function.
+  `#4259 <https://github.com/pybind/pybind11/pull/4259>`_
+
+
+* Fix FindPython mode exports & avoid ``pkg_resources`` if
+  ``importlib.metadata`` available.
+  `#4941 <https://github.com/pybind/pybind11/pull/4941>`_
+
+*  ``Python_ADDITIONAL_VERSIONS`` (classic search) now includes 3.12.
+  `#4909 <https://github.com/pybind/pybind11/pull/4909>`_
+
+* ``pybind11.pc`` is now relocatable by default as long as install destinations
+  are not absolute paths.
+  `#4830 <https://github.com/pybind/pybind11/pull/4830>`_
+
+* Correctly detect CMake FindPython removal when used as a subdirectory.
+  `#4806 <https://github.com/pybind/pybind11/pull/4806>`_
+
+* Don't require the libs component on CMake 3.18+ when using
+  PYBIND11_FINDPYTHON (fixes manylinux builds).
+  `#4805 <https://github.com/pybind/pybind11/pull/4805>`_
+
+* ``pybind11_strip`` is no longer automatically applied when
+  ``CMAKE_BUILD_TYPE`` is unset.
+  `#4780 <https://github.com/pybind/pybind11/pull/4780>`_
+
+* Support DEBUG_POSFIX correctly for debug builds.
+  `#4761 <https://github.com/pybind/pybind11/pull/4761>`_
+
+* Hardcode lto/thin lto for Emscripten cross-compiles.
+  `#4642 <https://github.com/pybind/pybind11/pull/4642>`_
+
+Documentation:
+
+* Small fix to grammar in functions.rst.
+  `#4791 <https://github.com/pybind/pybind11/pull/4791>`_
+
+* Remove upper bound in example pyproject.toml for setuptools.
+  `#4774 <https://github.com/pybind/pybind11/pull/4774>`_
+
+CI:
+
+* CI: Update NVHPC to 23.5 and Ubuntu 20.04.
+  `#4764 <https://github.com/pybind/pybind11/pull/4764>`_
+
+* Test on PyPy 3.10.
+  `#4714 <https://github.com/pybind/pybind11/pull/4714>`_
+
+Other:
+
+* Use new PyCode API on Python 3.12+.
+  `#4916 <https://github.com/pybind/pybind11/pull/4916>`_
+
+* Use Ruff formatter instead of Black.
+  `#4912 <https://github.com/pybind/pybind11/pull/4912>`_
+
+* An ``assert()`` was added to help Coverty avoid generating a false positive.
+  `#4817 <https://github.com/pybind/pybind11/pull/4817>`_
+
+
 Version 2.11.1 (July 17, 2023)
------------------------------
+------------------------------
 
 Changes:
 
@@ -32,7 +170,7 @@ Changes:
 
 
 Version 2.11.0 (July 14, 2023)
------------------------------
+------------------------------
 
 New features:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,13 @@ Changes will be summarized here periodically.
 
 New Features:
 
+* ``pybind11`` now supports compiling for
+  `NumPy 2 <https://numpy.org/devdocs/numpy_2_0_migration_guide.html>`_. Most
+  code shouldn't change (see :ref:`upgrade-guide-2.12` for details). However,
+  if you experience issues you can define ``PYBIND11_NUMPY_1_ONLY`` to disable
+  the new support for now, but this will be removed in the future.
+  `#5050 <https://github.com/pybind/pybind11/pull/5050>`_
+
 * ``pybind11/gil_safe_call_once.h`` was added (it needs to be included
   explicitly). The primary use case is GIL-safe initialization of C++
   ``static`` variables.
@@ -35,12 +42,6 @@ New Features:
   `#4772 <https://github.com/pybind/pybind11/pull/4772>`_
 
 Bug fixes:
-
-* ``pybind11`` now supports compiling for NumPy 2.  The required changes are
-  small and should not matter to most projects. However, if you experience
-  issues you can use   ``#define PYBIND11_NUMPY_1_ONLY`` to disable the new
-  support for now.
-  `#5050 <https://github.com/pybind/pybind11/pull/5050>`_
 
 * Removes potential for Undefined Behavior during process teardown.
   `#4897 <https://github.com/pybind/pybind11/pull/4897>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -81,6 +81,10 @@ Bug fixes:
 * Fix ``bind_map`` with ``using`` declarations.
   `#4952 <https://github.com/pybind/pybind11/pull/4952>`_
 
+* Qualify ``py::detail::concat`` usage to avoid ADL selecting one from
+  somewhere else, such as modernjson's concat.
+  `#4955 <https://github.com/pybind/pybind11/pull/4955>`_
+
 
 * Render typed iterators for ``make_iterator``, ``make_key_iterator``,
   ``make_value_iterator``.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -36,19 +36,19 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
 
   - Run ``nox -s tests_packaging`` to ensure this was done correctly.
 
-  - Ensure that all the information in ``setup.cfg`` is up-to-date, like
+- Ensure that all the information in ``setup.cfg`` is up-to-date, like
     supported Python versions.
 
-  - Add release date in ``docs/changelog.rst`` and integrate the output of
-    ``nox -s make_changelog``.
+- Add release date in ``docs/changelog.rst`` and integrate the output of
+  ``nox -s make_changelog``.
 
-    - Note that the ``make_changelog`` command inspects
-      `needs changelog <https://github.com/pybind/pybind11/pulls?q=is%3Apr+is%3Aclosed+label%3A%22needs+changelog%22>`_.
+  - Note that the ``nox -s make_changelog`` command inspects
+    `needs changelog <https://github.com/pybind/pybind11/pulls?q=is%3Apr+is%3Aclosed+label%3A%22needs+changelog%22>`_.
 
-    - Manually clear the ``needs changelog`` labels using the GitHub web
-      interface (very easy: start by clicking the link above).
+  - Manually clear the ``needs changelog`` labels using the GitHub web
+    interface (very easy: start by clicking the link above).
 
-  - ``git add`` and ``git commit``, ``git push``. **Ensure CI passes**. (If it
+- ``git add`` and ``git commit``, ``git push``. **Ensure CI passes**. (If it
     fails due to a known flake issue, either ignore or restart CI.)
 
 - Add a release branch if this is a new MINOR version, or update the existing

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -8,6 +8,34 @@ to a new version. But it goes into more detail. This includes things like
 deprecated APIs and their replacements, build system changes, general code
 modernization and other useful information.
 
+.. _upgrade-guide-2.12:
+
+v2.12
+=====
+
+NumPy support has been upgraded to support the 2.x series too. The two relevant
+changes are that:
+
+* ``dtype.flags()`` is now a ``uint64`` and ``dtype.alignment()`` an
+  ``ssize_t`` (and NumPy may return an larger than integer value for
+  ``itemsize()`` in NumPy 2.x).
+
+* The long deprecated NumPy function ``PyArray_GetArrayParamsFromObject``
+  function is not available anymore.
+
+Due to NumPy changes, you may experience difficulties updating to NumPy 2.
+Please see the [NumPy 2 migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html) for details.
+For example, a more direct change could be that the default integer ``"int_"``
+(and ``"uint"``) is now ``ssize_t`` and not ``long`` (affects 64bit windows).
+
+If you want to only support NumPy 1.x for now and are having problems due to
+the two internal changes listed above, you can define
+``PYBIND11_NUMPY_1_ONLY`` to disable the new support for now. Make sure you
+define this on all pybind11 compile units, since it could be a source of ODR
+violations if used inconsistently. This option will be removed in the future,
+so adapting your code is highly recommended.
+
+
 .. _upgrade-guide-2.11:
 
 v2.11

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -11,11 +11,11 @@
 
 #define PYBIND11_VERSION_MAJOR 2
 #define PYBIND11_VERSION_MINOR 12
-#define PYBIND11_VERSION_PATCH 0.dev1
+#define PYBIND11_VERSION_PATCH 0
 
 // Similar to Python's convention: https://docs.python.org/3/c-api/apiabiversion.html
 // Additional convention: 0xD = dev
-#define PYBIND11_VERSION_HEX 0x020C00D1
+#define PYBIND11_VERSION_HEX 0x020C0000
 
 // Define some generic pybind11 helper macros for warning management.
 //

--- a/pybind11/_version.py
+++ b/pybind11/_version.py
@@ -8,5 +8,5 @@ def _to_int(s: str) -> Union[int, str]:
         return s
 
 
-__version__ = "2.12.0.dev1"
+__version__ = "2.12.0"
 version_info = tuple(_to_int(s) for s in __version__.split("."))

--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -67,7 +67,8 @@ for issue in issues:
 for cat, msgs in cats.items():
     if msgs:
         desc = cats_descr[cat]
-        print(f"[bold]{desc}:\n\n" if desc else "", end="")
+        print(f"[bold]{desc}:" if desc else f".. {cat}")
+        print()
         for msg in msgs:
             print(Syntax(msg, "rst", theme="ansi_light", word_wrap=True))
             print()

--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -67,9 +67,10 @@ for issue in issues:
 for cat, msgs in cats.items():
     if msgs:
         desc = cats_descr[cat]
-        print(f"[bold]{desc}:\n" if desc else "")
+        print(f"[bold]{desc}:\n\n" if desc else "", end="")
         for msg in msgs:
             print(Syntax(msg, "rst", theme="ansi_light", word_wrap=True))
+            print()
         print()
 
 if missing:


### PR DESCRIPTION
Preparing 2.12. Blocking on #5050 (included in changelog). Would also like #4955. Needs release date.
