### PR TITLE
ci: Systematically change macos-latest to macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-20.04, windows-2022, macos-latest]
+        runs-on: [ubuntu-20.04, windows-2022, macos-13]
         python:
         - '3.6'
         - '3.9'
@@ -1118,8 +1118,8 @@ jobs:
         run: git clean -fdx
 
   macos_brew_install_llvm:
-    name: "macos-latest • brew install llvm"
-    runs-on: macos-latest
+    name: "macos-13 • brew install llvm"
+    runs-on: macos-13
 
     env:
       # https://apple.stackexchange.com/questions/227026/how-to-install-recent-clang-with-homebrew

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-20.04, macos-latest, windows-latest]
+        runs-on: [ubuntu-20.04, macos-13, windows-latest]
         arch: [x64]
         cmake: ["3.26"]
 
@@ -37,7 +37,7 @@ jobs:
           arch: x64
           cmake: "3.29"
 
-        - runs-on: macos-latest
+        - runs-on: macos-13
           arch: x64
           cmake: "3.7"
 


### PR DESCRIPTION
macos-latest is moving from macos-13 (Intel) to to macos-14 (Apple Silicon) runners. This PR isolates us from the infrastructure change for now.

We'll need to drop Python <3.8 and update any binary pinned versions of packages (like NumPy and SciPy) to use the new runners, since 3.8 was the first version to support Apple Silicon, and older releases of packages don't have AS support or wheels.