### PR TITLE
Added check on iterator end position

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -388,15 +388,19 @@ inline void clear_patients(PyObject *self) {
     auto *instance = reinterpret_cast<detail::instance *>(self);
     auto &internals = get_internals();
     auto pos = internals.patients.find(self);
-    assert(pos != internals.patients.end());
-    // Clearing the patients can cause more Python code to run, which
-    // can invalidate the iterator. Extract the vector of patients
-    // from the unordered_map first.
-    auto patients = std::move(pos->second);
-    internals.patients.erase(pos);
-    instance->has_patients = false;
-    for (PyObject *&patient : patients) {
-        Py_CLEAR(patient);
+
+    if (pos != internals.patients.end()) {
+        // Clearing the patients can cause more Python code to run, which
+        // can invalidate the iterator. Extract the vector of patients
+        // from the unordered_map first.
+        auto patients = std::move(pos->second);
+        internals.patients.erase(pos);
+        instance->has_patients = false;
+        for (PyObject *&patient : patients) {
+            Py_CLEAR(patient);
+        }
+    } else {
+        assert(pos != internals.patients.end());
     }
 }
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -401,6 +401,9 @@ inline void clear_patients(PyObject *self) {
             Py_CLEAR(patient);
         }
     }
+    else {
+        pybind11_fail("FATAL: Internal consistency check failed: Invalid clear_patients() call.");
+    }
 }
 
 /// Clears all internal data from the instance and removes it from registered instances in

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -389,18 +389,18 @@ inline void clear_patients(PyObject *self) {
     auto &internals = get_internals();
     auto pos = internals.patients.find(self);
 
-    if (pos != internals.patients.end()) {
-        // Clearing the patients can cause more Python code to run, which
-        // can invalidate the iterator. Extract the vector of patients
-        // from the unordered_map first.
-        auto patients = std::move(pos->second);
-        internals.patients.erase(pos);
-        instance->has_patients = false;
-        for (PyObject *&patient : patients) {
-            Py_CLEAR(patient);
-        }
-    } else {
+    if (pos == internals.patients.end()) {
         pybind11_fail("FATAL: Internal consistency check failed: Invalid clear_patients() call.");
+    }
+
+    // Clearing the patients can cause more Python code to run, which
+    // can invalidate the iterator. Extract the vector of patients
+    // from the unordered_map first.
+    auto patients = std::move(pos->second);
+    internals.patients.erase(pos);
+    instance->has_patients = false;
+    for (PyObject *&patient : patients) {
+        Py_CLEAR(patient);
     }
 }
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -389,7 +389,6 @@ inline void clear_patients(PyObject *self) {
     auto &internals = get_internals();
     auto pos = internals.patients.find(self);
 
-    assert(pos != internals.patients.end());
     if (pos != internals.patients.end()) {
         // Clearing the patients can cause more Python code to run, which
         // can invalidate the iterator. Extract the vector of patients

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -389,6 +389,7 @@ inline void clear_patients(PyObject *self) {
     auto &internals = get_internals();
     auto pos = internals.patients.find(self);
 
+    assert(pos != internals.patients.end());
     if (pos != internals.patients.end()) {
         // Clearing the patients can cause more Python code to run, which
         // can invalidate the iterator. Extract the vector of patients
@@ -399,8 +400,6 @@ inline void clear_patients(PyObject *self) {
         for (PyObject *&patient : patients) {
             Py_CLEAR(patient);
         }
-    } else {
-        assert(pos != internals.patients.end());
     }
 }
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -400,8 +400,7 @@ inline void clear_patients(PyObject *self) {
         for (PyObject *&patient : patients) {
             Py_CLEAR(patient);
         }
-    }
-    else {
+    } else {
         pybind11_fail("FATAL: Internal consistency check failed: Invalid clear_patients() call.");
     }
 }


### PR DESCRIPTION
Closes #4822 

## Description

Issue #4822 reported an issue Coverity found with an unchecked iterator in release mode. gcc13 also finds this by default and reports a warning.


## Suggested changelog entry:


