### PR TITLE
fix: Python 3.13t with GIL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,38 @@ jobs:
         pytest tests/extra_setuptools
       if: "!(matrix.runs-on == 'windows-2022')"
 
+  manylinux:
+    name: Manylinux on 🐍 ${{ matrix.python }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.13t", "3.13"]
+    timeout-minutes: 40
+    container: quay.io/pypa/musllinux_1_2_x86_64:latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare venv
+        run: python${{ matrix.python }} -m venv .venv
+
+      - name: Install Python deps
+        run: .venv/bin/pip install -r tests/requirements.txt
+
+      - name: Configure C++11
+        run: >
+          cmake -S. -Bbuild
+          -DPYBIND11_WERROR=ON
+          -DDOWNLOAD_CATCH=ON
+          -DDOWNLOAD_EIGEN=ON
+          -DPython_ROOT_DIR=.venv
+
+      - name: Build C++11
+        run: cmake --build build -j2
+
+      - name: Python tests C++11
+        run: cmake --build build --target pytest -j2
 
   deadsnakes:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,11 +197,8 @@ jobs:
       if: "!(matrix.runs-on == 'windows-2022')"
 
   manylinux:
-    name: Manylinux on 🐍 ${{ matrix.python }}
+    name: Manylinux on 🐍 3.13t • GIL
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ["3.13t", "3.13"]
     timeout-minutes: 40
     container: quay.io/pypa/musllinux_1_2_x86_64:latest
     steps:
@@ -210,7 +207,7 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare venv
-        run: python${{ matrix.python }} -m venv .venv
+        run: python3.13 -m venv .venv
 
       - name: Install Python deps
         run: .venv/bin/pip install -r tests/requirements.txt

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -183,7 +183,15 @@ public:
     str_attr_accessor doc() const;
 
     /// Return the object's current reference count
-    ssize_t ref_count() const { return Py_REFCNT(derived().ptr()); }
+    ssize_t ref_count() const {
+#ifdef PYPY_VERSION
+        // PyPy uses the top few bits for REFCNT_FROM_PYPY & REFCNT_FROM_PYPY_LIGHT
+        // Following pybind11 2.12.1 and older behavior and removing this part
+        return static_cast<ssize_t>(static_cast<int>(Py_REFCNT(derived().ptr())));
+#else
+        return Py_REFCNT(derived().ptr());
+#endif
+    }
 
     // TODO PYBIND11_DEPRECATED(
     //     "Call py::type::handle_of(h) or py::type::of(h) instead of h.get_type()")

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -183,7 +183,7 @@ public:
     str_attr_accessor doc() const;
 
     /// Return the object's current reference count
-    int ref_count() const { return static_cast<int>(Py_REFCNT(derived().ptr())); }
+    ssize_t ref_count() const { return Py_REFCNT(derived().ptr()); }
 
     // TODO PYBIND11_DEPRECATED(
     //     "Call py::type::handle_of(h) or py::type::of(h) instead of h.get_type()")

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -89,6 +89,7 @@ PYBIND11_MODULE(pybind11_tests, m) {
 #endif
     m.attr("cpp_std") = cpp_std();
     m.attr("PYBIND11_INTERNALS_ID") = PYBIND11_INTERNALS_ID;
+    m.attr("PYBIND11_REFCNT_IMMORTAL") = UINT32_MAX;
     m.attr("PYBIND11_SIMPLE_GIL_MANAGEMENT") =
 #if defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
         true;

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -89,6 +89,7 @@ PYBIND11_MODULE(pybind11_tests, m) {
 #endif
     m.attr("cpp_std") = cpp_std();
     m.attr("PYBIND11_INTERNALS_ID") = PYBIND11_INTERNALS_ID;
+    // Free threaded Python uses UINT32_MAX for immortal objects.
     m.attr("PYBIND11_REFCNT_IMMORTAL") = UINT32_MAX;
     m.attr("PYBIND11_SIMPLE_GIL_MANAGEMENT") =
 #if defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -377,7 +377,6 @@ def test_class_refcount():
         refcount_3 = getrefcount(cls)
 
         assert refcount_1 == refcount_3
-        # Free-threaded Python uses UINT32_MAX for immortal objects.
         assert (refcount_2 > refcount_1) or (
             refcount_2 == refcount_1 == PYBIND11_REFCNT_IMMORTAL
         )

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -377,7 +377,7 @@ def test_class_refcount():
         refcount_3 = getrefcount(cls)
 
         assert refcount_1 == refcount_3
-        # Free-threaded Python uses UINT32_MAX for immortal objects
+        # Free-threaded Python uses UINT32_MAX for immortal objects.
         assert (refcount_2 > refcount_1) or (refcount_2 == refcount_1 == 2**32 - 1)
 
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -377,7 +377,8 @@ def test_class_refcount():
         refcount_3 = getrefcount(cls)
 
         assert refcount_1 == refcount_3
-        assert refcount_2 > refcount_1
+        # Free-threaded Python uses UINT32_MAX for immortal objects
+        assert (refcount_2 > refcount_1) or (refcount_2 == refcount_1 == 2**32 - 1)
 
 
 def test_reentrant_implicit_conversion_failure(msg):

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 import env
-from pybind11_tests import ConstructorStats, UserType
+from pybind11_tests import PYBIND11_REFCNT_IMMORTAL, ConstructorStats, UserType
 from pybind11_tests import class_ as m
 
 
@@ -378,7 +378,9 @@ def test_class_refcount():
 
         assert refcount_1 == refcount_3
         # Free-threaded Python uses UINT32_MAX for immortal objects.
-        assert (refcount_2 > refcount_1) or (refcount_2 == refcount_1 == 2**32 - 1)
+        assert (refcount_2 > refcount_1) or (
+            refcount_2 == refcount_1 == PYBIND11_REFCNT_IMMORTAL
+        )
 
 
 def test_reentrant_implicit_conversion_failure(msg):

--- a/tests/test_embed/CMakeLists.txt
+++ b/tests/test_embed/CMakeLists.txt
@@ -7,6 +7,13 @@ if("${PYTHON_MODULE_EXTENSION}" MATCHES "pypy" OR "${Python_INTERPRETER_ID}" STR
   return()
 endif()
 
+if(TARGET Python::Module AND NOT TARGET Python::Python)
+  message(STATUS "Skipping embed test since no embed libs found")
+  add_custom_target(cpptest) # Dummy target since embedding is not supported.
+  set(_suppress_unused_variable_warning "${DOWNLOAD_CATCH}")
+  return()
+endif()
+
 find_package(Catch 2.13.9)
 
 if(CATCH_FOUND)

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -150,6 +150,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
 
 // test_args_refcount
 // PyPy needs a garbage collection to get the reference count values to match CPython's behaviour
+// PyPy uses the top few bits for REFCNT_FROM_PYPY & REFCNT_FROM_PYPY_LIGHT, so truncate
 #ifdef PYPY_VERSION
 #    define GC_IF_NEEDED ConstructorStats::gc()
 #    define REFCNT(x) (int) Py_REFCNT(x)

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -152,8 +152,10 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
 // PyPy needs a garbage collection to get the reference count values to match CPython's behaviour
 #ifdef PYPY_VERSION
 #    define GC_IF_NEEDED ConstructorStats::gc()
+#    define REFCNT(x) (int) Py_REFCNT(x)
 #else
 #    define GC_IF_NEEDED
+#    define REFCNT(x) Py_REFCNT(x)
 #endif
     m.def("arg_refcount_h", [](py::handle h) {
         GC_IF_NEEDED;
@@ -172,7 +174,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
         py::tuple t(a.size());
         for (size_t i = 0; i < a.size(); i++) {
             // Use raw Python API here to avoid an extra, intermediate incref on the tuple item:
-            t[i] = (int) Py_REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i)));
+            t[i] = REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i)));
         }
         return t;
     });
@@ -182,7 +184,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
         t[0] = o.ref_count();
         for (size_t i = 0; i < a.size(); i++) {
             // Use raw Python API here to avoid an extra, intermediate incref on the tuple item:
-            t[i + 1] = (int) Py_REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i)));
+            t[i + 1] = REFCNT(PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i)));
         }
         return t;
     });

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -420,6 +420,7 @@ def test_args_refcount():
     # for the `py::args`; in the previous case, we could simply inc_ref and pass on Python's input
     # tuple without having to inc_ref the individual elements, but here we can't, hence the extra
     # refs.
-    assert m.mixed_args_refcount(myval, myval, myval) == (exp3 + 3, exp3 + 3, exp3 + 3)
+    exp3_3 = 2**32 - 1 if exp3 == 2**32 - 1 else exp3 + 3
+    assert m.mixed_args_refcount(myval, myval, myval) == (exp3_3, exp3_3, exp3_3)
 
     assert m.class_default_argument() == "<class 'decimal.Decimal'>"

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pybind11_tests import PYBIND11_REFCNT_IMMORTAL
 from pybind11_tests import kwargs_and_defaults as m
 
 
@@ -385,7 +386,7 @@ def test_args_refcount():
     expected = refcount(myval)
     assert m.arg_refcount_h(myval) == expected
     # Free threaded Python uses UINT32_MAX for immortal objects.
-    assert m.arg_refcount_o(myval) in {expected + 1, 2**32 - 1}
+    assert m.arg_refcount_o(myval) in {expected + 1, PYBIND11_REFCNT_IMMORTAL}
     assert m.arg_refcount_h(myval) == expected
     assert refcount(myval) == expected
 
@@ -422,7 +423,7 @@ def test_args_refcount():
     # tuple without having to inc_ref the individual elements, but here we can't, hence the extra
     # refs.
     # Free threaded Python uses UINT32_MAX for immortal objects.
-    exp3_3 = 2**32 - 1 if exp3 == 2**32 - 1 else exp3 + 3
+    exp3_3 = PYBIND11_REFCNT_IMMORTAL if exp3 == PYBIND11_REFCNT_IMMORTAL else exp3 + 3
     assert m.mixed_args_refcount(myval, myval, myval) == (exp3_3, exp3_3, exp3_3)
 
     assert m.class_default_argument() == "<class 'decimal.Decimal'>"

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -384,7 +384,7 @@ def test_args_refcount():
     myval = 54321
     expected = refcount(myval)
     assert m.arg_refcount_h(myval) == expected
-    assert m.arg_refcount_o(myval) == expected + 1
+    assert m.arg_refcount_o(myval) in {expected + 1, 2**32 - 1}
     assert m.arg_refcount_h(myval) == expected
     assert refcount(myval) == expected
 

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -384,6 +384,7 @@ def test_args_refcount():
     myval = 54321
     expected = refcount(myval)
     assert m.arg_refcount_h(myval) == expected
+    # Free threaded Python uses UINT32_MAX for immortal objects.
     assert m.arg_refcount_o(myval) in {expected + 1, 2**32 - 1}
     assert m.arg_refcount_h(myval) == expected
     assert refcount(myval) == expected
@@ -420,6 +421,7 @@ def test_args_refcount():
     # for the `py::args`; in the previous case, we could simply inc_ref and pass on Python's input
     # tuple without having to inc_ref the individual elements, but here we can't, hence the extra
     # refs.
+    # Free threaded Python uses UINT32_MAX for immortal objects.
     exp3_3 = 2**32 - 1 if exp3 == 2**32 - 1 else exp3 + 3
     assert m.mixed_args_refcount(myval, myval, myval) == (exp3_3, exp3_3, exp3_3)
 

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -385,7 +385,6 @@ def test_args_refcount():
     myval = 54321
     expected = refcount(myval)
     assert m.arg_refcount_h(myval) == expected
-    # Free threaded Python uses UINT32_MAX for immortal objects.
     assert m.arg_refcount_o(myval) in {expected + 1, PYBIND11_REFCNT_IMMORTAL}
     assert m.arg_refcount_h(myval) == expected
     assert refcount(myval) == expected
@@ -422,7 +421,6 @@ def test_args_refcount():
     # for the `py::args`; in the previous case, we could simply inc_ref and pass on Python's input
     # tuple without having to inc_ref the individual elements, but here we can't, hence the extra
     # refs.
-    # Free threaded Python uses UINT32_MAX for immortal objects.
     exp3_3 = PYBIND11_REFCNT_IMMORTAL if exp3 == PYBIND11_REFCNT_IMMORTAL else exp3 + 3
     assert m.mixed_args_refcount(myval, myval, myval) == (exp3_3, exp3_3, exp3_3)
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -635,7 +635,7 @@ def test_memoryview_refcount(method):
     ref_before = sys.getrefcount(buf)
     view = method(buf)
     ref_after = sys.getrefcount(buf)
-    # Free threaded Python uses UINT32_MAX
+    # Free threaded Python uses UINT32_MAX for immortal objects.
     assert ref_before < ref_after or ref_before == ref_after == 2**32 - 1
     assert list(view) == list(buf)
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -635,7 +635,6 @@ def test_memoryview_refcount(method):
     ref_before = sys.getrefcount(buf)
     view = method(buf)
     ref_after = sys.getrefcount(buf)
-    # Free threaded Python uses UINT32_MAX for immortal objects.
     assert ref_before < ref_after or ref_before == ref_after == PYBIND11_REFCNT_IMMORTAL
     assert list(view) == list(buf)
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -635,7 +635,8 @@ def test_memoryview_refcount(method):
     ref_before = sys.getrefcount(buf)
     view = method(buf)
     ref_after = sys.getrefcount(buf)
-    assert ref_before < ref_after
+    # Free threaded Python uses UINT32_MAX
+    assert ref_before < ref_after or ref_before == ref_after == 2**32 - 1
     assert list(view) == list(buf)
 
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -5,7 +5,7 @@ import types
 import pytest
 
 import env
-from pybind11_tests import detailed_error_messages_enabled
+from pybind11_tests import PYBIND11_REFCNT_IMMORTAL, detailed_error_messages_enabled
 from pybind11_tests import pytypes as m
 
 
@@ -636,7 +636,7 @@ def test_memoryview_refcount(method):
     view = method(buf)
     ref_after = sys.getrefcount(buf)
     # Free threaded Python uses UINT32_MAX for immortal objects.
-    assert ref_before < ref_after or ref_before == ref_after == 2**32 - 1
+    assert ref_before < ref_after or ref_before == ref_after == PYBIND11_REFCNT_IMMORTAL
     assert list(view) == list(buf)
 
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

First step toward #5112, just trying to compile against 3.13t.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Compile against Python 3.13t in CI.
* Return ``py::ssize_t`` from ``.ref_count()`` instead of ``int`` 
```

<!-- If the upgrade guide needs updating, note that here too -->
