### PR TITLE
tests: avoid immortal objects in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare venv
-        run: python3.13 -m venv .venv
+        run: python3.13t -m venv .venv
 
       - name: Install Python deps
         run: .venv/bin/pip install -r tests/requirements.txt

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -1,6 +1,5 @@
 import pytest
 
-from pybind11_tests import PYBIND11_REFCNT_IMMORTAL
 from pybind11_tests import kwargs_and_defaults as m
 
 
@@ -382,10 +381,10 @@ def test_args_refcount():
     arguments"""
     refcount = m.arg_refcount_h
 
-    myval = 54321
+    myval = object()
     expected = refcount(myval)
     assert m.arg_refcount_h(myval) == expected
-    assert m.arg_refcount_o(myval) in {expected + 1, PYBIND11_REFCNT_IMMORTAL}
+    assert m.arg_refcount_o(myval) == expected + 1
     assert m.arg_refcount_h(myval) == expected
     assert refcount(myval) == expected
 
@@ -421,7 +420,7 @@ def test_args_refcount():
     # for the `py::args`; in the previous case, we could simply inc_ref and pass on Python's input
     # tuple without having to inc_ref the individual elements, but here we can't, hence the extra
     # refs.
-    exp3_3 = PYBIND11_REFCNT_IMMORTAL if exp3 == PYBIND11_REFCNT_IMMORTAL else exp3 + 3
+    exp3_3 = exp3 + 3
     assert m.mixed_args_refcount(myval, myval, myval) == (exp3_3, exp3_3, exp3_3)
 
     assert m.class_default_argument() == "<class 'decimal.Decimal'>"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -5,7 +5,7 @@ import types
 import pytest
 
 import env
-from pybind11_tests import PYBIND11_REFCNT_IMMORTAL, detailed_error_messages_enabled
+from pybind11_tests import detailed_error_messages_enabled
 from pybind11_tests import pytypes as m
 
 
@@ -631,11 +631,12 @@ def test_memoryview(method, args, fmt, expected_view):
     ],
 )
 def test_memoryview_refcount(method):
-    buf = b"\x0a\x0b\x0c\x0d"
+    # Avoiding a literal to avoid an immortal object in free-threaded builds
+    buf = "\x0a\x0b\x0c\x0d".encode("ascii")
     ref_before = sys.getrefcount(buf)
     view = method(buf)
     ref_after = sys.getrefcount(buf)
-    assert ref_before < ref_after or ref_before == ref_after == PYBIND11_REFCNT_IMMORTAL
+    assert ref_before < ref_after
     assert list(view) == list(buf)
 
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Follow up #5139, from #5148. Avoid immortal objects so we can track the refcounts.

Also actually compiles against 3.13t in tests, missed that in #5139, though I was doing it locally.

<!-- Include relevant issues or PRs here, describe what changed and why -->

