### PR TITLE
Add a pybind function to clear a list.

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2183,7 +2183,11 @@ public:
             throw error_already_set();
         }
     }
-    void clear() { PyList_SetSlice(m_ptr, 0, PyList_Size(m_ptr), nullptr); }
+    void clear() {
+        if (PyList_SetSlice(m_ptr, 0, PyList_Size(m_ptr), nullptr) == -1) {
+            throw error_already_set();
+        }
+    }
 };
 
 class args : public tuple {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2183,7 +2183,7 @@ public:
             throw error_already_set();
         }
     }
-    void clear() {
+    void clear() /* py-non-const */ {
         if (PyList_SetSlice(m_ptr, 0, PyList_Size(m_ptr), nullptr) == -1) {
             throw error_already_set();
         }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2183,6 +2183,7 @@ public:
             throw error_already_set();
         }
     }
+    void clear() { PyList_SetSlice(m_ptr, 0, PyList_Size(m_ptr), nullptr); }
 };
 
 class args : public tuple {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -135,6 +135,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("list_size_t", []() { return py::list{(py::size_t) 0}; });
     m.def("list_insert_ssize_t", [](py::list *l) { return l->insert((py::ssize_t) 1, 83); });
     m.def("list_insert_size_t", [](py::list *l) { return l->insert((py::size_t) 3, 57); });
+    m.def("list_clear", [](py::list *l) { l->clear(); });
     m.def("get_list", []() {
         py::list list;
         list.append("value");

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -65,6 +65,8 @@ def test_list(capture, doc):
     assert lins == [1, 83, 2]
     m.list_insert_size_t(lins)
     assert lins == [1, 83, 2, 57]
+    m.list_clear(lins)
+    assert lins == []
 
     with capture:
         lst = m.get_list()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Add `py::list::clear()`.

See also: https://stackoverflow.com/questions/23489177/how-to-clear-a-pylistobject

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
``py::list`` gained a ``.clear()`` method.
```

<!-- If the upgrade guide needs updating, note that here too -->
