### PR TITLE
Fix refcount bug involving trampoline functions with `PyObject *` return type.

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1339,13 +1339,24 @@ enable_if_t<!cast_is_temporary_value_reference<T>::value, T> cast_ref(object &&,
 // static_assert, even though if it's in dead code, so we provide a "trampoline" to pybind11::cast
 // that only does anything in cases where pybind11::cast is valid.
 template <typename T>
-enable_if_t<cast_is_temporary_value_reference<T>::value, T> cast_safe(object &&) {
+enable_if_t<cast_is_temporary_value_reference<T>::value
+                && !detail::is_same_ignoring_cvref<T, PyObject *>::value,
+            T>
+cast_safe(object &&) {
     pybind11_fail("Internal error: cast_safe fallback invoked");
 }
 template <typename T>
 enable_if_t<std::is_void<T>::value, void> cast_safe(object &&) {}
 template <typename T>
-enable_if_t<detail::none_of<cast_is_temporary_value_reference<T>, std::is_void<T>>::value, T>
+enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value, PyObject *>
+cast_safe(object &&o) {
+    return o.release().ptr();
+}
+template <typename T>
+enable_if_t<detail::none_of<cast_is_temporary_value_reference<T>,
+                            std::is_void<T>,
+                            detail::is_same_ignoring_cvref<T, PyObject *>>::value,
+            T>
 cast_safe(object &&o) {
     return pybind11::cast<T>(std::move(o));
 }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1354,8 +1354,8 @@ cast_safe(object &&o) {
 }
 template <typename T>
 enable_if_t<detail::none_of<cast_is_temporary_value_reference<T>,
-                            std::is_void<T>,
-                            detail::is_same_ignoring_cvref<T, PyObject *>>::value,
+                            detail::is_same_ignoring_cvref<T, PyObject *>,
+                            std::is_void<T>>::value,
             T>
 cast_safe(object &&o) {
     return pybind11::cast<T>(std::move(o));

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2868,8 +2868,11 @@ function get_override(const T *this_ptr, const char *name) {
             = pybind11::get_override(static_cast<const cname *>(this), name);                     \
         if (override) {                                                                           \
             auto o = override(__VA_ARGS__);                                                       \
+            PYBIND11_WARNING_PUSH                                                                 \
+            PYBIND11_WARNING_DISABLE_MSVC(4127)                                                   \
             if (!pybind11::detail::is_same_ignoring_cvref<ret_type, PyObject *>::value            \
                 && pybind11::detail::cast_is_temporary_value_reference<ret_type>::value) {        \
+                PYBIND11_WARNING_POP                                                              \
                 static pybind11::detail::override_caster_t<ret_type> caster;                      \
                 return pybind11::detail::cast_ref<ret_type>(std::move(o), caster);                \
             }                                                                                     \

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2870,10 +2870,9 @@ function get_override(const T *this_ptr, const char *name) {
             auto o = override(__VA_ARGS__);                                                       \
             PYBIND11_WARNING_PUSH                                                                 \
             PYBIND11_WARNING_DISABLE_MSVC(4127)                                                   \
-            if (!pybind11::detail::is_same_ignoring_cvref<ret_type, PyObject *>::value            \
-                && pybind11::detail::cast_is_temporary_value_reference<ret_type>::value) {        \
-                PYBIND11_WARNING_POP                                                              \
-                static pybind11::detail::override_caster_t<ret_type> caster;                      \
+            if (pybind11::detail::cast_is_temporary_value_reference<ret_type>::value              \
+                && !pybind11::detail::is_same_ignoring_cvref<ret_type, PyObject *>::value) {      \
+                PYBIND11_WARNING_POP static pybind11::detail::override_caster_t<ret_type> caster; \
                 return pybind11::detail::cast_ref<ret_type>(std::move(o), caster);                \
             }                                                                                     \
             return pybind11::detail::cast_safe<ret_type>(std::move(o));                           \

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2868,7 +2868,8 @@ function get_override(const T *this_ptr, const char *name) {
             = pybind11::get_override(static_cast<const cname *>(this), name);                     \
         if (override) {                                                                           \
             auto o = override(__VA_ARGS__);                                                       \
-            if (pybind11::detail::cast_is_temporary_value_reference<ret_type>::value) {           \
+            if (!pybind11::detail::is_same_ignoring_cvref<ret_type, PyObject *>::value            \
+                && pybind11::detail::cast_is_temporary_value_reference<ret_type>::value) {        \
                 static pybind11::detail::override_caster_t<ret_type> caster;                      \
                 return pybind11::detail::cast_ref<ret_type>(std::move(o), caster);                \
             }                                                                                     \

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2872,9 +2872,10 @@ function get_override(const T *this_ptr, const char *name) {
             PYBIND11_WARNING_DISABLE_MSVC(4127)                                                   \
             if (pybind11::detail::cast_is_temporary_value_reference<ret_type>::value              \
                 && !pybind11::detail::is_same_ignoring_cvref<ret_type, PyObject *>::value) {      \
-                PYBIND11_WARNING_POP static pybind11::detail::override_caster_t<ret_type> caster; \
+                static pybind11::detail::override_caster_t<ret_type> caster;                      \
                 return pybind11::detail::cast_ref<ret_type>(std::move(o), caster);                \
             }                                                                                     \
+            PYBIND11_WARNING_POP                                                                  \
             return pybind11::detail::cast_safe<ret_type>(std::move(o));                           \
         }                                                                                         \
     } while (false)

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -36,7 +36,7 @@ std::string call_return_pyobject_ptr(const WithPyObjectPtrReturn *base_class_ptr
     if (Py_REFCNT(returned_obj) != 1) {
         py::pybind11_fail(__FILE__ ":" PYBIND11_TOSTRING(__LINE__));
     }
-    std::string ret_val = py::repr(returned_obj).cast<std::string>();
+    auto ret_val = py::repr(returned_obj).cast<std::string>();
     Py_DECREF(returned_obj);
     return ret_val;
 }

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -5,9 +5,10 @@
 #include "pybind11_tests.h"
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
-namespace {
+namespace test_type_caster_pyobject_ptr {
 
 std::vector<PyObject *> make_vector_pyobject_ptr(const py::object &ValueHolder) {
     std::vector<PyObject *> vec_obj;
@@ -18,9 +19,33 @@ std::vector<PyObject *> make_vector_pyobject_ptr(const py::object &ValueHolder) 
     return vec_obj;
 }
 
-} // namespace
+struct WithPyObjectPtrReturn {
+    virtual ~WithPyObjectPtrReturn() = default;
+    virtual PyObject *return_pyobject_ptr() const = 0;
+};
+
+struct WithPyObjectPtrReturnTrampoline : WithPyObjectPtrReturn {
+    PyObject *return_pyobject_ptr() const {
+        PYBIND11_OVERRIDE_PURE(PyObject *, WithPyObjectPtrReturn, return_pyobject_ptr,
+                               /* no arguments */);
+    }
+};
+
+std::string call_return_pyobject_ptr(const WithPyObjectPtrReturn *base_class_ptr) {
+    PyObject *returned_obj = base_class_ptr->return_pyobject_ptr();
+    if (Py_REFCNT(returned_obj) != 1) {
+        py::pybind11_fail(__FILE__ ":" PYBIND11_TOSTRING(__LINE__));
+    }
+    std::string ret_val = py::repr(returned_obj).cast<std::string>();
+    Py_DECREF(returned_obj);
+    return ret_val;
+}
+
+} // namespace test_type_caster_pyobject_ptr
 
 TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
+    using namespace test_type_caster_pyobject_ptr;
+
     m.def("cast_from_pyobject_ptr", []() {
         PyObject *ptr = PyLong_FromLongLong(6758L);
         return py::cast(ptr, py::return_value_policy::take_ownership);
@@ -127,4 +152,10 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
         (void) py::cast(*ptr);
     }
 #endif
+
+    py::class_<WithPyObjectPtrReturn, WithPyObjectPtrReturnTrampoline>(m, "WithPyObjectPtrReturn")
+        .def(py::init<>())
+        .def("return_pyobject_ptr", &WithPyObjectPtrReturn::return_pyobject_ptr);
+
+    m.def("call_return_pyobject_ptr", call_return_pyobject_ptr);
 }

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -20,6 +20,10 @@ std::vector<PyObject *> make_vector_pyobject_ptr(const py::object &ValueHolder) 
 }
 
 struct WithPyObjectPtrReturn {
+#if defined(__clang_major__) && __clang_major__ < 4
+    WithPyObjectPtrReturn() = default;
+    WithPyObjectPtrReturn(const WithPyObjectPtrReturn &) = default;
+#endif
     virtual ~WithPyObjectPtrReturn() = default;
     virtual PyObject *return_pyobject_ptr() const = 0;
 };

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -29,7 +29,7 @@ struct WithPyObjectPtrReturn {
 };
 
 struct WithPyObjectPtrReturnTrampoline : WithPyObjectPtrReturn {
-    PyObject *return_pyobject_ptr() const {
+    PyObject *return_pyobject_ptr() const override {
         PYBIND11_OVERRIDE_PURE(PyObject *, WithPyObjectPtrReturn, return_pyobject_ptr,
                                /* no arguments */);
     }

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -33,9 +33,11 @@ struct WithPyObjectPtrReturnTrampoline : WithPyObjectPtrReturn {
 
 std::string call_return_pyobject_ptr(const WithPyObjectPtrReturn *base_class_ptr) {
     PyObject *returned_obj = base_class_ptr->return_pyobject_ptr();
+#if !defined(PYPY_VERSION) // It is not worth the trouble doing something special for PyPy.
     if (Py_REFCNT(returned_obj) != 1) {
         py::pybind11_fail(__FILE__ ":" PYBIND11_TOSTRING(__LINE__));
     }
+#endif
     auto ret_val = py::repr(returned_obj).cast<std::string>();
     Py_DECREF(returned_obj);
     return ret_val;

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -102,3 +102,19 @@ def test_return_list_pyobject_ptr_reference():
 def test_type_caster_name_via_incompatible_function_arguments_type_error():
     with pytest.raises(TypeError, match=r"1\. \(arg0: object, arg1: int\) -> None"):
         m.pass_pyobject_ptr_and_int(ValueHolder(101), ValueHolder(202))
+
+
+def test_trampoline_with_pyobject_ptr_return():
+    class Drvd(m.WithPyObjectPtrReturn):
+        def return_pyobject_ptr(self):
+            return ["11", "22", "33"]
+
+    # Basic health check: First make sure this works as expected.
+    d = Drvd()
+    assert d.return_pyobject_ptr() == ["11", "22", "33"]
+
+    while True:
+        # This failed before PR #5156: AddressSanitizer: heap-use-after-free ... in Py_DECREF
+        d_repr = m.call_return_pyobject_ptr(d)
+        assert d_repr == repr(["11", "22", "33"])
+        break  # Comment out for manual leak checking.


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The heap-use-after-free bug was discovered through PyCLIF-pybind11 testing with ASAN (see https://github.com/pybind/pybind11/pull/5156#issuecomment-2156823687). The fix has two simple parts:

1. Introduce a `cast_safe()` specialization for `PyObject *`.
2. Preempt use of `cast_ref` in `PYBIND11_OVERRIDE_IMPL` (so that `cast_safe()` is used instead).

These changes ensure that

```
                return hfunc.f(std::forward<Args>(args)...).template cast<Return>();
```

in [pybind11/functional.h](https://github.com/pybind/pybind11/blob/35ff42b56e9d34d9a944266eb25f2c899dbdfed7/include/pybind11/functional.h#L109) does not incorrectly drop a Python reference  count.

See also: PR #4601, which introduced `type_caster<PyObject>` but missed the corner case fixed by this PR.

For easy reference: Google-internal global testing ID: OCL:641800583:BASE:641923381:1718036131555:271433f2
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
A refcount bug (leading to heap-use-after-free) involving trampoline functions with ``PyObject *`` return type was fixed.
```

<!-- If the upgrade guide needs updating, note that here too -->
