### PR TITLE
[smart_holder] Fix terrible merge accident: `PYBIND11_INTERNALS_SH_DEF` missing in `PYBIND11_INTERNALS_ID` and `PYBIND11_MODULE_LOCAL_ID`

### DIFF
--- a/.github/workflows/ci_sh_def.yml
+++ b/.github/workflows/ci_sh_def.yml
@@ -235,6 +235,7 @@ jobs:
           -DDOWNLOAD_CATCH=ON
           -DDOWNLOAD_EIGEN=ON
           -DPython_ROOT_DIR=.venv
+          -DCMAKE_CXX_FLAGS="-DPYBIND11_USE_SMART_HOLDER_AS_DEFAULT"
 
       - name: Build C++11
         run: cmake --build build -j2

--- a/.github/workflows/ci_sh_def.yml.patch
+++ b/.github/workflows/ci_sh_def.yml.patch
@@ -1,5 +1,5 @@
---- ci.yml	2024-06-09 23:55:50.405348417 -0700
-+++ ci_sh_def.yml	2024-06-09 23:56:22.061331136 -0700
+--- ci.yml	2024-06-10 13:25:02.926609611 -0700
++++ ci_sh_def.yml	2024-06-10 15:09:50.700252443 -0700
 @@ -1,4 +1,16 @@
 -name: CI
 +# PLEASE KEEP THIS GROUP OF FILES IN SYNC AT ALL TIMES:
@@ -51,7 +51,15 @@
          -DPYBIND11_INTERNALS_VERSION=10000000
          ${{ matrix.args }}
  
-@@ -293,6 +308,7 @@
+@@ -220,6 +235,7 @@
+           -DDOWNLOAD_CATCH=ON
+           -DDOWNLOAD_EIGEN=ON
+           -DPython_ROOT_DIR=.venv
++          -DCMAKE_CXX_FLAGS="-DPYBIND11_USE_SMART_HOLDER_AS_DEFAULT"
+ 
+       - name: Build C++11
+         run: cmake --build build -j2
+@@ -293,6 +309,7 @@
          -DDOWNLOAD_CATCH=ON
          -DDOWNLOAD_EIGEN=ON
          -DCMAKE_CXX_STANDARD=17
@@ -59,7 +67,7 @@
  
      - name: Build
        run: cmake --build build -j 2
-@@ -361,6 +377,7 @@
+@@ -361,6 +378,7 @@
          -DPYBIND11_WERROR=ON
          -DDOWNLOAD_CATCH=ON
          -DCMAKE_CXX_STANDARD=${{ matrix.std }}
@@ -67,7 +75,7 @@
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
      - name: Build
-@@ -390,7 +407,7 @@
+@@ -390,7 +408,7 @@
        run: apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y cmake git python3-dev python3-pytest python3-numpy
  
      - name: Configure
@@ -76,7 +84,7 @@
  
      - name: Build
        run: cmake --build build -j2 --verbose
-@@ -478,7 +495,7 @@
+@@ -478,7 +496,7 @@
          cmake -S . -B build -DDOWNLOAD_CATCH=ON \
                              -DCMAKE_CXX_STANDARD=17 \
                              -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") \
@@ -85,7 +93,7 @@
                              -DPYBIND11_TEST_FILTER="test_smart_ptr.cpp"
  
      - name: Build
-@@ -532,6 +549,7 @@
+@@ -532,6 +550,7 @@
          -DPYBIND11_WERROR=ON
          -DDOWNLOAD_CATCH=ON
          -DCMAKE_CXX_STANDARD=${{ matrix.std }}
@@ -93,7 +101,7 @@
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
      - name: Build
-@@ -554,6 +572,7 @@
+@@ -554,6 +573,7 @@
          -DPYBIND11_WERROR=ON
          -DDOWNLOAD_CATCH=ON
          -DCMAKE_CXX_STANDARD=${{ matrix.std }}
@@ -101,7 +109,7 @@
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
          "-DPYBIND11_TEST_OVERRIDE=test_call_policies.cpp;test_gil_scoped.cpp;test_thread.cpp"
  
-@@ -603,6 +622,7 @@
+@@ -603,6 +623,7 @@
          -DDOWNLOAD_CATCH=ON     \
          -DDOWNLOAD_EIGEN=OFF    \
          -DCMAKE_CXX_STANDARD=11             \
@@ -109,7 +117,7 @@
          -DCMAKE_CXX_COMPILER=$(which icpc)  \
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
-@@ -635,6 +655,7 @@
+@@ -635,6 +656,7 @@
          -DDOWNLOAD_CATCH=ON     \
          -DDOWNLOAD_EIGEN=OFF    \
          -DCMAKE_CXX_STANDARD=17             \
@@ -117,7 +125,7 @@
          -DCMAKE_CXX_COMPILER=$(which icpc)  \
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
-@@ -713,6 +734,7 @@
+@@ -713,6 +735,7 @@
          -DDOWNLOAD_CATCH=ON
          -DDOWNLOAD_EIGEN=ON
          -DCMAKE_CXX_STANDARD=11
@@ -125,7 +133,7 @@
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
      - name: Build
-@@ -763,6 +785,7 @@
+@@ -763,6 +786,7 @@
          cmake ../pybind11-tests
          -DDOWNLOAD_CATCH=ON
          -DPYBIND11_WERROR=ON
@@ -133,7 +141,7 @@
          -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
        working-directory: /build-tests
  
-@@ -858,6 +881,7 @@
+@@ -858,6 +882,7 @@
          -DPYBIND11_WERROR=ON
          -DDOWNLOAD_CATCH=ON
          -DDOWNLOAD_EIGEN=ON
@@ -141,7 +149,7 @@
          ${{ matrix.args }}
      - name: Build C++11
        run: cmake --build build -j 2
-@@ -912,6 +936,7 @@
+@@ -912,6 +937,7 @@
          -DPYBIND11_WERROR=ON
          -DDOWNLOAD_CATCH=ON
          -DDOWNLOAD_EIGEN=ON
@@ -149,7 +157,7 @@
          ${{ matrix.args }}
      - name: Build C++11
        run: cmake --build build --config Debug -j 2
-@@ -954,6 +979,7 @@
+@@ -954,6 +980,7 @@
          -DDOWNLOAD_CATCH=ON
          -DDOWNLOAD_EIGEN=ON
          -DCMAKE_CXX_STANDARD=20
@@ -157,7 +165,7 @@
  
      - name: Build C++20
        run: cmake --build build -j 2
-@@ -974,6 +1000,7 @@
+@@ -974,6 +1001,7 @@
          -DDOWNLOAD_CATCH=ON
          -DDOWNLOAD_EIGEN=ON
          -DCMAKE_CXX_STANDARD=20
@@ -165,7 +173,7 @@
          "-DPYBIND11_TEST_OVERRIDE=test_call_policies.cpp;test_gil_scoped.cpp;test_thread.cpp"
  
      - name: Build C++20 - Exercise cmake -DPYBIND11_TEST_OVERRIDE
-@@ -1026,6 +1053,7 @@
+@@ -1026,6 +1054,7 @@
        run: >-
          cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=11 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON
          -DPYTHON_EXECUTABLE=$(python -c "import sys; print(sys.executable)")
@@ -173,7 +181,7 @@
          -S . -B build
  
      - name: Build C++11
-@@ -1047,6 +1075,7 @@
+@@ -1047,6 +1076,7 @@
        run: >-
          cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=14 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON
          -DPYTHON_EXECUTABLE=$(python -c "import sys; print(sys.executable)")
@@ -181,7 +189,7 @@
          -S . -B build2
  
      - name: Build C++14
-@@ -1068,6 +1097,7 @@
+@@ -1068,6 +1098,7 @@
        run: >-
          cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD=17 -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON
          -DPYTHON_EXECUTABLE=$(python -c "import sys; print(sys.executable)")
@@ -189,7 +197,7 @@
          -S . -B build3
  
      - name: Build C++17
-@@ -1135,6 +1165,7 @@
+@@ -1135,6 +1166,7 @@
            -DDOWNLOAD_EIGEN=ON
            -DCMAKE_CXX_COMPILER=clang++
            -DCMAKE_CXX_STANDARD=17
@@ -197,7 +205,7 @@
  
        - name: Build
          run: cmake --build . -j 2
-@@ -1200,6 +1231,7 @@
+@@ -1200,6 +1232,7 @@
            -DDOWNLOAD_EIGEN=ON
            -DCMAKE_CXX_COMPILER=clang++
            -DCMAKE_CXX_STANDARD=17
@@ -205,7 +213,7 @@
            -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
  
        - name: Build
-@@ -1223,6 +1255,7 @@
+@@ -1223,6 +1256,7 @@
            -DDOWNLOAD_EIGEN=ON
            -DCMAKE_CXX_COMPILER=clang++
            -DCMAKE_CXX_STANDARD=17

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -329,13 +329,13 @@ struct type_info {
 
 #define PYBIND11_INTERNALS_ID                                                                     \
     "__pybind11_internals_v" PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION)                        \
-        PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB                            \
-            PYBIND11_BUILD_ABI PYBIND11_BUILD_TYPE "__"
+        PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI         \
+            PYBIND11_BUILD_TYPE PYBIND11_INTERNALS_SH_DEF "__"
 
 #define PYBIND11_MODULE_LOCAL_ID                                                                  \
     "__pybind11_module_local_v" PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION)                     \
-        PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB                            \
-            PYBIND11_BUILD_ABI PYBIND11_BUILD_TYPE "__"
+        PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI         \
+            PYBIND11_BUILD_TYPE PYBIND11_INTERNALS_SH_DEF "__"
 
 /// Each module locally stores a pointer to the `internals` data. The data
 /// itself is shared among modules with the same `PYBIND11_INTERNALS_ID`.


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This PR fixes two oversights:

1. A terrible merge accident introduced with pybind/pybind11#5085: `PYBIND11_INTERNALS_SH_DEF` was accidentally removed from `PYBIND11_INTERNALS_ID` and `PYBIND11_MODULE_LOCAL_ID`. — How did this happen? First PR #5084 on master introduced whitespace changes:

* https://github.com/pybind/pybind11/pull/5084/files#diff-b47e807c57dacc02a52aa80c712d77051f145748c3be9b8c4e90dd1aa27f7e34

Those were incorrectly applied in smart_holder PR #5085:

* https://github.com/pybind/pybind11/pull/5085/files#diff-b47e807c57dacc02a52aa80c712d77051f145748c3be9b8c4e90dd1aa27f7e34

2. Simple change that was overlooked before: missing `-DCMAKE_CXX_FLAGS="-DPYBIND11_USE_SMART_HOLDER_AS_DEFAULT"` (manylinux)

<!-- Include relevant issues or PRs here, describe what changed and why -->

Validation of both fixes:

ci.yml manylinux:

```
C++ Info: 13.2.1 20231014 C++17 __pybind11_internals_v5_gcc_libstdcpp_cxxabi1018__ PYBIND11_SIMPLE_GIL_MANAGEMENT=False PYBIND11_NUMPY_1_ONLY=False
```

ci_sh_def.yml manylinux:

```
C++ Info: 13.2.1 20231014 C++17 __pybind11_internals_v5_gcc_libstdcpp_cxxabi1018_sh_def__ PYBIND11_SIMPLE_GIL_MANAGEMENT=False PYBIND11_NUMPY_1_ONLY=False
```


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
