### PR TITLE
Add `Union` and `Optional` to typing.h

### DIFF
--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -63,6 +63,12 @@ class Callable<Return(Args...)> : public function {
     using function::function;
 };
 
+template <typename... Types>
+class Union {};
+
+template <typename T>
+class Optional {};
+
 PYBIND11_NAMESPACE_END(typing)
 
 PYBIND11_NAMESPACE_BEGIN(detail)
@@ -119,6 +125,18 @@ struct handle_type_name<typing::Callable<Return(Args...)>> {
     static constexpr auto name
         = const_name("Callable[[") + ::pybind11::detail::concat(make_caster<Args>::name...)
           + const_name("], ") + make_caster<retval_type>::name + const_name("]");
+};
+
+template <typename... Types>
+struct handle_type_name<typing::Union<Types...>> {
+    static constexpr auto name = const_name("Union[")
+                                 + ::pybind11::detail::concat(make_caster<Types>::name...)
+                                 + const_name("]");
+};
+
+template <typename T>
+struct handle_type_name<typing::Optional<T>> {
+    static constexpr auto name = const_name("Optional[") + make_caster<T>::name + const_name("]");
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -64,10 +64,14 @@ class Callable<Return(Args...)> : public function {
 };
 
 template <typename... Types>
-class Union {};
+class Union : public type{
+    using type::type;
+};
 
 template <typename T>
-class Optional {};
+class Optional : public type{
+    using type::type;
+};
 
 PYBIND11_NAMESPACE_END(typing)
 

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -64,12 +64,12 @@ class Callable<Return(Args...)> : public function {
 };
 
 template <typename... Types>
-class Union : public type{
+class Union : public type {
     using type::type;
 };
 
 template <typename T>
-class Optional : public type{
+class Optional : public type {
     using type::type;
 };
 

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -64,13 +64,13 @@ class Callable<Return(Args...)> : public function {
 };
 
 template <typename... Types>
-class Union : public type {
-    using type::type;
+class Union : public object{
+    using object::object;
 };
 
 template <typename T>
-class Optional : public type {
-    using type::type;
+class Optional : public object{
+    using object::object;
 };
 
 PYBIND11_NAMESPACE_END(typing)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -852,6 +852,10 @@ TEST_SUBMODULE(pytypes, m) {
         return l;
     });
 
+    m.def("union_typing_only", [](py::typing::List<py::typing::Union<py::str>> l) -> py::typing::List<py::typing::Union<py::int_>>  {
+        return l;
+    });
+
     m.def("annotate_optional", []() -> py::typing::List<py::typing::Optional<py::str>> {
         auto list = py::list();
         list.append(py::str("hi"));

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -858,12 +858,12 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.def("union_typing_only",
           [](py::typing::List<py::typing::Union<py::str>> l)
-              -> py::typing::List<py::typing::Union<py::int_>> { return l; });
+              -> py::typing::List<py::typing::Union<py::int_>> { return std::move(l); });
 
     m.def("annotate_optional", []() -> py::typing::List<py::typing::Optional<py::str>> {
         auto list = py::list();
         list.append(py::str("hi"));
         list.append(py::none());
-        return list;
+        return std::move(list);
     });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -860,8 +860,7 @@ TEST_SUBMODULE(pytypes, m) {
           [](py::typing::List<py::typing::Union<py::str>> &l)
               -> py::typing::List<py::typing::Union<py::int_>> { return l; });
 
-    m.def("annotate_optional", []() -> py::typing::List<py::typing::Optional<py::str>> {
-        py::list list;
+    m.def("annotate_optional", [](py::list &list) -> py::typing::List<py::typing::Optional<py::str>> {
         list.append(py::str("hi"));
         list.append(py::none());
         return list;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -844,6 +844,18 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_iterator_int", [](const py::typing::Iterator<int> &) {});
     m.def("annotate_fn",
           [](const py::typing::Callable<int(py::typing::List<py::str>, py::str)> &) {});
-    m.def("annotate_union", [](const py::typing::Union<py::int_, py::str> &) {});
-    m.def("annotate_optional", [](const py::typing::Optional<float> &) {});
+    
+    m.def("annotate_union", [](py::typing::List<py::typing::Union<py::str, py::int_, py::object>> l, py::str a, py::int_ b, py::object c) -> py::typing::List<py::typing::Union<py::str, py::int_,  py::object>>  {
+        l.append(a);
+        l.append(b);
+        l.append(c);
+        return l;
+    });
+
+    m.def("annotate_optional", []() -> py::typing::List<py::typing::Optional<py::str>> {
+        auto list = py::list();
+        list.append(py::str("hi"));
+        list.append(py::none());
+        return list;
+    });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -856,9 +856,9 @@ TEST_SUBMODULE(pytypes, m) {
               return l;
           });
 
-    m.def("union_typing_only", [](py::typing::List<py::typing::Union<py::str>> l) -> py::typing::List<py::typing::Union<py::int_>>  {
-        return l;
-    });
+    m.def("union_typing_only",
+          [](py::typing::List<py::typing::Union<py::str>> l)
+              -> py::typing::List<py::typing::Union<py::int_>> { return l; });
 
     m.def("annotate_optional", []() -> py::typing::List<py::typing::Optional<py::str>> {
         auto list = py::list();

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -844,4 +844,6 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_iterator_int", [](const py::typing::Iterator<int> &) {});
     m.def("annotate_fn",
           [](const py::typing::Callable<int(py::typing::List<py::str>, py::str)> &) {});
+    m.def("annotate_union", [](const py::typing::Union<py::int_, py::str> &) {});
+    m.def("annotate_optional", [](const py::typing::Optional<float> &) {});
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -857,13 +857,13 @@ TEST_SUBMODULE(pytypes, m) {
           });
 
     m.def("union_typing_only",
-          [](py::typing::List<py::typing::Union<py::str>> l)
-              -> py::typing::List<py::typing::Union<py::int_>> { return std::move(l); });
+          [](py::typing::List<py::typing::Union<py::str>> &l)
+              -> py::typing::List<py::typing::Union<py::int_>> { return l; });
 
     m.def("annotate_optional", []() -> py::typing::List<py::typing::Optional<py::str>> {
-        auto list = py::list();
+        py::list list;
         list.append(py::str("hi"));
         list.append(py::none());
-        return std::move(list);
+        return list;
     });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -860,9 +860,10 @@ TEST_SUBMODULE(pytypes, m) {
           [](py::typing::List<py::typing::Union<py::str>> &l)
               -> py::typing::List<py::typing::Union<py::int_>> { return l; });
 
-    m.def("annotate_optional", [](py::list &list) -> py::typing::List<py::typing::Optional<py::str>> {
-        list.append(py::str("hi"));
-        list.append(py::none());
-        return list;
-    });
+    m.def("annotate_optional",
+          [](py::list &list) -> py::typing::List<py::typing::Optional<py::str>> {
+              list.append(py::str("hi"));
+              list.append(py::none());
+              return list;
+          });
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -958,10 +958,10 @@ def test_fn_annotations(doc):
 
 
 def test_union_annotations(doc):
-    assert doc(m.annotate_union) == "annotate_union(arg0: Union[int, str]) -> None"
+    assert doc(m.annotate_union) == "annotate_union(arg0: list[Union[str, int, object], arg1: str, arg2: int, arg3: object) -> list[Union[str, int, object]]"
 
 
 def test_optional_annotations(doc):
     assert (
-        doc(m.annotate_optional) == "annotate_optional(arg0: Optional[float]) -> None"
+        doc(m.annotate_optional) == "annotate_optional() -> list[Optional[str]]"
     )

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -958,7 +958,11 @@ def test_fn_annotations(doc):
 
 
 def test_union_annotations(doc):
-    assert doc(m.annotate_union) == "annotate_union(arg0: list[Union[str, int, object], arg1: str, arg2: int, arg3: object) -> list[Union[str, int, object]]"
+    assert doc(m.annotate_union) == "annotate_union(arg0: list[Union[str, int, object]], arg1: str, arg2: int, arg3: object) -> list[Union[str, int, object]]"
+
+
+def test_union_typing_only(doc):
+    assert doc(m.annotate_union) == "annotate_union(arg0: list[Union[str]) -> list[Union[int]]"
 
 
 def test_optional_annotations(doc):

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -955,3 +955,13 @@ def test_fn_annotations(doc):
         doc(m.annotate_fn)
         == "annotate_fn(arg0: Callable[[list[str], str], int]) -> None"
     )
+
+
+def test_union_annotations(doc):
+    assert doc(m.annotate_union) == "annotate_union(arg0: Union[int, str]) -> None"
+
+
+def test_optional_annotations(doc):
+    assert (
+        doc(m.annotate_optional) == "annotate_optional(arg0: Optional[float]) -> None"
+    )

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -972,4 +972,4 @@ def test_union_typing_only(doc):
 
 
 def test_optional_annotations(doc):
-    assert doc(m.annotate_optional) == "annotate_optional() -> list[Optional[str]]"
+    assert doc(m.annotate_optional) == "annotate_optional(arg0: list) -> list[Optional[str]]"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -967,7 +967,7 @@ def test_union_annotations(doc):
 def test_union_typing_only(doc):
     assert (
         doc(m.union_typing_only)
-        == "annotate_union(arg0: list[Union[str]) -> list[Union[int]]"
+        == "union_typing_only(arg0: list[Union[str]]) -> list[Union[int]]"
     )
 
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -963,8 +963,12 @@ def test_union_annotations(doc):
         == "annotate_union(arg0: list[Union[str, int, object]], arg1: str, arg2: int, arg3: object) -> list[Union[str, int, object]]"
     )
 
+
 def test_union_typing_only(doc):
-    assert doc(m.annotate_union) == "annotate_union(arg0: list[Union[str]) -> list[Union[int]]"
+    assert (
+        doc(m.annotate_union)
+        == "annotate_union(arg0: list[Union[str]) -> list[Union[int]]"
+    )
 
 
 def test_optional_annotations(doc):

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -972,4 +972,7 @@ def test_union_typing_only(doc):
 
 
 def test_optional_annotations(doc):
-    assert doc(m.annotate_optional) == "annotate_optional(arg0: list) -> list[Optional[str]]"
+    assert (
+        doc(m.annotate_optional)
+        == "annotate_optional(arg0: list) -> list[Optional[str]]"
+    )

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -966,7 +966,7 @@ def test_union_annotations(doc):
 
 def test_union_typing_only(doc):
     assert (
-        doc(m.annotate_union)
+        doc(m.union_typing_only)
         == "annotate_union(arg0: list[Union[str]) -> list[Union[int]]"
     )
 


### PR DESCRIPTION
## Description

Add `Union` and `Optional` for better static typing on the python side.

## Suggested changelog entry:

```rst
`Union` and `Optional` were added to pybind11/typing.h
```
