### PR TITLE
Add type[T] support to typing.h

### DIFF
--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -66,7 +66,9 @@ class Callable<Return(Args...)> : public function {
 template <typename T>
 class Type : public type {
     using type::type;
-} template <typename... Types>
+};
+
+template <typename... Types>
 class Union : public object {
     using object::object;
 };
@@ -137,7 +139,9 @@ struct handle_type_name<typing::Callable<Return(Args...)>> {
 template <typename T>
 struct handle_type_name<typing::Type<T>> {
     static constexpr auto name = const_name("type[") + make_caster<T>::name + const_name("]");
-} template <typename... Types>
+};
+
+template <typename... Types>
 struct handle_type_name<typing::Union<Types...>> {
     static constexpr auto name = const_name("Union[")
                                  + ::pybind11::detail::concat(make_caster<Types>::name...)

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -63,6 +63,11 @@ class Callable<Return(Args...)> : public function {
     using function::function;
 };
 
+template <typename T>
+class Type : public type {
+    using type::type;
+};
+
 PYBIND11_NAMESPACE_END(typing)
 
 PYBIND11_NAMESPACE_BEGIN(detail)
@@ -119,6 +124,11 @@ struct handle_type_name<typing::Callable<Return(Args...)>> {
     static constexpr auto name
         = const_name("Callable[[") + ::pybind11::detail::concat(make_caster<Args>::name...)
           + const_name("], ") + make_caster<retval_type>::name + const_name("]");
+};
+
+template <typename T>
+struct handle_type_name<typing::Type<T>> {
+    static constexpr auto name = const_name("type[") + make_caster<T>::name + const_name("]");
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -844,4 +844,5 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_iterator_int", [](const py::typing::Iterator<int> &) {});
     m.def("annotate_fn",
           [](const py::typing::Callable<int(py::typing::List<py::str>, py::str)> &) {});
+    m.def("annotate_type", [](const py::typing::Type<int> &) {});
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -955,3 +955,10 @@ def test_fn_annotations(doc):
         doc(m.annotate_fn)
         == "annotate_fn(arg0: Callable[[list[str], str], int]) -> None"
     )
+
+
+def test_type_annotation(doc):
+    assert (
+        doc(m.annotate_type)
+        == "annotate_type(arg0: type[int]) -> None"
+    )

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -958,7 +958,4 @@ def test_fn_annotations(doc):
 
 
 def test_type_annotation(doc):
-    assert (
-        doc(m.annotate_type)
-        == "annotate_type(arg0: type[int]) -> None"
-    )
+    assert doc(m.annotate_type) == "annotate_type(arg0: type[int]) -> None"


### PR DESCRIPTION
## Description
Similar to #5165 but, adds support for `type[]` (see https://docs.python.org/3.10/library/typing.html#typing.Type).

The benefit of adding support for `type[]` allows type checkers to differentiate between different types. 

By default foo could take any valid python type E.g. `float` or `str`

```python
def foo(a: type) -> None: ...
```

But with allowing specific the type it can narrow valid input properly and `str` would no long be valid.

```python
def foo(a: type[int]) -> None: ...
```

## Suggested changelog entry:

```rst

```