### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ platform:
 - x86
 environment:
   matrix:
-  - PYTHON: 36
+  - PYTHON: 38
     CONFIG: Debug
 install:
 - ps: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,6 @@ jobs:
         run: cmake --build build --target pytest -j2
 
   deadsnakes:
-    if: github.actor_id == 'THIS IS JUST A TRICK TO DISABLE THIS JOB'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,7 @@ jobs:
       run: cmake --build . --target pytest -j 2
 
     - name: C++11 tests
-      # TODO: Figure out how to load the DLL on Python 3.8+
-      if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9 || matrix.python == '3.10' || matrix.python == '3.11' || matrix.python == 'pypy-3.8'))"
-      run: cmake --build .  --target cpptest -j 2
+      run: cmake --build . --target cpptest -j 2
 
     - name: Interface test C++11
       run: cmake --build . --target test_cmake_build
@@ -164,8 +162,6 @@ jobs:
       run: cmake --build build2 --target pytest
 
     - name: C++ tests
-      # TODO: Figure out how to load the DLL on Python 3.8+
-      if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9 || matrix.python == '3.10' || matrix.python == '3.11' || matrix.python == 'pypy-3.8'))"
       run: cmake --build build2 --target cpptest
 
     # Third build - C++17 mode with unstable ABI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,14 @@ jobs:
         # existing keys match.
         #
         # We support an optional key: args, for cmake args
-        # TODO: Find a platform to test -DCMAKE_CXX_FLAGS="-D_=1"
         include:
           # Just add a key
           - runs-on: ubuntu-20.04
             python: '3.8'
             args: >
               -DPYBIND11_FINDPYTHON=ON
+              -DCMAKE_CXX_FLAGS="-D_=1"
+            exercise_D_: 1
           - runs-on: ubuntu-20.04
             python: 'pypy-3.8'
             args: >
@@ -82,7 +83,7 @@ jobs:
 
     - name: Setup Boost (Linux)
       # Can't use boost + define _
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.exercise_D_ != 1
       run: sudo apt-get install libboost-dev
 
     - name: Setup Boost (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,13 @@ jobs:
         # existing keys match.
         #
         # We support an optional key: args, for cmake args
+        # TODO: Find a platform to test -DCMAKE_CXX_FLAGS="-D_=1"
         include:
           # Just add a key
           - runs-on: ubuntu-20.04
             python: '3.8'
             args: >
               -DPYBIND11_FINDPYTHON=ON
-              -DCMAKE_CXX_FLAGS="-D_=1"
           - runs-on: ubuntu-20.04
             python: 'pypy-3.8'
             args: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -801,16 +801,25 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - 3.7
-        - 3.8
-        - 3.9
+        - '3.7'
+        - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
+        - '3.12'
 
         include:
-          - python: 3.9
+          - python: '3.12'
             args: -DCMAKE_CXX_STANDARD=20
-          - python: 3.8
+          - python: '3.11'
+            args: -DCMAKE_CXX_STANDARD=20
+          - python: '3.10'
+            args: -DCMAKE_CXX_STANDARD=20
+          - python: '3.9'
+            args: -DCMAKE_CXX_STANDARD=20
+          - python: '3.8'
             args: -DCMAKE_CXX_STANDARD=17
-          - python: 3.7
+          - python: '3.7'
             args: -DCMAKE_CXX_STANDARD=14
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,15 +659,13 @@ jobs:
         cmake --build build-17 --target test_cmake_build
 
 
-  # Testing on CentOS (manylinux uses a centos base, and this is an easy way
-  # to get GCC 4.8, which is the manylinux1 compiler).
+  # Testing on CentOS (manylinux uses a centos base).
   centos:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         container:
-          - "centos:7"  # GCC 4.8
           - "almalinux:8"
           - "almalinux:9"
 
@@ -677,18 +675,13 @@ jobs:
     steps:
     - name: Latest actions/checkout
       uses: actions/checkout@v4
-      if: matrix.container != 'centos:7'
 
-    - name: Pin actions/checkout as required for centos:7
-      uses: actions/checkout@v3
-      if: matrix.container == 'centos:7'
+    - name: Add Python 3.8
+      if: matrix.container == 'almalinux:8'
+      run: dnf update -y && dnf install -y python38-devel gcc-c++ make git
 
-    - name: Add Python 3 (RHEL 7)
-      if: matrix.container == 'centos:7'
-      run: yum update -y && yum install -y python3-devel gcc-c++ make git
-
-    - name: Add Python 3 (RHEL 8+)
-      if: matrix.container != 'centos:7'
+    - name: Add Python 3 (default)
+      if: matrix.container != 'almalinux:8'
       run: dnf update -y && dnf install -y python3-devel gcc-c++ make git
 
     - name: Update pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,7 @@ jobs:
         run: cmake --build build --target pytest -j2
 
   deadsnakes:
+    if: github.actor_id == 'THIS IS JUST A TRICK TO DISABLE THIS JOB'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         runs-on: [ubuntu-20.04, windows-2022, macos-13]
         python:
-        - '3.6'
+        - '3.8'
         - '3.9'
         - '3.12'
         - '3.13'
@@ -48,7 +48,7 @@ jobs:
         include:
           # Just add a key
           - runs-on: ubuntu-20.04
-            python: '3.6'
+            python: '3.8'
             args: >
               -DPYBIND11_FINDPYTHON=ON
               -DCMAKE_CXX_FLAGS="-D_=1"
@@ -57,7 +57,7 @@ jobs:
             args: >
               -DPYBIND11_FINDPYTHON=ON
           - runs-on: windows-2019
-            python: '3.6'
+            python: '3.8'
             args: >
               -DPYBIND11_FINDPYTHON=ON
           # Inject a couple Windows 2019 runs
@@ -82,7 +82,7 @@ jobs:
 
     - name: Setup Boost (Linux)
       # Can't use boost + define _
-      if: runner.os == 'Linux' && matrix.python != '3.6'
+      if: runner.os == 'Linux'
       run: sudo apt-get install libboost-dev
 
     - name: Setup Boost (macOS)
@@ -811,7 +811,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - 3.6
         - 3.7
         - 3.8
         - 3.9

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -21,19 +21,18 @@ env:
 
 jobs:
   # This builds the sdists and wheels and makes sure the files are exactly as
-  # expected. Using Windows and Python 3.6, since that is often the most
-  # challenging matrix element.
+  # expected.
   test-packaging:
-    name: 🐍 3.6 • 📦 tests • windows-latest
+    name: 🐍 3.8 • 📦 tests • windows-latest
     runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup 🐍 3.6
+    - name: Setup 🐍 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.6
+        python-version: 3.8
 
     - name: Prepare env
       run: |

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ dependency.
 Think of this library as a tiny self-contained version of Boost.Python
 with everything stripped away that isn't relevant for binding
 generation. Without comments, the core header files only require ~4K
-lines of code and depend on Python (3.6+, or PyPy) and the C++
+lines of code and depend on Python (3.7+, or PyPy) and the C++
 standard library. This compact implementation was possible thanks to
 some C++11 language features (specifically: tuples, lambda functions and
 variadic templates). Since its creation, this library has grown beyond
@@ -79,7 +79,7 @@ Goodies
 In addition to the core functionality, pybind11 provides some extra
 goodies:
 
-- Python 3.6+, and PyPy3 7.3 are supported with an implementation-agnostic
+- Python 3.7+, and PyPy3 7.3 are supported with an implementation-agnostic
   interface (pybind11 2.9 was the last version to support Python 2 and 3.5).
 
 - It is possible to bind C++11 lambda functions with captured

--- a/docs/benchmark.py
+++ b/docs/benchmark.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 import os
 import random

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -426,7 +426,7 @@ with ``PYTHON_EXECUTABLE``.  For example:
 
 .. code-block:: bash
 
-    cmake -DPYBIND11_PYTHON_VERSION=3.6 ..
+    cmake -DPYBIND11_PYTHON_VERSION=3.7 ..
 
     # Another method:
     cmake -DPYTHON_EXECUTABLE=/path/to/python ..
@@ -493,7 +493,7 @@ existing targets instead:
     cmake_minimum_required(VERSION 3.15...3.22)
     project(example LANGUAGES CXX)
 
-    find_package(Python 3.6 COMPONENTS Interpreter Development REQUIRED)
+    find_package(Python 3.7 COMPONENTS Interpreter Development REQUIRED)
     find_package(pybind11 CONFIG REQUIRED)
     # or add_subdirectory(pybind11)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
+from __future__ import annotations
 
 import os
 import re

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -158,7 +158,7 @@ public:
         } else {
             handle src_or_index = src;
             // PyPy: 7.3.7's 3.8 does not implement PyLong_*'s __index__ calls.
-#if PY_VERSION_HEX < 0x03080000 || defined(PYPY_VERSION)
+#if defined(PYPY_VERSION)
             object index;
             if (!PYBIND11_LONG_CHECK(src.ptr())) { // So: index_check(src.ptr())
                 index = reinterpret_steal<object>(PyNumber_Index(src.ptr()));

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -158,7 +158,7 @@ public:
         } else {
             handle src_or_index = src;
             // PyPy: 7.3.7's 3.8 does not implement PyLong_*'s __index__ calls.
-#if defined(PYPY_VERSION)
+#if PY_VERSION_HEX < 0x03080000 || defined(PYPY_VERSION)
             object index;
             if (!PYBIND11_LONG_CHECK(src.ptr())) { // So: index_check(src.ptr())
                 index = reinterpret_steal<object>(PyNumber_Index(src.ptr()));

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -567,17 +567,9 @@ inline void enable_dynamic_attributes(PyHeapTypeObject *heap_type) {
     type->tp_traverse = pybind11_traverse;
     type->tp_clear = pybind11_clear;
 
-    static PyGetSetDef getset[] = {{
-#if PY_VERSION_HEX < 0x03070000
-                                       const_cast<char *>("__dict__"),
-#else
-                                       "__dict__",
-#endif
-                                       PyObject_GenericGetDict,
-                                       PyObject_GenericSetDict,
-                                       nullptr,
-                                       nullptr},
-                                   {nullptr, nullptr, nullptr, nullptr, nullptr}};
+    static PyGetSetDef getset[]
+        = {{"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict, nullptr, nullptr},
+           {nullptr, nullptr, nullptr, nullptr, nullptr}};
     type->tp_getset = getset;
 }
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -272,7 +272,6 @@ PYBIND11_WARNING_DISABLE_MSVC(4505)
 #endif
 
 #include <Python.h>
-// Reminder: WITH_THREAD is always defined if PY_VERSION_HEX >= 0x03070000
 #if PY_VERSION_HEX < 0x03070000
 #    error "PYTHON < 3.7 IS UNSUPPORTED. pybind11 v2.12 was the last to support Python 3.6."
 #endif

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -273,8 +273,8 @@ PYBIND11_WARNING_DISABLE_MSVC(4505)
 
 #include <Python.h>
 // Reminder: WITH_THREAD is always defined if PY_VERSION_HEX >= 0x03070000
-#if PY_VERSION_HEX < 0x03060000
-#    error "PYTHON < 3.6 IS UNSUPPORTED. pybind11 v2.9 was the last to support Python 2 and 3.5."
+#if PY_VERSION_HEX < 0x03070000
+#    error "PYTHON < 3.7 IS UNSUPPORTED. pybind11 v2.12 was the last to support Python 3.6."
 #endif
 #include <frameobject.h>
 #include <pythread.h>

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -11,7 +11,7 @@
 
 #include "common.h"
 
-#if defined(WITH_THREAD) && defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
+#if defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
 #    include "../gil.h"
 #endif
 
@@ -192,28 +192,27 @@ struct internals {
     PyTypeObject *static_property_type;
     PyTypeObject *default_metaclass;
     PyObject *instance_base;
-#if defined(WITH_THREAD)
     // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
     PYBIND11_TLS_KEY_INIT(tstate)
-#    if PYBIND11_INTERNALS_VERSION > 4
+#if PYBIND11_INTERNALS_VERSION > 4
     PYBIND11_TLS_KEY_INIT(loader_life_support_tls_key)
-#    endif // PYBIND11_INTERNALS_VERSION > 4
+#endif // PYBIND11_INTERNALS_VERSION > 4
     // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
     PyInterpreterState *istate = nullptr;
 
-#    if PYBIND11_INTERNALS_VERSION > 4
+#if PYBIND11_INTERNALS_VERSION > 4
     // Note that we have to use a std::string to allocate memory to ensure a unique address
     // We want unique addresses since we use pointer equality to compare function records
     std::string function_record_capsule_name = internals_function_record_capsule_name;
-#    endif
+#endif
 
     internals() = default;
     internals(const internals &other) = delete;
     internals &operator=(const internals &other) = delete;
     ~internals() {
-#    if PYBIND11_INTERNALS_VERSION > 4
+#if PYBIND11_INTERNALS_VERSION > 4
         PYBIND11_TLS_FREE(loader_life_support_tls_key);
-#    endif // PYBIND11_INTERNALS_VERSION > 4
+#endif // PYBIND11_INTERNALS_VERSION > 4
 
         // This destructor is called *after* Py_Finalize() in finalize_interpreter().
         // That *SHOULD BE* fine. The following details what happens when PyThread_tss_free is
@@ -224,7 +223,6 @@ struct internals {
         // that the `tstate` be allocated with the CPython allocator.
         PYBIND11_TLS_FREE(tstate);
     }
-#endif
 };
 
 /// Additional type information which does not fit into the PyTypeObject.
@@ -309,11 +307,7 @@ struct type_info {
 #endif
 
 #ifndef PYBIND11_INTERNALS_KIND
-#    if defined(WITH_THREAD)
-#        define PYBIND11_INTERNALS_KIND ""
-#    else
-#        define PYBIND11_INTERNALS_KIND "_without_thread"
-#    endif
+#    define PYBIND11_INTERNALS_KIND ""
 #endif
 
 #define PYBIND11_INTERNALS_ID                                                                     \
@@ -496,10 +490,9 @@ PYBIND11_NOINLINE internals &get_internals() {
         return **internals_pp;
     }
 
-#if defined(WITH_THREAD)
-#    if defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
+#if defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
     gil_scoped_acquire gil;
-#    else
+#else
     // Ensure that the GIL is held since we will need to make Python calls.
     // Cannot use py::gil_scoped_acquire here since that constructor calls get_internals.
     struct gil_scoped_acquire_local {
@@ -509,7 +502,6 @@ PYBIND11_NOINLINE internals &get_internals() {
         ~gil_scoped_acquire_local() { PyGILState_Release(state); }
         const PyGILState_STATE state;
     } gil;
-#    endif
 #endif
     error_scope err_scope;
 
@@ -534,7 +526,6 @@ PYBIND11_NOINLINE internals &get_internals() {
         }
         auto *&internals_ptr = *internals_pp;
         internals_ptr = new internals();
-#if defined(WITH_THREAD)
 
         PyThreadState *tstate = PyThreadState_Get();
         // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
@@ -543,15 +534,14 @@ PYBIND11_NOINLINE internals &get_internals() {
         }
         PYBIND11_TLS_REPLACE_VALUE(internals_ptr->tstate, tstate);
 
-#    if PYBIND11_INTERNALS_VERSION > 4
+#if PYBIND11_INTERNALS_VERSION > 4
         // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
         if (!PYBIND11_TLS_KEY_CREATE(internals_ptr->loader_life_support_tls_key)) {
             pybind11_fail("get_internals: could not successfully initialize the "
                           "loader_life_support TSS key!");
         }
-#    endif
-        internals_ptr->istate = tstate->interp;
 #endif
+        internals_ptr->istate = tstate->interp;
         state_dict[PYBIND11_INTERNALS_ID] = capsule(internals_pp);
         internals_ptr->registered_exception_translators.push_front(&translate_exception);
         internals_ptr->static_property_type = make_static_property_type();
@@ -580,7 +570,7 @@ PYBIND11_NOINLINE internals &get_internals() {
 struct local_internals {
     type_map<type_info *> registered_types_cpp;
     std::forward_list<ExceptionTranslator> registered_exception_translators;
-#if defined(WITH_THREAD) && PYBIND11_INTERNALS_VERSION == 4
+#if PYBIND11_INTERNALS_VERSION == 4
 
     // For ABI compatibility, we can't store the loader_life_support TLS key in
     // the `internals` struct directly.  Instead, we store it in `shared_data` and
@@ -613,7 +603,7 @@ struct local_internals {
         loader_life_support_tls_key
             = static_cast<shared_loader_life_support_data *>(ptr)->loader_life_support_tls_key;
     }
-#endif //  defined(WITH_THREAD) && PYBIND11_INTERNALS_VERSION == 4
+#endif //  PYBIND11_INTERNALS_VERSION == 4
 };
 
 /// Works like `get_internals`, but for things which are locally registered.

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -36,14 +36,13 @@ private:
     loader_life_support *parent = nullptr;
     std::unordered_set<PyObject *> keep_alive;
 
-#if defined(WITH_THREAD)
     // Store stack pointer in thread-local storage.
     static PYBIND11_TLS_KEY_REF get_stack_tls_key() {
-#    if PYBIND11_INTERNALS_VERSION == 4
+#if PYBIND11_INTERNALS_VERSION == 4
         return get_local_internals().loader_life_support_tls_key;
-#    else
+#else
         return get_internals().loader_life_support_tls_key;
-#    endif
+#endif
     }
     static loader_life_support *get_stack_top() {
         return static_cast<loader_life_support *>(PYBIND11_TLS_GET_VALUE(get_stack_tls_key()));
@@ -51,15 +50,6 @@ private:
     static void set_stack_top(loader_life_support *value) {
         PYBIND11_TLS_REPLACE_VALUE(get_stack_tls_key(), value);
     }
-#else
-    // Use single global variable for stack.
-    static loader_life_support **get_stack_pp() {
-        static loader_life_support *global_stack = nullptr;
-        return global_stack;
-    }
-    static loader_life_support *get_stack_top() { return *get_stack_pp(); }
-    static void set_stack_top(loader_life_support *value) { *get_stack_pp() = value; }
-#endif
 
 public:
     /// A new patient frame is created when a function is entered

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -103,9 +103,6 @@ inline void initialize_interpreter_pre_pyconfig(bool init_signal_handlers,
                                                 bool add_program_dir_to_path) {
     detail::precheck_interpreter();
     Py_InitializeEx(init_signal_handlers ? 1 : 0);
-#    if defined(WITH_THREAD) && PY_VERSION_HEX < 0x03070000
-    PyEval_InitThreads();
-#    endif
 
     // Before it was special-cased in python 3.8, passing an empty or null argv
     // caused a segfault, so we have to reimplement the special case ourselves.

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -14,8 +14,7 @@
 
 #ifdef __has_include
 #    if defined(PYBIND11_CPP17)
-#        if __has_include(<filesystem>) && \
-          PY_VERSION_HEX >= 0x03060000
+#        if __has_include(<filesystem>)
 #            include <filesystem>
 #            define PYBIND11_HAS_FILESYSTEM 1
 #        elif __has_include(<experimental/filesystem>)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 
 import nox

--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 if sys.version_info < (3, 7):  # noqa: UP036

--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
-if sys.version_info < (3, 6):  # noqa: UP036
-    msg = "pybind11 does not support Python < 3.6. 2.9 was the last release supporting Python 2.7 and 3.5."
+if sys.version_info < (3, 7):  # noqa: UP036
+    msg = "pybind11 does not support Python < 3.7. v2.12 was the last release supporting Python 3.6."
     raise ImportError(msg)
 
 

--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-function-docstring
+from __future__ import annotations
 
 import argparse
 import sys

--- a/pybind11/_version.py
+++ b/pybind11/_version.py
@@ -1,7 +1,7 @@
-from typing import Union
+from __future__ import annotations
 
 
-def _to_int(s: str) -> Union[int, str]:
+def _to_int(s: str) -> int | str:
     try:
         return int(s)
     except ValueError:

--- a/pybind11/commands.py
+++ b/pybind11/commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 DIR = os.path.abspath(os.path.dirname(__file__))

--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 # If you copy this file in, you don't
 # need the .pyi file; it's just an interface file for static type checkers.
+from __future__ import annotations
 
 import contextlib
 import os
@@ -52,7 +53,6 @@ from pathlib import Path
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterable,
     Iterator,
     List,
@@ -113,10 +113,10 @@ class Pybind11Extension(_Extension):
     # flags are prepended, so that they can be further overridden, e.g. by
     # ``extra_compile_args=["-g"]``.
 
-    def _add_cflags(self, flags: List[str]) -> None:
+    def _add_cflags(self, flags: list[str]) -> None:
         self.extra_compile_args[:0] = flags
 
-    def _add_ldflags(self, flags: List[str]) -> None:
+    def _add_ldflags(self, flags: list[str]) -> None:
         self.extra_link_args[:0] = flags
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -250,7 +250,7 @@ cpp_flag_cache = None
 
 
 @lru_cache()
-def auto_cpp_level(compiler: Any) -> Union[str, int]:
+def auto_cpp_level(compiler: Any) -> str | int:
     """
     Return the max supported C++ std level (17, 14, or 11). Returns latest on Windows.
     """
@@ -288,8 +288,8 @@ class build_ext(_build_ext):  # noqa: N801
 
 
 def intree_extensions(
-    paths: Iterable[str], package_dir: Optional[Dict[str, str]] = None
-) -> List[Pybind11Extension]:
+    paths: Iterable[str], package_dir: dict[str, str] | None = None
+) -> list[Pybind11Extension]:
     """
     Generate Pybind11Extensions from source files directly located in a Python
     source tree.
@@ -409,7 +409,7 @@ class ParallelCompile:
 
     def __init__(
         self,
-        envvar: Optional[str] = None,
+        envvar: str | None = None,
         default: int = 0,
         max: int = 0,  # pylint: disable=redefined-builtin
         needs_recompile: Callable[[str, str], bool] = no_recompile,
@@ -418,7 +418,7 @@ class ParallelCompile:
         self.default = default
         self.max = max
         self.needs_recompile = needs_recompile
-        self._old: List[CCompilerMethod] = []
+        self._old: list[CCompilerMethod] = []
 
     def function(self) -> CCompilerMethod:
         """
@@ -427,14 +427,14 @@ class ParallelCompile:
 
         def compile_function(
             compiler: distutils.ccompiler.CCompiler,
-            sources: List[str],
-            output_dir: Optional[str] = None,
-            macros: Optional[List[Union[Tuple[str], Tuple[str, Optional[str]]]]] = None,
-            include_dirs: Optional[List[str]] = None,
+            sources: list[str],
+            output_dir: str | None = None,
+            macros: list[tuple[str] | tuple[str, str | None]] | None = None,
+            include_dirs: list[str] | None = None,
             debug: bool = False,
-            extra_preargs: Optional[List[str]] = None,
-            extra_postargs: Optional[List[str]] = None,
-            depends: Optional[List[str]] = None,
+            extra_preargs: list[str] | None = None,
+            extra_postargs: list[str] | None = None,
+            depends: list[str] | None = None,
         ) -> Any:
             # These lines are directly from distutils.ccompiler.CCompiler
             macros, objects, extra_postargs, pp_opts, build = compiler._setup_compile(  # type: ignore[attr-defined]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ ignore_missing_imports = true
 
 
 [tool.pylint]
-master.py-version = "3.8"
+master.py-version = "3.7"
 reports.output-format = "colorized"
 messages_control.disable = [
   "design",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ ignore = [
 ]
 unfixable = ["T20"]
 isort.known-first-party = ["env", "pybind11_cross_module_tests", "pybind11_tests"]
+isort.required-imports = ["from __future__ import annotations"]
+
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["EM", "N", "E721"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ ignore_missing_imports = true
 
 
 [tool.pylint]
-master.py-version = "3.6"
+master.py-version = "3.8"
 reports.output-format = "colorized"
 messages_control.disable = [
   "design",

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Topic :: Utilities
     Programming Language :: C++
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -39,5 +38,5 @@ project_urls =
     Chat = https://gitter.im/pybind/Lobby
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 zip_safe = False

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Setup script for PyPI; use CMakeFile.txt to build extension modules
+from __future__ import annotations
 
 import contextlib
 import os
@@ -9,9 +10,9 @@ import shutil
 import string
 import subprocess
 import sys
+from collections.abc import Generator
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Dict, Iterator, List, Union
 
 import setuptools.command.sdist
 
@@ -23,7 +24,7 @@ VERSION_FILE = Path("pybind11/_version.py")
 COMMON_FILE = Path("include/pybind11/detail/common.h")
 
 
-def build_expected_version_hex(matches: Dict[str, str]) -> str:
+def build_expected_version_hex(matches: dict[str, str]) -> str:
     patch_level_serial = matches["PATCH"]
     serial = None
     major = int(matches["MAJOR"])
@@ -64,7 +65,7 @@ to_src = (
 
 
 # Read the listed version
-loc: Dict[str, str] = {}
+loc: dict[str, str] = {}
 code = compile(VERSION_FILE.read_text(encoding="utf-8"), "pybind11/_version.py", "exec")
 exec(code, loc)
 version = loc["__version__"]
@@ -84,9 +85,7 @@ if version_hex != exp_version_hex:
 
 
 # TODO: use literals & overload (typing extensions or Python 3.8)
-def get_and_replace(
-    filename: Path, binary: bool = False, **opts: str
-) -> Union[bytes, str]:
+def get_and_replace(filename: Path, binary: bool = False, **opts: str) -> bytes | str:
     if binary:
         contents = filename.read_bytes()
         return string.Template(contents.decode()).substitute(opts).encode()
@@ -97,7 +96,7 @@ def get_and_replace(
 # Use our input files instead when making the SDist (and anything that depends
 # on it, like a wheel)
 class SDist(setuptools.command.sdist.sdist):
-    def make_release_tree(self, base_dir: str, files: List[str]) -> None:
+    def make_release_tree(self, base_dir: str, files: list[str]) -> None:
         super().make_release_tree(base_dir, files)
 
         for to, src in to_src:
@@ -112,7 +111,7 @@ class SDist(setuptools.command.sdist.sdist):
 
 # Remove the CMake install directory when done
 @contextlib.contextmanager
-def remove_output(*sources: str) -> Iterator[None]:
+def remove_output(*sources: str) -> Generator[None, None, None]:
     try:
         yield
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ Extends output capture as needed by pybind11: ignore constructors, optional unor
 Adds docstring and exceptions message sanitizers.
 """
 
+from __future__ import annotations
+
 import contextlib
 import difflib
 import gc

--- a/tests/env.py
+++ b/tests/env.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform
 import sys
 import sysconfig

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import os
 import string

--- a/tests/extra_setuptools/test_setuphelper.py
+++ b/tests/extra_setuptools/test_setuphelper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -11,5 +11,5 @@ numpy~=1.26.0; platform_python_implementation!="PyPy" and python_version>="3.11"
 pytest~=7.0
 pytest-timeout
 scipy~=1.5.4; platform_python_implementation!="PyPy" and python_version<"3.10"
-scipy~=1.8.0; platform_python_implementation!="PyPy" and python_version=="3.10"
-scipy~=1.11.1; platform_python_implementation!="PyPy" and python_version>="3.11" and python_version<"3.13"
+scipy~=1.8.0; platform_python_implementation!="PyPy" and python_version=="3.10" and sys_platform!='win32'
+scipy~=1.11.1; platform_python_implementation!="PyPy" and python_version>="3.11" and python_version<"3.13" and sys_platform!='win32'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,10 +1,8 @@
 --only-binary=:all:
-build~=0.9; python_version=="3.6"
 build~=1.0; python_version>="3.7"
 numpy~=1.20.0; python_version=="3.7" and platform_python_implementation=="PyPy"
 numpy~=1.23.0; python_version=="3.8" and platform_python_implementation=="PyPy"
 numpy~=1.25.0; python_version=="3.9" and platform_python_implementation=='PyPy'
-numpy~=1.19.3; platform_python_implementation!="PyPy" and python_version=="3.6"
 numpy~=1.21.5; platform_python_implementation!="PyPy" and python_version>="3.7" and python_version<"3.10"
 numpy~=1.22.2; platform_python_implementation!="PyPy" and python_version=="3.10"
 numpy~=1.26.0; platform_python_implementation!="PyPy" and python_version>="3.11" and python_version<"3.13"

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 asyncio = pytest.importorskip("asyncio")

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ctypes
 import io
 import struct

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -95,7 +95,7 @@ TEST_SUBMODULE(call_policies, m) {
         },
         py::call_guard<DependentGuard, CustomGuard>());
 
-#if defined(WITH_THREAD) && !defined(PYPY_VERSION)
+#if !defined(PYPY_VERSION)
     // `py::call_guard<py::gil_scoped_release>()` should work in PyPy as well,
     // but it's unclear how to test it without `PyGILState_GetThisThreadState`.
     auto report_gil_status = []() {

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import env  # noqa: F401

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from threading import Thread
 

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/test_cmake_build/test.py
+++ b/tests/test_cmake_build/test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import test_cmake_build

--- a/tests/test_const_name.py
+++ b/tests/test_const_name.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import const_name as m

--- a/tests/test_constants_and_functions.py
+++ b/tests/test_constants_and_functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 m = pytest.importorskip("pybind11_tests.constants_and_functions")

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import copy_move_policies as m

--- a/tests/test_custom_type_casters.py
+++ b/tests/test_custom_type_casters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import custom_type_casters as m

--- a/tests/test_custom_type_setup.py
+++ b/tests/test_custom_type_setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gc
 import weakref
 

--- a/tests/test_docstring_options.py
+++ b/tests/test_docstring_options.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pybind11_tests import docstring_options as m
 
 

--- a/tests/test_eigen_matrix.py
+++ b/tests/test_eigen_matrix.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import ConstructorStats

--- a/tests/test_eigen_tensor.py
+++ b/tests/test_eigen_tensor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/test_embed/test_interpreter.py
+++ b/tests/test_embed/test_interpreter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from widget_module import Widget

--- a/tests/test_embed/test_trampoline.py
+++ b/tests/test_embed/test_trampoline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import trampoline_module
 
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,4 +1,5 @@
 # ruff: noqa: SIM201 SIM300 SIM202
+from __future__ import annotations
 
 import pytest
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import pytest

--- a/tests/test_eval_call.py
+++ b/tests/test_eval_call.py
@@ -1,4 +1,5 @@
 # This file is called from 'test_eval.py'
+from __future__ import annotations
 
 if "call_test2" in locals():
     call_test2(y)  # noqa: F821 undefined name

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/test_factory_constructors.py
+++ b/tests/test_factory_constructors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 import pytest

--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import multiprocessing
 import sys
 import threading

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import kwargs_and_defaults as m

--- a/tests/test_local_bindings.py
+++ b/tests/test_local_bindings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import env  # noqa: F401

--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import builtins
 
 import pytest

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import env  # noqa: F401

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import env  # noqa: F401

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -200,8 +200,7 @@ def test_wrap():
         assert a.flags.f_contiguous == b.flags.f_contiguous
         assert a.flags.writeable == b.flags.writeable
         assert a.flags.aligned == b.flags.aligned
-        if tuple(int(x) for x in np.__version__.split(".")[:2]) >= (1, 14):
-            assert a.flags.writebackifcopy == b.flags.writebackifcopy
+        assert a.flags.writebackifcopy == b.flags.writebackifcopy
         else:
             assert a.flags.updateifcopy == b.flags.updateifcopy
         assert np.all(a == b)

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -198,7 +198,6 @@ def test_wrap():
         assert a.flags.f_contiguous == b.flags.f_contiguous
         assert a.flags.writeable == b.flags.writeable
         assert a.flags.aligned == b.flags.aligned
-        # 1.13 supported Python 3.6
         if tuple(int(x) for x in np.__version__.split(".")[:2]) >= (1, 14):
             assert a.flags.writebackifcopy == b.flags.writebackifcopy
         else:

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -201,8 +201,6 @@ def test_wrap():
         assert a.flags.writeable == b.flags.writeable
         assert a.flags.aligned == b.flags.aligned
         assert a.flags.writebackifcopy == b.flags.writebackifcopy
-        else:
-            assert a.flags.updateifcopy == b.flags.updateifcopy
         assert np.all(a == b)
         assert not b.flags.owndata
         assert b.base is base

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 import pytest

--- a/tests/test_numpy_vectorize.py
+++ b/tests/test_numpy_vectorize.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import numpy_vectorize as m

--- a/tests/test_opaque_types.py
+++ b/tests/test_opaque_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import ConstructorStats, UserType

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import ConstructorStats

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 import re
 

--- a/tests/test_python_multiple_inheritance.py
+++ b/tests/test_python_multiple_inheritance.py
@@ -1,5 +1,6 @@
 # Adapted from:
 # https://github.com/google/clif/blob/5718e4d0807fd3b6a8187dde140069120b81ecef/clif/testing/python/python_multiple_inheritance_test.py
+from __future__ import annotations
 
 from pybind11_tests import python_multiple_inheritance as m
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import sys
 import types

--- a/tests/test_sequences_and_iterators.py
+++ b/tests/test_sequences_and_iterators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pytest import approx  # noqa: PT013
 

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 m = pytest.importorskip("pybind11_tests.smart_ptr")

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import ConstructorStats, UserType

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import stl_binders as m

--- a/tests/test_tagbased_polymorphic.py
+++ b/tests/test_tagbased_polymorphic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pybind11_tests import tagbased_polymorphic as m
 
 

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import threading
 
 from pybind11_tests import thread as m

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import type_caster_pyobject_ptr as m

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pybind11_tests import union_ as m
 
 

--- a/tests/test_unnamed_namespace_a.py
+++ b/tests/test_unnamed_namespace_a.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import unnamed_namespace_a as m

--- a/tests/test_unnamed_namespace_b.py
+++ b/tests/test_unnamed_namespace_b.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pybind11_tests import unnamed_namespace_b as m
 
 

--- a/tests/test_vector_unique_ptr_member.py
+++ b/tests/test_vector_unique_ptr_member.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pybind11_tests import vector_unique_ptr_member as m

--- a/tests/test_virtual_functions.py
+++ b/tests/test_virtual_functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import env  # noqa: F401

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -92,7 +92,7 @@ endif()
 
 # Use the Python interpreter to find the libs.
 if(NOT PythonLibsNew_FIND_VERSION)
-  set(PythonLibsNew_FIND_VERSION "3.6")
+  set(PythonLibsNew_FIND_VERSION "3.7")
 endif()
 
 if(NOT CMAKE_VERSION VERSION_LESS "3.27")

--- a/tools/codespell_ignore_lines_from_errors.py
+++ b/tools/codespell_ignore_lines_from_errors.py
@@ -9,11 +9,12 @@ python3 tools/codespell_ignore_lines_from_errors.py /tmp/codespell_errors.txt > 
 git diff to review changes, then commit, push.
 """
 
+from __future__ import annotations
+
 import sys
-from typing import List
 
 
-def run(args: List[str]) -> None:
+def run(args: list[str]) -> None:
     assert len(args) == 1, "codespell_errors.txt"
     cache = {}
     done = set()

--- a/tools/libsize.py
+++ b/tools/libsize.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -56,7 +56,7 @@ if(NOT Python_FOUND AND NOT Python3_FOUND)
   endif()
 
   find_package(
-    Python 3.6 REQUIRED COMPONENTS ${_pybind11_interp_component} ${_pybind11_dev_component}
+    Python 3.7 REQUIRED COMPONENTS ${_pybind11_interp_component} ${_pybind11_dev_component}
                                    ${_pybind11_quiet} ${_pybind11_global_keyword})
 
   # If we are in submodule mode, export the Python targets to global targets.

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -43,7 +43,7 @@ endif()
 
 # A user can set versions manually too
 set(Python_ADDITIONAL_VERSIONS
-    "3.12;3.11;3.10;3.9;3.8;3.7;3.6"
+    "3.12;3.11;3.10;3.9;3.8;3.7"
     CACHE INTERNAL "")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Remove Python 3.6 support entirely. ([Official end-of-life](https://devguide.python.org/versions/): 2021-12-23)

NOTE: We're losing testing with GCC 4.8 (`centos:7`), but we're deliberately deferring reviewing the C++ code to remove related `#ifdef`s.
________

Stage 1: Change the Python version guard, then fix up GitHub Actions.

```C++
#if PY_VERSION_HEX < 0x03070000
#    error "PYTHON < 3.7 IS UNSUPPORTED. pybind11 v2.12 was the last to support Python 3.6."
#endif
```

First round end of stage 1: @ commit 51851f43af9c5117cb0788c71e038921c8b52fa6
________

Stage 2: Review & fix-as-needed the matching lines:

```bash
#! /bin/bash
set -x
git grep WITH_THREAD
git grep PY_VERSION_HEX
git grep PY_MINOR_VERSION
git grep PYPY_VERSION
git grep -I -E '3\.6'
git grep -I -E '3\.7'
git grep -I -E '\(3, 6'
git grep -I -E '\(3, 7'
git grep -I -E '3[^A-Za-z0-9.]+6'
git grep -I -E '3[^A-Za-z0-9.]+7'
```
________

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Support for Python 3.6 was removed. (Official end-of-life: 2021-12-23)
```

<!-- If the upgrade guide needs updating, note that here too -->
