### PR TITLE
feat: remove Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,11 +311,6 @@ jobs:
       fail-fast: false
       matrix:
         clang:
-          - 3.6
-          - 3.7
-          - 3.9
-          - 7
-          - 9
           - dev
         std:
           - 11
@@ -324,8 +319,6 @@ jobs:
         include:
           - clang: 5
             std: 14
-          - clang: 10
-            std: 17
           - clang: 11
             std: 20
           - clang: 12
@@ -497,10 +490,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { gcc: 7, std: 11 }
-          - { gcc: 7, std: 17 }
-          - { gcc: 8, std: 14 }
-          - { gcc: 8, std: 17 }
           - { gcc: 10, std: 17 }
           - { gcc: 11, std: 20 }
           - { gcc: 12, std: 20 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
           - '3.8'
 
     name: "🐍 ${{ matrix.python }} • GCC 7 • C++${{ matrix.std }} • x64"
-    container: ubuntu-18.04
+    container: ubuntu:18.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,56 @@ jobs:
       run: cmake --build build --target test_cmake_build
 
 
+  gcc7:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        std:
+          - 11
+        python:
+          - '3.8'
+
+    name: "🐍 ${{ matrix.python }} • GCC 7 • C++${{ matrix.std }} • x64"
+    container: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add GCC
+      run: apt-get update && apt-get install -y gcc
+
+    - name: Setup Python ${{ matrix.python }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Prepare env
+      run: |
+        python -m pip install -r tests/requirements.txt
+
+    - name: Configure
+      shell: bash
+      run: >
+        cmake -S . -B build
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+        -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
+
+    - name: Build
+      run: cmake --build build -j 2
+
+    - name: Python tests
+      run: cmake --build build --target pytest
+
+    - name: C++ tests
+      run: cmake --build build --target cpptest
+
+    - name: Interface test
+      run: cmake --build build --target test_cmake_build
+
+
   # Testing NVCC; forces sources to behave like .cu files
   cuda:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,9 +719,9 @@ jobs:
 
   # This tests an "install" with the CMake tools
   install-classic:
-    name: "🐍 3.7 • Debian • x86 •  Install"
+    name: "🐍 3.9 • Debian • x86 •  Install"
     runs-on: ubuntu-latest
-    container: i386/debian:buster
+    container: i386/debian:bullseye
 
     steps:
     - uses: actions/checkout@v1  # v1 is required to run inside docker
@@ -801,7 +801,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
@@ -819,8 +818,6 @@ jobs:
             args: -DCMAKE_CXX_STANDARD=20
           - python: '3.8'
             args: -DCMAKE_CXX_STANDARD=17
-          - python: '3.7'
-            args: -DCMAKE_CXX_STANDARD=14
 
 
     name: "🐍 ${{ matrix.python }} • MSVC 2019 • x86 ${{ matrix.args }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,7 @@ jobs:
           # Extra ubuntu latest job
           - runs-on: ubuntu-latest
             python: '3.11'
-          # For GCC 7
-          - runs-on: ubuntu-18.04
-            python: '3.8'
+
 
     name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
           # Extra ubuntu latest job
           - runs-on: ubuntu-latest
             python: '3.11'
-
+          # For GCC 7
+          - runs-on: ubuntu-18.04
+            python: '3.8'
 
     name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,9 @@ jobs:
           - clang: 16
             std: 20
             container_suffix: "-bullseye"
+          - clang: 17
+            std: 20
+            container_suffix: "-bookworm"
 
     name: "🐍 3 • Clang ${{ matrix.clang }} • C++${{ matrix.std }} • x64"
     container: "silkeh/clang:${{ matrix.clang }}${{ matrix.container_suffix }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,56 +368,6 @@ jobs:
       run: cmake --build build --target test_cmake_build
 
 
-  gcc7:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        std:
-          - 11
-        python:
-          - '3.8'
-
-    name: "🐍 ${{ matrix.python }} • GCC 7 • C++${{ matrix.std }} • x64"
-    container: ubuntu:18.04
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Add GCC
-      run: apt-get update && apt-get install -y gcc
-
-    - name: Setup Python ${{ matrix.python }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python }}
-
-    - name: Prepare env
-      run: |
-        python -m pip install -r tests/requirements.txt
-
-    - name: Configure
-      shell: bash
-      run: >
-        cmake -S . -B build
-        -DPYBIND11_WERROR=ON
-        -DDOWNLOAD_CATCH=ON
-        -DCMAKE_CXX_STANDARD=${{ matrix.std }}
-        -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
-
-    - name: Build
-      run: cmake --build build -j 2
-
-    - name: Python tests
-      run: cmake --build build --target pytest
-
-    - name: C++ tests
-      run: cmake --build build --target cpptest
-
-    - name: Interface test
-      run: cmake --build build --target test_cmake_build
-
-
   # Testing NVCC; forces sources to behave like .cu files
   cuda:
     runs-on: ubuntu-latest

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -39,22 +39,22 @@ jobs:
 
         - runs-on: macos-13
           arch: x64
-          cmake: "3.7"
+          cmake: "3.8"
 
         - runs-on: windows-2019
           arch: x64 # x86 compilers seem to be missing on 2019 image
           cmake: "3.18"
 
-    name: 🐍 3.7 • CMake ${{ matrix.cmake }} • ${{ matrix.runs-on }}
+    name: 🐍 3.8 • CMake ${{ matrix.cmake }} • ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Python 3.7
+    - name: Setup Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.8
         architecture: ${{ matrix.arch }}
 
     - name: Prepare env

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ dependency.
 Think of this library as a tiny self-contained version of Boost.Python
 with everything stripped away that isn't relevant for binding
 generation. Without comments, the core header files only require ~4K
-lines of code and depend on Python (3.7+, or PyPy) and the C++
+lines of code and depend on Python (3.8+, or PyPy) and the C++
 standard library. This compact implementation was possible thanks to
 some C++11 language features (specifically: tuples, lambda functions and
 variadic templates). Since its creation, this library has grown beyond
@@ -79,7 +79,7 @@ Goodies
 In addition to the core functionality, pybind11 provides some extra
 goodies:
 
-- Python 3.7+, and PyPy3 7.3 are supported with an implementation-agnostic
+- Python 3.8+, and PyPy3 7.3 are supported with an implementation-agnostic
   interface (pybind11 2.9 was the last version to support Python 2 and 3.5).
 
 - It is possible to bind C++11 lambda functions with captured

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -826,8 +826,7 @@ An instance can now be pickled as follows:
     always use the latest available version. Beware: failure to follow these
     instructions will cause important pybind11 memory allocation routines to be
     skipped during unpickling, which will likely lead to memory corruption
-    and/or segmentation faults. Python defaults to version 3 (Python 3-3.7) and
-    version 4 for Python 3.8+.
+    and/or segmentation faults.
 
 .. seealso::
 

--- a/docs/advanced/exceptions.rst
+++ b/docs/advanced/exceptions.rst
@@ -368,8 +368,7 @@ Should they throw or fail to catch any exceptions in their call graph,
 the C++ runtime calls ``std::terminate()`` to abort immediately.
 
 Similarly, Python exceptions raised in a class's ``__del__`` method do not
-propagate, but are logged by Python as an unraisable error. In Python 3.8+, a
-`system hook is triggered
+propagate, but ``sys.unraisablehook()`` `is triggered
 <https://docs.python.org/3/library/sys.html#sys.unraisablehook>`_
 and an auditing event is logged.
 

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -426,7 +426,7 @@ with ``PYTHON_EXECUTABLE``.  For example:
 
 .. code-block:: bash
 
-    cmake -DPYBIND11_PYTHON_VERSION=3.7 ..
+    cmake -DPYBIND11_PYTHON_VERSION=3.8 ..
 
     # Another method:
     cmake -DPYTHON_EXECUTABLE=/path/to/python ..
@@ -493,7 +493,7 @@ existing targets instead:
     cmake_minimum_required(VERSION 3.15...3.22)
     project(example LANGUAGES CXX)
 
-    find_package(Python 3.7 COMPONENTS Interpreter Development REQUIRED)
+    find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
     find_package(pybind11 CONFIG REQUIRED)
     # or add_subdirectory(pybind11)
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -158,7 +158,7 @@ public:
         } else {
             handle src_or_index = src;
             // PyPy: 7.3.7's 3.8 does not implement PyLong_*'s __index__ calls.
-#if PY_VERSION_HEX < 0x03080000 || defined(PYPY_VERSION)
+#if defined(PYPY_VERSION)
             object index;
             if (!PYBIND11_LONG_CHECK(src.ptr())) { // So: index_check(src.ptr())
                 index = reinterpret_steal<object>(PyNumber_Index(src.ptr()));

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1503,7 +1503,7 @@ struct kw_only {};
 
 /// \ingroup annotations
 /// Annotation indicating that all previous arguments are positional-only; the is the equivalent of
-/// an unnamed '/' argument (in Python 3.8)
+/// an unnamed '/' argument
 struct pos_only {};
 
 template <typename T>

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -466,19 +466,9 @@ extern "C" inline void pybind11_object_dealloc(PyObject *self) {
 
     type->tp_free(self);
 
-#if PY_VERSION_HEX < 0x03080000
-    // `type->tp_dealloc != pybind11_object_dealloc` means that we're being called
-    // as part of a derived type's dealloc, in which case we're not allowed to decref
-    // the type here. For cross-module compatibility, we shouldn't compare directly
-    // with `pybind11_object_dealloc`, but with the common one stashed in internals.
-    auto pybind11_object_type = (PyTypeObject *) get_internals().instance_base;
-    if (type->tp_dealloc == pybind11_object_type->tp_dealloc)
-        Py_DECREF(type);
-#else
     // This was not needed before Python 3.8 (Python issue 35810)
     // https://github.com/pybind/pybind11/issues/1946
     Py_DECREF(type);
-#endif
 }
 
 std::string error_string();

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -272,8 +272,8 @@ PYBIND11_WARNING_DISABLE_MSVC(4505)
 #endif
 
 #include <Python.h>
-#if PY_VERSION_HEX < 0x03070000
-#    error "PYTHON < 3.7 IS UNSUPPORTED. pybind11 v2.12 was the last to support Python 3.6."
+#if PY_VERSION_HEX < 0x03080000
+#    error "PYTHON < 3.8 IS UNSUPPORTED. pybind11 v2.13 was the last to support Python 3.7."
 #endif
 #include <frameobject.h>
 #include <pythread.h>

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -436,7 +436,7 @@ inline void translate_local_exception(std::exception_ptr p) {
 
 inline object get_python_state_dict() {
     object state_dict;
-#if PYBIND11_INTERNALS_VERSION <= 4 || PY_VERSION_HEX < 0x03080000 || defined(PYPY_VERSION)
+#if PYBIND11_INTERNALS_VERSION <= 4 || defined(PYPY_VERSION)
     state_dict = reinterpret_borrow<object>(PyEval_GetBuiltins());
 #else
 #    if PY_VERSION_HEX < 0x03090000

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -104,23 +104,13 @@ inline void initialize_interpreter_pre_pyconfig(bool init_signal_handlers,
     detail::precheck_interpreter();
     Py_InitializeEx(init_signal_handlers ? 1 : 0);
 
-    // Before it was special-cased in python 3.8, passing an empty or null argv
-    // caused a segfault, so we have to reimplement the special case ourselves.
-    bool special_case = (argv == nullptr || argc <= 0);
-
-    const char *const empty_argv[]{"\0"};
-    const char *const *safe_argv = special_case ? empty_argv : argv;
-    if (special_case) {
-        argc = 1;
-    }
-
     auto argv_size = static_cast<size_t>(argc);
     // SetArgv* on python 3 takes wchar_t, so we have to convert.
     std::unique_ptr<wchar_t *[]> widened_argv(new wchar_t *[argv_size]);
     std::vector<std::unique_ptr<wchar_t[], detail::wide_char_arg_deleter>> widened_argv_entries;
     widened_argv_entries.reserve(argv_size);
     for (size_t ii = 0; ii < argv_size; ++ii) {
-        widened_argv_entries.emplace_back(detail::widen_chars(safe_argv[ii]));
+        widened_argv_entries.emplace_back(detail::widen_chars(argv[ii]));
         if (!widened_argv_entries.back()) {
             // A null here indicates a character-encoding failure or the python
             // interpreter out of memory. Give up.

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -19,7 +19,7 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 inline void ensure_builtins_in_globals(object &global) {
-#if defined(PYPY_VERSION) || PY_VERSION_HEX < 0x03080000
+#if defined(PYPY_VERSION)
     // Running exec and eval adds `builtins` module under `__builtins__` key to
     // globals if not yet present.  Python 3.8 made PyRun_String behave
     // similarly. Let's also do that for older versions, for consistency. This

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -147,9 +147,7 @@ public:
         // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         tstate = PyEval_SaveThread();
         if (disassoc) {
-            // Python >= 3.7 can remove this, it's an int before 3.7
-            // NOLINTNEXTLINE(readability-qualified-auto)
-            auto key = internals.tstate;
+            auto key = internals.tstate; // NOLINT(readability-qualified-auto)
             PYBIND11_TLS_DELETE_VALUE(key);
         }
     }
@@ -173,9 +171,7 @@ public:
             PyEval_RestoreThread(tstate);
         }
         if (disassoc) {
-            // Python >= 3.7 can remove this, it's an int before 3.7
-            // NOLINTNEXTLINE(readability-qualified-auto)
-            auto key = detail::get_internals().tstate;
+            auto key = detail::get_internals().tstate; // NOLINT(readability-qualified-auto)
             PYBIND11_TLS_REPLACE_VALUE(key, tstate);
         }
     }

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -147,8 +147,6 @@ public:
         // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         tstate = PyEval_SaveThread();
         if (disassoc) {
-            // Python >= 3.7 can remove this, it's an int before 3.7
-            // NOLINTNEXTLINE(readability-qualified-auto)
             auto key = internals.tstate;
             PYBIND11_TLS_DELETE_VALUE(key);
         }
@@ -173,8 +171,6 @@ public:
             PyEval_RestoreThread(tstate);
         }
         if (disassoc) {
-            // Python >= 3.7 can remove this, it's an int before 3.7
-            // NOLINTNEXTLINE(readability-qualified-auto)
             auto key = detail::get_internals().tstate;
             PYBIND11_TLS_REPLACE_VALUE(key, tstate);
         }

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -147,6 +147,8 @@ public:
         // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         tstate = PyEval_SaveThread();
         if (disassoc) {
+            // Python >= 3.7 can remove this, it's an int before 3.7
+            // NOLINTNEXTLINE(readability-qualified-auto)
             auto key = internals.tstate;
             PYBIND11_TLS_DELETE_VALUE(key);
         }
@@ -171,6 +173,8 @@ public:
             PyEval_RestoreThread(tstate);
         }
         if (disassoc) {
+            // Python >= 3.7 can remove this, it's an int before 3.7
+            // NOLINTNEXTLINE(readability-qualified-auto)
             auto key = detail::get_internals().tstate;
             PYBIND11_TLS_REPLACE_VALUE(key, tstate);
         }

--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import sys
 
-if sys.version_info < (3, 7):  # noqa: UP036
-    msg = "pybind11 does not support Python < 3.7. v2.12 was the last release supporting Python 3.6."
+if sys.version_info < (3, 8):
+    msg = "pybind11 does not support Python < 3.8. v2.13 was the last release supporting Python 3.7."
     raise ImportError(msg)
 
 

--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 
-if sys.version_info < (3, 8):
+if sys.version_info < (3, 8):  # noqa: UP036
     msg = "pybind11 does not support Python < 3.8. v2.13 was the last release supporting Python 3.7."
     raise ImportError(msg)
 

--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -249,7 +249,7 @@ def has_flag(compiler: Any, flag: str) -> bool:
 cpp_flag_cache = None
 
 
-@lru_cache()
+@lru_cache
 def auto_cpp_level(compiler: Any) -> str | int:
     """
     Return the max supported C++ std level (17, 14, or 11). Returns latest on Windows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ messages_control.disable = [
 ]
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py38"
 src = ["src"]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ ignore_missing_imports = true
 
 
 [tool.pylint]
-master.py-version = "3.7"
+master.py-version = "3.8"
 reports.output-format = "colorized"
 messages_control.disable = [
   "design",

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Topic :: Utilities
     Programming Language :: C++
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -38,5 +37,5 @@ project_urls =
     Chat = https://gitter.im/pybind/Lobby
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 zip_safe = False

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,9 +1,8 @@
 --only-binary=:all:
-build~=1.0; python_version>="3.7"
-numpy~=1.20.0; python_version=="3.7" and platform_python_implementation=="PyPy"
+build~=1.0; python_version>="3.8"
 numpy~=1.23.0; python_version=="3.8" and platform_python_implementation=="PyPy"
 numpy~=1.25.0; python_version=="3.9" and platform_python_implementation=='PyPy'
-numpy~=1.21.5; platform_python_implementation!="PyPy" and python_version>="3.7" and python_version<"3.10"
+numpy~=1.21.5; platform_python_implementation!="PyPy" and python_version>="3.8" and python_version<"3.10"
 numpy~=1.22.2; platform_python_implementation!="PyPy" and python_version=="3.10"
 numpy~=1.26.0; platform_python_implementation!="PyPy" and python_version>="3.11" and python_version<"3.13"
 pytest~=7.0

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -297,7 +297,7 @@ def test_int_convert():
     cant_convert(3.14159)
     # TODO: Avoid DeprecationWarning in `PyLong_AsLong` (and similar)
     # TODO: PyPy 3.8 does not behave like CPython 3.8 here yet (7.3.7)
-    if (3, 8) <= sys.version_info < (3, 10) and env.CPYTHON:
+    if sys.version_info < (3, 10) and env.CPYTHON:
         with env.deprecated_call():
             assert convert(Int()) == 42
     else:

--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -92,7 +92,7 @@ endif()
 
 # Use the Python interpreter to find the libs.
 if(NOT PythonLibsNew_FIND_VERSION)
-  set(PythonLibsNew_FIND_VERSION "3.7")
+  set(PythonLibsNew_FIND_VERSION "3.8")
 endif()
 
 if(NOT CMAKE_VERSION VERSION_LESS "3.27")

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -56,7 +56,7 @@ if(NOT Python_FOUND AND NOT Python3_FOUND)
   endif()
 
   find_package(
-    Python 3.7 REQUIRED COMPONENTS ${_pybind11_interp_component} ${_pybind11_dev_component}
+    Python 3.8 REQUIRED COMPONENTS ${_pybind11_interp_component} ${_pybind11_dev_component}
                                    ${_pybind11_quiet} ${_pybind11_global_keyword})
 
   # If we are in submodule mode, export the Python targets to global targets.

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -43,7 +43,7 @@ endif()
 
 # A user can set versions manually too
 set(Python_ADDITIONAL_VERSIONS
-    "3.12;3.11;3.10;3.9;3.8;3.7"
+    "3.12;3.11;3.10;3.9;3.8"
     CACHE INTERNAL "")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Remove Python 3.7 support entirely. ([Official end-of-life](https://devguide.python.org/versions/): 2023-06-27)

NOTE: We're losing testing Clang versions 3, 7, 9, 10, and GCC version 7, but we're deliberately deferring reviewing the C++ code to remove related `#ifdef`s.

See also (below): https://github.com/pybind/pybind11/pull/5191#issuecomment-2187330041
________

For easy future reference, these were the `git grep` commands used to pin-point lines that may need to be changed:

```bash
#! /bin/bash
set -x
git grep 0x0307
git grep 0x0308
git grep PY_MINOR_VERSION
git grep PYPY_VERSION
git grep -I '[^0-9]37[^0-9]'
git grep -I '[^0-9]38[^0-9]'
git grep -I -E '3\.7'
git grep -I -E '3\.8'
git grep -I -E '\(3, 7'
git grep -I -E '\(3, 8'
git grep -I -E '3[^A-Za-z0-9.]+7'
git grep -I -E '3[^A-Za-z0-9.]+8'
```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Support for Python 3.7 was removed. (Official end-of-life: 2023-06-27)
```

<!-- If the upgrade guide needs updating, note that here too -->
