### PR TITLE
feat(types): adds support for Never and NoReturn from python Typing

### DIFF
--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -78,6 +78,14 @@ class Optional : public object {
     using object::object;
 };
 
+class NoReturn : public none {
+    using none::none;
+};
+
+class Never : public none {
+    using none::none;
+};
+
 PYBIND11_NAMESPACE_END(typing)
 
 PYBIND11_NAMESPACE_BEGIN(detail)
@@ -151,6 +159,16 @@ struct handle_type_name<typing::Union<Types...>> {
 template <typename T>
 struct handle_type_name<typing::Optional<T>> {
     static constexpr auto name = const_name("Optional[") + make_caster<T>::name + const_name("]");
+};
+
+template <>
+struct handle_type_name<typing::NoReturn> {
+    static constexpr auto name = const_name("NoReturn");
+};
+
+template <>
+struct handle_type_name<typing::Never> {
+    static constexpr auto name = const_name("Never");
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -867,4 +867,7 @@ TEST_SUBMODULE(pytypes, m) {
               list.append(py::none());
               return list;
           });
+
+    m.def("annotate_no_return", []() -> py::typing::NoReturn { throw 0; });
+    m.def("annotate_never", []() -> py::typing::Never { throw 0; });
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -982,3 +982,11 @@ def test_optional_annotations(doc):
         doc(m.annotate_optional)
         == "annotate_optional(arg0: list) -> list[Optional[str]]"
     )
+
+
+def test_no_return_annotation(doc):
+    assert doc(m.annotate_no_return) == "annotate_no_return() -> NoReturn"
+
+
+def test_never_annotation(doc):
+    assert doc(m.annotate_never) == "annotate_never() -> Never"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -997,6 +997,8 @@ def test_no_return_annotation(doc):
 
 def test_never_annotation(doc):
     assert doc(m.annotate_never) == "annotate_never() -> Never"
+
+
 def test_optional_object_annotations(doc):
     assert (
         doc(m.annotate_optional_to_object)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Adds support for Never and NoReturn.

Allows support for annotating functions that do not return. It is typically used in superclass that do not implement functions.

```python
class Foo:

   def func() -> Never:
         raise Exception()

   def func2() -> NoReturn:
         raise Exception()

class Bar(Foo):

    def func() -> int:
          return 3
    def func2() -> int:
          return 3
```

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
  Adds support for `typing.Never` and `typing.NoReturn`.
```

<!-- If the upgrade guide needs updating, note that here too -->
