### PR TITLE
feat(types): adds support for TypeGuard and TypeIs

### DIFF
--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -78,6 +78,16 @@ class Optional : public object {
     using object::object;
 };
 
+template <typename T>
+class TypeGuard : public bool_ {
+    using bool_::bool_;
+};
+
+template <typename T>
+class TypeIs : public bool_ {
+    using bool_::bool_;
+};
+
 PYBIND11_NAMESPACE_END(typing)
 
 PYBIND11_NAMESPACE_BEGIN(detail)
@@ -151,6 +161,16 @@ struct handle_type_name<typing::Union<Types...>> {
 template <typename T>
 struct handle_type_name<typing::Optional<T>> {
     static constexpr auto name = const_name("Optional[") + make_caster<T>::name + const_name("]");
+};
+
+template <typename T>
+struct handle_type_name<typing::TypeGuard<T>> {
+    static constexpr auto name = const_name("TypeGuard[") + make_caster<T>::name + const_name("]");
+};
+
+template <typename T>
+struct handle_type_name<typing::TypeIs<T>> {
+    static constexpr auto name = const_name("TypeIs[") + make_caster<T>::name + const_name("]");
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -97,7 +97,7 @@ class NoReturn : public none {
 class Never : public none {
     using none::none;
 };
-  
+
 #if defined(__cpp_nontype_template_parameter_class)
 template <size_t N>
 struct StringLiteral {
@@ -203,7 +203,7 @@ template <typename T>
 struct handle_type_name<typing::TypeIs<T>> {
     static constexpr auto name = const_name("TypeIs[") + make_caster<T>::name + const_name("]");
 };
-  
+
 template <>
 struct handle_type_name<typing::NoReturn> {
     static constexpr auto name = const_name("NoReturn");

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -867,4 +867,10 @@ TEST_SUBMODULE(pytypes, m) {
               list.append(py::none());
               return list;
           });
+
+    m.def("annotate_type_guard", [](py::object &o) -> py::typing::TypeGuard<py::str> {
+        return py::isinstance<py::str>(o);
+    });
+    m.def("annotate_type_is",
+          [](py::object &o) -> py::typing::TypeIs<py::str> { return py::isinstance<py::str>(o); });
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -982,3 +982,14 @@ def test_optional_annotations(doc):
         doc(m.annotate_optional)
         == "annotate_optional(arg0: list) -> list[Optional[str]]"
     )
+
+
+def test_type_guard_annotations(doc):
+    assert (
+        doc(m.annotate_type_guard)
+        == "annotate_type_guard(arg0: object) -> TypeGuard[str]"
+    )
+
+
+def test_type_is_annotations(doc):
+    assert doc(m.annotate_type_is) == "annotate_type_is(arg0: object) -> TypeIs[str]"


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Allows annotating functions for type narrowing using TypeGuard or TypeIs.

For additional information relating to the specific differences between TypeGuard and TypeIs can be found [here](https://peps.python.org/pep-0742/#typeis-and-typeguard).

```python
def is_str_type_guard(x: object) -> TypeGuard[str]:
    return isinstance(x, str)

def is_str_type_is(x: object) -> TypeIs[str]:
    return isinstance(x, str)
```


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
   Adds support for `typing.TypeGuard` and `typing.TypeIs`.
```

<!-- If the upgrade guide needs updating, note that here too -->
