### PR TITLE
ci: release with trusted publisher and attestations

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -91,23 +91,27 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     needs: [packaging]
+    environment: pypi
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
 
     steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.x"
-
     # Downloads all to directories matching the artifact names
     - uses: actions/download-artifact@v4
+
+    - name: Generate artifact attestation for sdist and wheel
+      uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+      with:
+        subject-path: "*/pybind11*"
 
     - name: Publish standard package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.pypi_password }}
         packages-dir: standard/
 
     - name: Publish global package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.pypi_password_global }}
         packages-dir: global/


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Use trusted publisher config (https://learn.scientific-python.org/development/guides/gha-pure/) and artifact attestations (https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/) for releases.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Releases now have artifact attestations, visable at https://github.com/pybind/pybind11/attestations.
```

<!-- If the upgrade guide needs updating, note that here too -->
