### PR TITLE
fix: use manual padding of instance_map_shard

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -153,7 +153,7 @@ struct instance_map_shard {
     std::mutex mutex;
     instance_map registered_instances;
     // alignas(64) would be better, but causes compile errors in macOS before 10.14 (see #5200)
-    PYBIND11_MAYBE_UNUSED char padding[64 - (sizeof(std::mutex) + sizeof(instance_map)) % 64];
+    char padding[64 - (sizeof(std::mutex) + sizeof(instance_map)) % 64];
 };
 
 /// Internal data structure used to track registered instances and types.

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -148,17 +148,13 @@ struct override_hash {
 
 using instance_map = std::unordered_multimap<const void *, instance *>;
 
-// ignore: structure was padded due to alignment specifier
-PYBIND11_WARNING_PUSH
-PYBIND11_WARNING_DISABLE_MSVC(4324)
-
 // Instance map shards are used to reduce mutex contention in free-threaded Python.
-struct alignas(64) instance_map_shard {
+struct instance_map_shard {
     std::mutex mutex;
     instance_map registered_instances;
+    // alignas(64) would be better, but causes compile errors in macOS before 10.14
+    char padding[64 - (sizeof(std::mutex) + sizeof(instance_map)) % 64];
 };
-
-PYBIND11_WARNING_POP
 
 /// Internal data structure used to track registered instances and types.
 /// Whenever binary incompatible changes are made to this structure,

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -153,7 +153,7 @@ struct instance_map_shard {
     std::mutex mutex;
     instance_map registered_instances;
     // alignas(64) would be better, but causes compile errors in macOS before 10.14 (see #5200)
-    char padding[64 - (sizeof(std::mutex) + sizeof(instance_map)) % 64];
+    PYBIND11_MAYBE_UNUSED char padding[64 - (sizeof(std::mutex) + sizeof(instance_map)) % 64];
 };
 
 /// Internal data structure used to track registered instances and types.

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -152,7 +152,7 @@ using instance_map = std::unordered_multimap<const void *, instance *>;
 struct instance_map_shard {
     std::mutex mutex;
     instance_map registered_instances;
-    // alignas(64) would be better, but causes compile errors in macOS before 10.14
+    // alignas(64) would be better, but causes compile errors in macOS before 10.14 (see #5200)
     char padding[64 - (sizeof(std::mutex) + sizeof(instance_map)) % 64];
 };
 


### PR DESCRIPTION
## Description

The alignas(64) specifier requires aligned allocation, which is not available on macOS when targeting versions before 10.14.

See https://github.com/scipy/scipy/issues/21056.

## Suggested changelog entry:

```rst
Avoid aligned allocation in free-threaded build in order to support macOS versions before 10.14.
```