### PR TITLE
feat(types) Adds support for Typing.Callable Special Case

### DIFF
--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -177,6 +177,14 @@ struct handle_type_name<typing::Callable<Return(Args...)>> {
           + const_name("], ") + make_caster<retval_type>::name + const_name("]");
 };
 
+template <typename Return>
+struct handle_type_name<typing::Callable<Return(ellipsis)>> {
+    // PEP 484 specifies this syntax for defining only return types of callables
+    using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
+    static constexpr auto name
+        = const_name("Callable[..., ") + make_caster<retval_type>::name + const_name("]");
+};
+
 template <typename T>
 struct handle_type_name<typing::Type<T>> {
     static constexpr auto name = const_name("type[") + make_caster<T>::name + const_name("]");

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -865,6 +865,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_fn",
           [](const py::typing::Callable<int(py::typing::List<py::str>, py::str)> &) {});
 
+    m.def("annotate_fn_only_return", [](const py::typing::Callable<int(py::ellipsis)> &) {});
     m.def("annotate_type", [](const py::typing::Type<int> &t) -> py::type { return t; });
 
     m.def("annotate_union",

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -958,6 +958,12 @@ def test_fn_annotations(doc):
         == "annotate_fn(arg0: Callable[[list[str], str], int]) -> None"
     )
 
+def test_fn_return_only(doc):
+    assert (
+        doc(m.annotate_fn_only_return)
+        == "annotate_fn_only_return(arg0: Callable[..., int]) -> None"
+    )
+
 
 def test_type_annotation(doc):
     assert doc(m.annotate_type) == "annotate_type(arg0: type[int]) -> type"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -958,6 +958,7 @@ def test_fn_annotations(doc):
         == "annotate_fn(arg0: Callable[[list[str], str], int]) -> None"
     )
 
+
 def test_fn_return_only(doc):
     assert (
         doc(m.annotate_fn_only_return)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Adds support for special case defined by pep 484.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
  Adds support for `Typing.Callable[..., T]`
```

<!-- If the upgrade guide needs updating, note that here too -->
