### PR TITLE
fix: add guard for GCC <10.3 on C++20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,9 @@ jobs:
           - { gcc: 7, std: 17 }
           - { gcc: 8, std: 14 }
           - { gcc: 8, std: 17 }
+          - { gcc: 9, std: 20 }
           - { gcc: 10, std: 17 }
+          - { gcc: 10, std: 20 }
           - { gcc: 11, std: 20 }
           - { gcc: 12, std: 20 }
           - { gcc: 13, std: 20 }

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -100,7 +100,8 @@ class Never : public none {
 
 // Define guard around specific GCC version
 // https://github.com/pybind/pybind11/issues/5201
-#if defined(__cpp_nontype_template_parameter_class)
+#if defined(__cpp_nontype_template_parameter_class) || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
+__gcc_major
 template <size_t N>
 struct StringLiteral {
     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
@@ -224,7 +225,8 @@ struct handle_type_name<typing::Never> {
     static constexpr auto name = const_name("Never");
 };
 
-#if defined(__cpp_nontype_template_parameter_class)
+
+#if defined(__cpp_nontype_template_parameter_class) || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
 template <typing::StringLiteral... Literals>
 struct handle_type_name<typing::Literal<Literals...>> {
     static constexpr auto name = const_name("Literal[")

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -100,8 +100,7 @@ class Never : public none {
 
 // Define guard around specific GCC version
 // https://github.com/pybind/pybind11/issues/5201
-#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUC__))                       \
-    || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
+#if defined(__cpp_nontype_template_parameter_class) && (!defined(__GNUC__) || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
 template <size_t N>
 struct StringLiteral {
     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
@@ -225,8 +224,7 @@ struct handle_type_name<typing::Never> {
     static constexpr auto name = const_name("Never");
 };
 
-#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUC__))                       \
-    || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
+#if defined(__cpp_nontype_template_parameter_class) && (!defined(__GNUC__) || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
 template <typing::StringLiteral... Literals>
 struct handle_type_name<typing::Literal<Literals...>> {
     static constexpr auto name = const_name("Literal[")

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -102,7 +102,7 @@ class Never : public none {
 // https://github.com/pybind/pybind11/issues/5201
 #if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
     || defined(__cpp_nontype_template_parameter_class)                                            \
-           && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
+           && (!(__GNUC__ < 10) && __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
 template <size_t N>
 struct StringLiteral {
     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
@@ -228,7 +228,7 @@ struct handle_type_name<typing::Never> {
 
 #if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
     || defined(__cpp_nontype_template_parameter_class)                                            \
-           && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
+           && (!(__GNUC__ < 10) && __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
 template <typing::StringLiteral... Literals>
 struct handle_type_name<typing::Literal<Literals...>> {
     static constexpr auto name = const_name("Literal[")

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -98,6 +98,8 @@ class Never : public none {
     using none::none;
 };
 
+// Define guard around specific GCC version
+// https://github.com/pybind/pybind11/issues/5201
 #if defined(__cpp_nontype_template_parameter_class)
 template <size_t N>
 struct StringLiteral {

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -100,7 +100,9 @@ class Never : public none {
 
 // Define guard around specific GCC version
 // https://github.com/pybind/pybind11/issues/5201
-#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__)) || defined(__cpp_nontype_template_parameter_class) && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
+#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
+    || defined(__cpp_nontype_template_parameter_class)                                            \
+           && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
 template <size_t N>
 struct StringLiteral {
     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
@@ -224,8 +226,9 @@ struct handle_type_name<typing::Never> {
     static constexpr auto name = const_name("Never");
 };
 
-
-#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__)) || defined(__cpp_nontype_template_parameter_class) && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
+#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
+    || defined(__cpp_nontype_template_parameter_class)                                            \
+           && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
 template <typing::StringLiteral... Literals>
 struct handle_type_name<typing::Literal<Literals...>> {
     static constexpr auto name = const_name("Literal[")

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -100,9 +100,8 @@ class Never : public none {
 
 // Define guard around specific GCC version
 // https://github.com/pybind/pybind11/issues/5201
-#if defined(__cpp_nontype_template_parameter_class)                                               \
-    || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
-__gcc_major template <size_t N>
+#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__)) || defined(__cpp_nontype_template_parameter_class) && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
+template <size_t N>
 struct StringLiteral {
     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
     char name[N];
@@ -225,8 +224,8 @@ struct handle_type_name<typing::Never> {
     static constexpr auto name = const_name("Never");
 };
 
-#if defined(__cpp_nontype_template_parameter_class)                                               \
-    || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
+
+#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__)) || defined(__cpp_nontype_template_parameter_class) && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
 template <typing::StringLiteral... Literals>
 struct handle_type_name<typing::Literal<Literals...>> {
     static constexpr auto name = const_name("Literal[")

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -102,7 +102,7 @@ class Never : public none {
 // https://github.com/pybind/pybind11/issues/5201
 #if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
     || defined(__cpp_nontype_template_parameter_class)                                            \
-           && (!(__GNUC__ < 10) && __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
+           && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
 template <size_t N>
 struct StringLiteral {
     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
@@ -228,7 +228,7 @@ struct handle_type_name<typing::Never> {
 
 #if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
     || defined(__cpp_nontype_template_parameter_class)                                            \
-           && (!(__GNUC__ < 10) && __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
+           && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
 template <typing::StringLiteral... Literals>
 struct handle_type_name<typing::Literal<Literals...>> {
     static constexpr auto name = const_name("Literal[")

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -98,11 +98,10 @@ class Never : public none {
     using none::none;
 };
 
-// Define guard around specific GCC version
-// https://github.com/pybind/pybind11/issues/5201
 #if defined(__cpp_nontype_template_parameter_class)                                               \
-    && (!defined(__GNUC__)                                                                        \
-        || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
+    && (/* See #5201 */ !defined(__GNUC__)                                                        \
+        || (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
+#    define PYBIND11_TYPING_H_HAS_STRING_LITERAL
 template <size_t N>
 struct StringLiteral {
     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
@@ -226,9 +225,7 @@ struct handle_type_name<typing::Never> {
     static constexpr auto name = const_name("Never");
 };
 
-#if defined(__cpp_nontype_template_parameter_class)                                               \
-    && (!defined(__GNUC__)                                                                        \
-        || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
+#if defined(PYBIND11_TYPING_H_HAS_STRING_LITERAL)
 template <typing::StringLiteral... Literals>
 struct handle_type_name<typing::Literal<Literals...>> {
     static constexpr auto name = const_name("Literal[")

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -100,7 +100,9 @@ class Never : public none {
 
 // Define guard around specific GCC version
 // https://github.com/pybind/pybind11/issues/5201
-#if defined(__cpp_nontype_template_parameter_class) && (!defined(__GNUC__) || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
+#if defined(__cpp_nontype_template_parameter_class)                                               \
+    && (!defined(__GNUC__)                                                                        \
+        || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
 template <size_t N>
 struct StringLiteral {
     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
@@ -224,7 +226,9 @@ struct handle_type_name<typing::Never> {
     static constexpr auto name = const_name("Never");
 };
 
-#if defined(__cpp_nontype_template_parameter_class) && (!defined(__GNUC__) || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
+#if defined(__cpp_nontype_template_parameter_class)                                               \
+    && (!defined(__GNUC__)                                                                        \
+        || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
 template <typing::StringLiteral... Literals>
 struct handle_type_name<typing::Literal<Literals...>> {
     static constexpr auto name = const_name("Literal[")

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -100,9 +100,9 @@ class Never : public none {
 
 // Define guard around specific GCC version
 // https://github.com/pybind/pybind11/issues/5201
-#if defined(__cpp_nontype_template_parameter_class) || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
-__gcc_major
-template <size_t N>
+#if defined(__cpp_nontype_template_parameter_class)                                               \
+    || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
+__gcc_major template <size_t N>
 struct StringLiteral {
     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
     char name[N];
@@ -225,8 +225,8 @@ struct handle_type_name<typing::Never> {
     static constexpr auto name = const_name("Never");
 };
 
-
-#if defined(__cpp_nontype_template_parameter_class) || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
+#if defined(__cpp_nontype_template_parameter_class)                                               \
+    || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
 template <typing::StringLiteral... Literals>
 struct handle_type_name<typing::Literal<Literals...>> {
     static constexpr auto name = const_name("Literal[")

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -100,9 +100,8 @@ class Never : public none {
 
 // Define guard around specific GCC version
 // https://github.com/pybind/pybind11/issues/5201
-#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
-    || defined(__cpp_nontype_template_parameter_class)                                            \
-           && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
+#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUC__))                       \
+    || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
 template <size_t N>
 struct StringLiteral {
     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
@@ -226,9 +225,8 @@ struct handle_type_name<typing::Never> {
     static constexpr auto name = const_name("Never");
 };
 
-#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
-    || defined(__cpp_nontype_template_parameter_class)                                            \
-           && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
+#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUC__))                       \
+    || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
 template <typing::StringLiteral... Literals>
 struct handle_type_name<typing::Literal<Literals...>> {
     static constexpr auto name = const_name("Literal[")

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -905,7 +905,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_optional_to_object",
           [](py::typing::Optional<int> &o) -> py::object { return o; });
 
-#if defined(__cpp_nontype_template_parameter_class)
+
+#if defined(__cpp_nontype_template_parameter_class) || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
     py::enum_<literals::Color>(m, "Color")
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -109,9 +109,7 @@ void m_defs(py::module_ &m) {
 
 } // namespace handle_from_move_only_type_with_operator_PyObject
 
-#if defined(__cpp_nontype_template_parameter_class)                                               \
-    && (!defined(__GNUC__)                                                                        \
-        || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
+#if defined(PYBIND11_TYPING_H_HAS_STRING_LITERAL)
 namespace literals {
 enum Color { RED = 0, BLUE = 1 };
 
@@ -907,9 +905,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_optional_to_object",
           [](py::typing::Optional<int> &o) -> py::object { return o; });
 
-#if defined(__cpp_nontype_template_parameter_class)                                               \
-    && (!defined(__GNUC__)                                                                        \
-        || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
+#if defined(PYBIND11_TYPING_H_HAS_STRING_LITERAL)
     py::enum_<literals::Color>(m, "Color")
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);
@@ -923,8 +919,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_listT_to_T",
           [](const py::typing::List<typevar::TypeVarT> &l) -> typevar::TypeVarT { return l[0]; });
     m.def("annotate_object_to_T", [](const py::object &o) -> typevar::TypeVarT { return o; });
-    m.attr("if_defined__cpp_nontype_template_parameter_class") = true;
+    m.attr("defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL") = true;
 #else
-    m.attr("if_defined__cpp_nontype_template_parameter_class") = false;
+    m.attr("defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL") = false;
 #endif
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -905,8 +905,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_optional_to_object",
           [](py::typing::Optional<int> &o) -> py::object { return o; });
 
-
-#if defined(__cpp_nontype_template_parameter_class) || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
+#if defined(__cpp_nontype_template_parameter_class)                                               \
+    || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
     py::enum_<literals::Color>(m, "Color")
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -905,8 +905,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_optional_to_object",
           [](py::typing::Optional<int> &o) -> py::object { return o; });
 
-#if defined(__cpp_nontype_template_parameter_class)                                               \
-    || define(__GNUG__) && (__GNUC__ >= 10 && __GNUC_MINOR__ < 2)
+
+#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__)) || defined(__cpp_nontype_template_parameter_class) && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
     py::enum_<literals::Color>(m, "Color")
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -907,7 +907,7 @@ TEST_SUBMODULE(pytypes, m) {
 
 #if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
     || defined(__cpp_nontype_template_parameter_class)                                            \
-           && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
+           && (!(__GNUC__ < 10) && __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
     py::enum_<literals::Color>(m, "Color")
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -109,7 +109,8 @@ void m_defs(py::module_ &m) {
 
 } // namespace handle_from_move_only_type_with_operator_PyObject
 
-#if defined(__cpp_nontype_template_parameter_class)
+#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUC__))                       \
+    || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
 namespace literals {
 enum Color { RED = 0, BLUE = 1 };
 
@@ -905,9 +906,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_optional_to_object",
           [](py::typing::Optional<int> &o) -> py::object { return o; });
 
-#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
-    || defined(__cpp_nontype_template_parameter_class)                                            \
-           && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
+#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUC__))                       \
+    || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
     py::enum_<literals::Color>(m, "Color")
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -109,7 +109,9 @@ void m_defs(py::module_ &m) {
 
 } // namespace handle_from_move_only_type_with_operator_PyObject
 
-#if defined(__cpp_nontype_template_parameter_class) && (!defined(__GNUC__) || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
+#if defined(__cpp_nontype_template_parameter_class)                                               \
+    && (!defined(__GNUC__)                                                                        \
+        || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
 namespace literals {
 enum Color { RED = 0, BLUE = 1 };
 
@@ -905,7 +907,9 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_optional_to_object",
           [](py::typing::Optional<int> &o) -> py::object { return o; });
 
-#if defined(__cpp_nontype_template_parameter_class) && (!defined(__GNUC__) || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
+#if defined(__cpp_nontype_template_parameter_class)                                               \
+    && (!defined(__GNUC__)                                                                        \
+        || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
     py::enum_<literals::Color>(m, "Color")
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -109,8 +109,7 @@ void m_defs(py::module_ &m) {
 
 } // namespace handle_from_move_only_type_with_operator_PyObject
 
-#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUC__))                       \
-    || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
+#if defined(__cpp_nontype_template_parameter_class) && (!defined(__GNUC__) || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
 namespace literals {
 enum Color { RED = 0, BLUE = 1 };
 
@@ -906,8 +905,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_optional_to_object",
           [](py::typing::Optional<int> &o) -> py::object { return o; });
 
-#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUC__))                       \
-    || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
+#if defined(__cpp_nontype_template_parameter_class) && (!defined(__GNUC__) || defined(__GNUC__) && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
     py::enum_<literals::Color>(m, "Color")
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -905,8 +905,9 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_optional_to_object",
           [](py::typing::Optional<int> &o) -> py::object { return o; });
 
-
-#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__)) || defined(__cpp_nontype_template_parameter_class) && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
+#if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
+    || defined(__cpp_nontype_template_parameter_class)                                            \
+           && (__GNUC__ > 10 || __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
     py::enum_<literals::Color>(m, "Color")
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -907,7 +907,7 @@ TEST_SUBMODULE(pytypes, m) {
 
 #if (defined(__cpp_nontype_template_parameter_class) && !defined(__GNUG__))                       \
     || defined(__cpp_nontype_template_parameter_class)                                            \
-           && (!(__GNUC__ < 10) && __GNUC__ == 10 && __GNUC_MINOR__ >= 3)
+           && (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3))
     py::enum_<literals::Color>(m, "Color")
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1025,7 +1025,7 @@ def test_optional_object_annotations(doc):
 
 
 @pytest.mark.skipif(
-    not m.if_defined__cpp_nontype_template_parameter_class,
+    not m.defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL,
     reason="C++20 feature not available.",
 )
 def test_literal(doc):
@@ -1036,7 +1036,7 @@ def test_literal(doc):
 
 
 @pytest.mark.skipif(
-    not m.if_defined__cpp_nontype_template_parameter_class,
+    not m.defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL,
     reason="C++20 feature not available.",
 )
 def test_typevar(doc):


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Fixes #5201 and updates CI.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
   Fix regression introduced in #5201 for GCC<10.3 in C++20 mode.
```

<!-- If the upgrade guide needs updating, note that here too -->
