### PR TITLE
Remove extra = in flto assignment

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -335,7 +335,7 @@ function(_pybind11_generate_lto target prefer_thin_lto)
       set(PYBIND11_LTO_LINKER_FLAGS "-flto${thin}${linker_append}")
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       _pybind11_return_if_cxx_and_linker_flags_work(
-        HAS_FLTO_THIN "-flto${thin}${cxx_append}" "-flto=${thin}${linker_append}"
+        HAS_FLTO_THIN "-flto${thin}${cxx_append}" "-flto${thin}${linker_append}"
         PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
     endif()
     if(NOT HAS_FLTO_THIN)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
When compiling a library with Pybind11 v2.13.1 on MacOS with Clang, CMake throws the error
```sh
clang: error: unsupported argument '' to option 'flto='
```

This is due to a stray `=` when defining `flto=` in the Clang case within `pybind11Common.cmake`.
This PR fixes this issue by removing the extra `=`, and after that the library compiles normally.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Remove extra = when assigning flto value in the case for Clang.
```

<!-- If the upgrade guide needs updating, note that here too -->
