### PR TITLE
Fixed a compilation error with gcc 14

### DIFF
--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -14,6 +14,8 @@
 #include "cast.h"
 #include "pytypes.h"
 
+#include <algorithm>
+
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(typing)
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Fixes #5206, which is caused by a missed header `algorithm` .

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
A missing ``#include <algorithm>`` in pybind11/typing.h was added, to fix a GCC 14 build error.
```

<!-- If the upgrade guide needs updating, note that here too -->



