### PR TITLE
feat(types) Adds special Case for empty C++ tuple type annotation

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -746,6 +746,7 @@ public:
     // PEP 484 specifies this syntax for an empty tuple
     static constexpr auto name = const_name("tuple[()]");
 };
+
 /// Helper class which abstracts away certain actions. Users can provide specializations for
 /// custom holders, but it's only necessary if the type has a non-standard interface.
 template <typename T>

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -740,6 +740,12 @@ class type_caster<std::pair<T1, T2>> : public tuple_caster<std::pair, T1, T2> {}
 template <typename... Ts>
 class type_caster<std::tuple<Ts...>> : public tuple_caster<std::tuple, Ts...> {};
 
+template <>
+class type_caster<std::tuple<>> : public tuple_caster<std::tuple> {
+public:
+    // PEP 484 specifies this syntax for an empty tuple
+    static constexpr auto name = const_name("tuple[()]");
+};
 /// Helper class which abstracts away certain actions. Users can provide specializations for
 /// custom holders, but it's only necessary if the type has a non-standard interface.
 template <typename T>

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -368,6 +368,8 @@ def test_tuple(doc):
     """
     )
 
+    assert doc(m.empty_tuple) == """empty_tuple() -> tuple[()]"""
+
     assert m.rvalue_pair() == ("rvalue", "rvalue")
     assert m.lvalue_pair() == ("lvalue", "lvalue")
     assert m.rvalue_tuple() == ("rvalue", "rvalue", "rvalue")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Split off from #5212

Due to how tuple_caster implements it's type generation it works for all tuples except the empty tuple which previously generated `tuple[]` rather than the correct `tuple[()]`

 https://github.com/pybind/pybind11/blob/51c2aa16de5b50fe4be6a0016d6090d4a831899e/include/pybind11/cast.h#L675-L677

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
   Adds Special type annotation for C++ empty tuple.
```

<!-- If the upgrade guide needs updating, note that here too -->
