### PR TITLE
Changelog entry for  PR #5208

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,10 @@ Bug fixes:
   versions before 10.14.
   `#5200 <https://github.com/pybind/pybind11/pull/5200>`_
 
+* A missing ``#include <algorithm>`` in pybind11/typing.h was added, to
+  fix a GCC 14 build error.
+  `#5200 <https://github.com/pybind/pybind11/pull/5208>`_
+
 Version 2.13.0 (June 25, 2024)
 ------------------------------
 


### PR DESCRIPTION
## Description
This PR adds the missed  changelog entry for PR #5208.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* A missing ``#include <algorithm>`` in pybind11/typing.h was added, to
  fix a GCC 14 build error.
  `#5200 <https://github.com/pybind/pybind11/pull/5208>`_

```

<!-- If the upgrade guide needs updating, note that here too -->
