### PR TITLE
test: embed `multiprocessing.Process` can be created with spawn context

### DIFF
--- a/tests/test_embed/CMakeLists.txt
+++ b/tests/test_embed/CMakeLists.txt
@@ -32,7 +32,8 @@ pybind11_enable_warnings(test_embed)
 target_link_libraries(test_embed PRIVATE pybind11::embed Catch2::Catch2 Threads::Threads)
 
 if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
-  file(COPY test_interpreter.py test_trampoline.py DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+  file(COPY test_interpreter.py test_trampoline.py test_multiprocessing.py
+       DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
 add_custom_target(

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -486,3 +486,12 @@ TEST_CASE("make_iterator can be called before then after finalizing an interpret
 
     py::initialize_interpreter();
 }
+
+TEST_CASE("scoped_interpreter multiprocessing.Process can be created with spawn context") {
+    py::finalize_interpreter();
+    REQUIRE_NOTHROW([&]() {
+        py::scoped_interpreter default_scope;
+        py::module_::import("test_multiprocessing").attr("main")();
+    }());
+    py::initialize_interpreter();
+}

--- a/tests/test_embed/test_multiprocessing.py
+++ b/tests/test_embed/test_multiprocessing.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import multiprocessing
+import multiprocessing.connection
+
+
+def f(tx: multiprocessing.connection.Connection, n: int):
+    tx.send(n**2)
+    tx.close()
+
+
+def main():
+    multiprocessing.set_start_method("spawn")
+    assert multiprocessing.get_start_method() == "spawn", "expected spawn"
+
+    rx, tx = multiprocessing.Pipe()
+    proc = multiprocessing.Process(target=f, args=(tx, 5))
+    proc.start()
+
+    value: int | None = None
+    for _ in range(5):
+        if rx.poll(1.0):
+            value = rx.recv()
+            break
+    rx.close()
+    proc.join(1.0)
+
+    assert value is not None, "no data received"
+    assert value == 5**2, f"expected {5**2} got {value}"


### PR DESCRIPTION
## Description

Add a embedded interpreter test to verify that a multiprocessing process can be created, communicated with, and joined using [`spawn`](https://docs.python.org/3.12/library/multiprocessing.html#contexts-and-start-methods). The test is failing on mac and windows, however it shouldn't. It appears that on windows and mac the child process's name is not updated and a new instance of the parent process is created as a child. The child processes (at least on mac) are created with arguments similar to:

```shell
build/tests/test_embed/test_embed -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=5, pipe_handle=7) --multiprocessing-fork
```

Related:
- https://github.com/pybind/pybind11/issues/2045