### PR TITLE
fix: make gil_safe_call_once thread-safe in free-threaded CPython

### DIFF
--- a/include/pybind11/gil_safe_call_once.h
+++ b/include/pybind11/gil_safe_call_once.h
@@ -7,6 +7,9 @@
 
 #include <cassert>
 #include <mutex>
+#ifdef Py_GIL_DISABLED
+#include <atomic>
+#endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
@@ -82,7 +85,11 @@ public:
 private:
     alignas(T) char storage_[sizeof(T)] = {};
     std::once_flag once_flag_ = {};
+#ifdef Py_GIL_DISABLED
+    std::atomic_bool is_initialized_{false};
+#else
     bool is_initialized_ = false;
+#endif
     // The `is_initialized_`-`storage_` pair is very similar to `std::optional`,
     // but the latter does not have the triviality properties of former,
     // therefore `std::optional` is not a viable alternative here.

--- a/include/pybind11/gil_safe_call_once.h
+++ b/include/pybind11/gil_safe_call_once.h
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <mutex>
+
 #ifdef Py_GIL_DISABLED
 #    include <atomic>
 #endif
@@ -86,10 +87,11 @@ private:
     alignas(T) char storage_[sizeof(T)] = {};
     std::once_flag once_flag_ = {};
 #ifdef Py_GIL_DISABLED
-    std::atomic_bool is_initialized_{false};
+    std::atomic_bool
 #else
-    bool is_initialized_ = false;
+    bool
 #endif
+        is_initialized_{false};
     // The `is_initialized_`-`storage_` pair is very similar to `std::optional`,
     // but the latter does not have the triviality properties of former,
     // therefore `std::optional` is not a viable alternative here.

--- a/include/pybind11/gil_safe_call_once.h
+++ b/include/pybind11/gil_safe_call_once.h
@@ -8,7 +8,7 @@
 #include <cassert>
 #include <mutex>
 #ifdef Py_GIL_DISABLED
-#include <atomic>
+#    include <atomic>
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
The "is_initialized_" flags is not protected by the GIL in free-threaded Python, so it needs to be an atomic field.

Fixes #5245

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Make ``gil_safe_call_once_and_store`` thread-safe in free-threaded CPython.
```

<!-- If the upgrade guide needs updating, note that here too -->
