### PR TITLE
[smart_holder] Import additional test code originally added under PR #5213 (test_class_sh_property_bakein)

### DIFF
--- a/tests/test_class_sh_property.cpp
+++ b/tests/test_class_sh_property.cpp
@@ -35,6 +35,15 @@ struct Outer {
 
 inline void DisownOuter(std::unique_ptr<Outer>) {}
 
+struct WithCharArrayMember {
+    WithCharArrayMember() { std::memcpy(char6_member, "Char6", 6); }
+    char char6_member[6];
+};
+
+struct WithConstCharPtrMember {
+    const char *const_char_ptr_member = "ConstChar*";
+};
+
 } // namespace test_class_sh_property
 
 PYBIND11_TYPE_CASTER_BASE_HOLDER(test_class_sh_property::ClassicField,
@@ -44,6 +53,9 @@ PYBIND11_TYPE_CASTER_BASE_HOLDER(test_class_sh_property::ClassicOuter,
 
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(test_class_sh_property::Field)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(test_class_sh_property::Outer)
+
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(test_class_sh_property::WithCharArrayMember)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(test_class_sh_property::WithConstCharPtrMember)
 
 TEST_SUBMODULE(class_sh_property, m) {
     using namespace test_class_sh_property;
@@ -83,4 +95,12 @@ TEST_SUBMODULE(class_sh_property, m) {
         .def_readwrite("m_shcp_readwrite", &Outer::m_shcp);
 
     m.def("DisownOuter", DisownOuter);
+
+    py::classh<WithCharArrayMember>(m, "WithCharArrayMember")
+        .def(py::init<>())
+        .def_readonly("char6_member", &WithCharArrayMember::char6_member);
+
+    py::classh<WithConstCharPtrMember>(m, "WithConstCharPtrMember")
+        .def(py::init<>())
+        .def_readonly("const_char_ptr_member", &WithConstCharPtrMember::const_char_ptr_member);
 }

--- a/tests/test_class_sh_property.py
+++ b/tests/test_class_sh_property.py
@@ -152,3 +152,13 @@ def test_unique_ptr_field_proxy_poc(m_attr):
     with pytest.raises(AttributeError):
         del field_proxy.num
     assert field_proxy.num == 82
+
+
+def test_readonly_char6_member():
+    obj = m.WithCharArrayMember()
+    assert obj.char6_member == "Char6"
+
+
+def test_readonly_const_char_ptr_member():
+    obj = m.WithConstCharPtrMember()
+    assert obj.const_char_ptr_member == "ConstChar*"


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Corresponding to PR #5213 commit 3406be68772fa3fe20db10b9e149b65f2a18ecec

Reduced from use cases in the wild:

* `test_readonly_char6_member()`: https://github.com/pytorch/pytorch/blob/4410c44ae6fd8eb36f2358ac76f7d988ca7537c5/torch/csrc/cuda/Module.cpp#L961

* `test_readonly_const_char_ptr_member()`: https://github.com/facebookresearch/nle/blob/862a439a84f52abca94d1f744d57061da12c5831/include/permonst.h#L43

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
