### PR TITLE
[smart_holder] Backport non-functional test changes from PR #5231

### DIFF
--- a/tests/test_class_sh_shared_ptr_copy_move.cpp
+++ b/tests/test_class_sh_shared_ptr_copy_move.cpp
@@ -50,6 +50,7 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::FooSmHld)
 namespace pybind11_tests {
 
 TEST_SUBMODULE(class_sh_shared_ptr_copy_move, m) {
+#if true // Trick to avoid clang-format changes, in support of PR #5213.
     namespace py = pybind11;
 
     py::class_<FooShPtr, std::shared_ptr<FooShPtr>>(m, "FooShPtr")
@@ -57,30 +58,30 @@ TEST_SUBMODULE(class_sh_shared_ptr_copy_move, m) {
     py::classh<FooSmHld>(m, "FooSmHld").def("get_history", &FooSmHld::get_history);
 
     auto outer = py::class_<Outer>(m, "Outer").def(py::init());
-#define MAKE_PROP(PropTyp)                                                                        \
-    MAKE_PROP_FOO(ShPtr, PropTyp)                                                                 \
-    MAKE_PROP_FOO(SmHld, PropTyp)
+#    define MAKE_PROP(PropTyp)                                                                    \
+        MAKE_PROP_FOO(ShPtr, PropTyp)                                                             \
+        MAKE_PROP_FOO(SmHld, PropTyp)
 
-#define MAKE_PROP_FOO(FooTyp, PropTyp)                                                            \
-    .def_##PropTyp(#FooTyp "_" #PropTyp "_default", &Outer::FooTyp)                               \
-        .def_##PropTyp(                                                                           \
-            #FooTyp "_" #PropTyp "_copy", &Outer::FooTyp, py::return_value_policy::copy)          \
-        .def_##PropTyp(                                                                           \
-            #FooTyp "_" #PropTyp "_move", &Outer::FooTyp, py::return_value_policy::move)
+#    define MAKE_PROP_FOO(FooTyp, PropTyp)                                                        \
+        .def_##PropTyp(#FooTyp "_" #PropTyp "_default", &Outer::FooTyp)                           \
+            .def_##PropTyp(                                                                       \
+                #FooTyp "_" #PropTyp "_copy", &Outer::FooTyp, py::return_value_policy::copy)      \
+            .def_##PropTyp(                                                                       \
+                #FooTyp "_" #PropTyp "_move", &Outer::FooTyp, py::return_value_policy::move)
     outer MAKE_PROP(readonly) MAKE_PROP(readwrite);
-#undef MAKE_PROP_FOO
+#    undef MAKE_PROP_FOO
 
-#define MAKE_PROP_FOO(FooTyp, PropTyp)                                                            \
-    .def_##PropTyp(#FooTyp "_property_" #PropTyp "_default", &Outer::FooTyp)                      \
-        .def_property_##PropTyp(#FooTyp "_property_" #PropTyp "_copy",                            \
-                                &Outer::get##FooTyp,                                              \
-                                py::return_value_policy::copy)                                    \
-        .def_property_##PropTyp(#FooTyp "_property_" #PropTyp "_move",                            \
-                                &Outer::get##FooTyp,                                              \
-                                py::return_value_policy::move)
+#    define MAKE_PROP_FOO(FooTyp, PropTyp)                                                        \
+        .def_##PropTyp(#FooTyp "_property_" #PropTyp "_default", &Outer::FooTyp)                  \
+            .def_property_##PropTyp(#FooTyp "_property_" #PropTyp "_copy",                        \
+                                    &Outer::get##FooTyp,                                          \
+                                    py::return_value_policy::copy)                                \
+            .def_property_##PropTyp(#FooTyp "_property_" #PropTyp "_move",                        \
+                                    &Outer::get##FooTyp,                                          \
+                                    py::return_value_policy::move)
     outer MAKE_PROP(readonly);
-#undef MAKE_PROP_FOO
-#undef MAKE_PROP
+#    undef MAKE_PROP_FOO
+#    undef MAKE_PROP
 
     m.def("test_ShPtr_copy", []() {
         auto o = std::make_shared<FooShPtr>("copy");
@@ -107,6 +108,7 @@ TEST_SUBMODULE(class_sh_shared_ptr_copy_move, m) {
         l.append(std::move(o));
         return l;
     });
+#endif
 }
 
 } // namespace pybind11_tests

--- a/tests/test_class_sh_trampoline_basic.cpp
+++ b/tests/test_class_sh_trampoline_basic.cpp
@@ -76,11 +76,12 @@ void wrap(py::module_ m, const char *py_class_name) {
 } // namespace class_sh_trampoline_basic
 } // namespace pybind11_tests
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_trampoline_basic::Abase<0>)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_trampoline_basic::Abase<1>)
+using namespace pybind11_tests::class_sh_trampoline_basic;
+
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Abase<0>)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Abase<1>)
 
 TEST_SUBMODULE(class_sh_trampoline_basic, m) {
-    using namespace pybind11_tests::class_sh_trampoline_basic;
     wrap<0>(m, "Abase0");
     wrap<1>(m, "Abase1");
 }

--- a/tests/test_class_sh_trampoline_self_life_support.cpp
+++ b/tests/test_class_sh_trampoline_self_life_support.cpp
@@ -10,7 +10,8 @@
 #include <string>
 #include <utility>
 
-namespace {
+namespace pybind11_tests {
+namespace class_sh_trampoline_self_life_support {
 
 struct Big5 { // Also known as "rule of five".
     std::string history;
@@ -41,7 +42,10 @@ struct Big5Trampoline : Big5, py::trampoline_self_life_support {
     using Big5::Big5;
 };
 
-} // namespace
+} // namespace class_sh_trampoline_self_life_support
+} // namespace pybind11_tests
+
+using namespace pybind11_tests::class_sh_trampoline_self_life_support;
 
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(Big5)
 

--- a/tests/test_class_sh_trampoline_shared_from_this.cpp
+++ b/tests/test_class_sh_trampoline_shared_from_this.cpp
@@ -8,7 +8,8 @@
 #include <memory>
 #include <string>
 
-namespace {
+namespace pybind11_tests {
+namespace class_sh_trampoline_shared_from_this {
 
 struct Sft : std::enable_shared_from_this<Sft> {
     std::string history;
@@ -98,7 +99,10 @@ std::shared_ptr<Sft> make_pure_cpp_sft_shd_ptr(const std::string &history_seed) 
 
 std::shared_ptr<Sft> pass_through_shd_ptr(const std::shared_ptr<Sft> &obj) { return obj; }
 
-} // namespace
+} // namespace class_sh_trampoline_shared_from_this
+} // namespace pybind11_tests
+
+using namespace pybind11_tests::class_sh_trampoline_shared_from_this;
 
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(Sft)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(SftSharedPtrStash)

--- a/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.cpp
+++ b/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.cpp
@@ -7,7 +7,8 @@
 
 #include <utility>
 
-namespace {
+namespace pybind11_tests {
+namespace class_sh_trampoline_shared_ptr_cpp_arg {
 
 // For testing whether a python subclass of a C++ object dies when the
 // last python reference is lost
@@ -51,7 +52,10 @@ struct SpGoAwayTester {
     std::shared_ptr<SpGoAway> m_obj;
 };
 
-} // namespace
+} // namespace class_sh_trampoline_shared_ptr_cpp_arg
+} // namespace pybind11_tests
+
+using namespace pybind11_tests::class_sh_trampoline_shared_ptr_cpp_arg;
 
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(SpBase)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(SpBaseTester)

--- a/tests/test_class_sh_trampoline_unique_ptr.cpp
+++ b/tests/test_class_sh_trampoline_unique_ptr.cpp
@@ -8,7 +8,8 @@
 
 #include <cstdint>
 
-namespace {
+namespace pybind11_tests {
+namespace class_sh_trampoline_unique_ptr {
 
 class Class {
 public:
@@ -30,11 +31,13 @@ private:
     std::uint64_t val_ = 0;
 };
 
-} // namespace
+} // namespace class_sh_trampoline_unique_ptr
+} // namespace pybind11_tests
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(Class)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_trampoline_unique_ptr::Class)
 
-namespace {
+namespace pybind11_tests {
+namespace class_sh_trampoline_unique_ptr {
 
 class PyClass : public Class, public py::trampoline_self_life_support {
 public:
@@ -45,9 +48,12 @@ public:
     int foo() const override { PYBIND11_OVERRIDE_PURE(int, Class, foo); }
 };
 
-} // namespace
+} // namespace class_sh_trampoline_unique_ptr
+} // namespace pybind11_tests
 
 TEST_SUBMODULE(class_sh_trampoline_unique_ptr, m) {
+    using namespace pybind11_tests::class_sh_trampoline_unique_ptr;
+
     py::classh<Class, PyClass>(m, "Class")
         .def(py::init<>())
         .def("set_val", &Class::setVal)

--- a/tests/test_class_sh_virtual_py_cpp_mix.cpp
+++ b/tests/test_class_sh_virtual_py_cpp_mix.cpp
@@ -46,13 +46,13 @@ struct CppDerivedVirtualOverrider : CppDerived, py::trampoline_self_life_support
 } // namespace class_sh_virtual_py_cpp_mix
 } // namespace pybind11_tests
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_virtual_py_cpp_mix::Base)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_virtual_py_cpp_mix::CppDerivedPlain)
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_virtual_py_cpp_mix::CppDerived)
+using namespace pybind11_tests::class_sh_virtual_py_cpp_mix;
+
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(Base)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(CppDerivedPlain)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(CppDerived)
 
 TEST_SUBMODULE(class_sh_virtual_py_cpp_mix, m) {
-    using namespace pybind11_tests::class_sh_virtual_py_cpp_mix;
-
     py::classh<Base, BaseVirtualOverrider>(m, "Base").def(py::init<>()).def("get", &Base::get);
 
     py::classh<CppDerivedPlain, Base>(m, "CppDerivedPlain").def(py::init<>());


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Non-functional test changes in support of PR #5213:

1. To avoid compiler warnings for unused code in the unnamed namespace.
2. To avoid clang-format changes.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
