### PR TITLE
fix: typo in documentation

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -25,7 +25,7 @@ A Python extension module can be created with just a few lines of code:
     find_package(pybind11 CONFIG REQUIRED)
 
     pybind11_add_module(example example.cpp)
-    install(TARGET example DESTINATION .)
+    install(TARGETS example DESTINATION .)
 
 (You use the ``add_subdirectory`` instead, see the example in :ref:`cmake`.) In
 this example, the code is located in a file named :file:`example.cpp`.  Either


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/command/install.html#targets

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Fix tiny typo in documentation
