### PR TITLE
fix(cmake): add required emscripten flags

### DIFF
--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -25,8 +25,6 @@ jobs:
     - uses: pypa/cibuildwheel@v2.20
       env:
         PYODIDE_BUILD_EXPORTS: whole_archive
-        CFLAGS: -fexceptions
-        LDFLAGS: -fexceptions
       with:
         package-dir: tests
         only: cp312-pyodide_wasm32

--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
     - master
+    - stable
+    - v*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,7 @@ if(NOT TARGET pybind11_headers)
   # (long name used here to keep this from clashing in subdirectory mode)
   add_library(pybind11_headers INTERFACE)
   add_library(pybind11::pybind11_headers ALIAS pybind11_headers) # to match exported target
-  add_library(pybind11::headers IMPORTED INTERFACE)
-  set_target_properties(pybind11::headers PROPERTIES INTERFACE_LINK_LIBRARIES pybind11_headers)
+  add_library(pybind11::headers ALIAS pybind11_headers)
 
   target_include_directories(
     pybind11_headers ${pybind11_system} INTERFACE $<BUILD_INTERFACE:${pybind11_INCLUDE_DIR}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,8 @@ if(NOT TARGET pybind11_headers)
   # (long name used here to keep this from clashing in subdirectory mode)
   add_library(pybind11_headers INTERFACE)
   add_library(pybind11::pybind11_headers ALIAS pybind11_headers) # to match exported target
-  add_library(pybind11::headers ALIAS pybind11_headers) # easier to use/remember
+  add_library(pybind11::headers IMPORTED INTERFACE)
+  set_target_properties(pybind11::headers PROPERTIES INTERFACE_LINK_LIBRARIES pybind11_headers)
 
   target_include_directories(
     pybind11_headers ${pybind11_system} INTERFACE $<BUILD_INTERFACE:${pybind11_INCLUDE_DIR}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ else()
   set(PYBIND11_INSTALL OFF)
 endif()
 
+set(_pybind11_is_config OFF)
 include("${CMAKE_CURRENT_SOURCE_DIR}/tools/pybind11Common.cmake")
 # https://github.com/jtojnar/cmake-snips/#concatenating-paths-when-building-pkg-config-files
 # TODO: cmake 3.20 adds the cmake_path() function, which obsoletes this snippet

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ if(NOT TARGET pybind11_headers)
   # (long name used here to keep this from clashing in subdirectory mode)
   add_library(pybind11_headers INTERFACE)
   add_library(pybind11::pybind11_headers ALIAS pybind11_headers) # to match exported target
-  add_library(pybind11::headers ALIAS pybind11_headers)
+  add_library(pybind11::headers ALIAS pybind11_headers) # easier to use/remember
 
   target_include_directories(
     pybind11_headers ${pybind11_system} INTERFACE $<BUILD_INTERFACE:${pybind11_INCLUDE_DIR}>
@@ -246,7 +246,6 @@ else()
   set(PYBIND11_INSTALL OFF)
 endif()
 
-set(_pybind11_is_config OFF)
 include("${CMAKE_CURRENT_SOURCE_DIR}/tools/pybind11Common.cmake")
 # https://github.com/jtojnar/cmake-snips/#concatenating-paths-when-building-pkg-config-files
 # TODO: cmake 3.20 adds the cmake_path() function, which obsoletes this snippet

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -10,6 +10,10 @@ name = "pybind11_tests"
 version = "0.0.1"
 dependencies = ["pytest", "pytest-timeout", "numpy", "scipy"]
 
+[tool.scikit-build]
+# Hide a warning while we also support CMake < 3.15
+cmake.version = ">=3.15"
+
 [tool.scikit-build.cmake.define]
 PYBIND11_FINDPYTHON = true
 

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -79,7 +79,7 @@ set_property(
 # _pybind11_no_exceptions is a private mechanism to disable this addition.
 # Please open an issue if you need to use it; it will be removed if no one
 # needs it.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES emscripten AND NOT _pybind11_no_exceptions)
+if(CMAKE_SYSTEM_NAME MATCHES Emscripten AND NOT _pybind11_no_exceptions)
   if(CMAKE_VERSION VERSION_LESS 3.13)
     message(WARNING "CMake 3.13+ is required to build for Emscripten. Some flags will be missing")
   else()
@@ -348,7 +348,7 @@ function(_pybind11_generate_lto target prefer_thin_lto)
 
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le" OR CMAKE_SYSTEM_PROCESSOR MATCHES "mips64")
       # Do nothing
-    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES emscripten)
+    elseif(CMAKE_SYSTEM_NAME MATCHES Emscripten)
       # This compile is very costly when cross-compiling, so set this without checking
       set(PYBIND11_LTO_CXX_FLAGS "-flto${thin}${cxx_append}")
       set(PYBIND11_LTO_LINKER_FLAGS "-flto${thin}${linker_append}")

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -30,7 +30,7 @@ endif()
 # which might be simpler than this check.
 get_property(
   is_config
-  TARGET pybind11::headers
+  TARGET pybind11::pybind11_headers
   PROPERTY IMPORTED)
 if(NOT is_config)
   set(optional_global GLOBAL)

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -79,14 +79,25 @@ if(CMAKE_SYSTEM_NAME MATCHES Emscripten AND NOT _pybind11_no_exceptions)
   if(CMAKE_VERSION VERSION_LESS 3.13)
     message(WARNING "CMake 3.13+ is required to build for Emscripten. Some flags will be missing")
   else()
-    set_property(
-      TARGET pybind11::headers
-      APPEND
-      PROPERTY INTERFACE_LINK_OPTIONS -fexceptions)
-    set_property(
-      TARGET pybind11::headers
-      APPEND
-      PROPERTY INTERFACE_COMPILE_OPTIONS -fexceptions)
+    if(_pybind11_is_config)
+      set_property(
+        TARGET pybind11::pybind11_headers
+        APPEND
+        PROPERTY INTERFACE_LINK_OPTIONS -fexceptions)
+      set_property(
+        TARGET pybind11::pybind11_headers
+        APPEND
+        PROPERTY INTERFACE_COMPILE_OPTIONS -fexceptions)
+    else()
+      set_property(
+        TARGET pybind11_headers
+        APPEND
+        PROPERTY INTERFACE_LINK_OPTIONS -fexceptions)
+      set_property(
+        TARGET pybind11_headers
+        APPEND
+        PROPERTY INTERFACE_COMPILE_OPTIONS -fexceptions)
+    endif()
   endif()
 endif()
 

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -28,11 +28,7 @@ endif()
 # are in CONFIG mode, they should be "normal" targets instead.
 # In CMake 3.11+ you can promote a target to global after you create it,
 # which might be simpler than this check.
-get_property(
-  is_config
-  TARGET pybind11::pybind11_headers
-  PROPERTY IMPORTED)
-if(NOT is_config)
+if(NOT _pybind11_is_config)
   set(optional_global GLOBAL)
 endif()
 

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -28,7 +28,11 @@ endif()
 # are in CONFIG mode, they should be "normal" targets instead.
 # In CMake 3.11+ you can promote a target to global after you create it,
 # which might be simpler than this check.
-if(NOT _pybind11_is_config)
+get_property(
+  is_config
+  TARGET pybind11::headers
+  PROPERTY IMPORTED)
+if(NOT is_config)
   set(optional_global GLOBAL)
 endif()
 
@@ -79,7 +83,7 @@ if(CMAKE_SYSTEM_NAME MATCHES Emscripten AND NOT _pybind11_no_exceptions)
   if(CMAKE_VERSION VERSION_LESS 3.13)
     message(WARNING "CMake 3.13+ is required to build for Emscripten. Some flags will be missing")
   else()
-    if(_pybind11_is_config)
+    if(_is_config)
       set_property(
         TARGET pybind11::pybind11_headers
         APPEND

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -75,6 +75,26 @@ set_property(
   APPEND
   PROPERTY INTERFACE_LINK_LIBRARIES pybind11::pybind11)
 
+# -------------- emscripten requires exceptions enabled -------------
+# _pybind11_no_exceptions is a private mechanism to disable this addition.
+# Please open an issue if you need to use it; it will be removed if no one
+# needs it.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES emscripten AND NOT _pybind11_no_exceptions)
+  if(CMAKE_VERSION VERSION_LESS 3.13)
+    message(WARNING "CMake 3.13+ is required to build for Emscripten. Some flags will be missing")
+  else()
+    set_property(
+      TARGET pybind11::pybind11
+      APPEND
+      PROPERTY INTERFACE_LINK_OPTIONS -fexceptions)
+    set_property(
+      TARGET pybind11::pybind11
+      APPEND
+      PROPERTY INTERFACE_COMPILE_OPTIONS -fexceptions)
+  endif()
+
+endif()
+
 # --------------------------- link helper ---------------------------
 
 add_library(pybind11::python_link_helper IMPORTED INTERFACE ${optional_global})

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -2,7 +2,7 @@
 
 Adds the following targets::
 
-    pybind11::pybind11 - link to headers and pybind11
+    pybind11::pybind11 - link to Python headers and pybind11::headers
     pybind11::module - Adds module links
     pybind11::embed - Adds embed links
     pybind11::lto - Link time optimizations (only if CMAKE_INTERPROCEDURAL_OPTIMIZATION is not set)
@@ -84,15 +84,14 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES emscripten AND NOT _pybind11_no_exceptions)
     message(WARNING "CMake 3.13+ is required to build for Emscripten. Some flags will be missing")
   else()
     set_property(
-      TARGET pybind11::pybind11
+      TARGET pybind11::headers
       APPEND
       PROPERTY INTERFACE_LINK_OPTIONS -fexceptions)
     set_property(
-      TARGET pybind11::pybind11
+      TARGET pybind11::headers
       APPEND
       PROPERTY INTERFACE_COMPILE_OPTIONS -fexceptions)
   endif()
-
 endif()
 
 # --------------------------- link helper ---------------------------

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -84,24 +84,20 @@ if(CMAKE_SYSTEM_NAME MATCHES Emscripten AND NOT _pybind11_no_exceptions)
     message(WARNING "CMake 3.13+ is required to build for Emscripten. Some flags will be missing")
   else()
     if(_is_config)
-      set_property(
-        TARGET pybind11::pybind11_headers
-        APPEND
-        PROPERTY INTERFACE_LINK_OPTIONS -fexceptions)
-      set_property(
-        TARGET pybind11::pybind11_headers
-        APPEND
-        PROPERTY INTERFACE_COMPILE_OPTIONS -fexceptions)
+      set(_tmp_config_target pybind11::pybind11_headers)
     else()
-      set_property(
-        TARGET pybind11_headers
-        APPEND
-        PROPERTY INTERFACE_LINK_OPTIONS -fexceptions)
-      set_property(
-        TARGET pybind11_headers
-        APPEND
-        PROPERTY INTERFACE_COMPILE_OPTIONS -fexceptions)
+      set(_tmp_config_target pybind11_headers)
     endif()
+
+    set_property(
+      TARGET ${_tmp_config_target}
+      APPEND
+      PROPERTY INTERFACE_LINK_OPTIONS -fexceptions)
+    set_property(
+      TARGET ${_tmp_config_target}
+      APPEND
+      PROPERTY INTERFACE_COMPILE_OPTIONS -fexceptions)
+    unset(_tmp_config_target)
   endif()
 endif()
 

--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -222,7 +222,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/pybind11Targets.cmake")
 add_library(pybind11::headers IMPORTED INTERFACE)
 set_target_properties(pybind11::headers PROPERTIES INTERFACE_LINK_LIBRARIES
                                                    pybind11::pybind11_headers)
-set(_pybind11_is_config ON)
+
 include("${CMAKE_CURRENT_LIST_DIR}/pybind11Common.cmake")
 
 if(NOT pybind11_FIND_QUIETLY)

--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -84,7 +84,7 @@ you can either use the basic targets, or use the FindPython tools:
 
   # Python method:
   Python_add_library(MyModule2 src2.cpp)
-  target_link_libraries(MyModule2 pybind11::headers)
+  target_link_libraries(MyModule2 PUBLIC pybind11::headers)
   set_target_properties(MyModule2 PROPERTIES
                                   INTERPROCEDURAL_OPTIMIZATION ON
                                   CXX_VISIBILITY_PRESET ON
@@ -222,7 +222,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/pybind11Targets.cmake")
 add_library(pybind11::headers IMPORTED INTERFACE)
 set_target_properties(pybind11::headers PROPERTIES INTERFACE_LINK_LIBRARIES
                                                    pybind11::pybind11_headers)
-
+set(_pybind11_is_config ON)
 include("${CMAKE_CURRENT_LIST_DIR}/pybind11Common.cmake")
 
 if(NOT pybind11_FIND_QUIETLY)


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Putting this in for our next release. The Pyodide authors thought this was a good idea in their Discord a while back.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* When compiling for WebAssembly, add the required exception flags (CMake 3.13+)
```

<!-- If the upgrade guide needs updating, note that here too -->

CC @hoodmane, @agriyakhetarpal
