### PR TITLE
fix: quote paths from pybind11-config

### DIFF
--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-function-docstring
 
 import argparse
+import shlex
 import sys
 import sysconfig
 
@@ -21,7 +22,7 @@ def print_includes() -> None:
         if d and d not in unique_dirs:
             unique_dirs.append(d)
 
-    print(" ".join("-I" + d for d in unique_dirs))
+    print(" ".join(shlex.quote(f"-I{d}") for d in unique_dirs))
 
 
 def main() -> None:
@@ -53,9 +54,9 @@ def main() -> None:
     if args.includes:
         print_includes()
     if args.cmakedir:
-        print(get_cmake_dir())
+        print(shlex.quote(get_cmake_dir()))
     if args.pkgconfigdir:
-        print(get_pkgconfig_dir())
+        print(shlex.quote(get_pkgconfig_dir()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Fix https://github.com/pybind/pybind11/issues/5300. I've been worried about the warning on https://docs.python.org/3/library/shlex.html#shlex.quote, but I think that doesn't mean it won't work, it just means that it doesn't protect from injection on Windows.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Quote paths from pybind11-config.
```

<!-- If the upgrade guide needs updating, note that here too -->
