### PR TITLE
feat: require CMake 3.15+

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -81,7 +81,7 @@ nox -s build
 ### Full setup
 
 To setup an ideal development environment, run the following commands on a
-system with CMake 3.14+:
+system with CMake 3.15+:
 
 ```bash
 python3 -m venv venv
@@ -96,8 +96,8 @@ Tips:
 * You can use `virtualenv` (faster, from PyPI) instead of `venv`.
 * You can select any name for your environment folder; if it contains "env" it
   will be ignored by git.
-* If you don't have CMake 3.14+, just add "cmake" to the pip install command.
-* You can use `-DPYBIND11_FINDPYTHON=ON` to use FindPython on CMake 3.12+
+* If you don't have CMake 3.15+, just add "cmake" to the pip install command.
+* You can use `-DPYBIND11_FINDPYTHON=ON` to use FindPython.
 * In classic mode, you may need to set `-DPYTHON_EXECUTABLE=/path/to/python`.
   FindPython uses `-DPython_ROOT_DIR=/path/to` or
   `-DPython_EXECUTABLE=/path/to/python`.
@@ -149,8 +149,8 @@ To run the tests, you can "build" the check target:
 cmake --build build --target check
 ```
 
-`--target` can be spelled `-t` in CMake 3.15+. You can also run individual
-tests with these targets:
+`--target` can be spelled `-t`. You can also run individual tests with these
+targets:
 
 * `pytest`: Python tests only, using the
 [pytest](https://docs.pytest.org/en/stable/) framework

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -31,7 +31,7 @@ jobs:
         include:
         - runs-on: ubuntu-20.04
           arch: x64
-          cmake: "3.5"
+          cmake: "3.15"
 
         - runs-on: ubuntu-20.04
           arch: x64
@@ -39,7 +39,7 @@ jobs:
 
         - runs-on: macos-13
           arch: x64
-          cmake: "3.8"
+          cmake: "3.15"
 
         - runs-on: windows-2019
           arch: x64 # x86 compilers seem to be missing on 2019 image

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,6 @@ if(PYBIND11_MASTER_PROJECT)
 endif()
 
 list(TRANSFORM PYBIND11_HEADERS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
-FetchContent_MakeAvailable ```
 
 # Cache variable so this can be used in parent projects
 set(pybind11_INCLUDE_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,16 +10,7 @@ if(NOT CMAKE_VERSION VERSION_LESS "3.27")
   cmake_policy(GET CMP0148 _pybind11_cmp0148)
 endif()
 
-cmake_minimum_required(VERSION 3.5)
-
-# The `cmake_minimum_required(VERSION 3.5...3.29)` syntax does not work with
-# some versions of VS that have a patched CMake 3.11. This forces us to emulate
-# the behavior using the following workaround:
-if(${CMAKE_VERSION} VERSION_LESS 3.29)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.29)
-endif()
+cmake_minimum_required(VERSION 3.15...3.30)
 
 if(_pybind11_cmp0148)
   cmake_policy(SET CMP0148 ${_pybind11_cmp0148})
@@ -27,9 +18,7 @@ if(_pybind11_cmp0148)
 endif()
 
 # Avoid infinite recursion if tests include this as a subdirectory
-if(DEFINED PYBIND11_MASTER_PROJECT)
-  return()
-endif()
+include_guard(GLOBAL)
 
 # Extract project version from source
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/include/pybind11/detail/common.h"
@@ -73,14 +62,6 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
   endif()
 
   set(PYBIND11_MASTER_PROJECT ON)
-
-  if(OSX AND CMAKE_VERSION VERSION_LESS 3.7)
-    # Bug in macOS CMake < 3.7 is unable to download catch
-    message(WARNING "CMAKE 3.7+ needed on macOS to download catch, and newer HIGHLY recommended")
-  elseif(WINDOWS AND CMAKE_VERSION VERSION_LESS 3.8)
-    # Only tested with 3.8+ in CI.
-    message(WARNING "CMAKE 3.8+ tested on Windows, previous versions untested")
-  endif()
 
   message(STATUS "CMake ${CMAKE_VERSION}")
 
@@ -133,8 +114,7 @@ cmake_dependent_option(
   "Install pybind11 headers in Python include directory instead of default installation prefix"
   OFF "PYBIND11_INSTALL" OFF)
 
-cmake_dependent_option(PYBIND11_FINDPYTHON "Force new FindPython" ${_pybind11_findpython_default}
-                       "NOT CMAKE_VERSION VERSION_LESS 3.12" OFF)
+option(PYBIND11_FINDPYTHON "Force new FindPython" ${_pybind11_findpython_default})
 
 # Allow PYTHON_EXECUTABLE if in FINDPYTHON mode and building pybind11's tests
 # (makes transition easier while we support both modes).
@@ -183,7 +163,7 @@ set(PYBIND11_HEADERS
     include/pybind11/typing.h)
 
 # Compare with grep and warn if mismatched
-if(PYBIND11_MASTER_PROJECT AND NOT CMAKE_VERSION VERSION_LESS 3.12)
+if(PYBIND11_MASTER_PROJECT)
   file(
     GLOB_RECURSE _pybind11_header_check
     LIST_DIRECTORIES false
@@ -201,10 +181,7 @@ if(PYBIND11_MASTER_PROJECT AND NOT CMAKE_VERSION VERSION_LESS 3.12)
   endif()
 endif()
 
-# CMake 3.12 added list(TRANSFORM <list> PREPEND
-# But we can't use it yet
-string(REPLACE "include/" "${CMAKE_CURRENT_SOURCE_DIR}/include/" PYBIND11_HEADERS
-               "${PYBIND11_HEADERS}")
+list(TRANSFORM PYBIND11_HEADERS PREPEND "include/")
 
 # Cache variable so this can be used in parent projects
 set(pybind11_INCLUDE_DIR
@@ -274,25 +251,11 @@ if(PYBIND11_INSTALL)
     tools/${PROJECT_NAME}Config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
     INSTALL_DESTINATION ${PYBIND11_CMAKECONFIG_INSTALL_DIR})
 
-  if(CMAKE_VERSION VERSION_LESS 3.14)
-    # Remove CMAKE_SIZEOF_VOID_P from ConfigVersion.cmake since the library does
-    # not depend on architecture specific settings or libraries.
-    set(_PYBIND11_CMAKE_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
-    unset(CMAKE_SIZEOF_VOID_P)
-
-    write_basic_package_version_file(
-      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-      VERSION ${PROJECT_VERSION}
-      COMPATIBILITY AnyNewerVersion)
-
-    set(CMAKE_SIZEOF_VOID_P ${_PYBIND11_CMAKE_SIZEOF_VOID_P})
-  else()
-    # CMake 3.14+ natively supports header-only libraries
-    write_basic_package_version_file(
-      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-      VERSION ${PROJECT_VERSION}
-      COMPATIBILITY AnyNewerVersion ARCH_INDEPENDENT)
-  endif()
+  # CMake natively supports header-only libraries
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion ARCH_INDEPENDENT)
 
   install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,8 @@ if(PYBIND11_MASTER_PROJECT)
   endif()
 endif()
 
-list(TRANSFORM PYBIND11_HEADERS PREPEND "include/")
+list(TRANSFORM PYBIND11_HEADERS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+FetchContent_MakeAvailable ```
 
 # Cache variable so this can be used in parent projects
 set(pybind11_INCLUDE_DIR

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -18,7 +18,7 @@ information, see :doc:`/compiling`.
 
 .. code-block:: cmake
 
-    cmake_minimum_required(VERSION 3.5...3.29)
+    cmake_minimum_required(VERSION 3.15...3.30)
     project(example)
 
     find_package(pybind11 REQUIRED)  # or `add_subdirectory(pybind11)`

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -18,7 +18,7 @@ A Python extension module can be created with just a few lines of code:
 
 .. code-block:: cmake
 
-    cmake_minimum_required(VERSION 3.15...3.29)
+    cmake_minimum_required(VERSION 3.15...3.30)
     project(example LANGUAGES CXX)
 
     set(PYBIND11_FINDPYTHON ON)
@@ -319,11 +319,11 @@ Building with CMake
 
 For C++ codebases that have an existing CMake-based build system, a Python
 extension module can be created with just a few lines of code, as seen above in
-the module section. Pybind11 currently supports a lower minimum if you don't
-use the modern FindPython, though be aware that CMake 3.27 removed the old
-mechanism, so pybind11 will automatically switch if the old mechanism is not
-available. Please opt into the new mechanism if at all possible. Our default
-may change in future versions. This is the minimum required:
+the module section. Pybind11 currently defaults to the old mechanism, though be
+aware that CMake 3.27 removed the old mechanism, so pybind11 will automatically
+switch if the old mechanism is not available. Please opt into the new mechanism
+if at all possible. Our default may change in future versions. This is the
+minimum required:
 
 
 
@@ -332,6 +332,9 @@ may change in future versions. This is the minimum required:
 
 .. versionchanged:: 2.11
    CMake 3.5+ is required.
+
+.. versionchanged:: 2.14
+   CMake 3.15+ is required.
 
 
 Further information can be found at :doc:`cmake/index`.
@@ -444,7 +447,7 @@ See the `Config file`_ docstring for details of relevant CMake variables.
 
 .. code-block:: cmake
 
-    cmake_minimum_required(VERSION 3.4...3.18)
+    cmake_minimum_required(VERSION 3.15...3.30)
     project(example LANGUAGES CXX)
 
     find_package(pybind11 REQUIRED)
@@ -483,14 +486,13 @@ can refer to the same [cmake_example]_ repository for a full sample project
 FindPython mode
 ---------------
 
-CMake 3.12+ (3.15+ recommended, 3.18.2+ ideal) added a new module called
-FindPython that had a highly improved search algorithm and modern targets
-and tools. If you use FindPython, pybind11 will detect this and use the
-existing targets instead:
+Modern CMake (3.18.2+ ideal) added a new module called FindPython that had a
+highly improved search algorithm and modern targets and tools. If you use
+FindPython, pybind11 will detect this and use the existing targets instead:
 
 .. code-block:: cmake
 
-    cmake_minimum_required(VERSION 3.15...3.22)
+    cmake_minimum_required(VERSION 3.15...3.30)
     project(example LANGUAGES CXX)
 
     find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
@@ -541,7 +543,7 @@ available in all modes. The targets provided are:
      Just the "linking" part of pybind11:module
 
    ``pybind11::module``
-     Everything for extension modules - ``pybind11::pybind11`` + ``Python::Module`` (FindPython CMake 3.15+) or ``pybind11::python_link_helper``
+     Everything for extension modules - ``pybind11::pybind11`` + ``Python::Module`` (FindPython) or ``pybind11::python_link_helper``
 
    ``pybind11::embed``
      Everything for embedding the Python interpreter - ``pybind11::pybind11`` + ``Python::Python`` (FindPython) or Python libs
@@ -568,7 +570,7 @@ You can use these targets to build complex applications. For example, the
 
 .. code-block:: cmake
 
-    cmake_minimum_required(VERSION 3.5...3.29)
+    cmake_minimum_required(VERSION 3.15...3.30)
     project(example LANGUAGES CXX)
 
     find_package(pybind11 REQUIRED)  # or add_subdirectory(pybind11)
@@ -626,7 +628,7 @@ information about usage in C++, see :doc:`/advanced/embedding`.
 
 .. code-block:: cmake
 
-    cmake_minimum_required(VERSION 3.5...3.29)
+    cmake_minimum_required(VERSION 3.15...3.30)
     project(example LANGUAGES CXX)
 
     find_package(pybind11 REQUIRED)  # or add_subdirectory(pybind11)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -258,9 +258,9 @@ CMake configure line. (Replace ``$(which python)`` with a path to python if
 your prefer.)
 
 You can alternatively try ``-DPYBIND11_FINDPYTHON=ON``, which will activate the
-new CMake FindPython support instead of pybind11's custom search. Requires
-CMake 3.12+, and 3.15+ or 3.18.2+ are even better. You can set this in your
-``CMakeLists.txt`` before adding or finding pybind11, as well.
+new CMake FindPython support instead of pybind11's custom search. Newer CMake,
+like, 3.18.2+, is recommended. You can set this in your ``CMakeLists.txt``
+before adding or finding pybind11, as well.
 
 Inconsistent detection of Python version in CMake and pybind11
 ==============================================================
@@ -281,11 +281,11 @@ There are three possible solutions:
    from CMake and rely on pybind11 in detecting Python version. If this is not
    possible, the CMake machinery should be called *before* including pybind11.
 2. Set ``PYBIND11_FINDPYTHON`` to ``True`` or use ``find_package(Python
-   COMPONENTS Interpreter Development)`` on modern CMake (3.12+, 3.15+ better,
-   3.18.2+ best). Pybind11 in these cases uses the new CMake FindPython instead
-   of the old, deprecated search tools, and these modules are much better at
-   finding the correct Python. If FindPythonLibs/Interp are not available
-   (CMake 3.27+), then this will be ignored and FindPython will be used.
+   COMPONENTS Interpreter Development)`` on modern CMake ( 3.18.2+ best).
+   Pybind11 in these cases uses the new CMake FindPython instead of the old,
+   deprecated search tools, and these modules are much better at finding the
+   correct Python. If FindPythonLibs/Interp are not available (CMake 3.27+),
+   then this will be ignored and FindPython will be used.
 3. Set ``PYBIND11_NOPYTHON`` to ``TRUE``. Pybind11 will not search for Python.
    However, you will have to use the target-based system, and do more setup
    yourself, because it does not know about or include things that depend on

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,16 +5,7 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-cmake_minimum_required(VERSION 3.5)
-
-# The `cmake_minimum_required(VERSION 3.5...3.29)` syntax does not work with
-# some versions of VS that have a patched CMake 3.11. This forces us to emulate
-# the behavior using the following workaround:
-if(${CMAKE_VERSION} VERSION_LESS 3.29)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.29)
-endif()
+cmake_minimum_required(VERSION 3.15...3.30)
 
 # Filter out items; print an optional message if any items filtered. This ignores extensions.
 #
@@ -76,8 +67,8 @@ project(pybind11_tests CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../tools")
 
 option(PYBIND11_WERROR "Report all warnings as errors" OFF)
-option(DOWNLOAD_EIGEN "Download EIGEN (requires CMake 3.11+)" OFF)
-option(PYBIND11_CUDA_TESTS "Enable building CUDA tests (requires CMake 3.12+)" OFF)
+option(DOWNLOAD_EIGEN "Download EIGEN" OFF)
+option(PYBIND11_CUDA_TESTS "Enable building CUDA tests" OFF)
 set(PYBIND11_TEST_OVERRIDE
     ""
     CACHE STRING "Tests from ;-separated list of *.cpp files will be built instead of all tests")
@@ -249,26 +240,13 @@ endif()
 if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
   # Try loading via newer Eigen's Eigen3Config first (bypassing tools/FindEigen3.cmake).
   # Eigen 3.3.1+ exports a cmake 3.0+ target for handling dependency requirements, but also
-  # produces a fatal error if loaded from a pre-3.0 cmake.
   if(DOWNLOAD_EIGEN)
-    if(CMAKE_VERSION VERSION_LESS 3.11)
-      message(FATAL_ERROR "CMake 3.11+ required when using DOWNLOAD_EIGEN")
-    endif()
-
     include(FetchContent)
     FetchContent_Declare(
       eigen
       GIT_REPOSITORY "${PYBIND11_EIGEN_REPO}"
       GIT_TAG "${PYBIND11_EIGEN_VERSION_HASH}")
-
-    FetchContent_GetProperties(eigen)
-    if(NOT eigen_POPULATED)
-      message(
-        STATUS
-          "Downloading Eigen ${PYBIND11_EIGEN_VERSION_STRING} (${PYBIND11_EIGEN_VERSION_HASH}) from ${PYBIND11_EIGEN_REPO}"
-      )
-      FetchContent_Populate(eigen)
-    endif()
+    FetchContent_MakeAvailable(eigen)
 
     set(EIGEN3_INCLUDE_DIR ${eigen_SOURCE_DIR})
     set(EIGEN3_FOUND TRUE)
@@ -315,8 +293,7 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
     if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
       list(REMOVE_AT PYBIND11_TEST_FILES ${PYBIND11_TEST_FILES_EIGEN_I})
     endif()
-    message(
-      STATUS "Building tests WITHOUT Eigen, use -DDOWNLOAD_EIGEN=ON on CMake 3.11+ to download")
+    message(STATUS "Building tests WITHOUT Eigen, use -DDOWNLOAD_EIGEN=ON to download")
   endif()
 endif()
 
@@ -501,12 +478,10 @@ foreach(target ${test_targets})
 endforeach()
 
 # Provide nice organisation in IDEs
-if(NOT CMAKE_VERSION VERSION_LESS 3.8)
-  source_group(
-    TREE "${CMAKE_CURRENT_SOURCE_DIR}/../include"
-    PREFIX "Header Files"
-    FILES ${PYBIND11_HEADERS})
-endif()
+source_group(
+  TREE "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+  PREFIX "Header Files"
+  FILES ${PYBIND11_HEADERS})
 
 # Make sure pytest is found or produce a warning
 pybind11_find_import(pytest VERSION 3.1)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -241,12 +241,21 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
   # Try loading via newer Eigen's Eigen3Config first (bypassing tools/FindEigen3.cmake).
   # Eigen 3.3.1+ exports a cmake 3.0+ target for handling dependency requirements, but also
   if(DOWNLOAD_EIGEN)
+    if(CMAKE_VERSION VERSION_LESS 3.18)
+      set(_opts)
+    else()
+      set(_opts SOURCE_SUBDIR no-cmake-build)
+    endif()
     include(FetchContent)
     FetchContent_Declare(
       eigen
       GIT_REPOSITORY "${PYBIND11_EIGEN_REPO}"
-      GIT_TAG "${PYBIND11_EIGEN_VERSION_HASH}")
+      GIT_TAG "${PYBIND11_EIGEN_VERSION_HASH}"
+      ${_opts})
     FetchContent_MakeAvailable(eigen)
+    if(NOT CMAKE_VERSION VERSION_LESS 3.18)
+      set(EIGEN3_INCLUDE_DIR "${eigen_SOURCE_DIR}")
+    endif()
 
     set(EIGEN3_INCLUDE_DIR ${eigen_SOURCE_DIR})
     set(EIGEN3_FOUND TRUE)

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -9,7 +9,6 @@ import tarfile
 import zipfile
 
 # These tests must be run explicitly
-# They require CMake 3.15+ (--install)
 
 DIR = os.path.abspath(os.path.dirname(__file__))
 MAIN_DIR = os.path.dirname(os.path.dirname(DIR))

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -10,10 +10,6 @@ name = "pybind11_tests"
 version = "0.0.1"
 dependencies = ["pytest", "pytest-timeout", "numpy", "scipy"]
 
-[tool.scikit-build]
-# Hide a warning while we also support CMake < 3.15
-cmake.version = ">=3.15"
-
 [tool.scikit-build.cmake.define]
 PYBIND11_FINDPYTHON = true
 

--- a/tests/test_cmake_build/installed_embed/CMakeLists.txt
+++ b/tests/test_cmake_build/installed_embed/CMakeLists.txt
@@ -1,13 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
-# The `cmake_minimum_required(VERSION 3.5...3.29)` syntax does not work with
-# some versions of VS that have a patched CMake 3.11. This forces us to emulate
-# the behavior using the following workaround:
-if(${CMAKE_VERSION} VERSION_LESS 3.29)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.29)
-endif()
+cmake_minimum_required(VERSION 3.15...3.30)
 
 project(test_installed_embed CXX)
 

--- a/tests/test_cmake_build/installed_function/CMakeLists.txt
+++ b/tests/test_cmake_build/installed_function/CMakeLists.txt
@@ -1,14 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-project(test_installed_module CXX)
-
-# The `cmake_minimum_required(VERSION 3.5...3.29)` syntax does not work with
-# some versions of VS that have a patched CMake 3.11. This forces us to emulate
-# the behavior using the following workaround:
-if(${CMAKE_VERSION} VERSION_LESS 3.29)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.29)
-endif()
+cmake_minimum_required(VERSION 3.15...3.30)
 
 project(test_installed_function CXX)
 

--- a/tests/test_cmake_build/installed_target/CMakeLists.txt
+++ b/tests/test_cmake_build/installed_target/CMakeLists.txt
@@ -1,13 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
-# The `cmake_minimum_required(VERSION 3.5...3.29)` syntax does not work with
-# some versions of VS that have a patched CMake 3.11. This forces us to emulate
-# the behavior using the following workaround:
-if(${CMAKE_VERSION} VERSION_LESS 3.29)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.29)
-endif()
+cmake_minimum_required(VERSION 3.15...3.30)
 
 project(test_installed_target CXX)
 

--- a/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
+++ b/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
@@ -1,13 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
-# The `cmake_minimum_required(VERSION 3.5...3.29)` syntax does not work with
-# some versions of VS that have a patched CMake 3.11. This forces us to emulate
-# the behavior using the following workaround:
-if(${CMAKE_VERSION} VERSION_LESS 3.29)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.29)
-endif()
+cmake_minimum_required(VERSION 3.15...3.30)
 
 project(test_subdirectory_embed CXX)
 

--- a/tests/test_cmake_build/subdirectory_function/CMakeLists.txt
+++ b/tests/test_cmake_build/subdirectory_function/CMakeLists.txt
@@ -1,13 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
-# The `cmake_minimum_required(VERSION 3.5...3.29)` syntax does not work with
-# some versions of VS that have a patched CMake 3.11. This forces us to emulate
-# the behavior using the following workaround:
-if(${CMAKE_VERSION} VERSION_LESS 3.29)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.29)
-endif()
+cmake_minimum_required(VERSION 3.15...3.30)
 
 project(test_subdirectory_function CXX)
 

--- a/tests/test_cmake_build/subdirectory_target/CMakeLists.txt
+++ b/tests/test_cmake_build/subdirectory_target/CMakeLists.txt
@@ -1,13 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
-# The `cmake_minimum_required(VERSION 3.5...3.29)` syntax does not work with
-# some versions of VS that have a patched CMake 3.11. This forces us to emulate
-# the behavior using the following workaround:
-if(${CMAKE_VERSION} VERSION_LESS 3.29)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.29)
-endif()
+cmake_minimum_required(VERSION 3.15...3.30)
 
 project(test_subdirectory_target CXX)
 

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -18,11 +18,7 @@ Adds the following functions::
 
 #]======================================================]
 
-# CMake 3.10 has an include_guard command, but we can't use that yet
-# include_guard(global) (pre-CMake 3.10)
-if(TARGET pybind11::pybind11)
-  return()
-endif()
+include_guard(GLOBAL)
 
 # If we are in subdirectory mode, all IMPORTED targets must be GLOBAL. If we
 # are in CONFIG mode, they should be "normal" targets instead.
@@ -80,47 +76,31 @@ set_property(
 # Please open an issue if you need to use it; it will be removed if no one
 # needs it.
 if(CMAKE_SYSTEM_NAME MATCHES Emscripten AND NOT _pybind11_no_exceptions)
-  if(CMAKE_VERSION VERSION_LESS 3.13)
-    message(WARNING "CMake 3.13+ is required to build for Emscripten. Some flags will be missing")
+  if(is_config)
+    set(_tmp_config_target pybind11::pybind11_headers)
   else()
-    if(is_config)
-      set(_tmp_config_target pybind11::pybind11_headers)
-    else()
-      set(_tmp_config_target pybind11_headers)
-    endif()
-
-    set_property(
-      TARGET ${_tmp_config_target}
-      APPEND
-      PROPERTY INTERFACE_LINK_OPTIONS -fexceptions)
-    set_property(
-      TARGET ${_tmp_config_target}
-      APPEND
-      PROPERTY INTERFACE_COMPILE_OPTIONS -fexceptions)
-    unset(_tmp_config_target)
+    set(_tmp_config_target pybind11_headers)
   endif()
+
+  set_property(
+    TARGET ${_tmp_config_target}
+    APPEND
+    PROPERTY INTERFACE_LINK_OPTIONS -fexceptions)
+  set_property(
+    TARGET ${_tmp_config_target}
+    APPEND
+    PROPERTY INTERFACE_COMPILE_OPTIONS -fexceptions)
+  unset(_tmp_config_target)
 endif()
 
 # --------------------------- link helper ---------------------------
 
 add_library(pybind11::python_link_helper IMPORTED INTERFACE ${optional_global})
 
-if(CMAKE_VERSION VERSION_LESS 3.13)
-  # In CMake 3.11+, you can set INTERFACE properties via the normal methods, and
-  # this would be simpler.
-  set_property(
-    TARGET pybind11::python_link_helper
-    APPEND
-    PROPERTY INTERFACE_LINK_LIBRARIES "$<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>")
-else()
-  # link_options was added in 3.13+
-  # This is safer, because you are ensured the deduplication pass in CMake will not consider
-  # these separate and remove one but not the other.
-  set_property(
-    TARGET pybind11::python_link_helper
-    APPEND
-    PROPERTY INTERFACE_LINK_OPTIONS "$<$<PLATFORM_ID:Darwin>:LINKER:-undefined,dynamic_lookup>")
-endif()
+set_property(
+  TARGET pybind11::python_link_helper
+  APPEND
+  PROPERTY INTERFACE_LINK_OPTIONS "$<$<PLATFORM_ID:Darwin>:LINKER:-undefined,dynamic_lookup>")
 
 # ------------------------ Windows extras -------------------------
 
@@ -136,22 +116,14 @@ if(MSVC) # That's also clang-cl
 
   # /MP enables multithreaded builds (relevant when there are many files) for MSVC
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") # no Clang no Intel
-    if(CMAKE_VERSION VERSION_LESS 3.11)
-      set_property(
-        TARGET pybind11::windows_extras
-        APPEND
-        PROPERTY INTERFACE_COMPILE_OPTIONS $<$<NOT:$<CONFIG:Debug>>:/MP>)
-    else()
-      # Only set these options for C++ files.  This is important so that, for
-      # instance, projects that include other types of source files like CUDA
-      # .cu files don't get these options propagated to nvcc since that would
-      # cause the build to fail.
-      set_property(
-        TARGET pybind11::windows_extras
-        APPEND
-        PROPERTY INTERFACE_COMPILE_OPTIONS
-                 $<$<NOT:$<CONFIG:Debug>>:$<$<COMPILE_LANGUAGE:CXX>:/MP>>)
-    endif()
+    # Only set these options for C++ files.  This is important so that, for
+    # instance, projects that include other types of source files like CUDA
+    # .cu files don't get these options propagated to nvcc since that would
+    # cause the build to fail.
+    set_property(
+      TARGET pybind11::windows_extras
+      APPEND
+      PROPERTY INTERFACE_COMPILE_OPTIONS $<$<NOT:$<CONFIG:Debug>>:$<$<COMPILE_LANGUAGE:CXX>:/MP>>)
   endif()
 endif()
 
@@ -397,11 +369,7 @@ function(_pybind11_generate_lto target prefer_thin_lto)
     set(is_debug "$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>")
     set(not_debug "$<NOT:${is_debug}>")
     set(cxx_lang "$<COMPILE_LANGUAGE:CXX>")
-    if(MSVC AND CMAKE_VERSION VERSION_LESS 3.11)
-      set(genex "${not_debug}")
-    else()
-      set(genex "$<AND:${not_debug},${cxx_lang}>")
-    endif()
+    set(genex "$<AND:${not_debug},${cxx_lang}>")
     set_property(
       TARGET ${target}
       APPEND
@@ -416,17 +384,10 @@ function(_pybind11_generate_lto target prefer_thin_lto)
   endif()
 
   if(PYBIND11_LTO_LINKER_FLAGS)
-    if(CMAKE_VERSION VERSION_LESS 3.11)
-      set_property(
-        TARGET ${target}
-        APPEND
-        PROPERTY INTERFACE_LINK_LIBRARIES "$<${not_debug}:${PYBIND11_LTO_LINKER_FLAGS}>")
-    else()
-      set_property(
-        TARGET ${target}
-        APPEND
-        PROPERTY INTERFACE_LINK_OPTIONS "$<${not_debug}:${PYBIND11_LTO_LINKER_FLAGS}>")
-    endif()
+    set_property(
+      TARGET ${target}
+      APPEND
+      PROPERTY INTERFACE_LINK_OPTIONS "$<${not_debug}:${PYBIND11_LTO_LINKER_FLAGS}>")
   endif()
 endfunction()
 

--- a/tools/pybind11GuessPythonExtSuffix.cmake
+++ b/tools/pybind11GuessPythonExtSuffix.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15...3.30)
 
 function(pybind11_guess_python_module_extension python)
 

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -5,10 +5,6 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  message(FATAL_ERROR "You cannot use the new FindPython module with CMake < 3.12")
-endif()
-
 include_guard(DIRECTORY)
 
 get_property(
@@ -236,7 +232,6 @@ if(TARGET ${_Python}::Python)
     PROPERTY INTERFACE_LINK_LIBRARIES ${_Python}::Python)
 endif()
 
-# CMake 3.15+ has this
 if(TARGET ${_Python}::Module)
   set_property(
     TARGET pybind11::module

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -5,13 +5,7 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-# include_guard(global) (pre-CMake 3.10)
-if(TARGET pybind11::python_headers)
-  return()
-endif()
-
-# Built-in in CMake 3.5+
-include(CMakeParseArguments)
+include_guard(GLOBAL)
 
 if(pybind11_FIND_QUIETLY)
   set(_pybind11_quiet QUIET)
@@ -116,36 +110,19 @@ if(PYTHON_IS_DEBUG)
     PROPERTY INTERFACE_COMPILE_DEFINITIONS Py_DEBUG)
 endif()
 
-# The <3.11 code here does not support release/debug builds at the same time, like on vcpkg
-if(CMAKE_VERSION VERSION_LESS 3.11)
-  set_property(
-    TARGET pybind11::module
-    APPEND
-    PROPERTY
-      INTERFACE_LINK_LIBRARIES
-      pybind11::python_link_helper
-      "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:$<BUILD_INTERFACE:${PYTHON_LIBRARIES}>>"
-  )
+# The IMPORTED INTERFACE library here is to ensure that "debug" and "release" get processed outside
+# of a generator expression - https://gitlab.kitware.com/cmake/cmake/-/issues/18424, as they are
+# target_link_library keywords rather than real libraries.
+add_library(pybind11::_ClassicPythonLibraries IMPORTED INTERFACE)
+target_link_libraries(pybind11::_ClassicPythonLibraries INTERFACE ${PYTHON_LIBRARIES})
+target_link_libraries(
+  pybind11::module
+  INTERFACE
+    pybind11::python_link_helper
+    "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:pybind11::_ClassicPythonLibraries>")
 
-  set_property(
-    TARGET pybind11::embed
-    APPEND
-    PROPERTY INTERFACE_LINK_LIBRARIES pybind11::pybind11 $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
-else()
-  # The IMPORTED INTERFACE library here is to ensure that "debug" and "release" get processed outside
-  # of a generator expression - https://gitlab.kitware.com/cmake/cmake/-/issues/18424, as they are
-  # target_link_library keywords rather than real libraries.
-  add_library(pybind11::_ClassicPythonLibraries IMPORTED INTERFACE)
-  target_link_libraries(pybind11::_ClassicPythonLibraries INTERFACE ${PYTHON_LIBRARIES})
-  target_link_libraries(
-    pybind11::module
-    INTERFACE
-      pybind11::python_link_helper
-      "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:pybind11::_ClassicPythonLibraries>")
-
-  target_link_libraries(pybind11::embed INTERFACE pybind11::pybind11
-                                                  pybind11::_ClassicPythonLibraries)
-endif()
+target_link_libraries(pybind11::embed INTERFACE pybind11::pybind11
+                                                pybind11::_ClassicPythonLibraries)
 
 function(pybind11_extension name)
   # The prefix and extension are provided by FindPythonLibsNew.cmake

--- a/tools/test-pybind11GuessPythonExtSuffix.cmake
+++ b/tools/test-pybind11GuessPythonExtSuffix.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15...3.30)
 
 # Tests for pybind11_guess_python_module_extension
 # Run using `cmake -P tools/test-pybind11GuessPythonExtSuffix.cmake`


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Remove support for ancient versions of CMake.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* CMake 3.15+ is now required.
```

<!-- If the upgrade guide needs updating, note that here too -->
