### PR TITLE
Revert "fix: quote paths from pybind11-config"

### DIFF
--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import shlex
 import sys
 import sysconfig
 
@@ -23,7 +22,7 @@ def print_includes() -> None:
         if d and d not in unique_dirs:
             unique_dirs.append(d)
 
-    print(" ".join(shlex.quote(f"-I{d}") for d in unique_dirs))
+    print(" ".join("-I" + d for d in unique_dirs))
 
 
 def main() -> None:
@@ -55,9 +54,9 @@ def main() -> None:
     if args.includes:
         print_includes()
     if args.cmakedir:
-        print(shlex.quote(get_cmake_dir()))
+        print(get_cmake_dir())
     if args.pkgconfigdir:
-        print(shlex.quote(get_pkgconfig_dir()))
+        print(get_pkgconfig_dir())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reverts pybind/pybind11#5302. We'll go with #4874 instead.