### PR TITLE
add `<ranges>` support for `py::tuple` and `py::list`

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -271,6 +271,12 @@ PYBIND11_WARNING_DISABLE_MSVC(4505)
 #    endif
 #endif
 
+#if defined(PYBIND11_CPP20)
+#   if __has_include(<ranges>)  // __has_include has been part of C++17, no need to check it
+#       define PYBIND11_HAS_RANGES
+#   endif
+#endif
+
 #include <Python.h>
 #if PY_VERSION_HEX < 0x03080000
 #    error "PYTHON < 3.8 IS UNSUPPORTED. pybind11 v2.13 was the last to support Python 3.7."

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -272,9 +272,9 @@ PYBIND11_WARNING_DISABLE_MSVC(4505)
 #endif
 
 #if defined(PYBIND11_CPP20)
-#   if __has_include(<ranges>)  // __has_include has been part of C++17, no need to check it
-#       define PYBIND11_HAS_RANGES
-#   endif
+#    if __has_include(<ranges>) // __has_include has been part of C++17, no need to check it
+#        define PYBIND11_HAS_RANGES
+#    endif
 #endif
 
 #include <Python.h>

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -273,7 +273,13 @@ PYBIND11_WARNING_DISABLE_MSVC(4505)
 
 #if defined(PYBIND11_CPP20)
 #    if __has_include(<ranges>) // __has_include has been part of C++17, no need to check it
-#        define PYBIND11_HAS_RANGES
+#        if !defined(PYBIND11_COMPILER_CLANG)
+#            define PYBIND11_HAS_RANGES
+#        else
+#            if __clang_major__ >= 16 // llvm/llvm-project#52696
+#                define PYBIND11_HAS_RANGES
+#            endif
+#        endif
 #    endif
 #endif
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -271,18 +271,6 @@ PYBIND11_WARNING_DISABLE_MSVC(4505)
 #    endif
 #endif
 
-#if defined(PYBIND11_CPP20)
-#    if __has_include(<ranges>) // __has_include has been part of C++17, no need to check it
-#        if !defined(PYBIND11_COMPILER_CLANG)
-#            define PYBIND11_HAS_RANGES
-#        else
-#            if __clang_major__ >= 16 // llvm/llvm-project#52696
-#                define PYBIND11_HAS_RANGES
-#            endif
-#        endif
-#    endif
-#endif
-
 #include <Python.h>
 #if PY_VERSION_HEX < 0x03080000
 #    error "PYTHON < 3.8 IS UNSUPPORTED. pybind11 v2.13 was the last to support Python 3.7."

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1259,6 +1259,7 @@ protected:
     using pointer = arrow_proxy<const handle>;
 
     sequence_fast_readonly(handle obj, ssize_t n) : ptr(PySequence_Fast_ITEMS(obj.ptr()) + n) {}
+    sequence_fast_readonly() = default;
 
     // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
     reference dereference() const { return *ptr; }
@@ -1281,6 +1282,7 @@ protected:
     using pointer = arrow_proxy<const sequence_accessor>;
 
     sequence_slow_readwrite(handle obj, ssize_t index) : obj(obj), index(index) {}
+    sequence_slow_readwrite() = default;
 
     reference dereference() const { return {obj, static_cast<size_t>(index)}; }
     void increment() { ++index; }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -13,7 +13,8 @@
 
 #include <utility>
 
-#if defined(PYBIND11_CPP20) && __has_include(<ranges>) // __has_include has been part of C++17, no need to check it
+#if defined(PYBIND11_CPP20)                                                                       \
+    && __has_include(<ranges>) // __has_include has been part of C++17, no need to check it
 #    if !defined(PYBIND11_COMPILER_CLANG) || __clang_major__ >= 16 // llvm/llvm-project#52696
 #        define PYBIND11_TEST_PYTYPES_HAS_RANGES
 #        include <ranges>

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -12,6 +12,9 @@
 #include "pybind11_tests.h"
 
 #include <utility>
+#if defined(PYBIND11_HAS_RANGES)
+#   include <ranges>
+#endif
 
 namespace external {
 namespace detail {
@@ -922,5 +925,42 @@ TEST_SUBMODULE(pytypes, m) {
     m.attr("defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL") = true;
 #else
     m.attr("defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL") = false;
+#endif
+
+#if defined(PYBIND11_HAS_RANGES) // test_ranges
+    m.attr("defined_PYBIND11_HAS_RANGES") = true;
+    m.def("iterator_default_initialization", []() {
+        using TupleIterator = decltype(py::tuple{}.begin());
+        using ListIterator = decltype(py::list{}.begin());
+        using DictIterator = decltype(py::dict{}.begin());
+        return py::bool_(TupleIterator{} == TupleIterator{} && 
+            ListIterator{} == ListIterator{} && 
+            DictIterator{} == DictIterator{}); // value initialization result must compared as true
+    });
+
+    m.def("transform_tuple_plus_one", [](py::tuple& tpl) {
+        static_assert(std::ranges::random_access_range<py::tuple>);
+        for (auto it : tpl | std::views::transform(
+            [](auto& o) { return py::cast<int>(o) + 1; })) {
+            py::print(it);
+        }
+    });
+    m.def("transform_list_plus_one", [](py::list& lst) {
+        static_assert(std::ranges::random_access_range<py::list>);
+        for (auto it : lst | std::views::transform(
+            [](auto& o) { return py::cast<int>(o) + 1; })) {
+            py::print(it);
+        }
+    });
+    m.def("transform_dict_plus_one", [](py::dict& dct) {
+        static_assert(std::ranges::forward_range<py::dict>);
+        for (auto it : dct | std::views::transform([](auto& o) {
+                return std::pair{py::cast<int>(o.first) + 1, py::cast<int>(o.second) + 1};
+            })) {
+                py::print("{} : {}"_s.format(it.first, it.second));
+            }
+    });
+#else
+    m.attr("defined_PYBIND11_HAS_RANGES") = false;
 #endif
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -12,7 +12,20 @@
 #include "pybind11_tests.h"
 
 #include <utility>
-#if defined(PYBIND11_HAS_RANGES)
+
+#if defined(PYBIND11_CPP20)
+#    if __has_include(<ranges>) // __has_include has been part of C++17, no need to check it
+#        if !defined(PYBIND11_COMPILER_CLANG)
+#            define PYBIND11_TEST_PYTYPES_HAS_RANGES
+#        else
+#            if __clang_major__ >= 16 // llvm/llvm-project#52696
+#                define PYBIND11_TEST_PYTYPES_HAS_RANGES
+#            endif
+#        endif
+#    endif
+#endif
+
+#if defined(PYBIND11_TEST_PYTYPES_HAS_RANGES)
 #    include <ranges>
 #endif
 
@@ -927,8 +940,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.attr("defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL") = false;
 #endif
 
-#if defined(PYBIND11_HAS_RANGES) // test_ranges
-    m.attr("defined_PYBIND11_HAS_RANGES") = true;
+#if defined(PYBIND11_TEST_PYTYPES_HAS_RANGES) // test_ranges
     m.def("iterator_default_initialization", []() {
         using TupleIterator = decltype(py::tuple{}.begin());
         using ListIterator = decltype(py::list{}.begin());
@@ -960,6 +972,7 @@ TEST_SUBMODULE(pytypes, m) {
             py::print("{} : {}"_s.format(it.first, it.second));
         }
     });
+    m.attr("defined_PYBIND11_TEST_PYTYPES_HAS_RANGES") = true;
 #else
     m.attr("defined_PYBIND11_HAS_RANGES") = false;
 #endif

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -13,7 +13,7 @@
 
 #include <utility>
 #if defined(PYBIND11_HAS_RANGES)
-#   include <ranges>
+#    include <ranges>
 #endif
 
 namespace external {
@@ -933,32 +933,32 @@ TEST_SUBMODULE(pytypes, m) {
         using TupleIterator = decltype(py::tuple{}.begin());
         using ListIterator = decltype(py::list{}.begin());
         using DictIterator = decltype(py::dict{}.begin());
-        return py::bool_(TupleIterator{} == TupleIterator{} && 
-            ListIterator{} == ListIterator{} && 
-            DictIterator{} == DictIterator{}); // value initialization result must compared as true
+        return py::bool_(
+            TupleIterator{} == TupleIterator{} && ListIterator{} == ListIterator{}
+            && DictIterator{}
+                   == DictIterator{}); // value initialization result must compared as true
     });
 
-    m.def("transform_tuple_plus_one", [](py::tuple& tpl) {
+    m.def("transform_tuple_plus_one", [](py::tuple &tpl) {
         static_assert(std::ranges::random_access_range<py::tuple>);
-        for (auto it : tpl | std::views::transform(
-            [](auto& o) { return py::cast<int>(o) + 1; })) {
+        for (auto it : tpl | std::views::transform([](auto &o) { return py::cast<int>(o) + 1; })) {
             py::print(it);
         }
     });
-    m.def("transform_list_plus_one", [](py::list& lst) {
+    m.def("transform_list_plus_one", [](py::list &lst) {
         static_assert(std::ranges::random_access_range<py::list>);
-        for (auto it : lst | std::views::transform(
-            [](auto& o) { return py::cast<int>(o) + 1; })) {
+        for (auto it : lst | std::views::transform([](auto &o) { return py::cast<int>(o) + 1; })) {
             py::print(it);
         }
     });
-    m.def("transform_dict_plus_one", [](py::dict& dct) {
+    m.def("transform_dict_plus_one", [](py::dict &dct) {
         static_assert(std::ranges::forward_range<py::dict>);
-        for (auto it : dct | std::views::transform([](auto& o) {
-                return std::pair{py::cast<int>(o.first) + 1, py::cast<int>(o.second) + 1};
-            })) {
-                py::print("{} : {}"_s.format(it.first, it.second));
-            }
+        for (auto it : dct | std::views::transform([](auto &o) {
+                           return std::pair{py::cast<int>(o.first) + 1,
+                                            py::cast<int>(o.second) + 1};
+                       })) {
+            py::print("{} : {}"_s.format(it.first, it.second));
+        }
     });
 #else
     m.attr("defined_PYBIND11_HAS_RANGES") = false;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -13,8 +13,8 @@
 
 #include <utility>
 
-#if defined(PYBIND11_CPP20)                                                                       \
-    && __has_include(<ranges>) // __has_include has been part of C++17, no need to check it
+//__has_include has been part of C++17, no need to check it
+#if defined(PYBIND11_CPP20) && __has_include(<ranges>)
 #    if !defined(PYBIND11_COMPILER_CLANG) || __clang_major__ >= 16 // llvm/llvm-project#52696
 #        define PYBIND11_TEST_PYTYPES_HAS_RANGES
 #        include <ranges>

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -13,20 +13,11 @@
 
 #include <utility>
 
-#if defined(PYBIND11_CPP20)
-#    if __has_include(<ranges>) // __has_include has been part of C++17, no need to check it
-#        if !defined(PYBIND11_COMPILER_CLANG)
-#            define PYBIND11_TEST_PYTYPES_HAS_RANGES
-#        else
-#            if __clang_major__ >= 16 // llvm/llvm-project#52696
-#                define PYBIND11_TEST_PYTYPES_HAS_RANGES
-#            endif
-#        endif
+#if defined(PYBIND11_CPP20) && __has_include(<ranges>) // __has_include has been part of C++17, no need to check it
+#    if !defined(PYBIND11_COMPILER_CLANG) || __clang_major__ >= 16 // llvm/llvm-project#52696
+#        define PYBIND11_TEST_PYTYPES_HAS_RANGES
+#        include <ranges>
 #    endif
-#endif
-
-#if defined(PYBIND11_TEST_PYTYPES_HAS_RANGES)
-#    include <ranges>
 #endif
 
 namespace external {

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1049,9 +1049,9 @@ def test_typevar(doc):
 
     assert doc(m.annotate_object_to_T) == "annotate_object_to_T(arg0: object) -> T"
 
+
 @pytest.mark.skipif(
-    not m.defined_PYBIND11_HAS_RANGES, 
-    reason="C++20 <ranges> not available."
+    not m.defined_PYBIND11_HAS_RANGES, reason="C++20 <ranges> not available."
 )
 def test_ranges(capture):
     assert m.iterator_default_initialization
@@ -1060,12 +1060,13 @@ def test_ranges(capture):
         m.transform_tuple_plus_one((1, 2, 3))
 
     assert (
-        capture.unordered 
+        capture.unordered
         == """
         2
         3
         4
-    """)
+    """
+    )
 
     with capture:
         m.transform_list_plus_one([1, 2, 3])
@@ -1076,7 +1077,8 @@ def test_ranges(capture):
         2
         3
         4
-    """)
+    """
+    )
 
     with capture:
         m.transform_dict_plus_one({1: 2, 3: 4, 5: 6})
@@ -1087,6 +1089,5 @@ def test_ranges(capture):
         2 : 3
         4 : 5
         6 : 7
-    """)
-
-
+    """
+    )

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1048,3 +1048,45 @@ def test_typevar(doc):
     assert doc(m.annotate_listT_to_T) == "annotate_listT_to_T(arg0: list[T]) -> T"
 
     assert doc(m.annotate_object_to_T) == "annotate_object_to_T(arg0: object) -> T"
+
+@pytest.mark.skipif(
+    not m.defined_PYBIND11_HAS_RANGES, 
+    reason="C++20 <ranges> not available."
+)
+def test_ranges(capture):
+    assert m.iterator_default_initialization
+
+    with capture:
+        m.transform_tuple_plus_one((1, 2, 3))
+
+    assert (
+        capture.unordered 
+        == """
+        2
+        3
+        4
+    """)
+
+    with capture:
+        m.transform_list_plus_one([1, 2, 3])
+
+    assert (
+        capture.unordered
+        == """
+        2
+        3
+        4
+    """)
+
+    with capture:
+        m.transform_dict_plus_one({1: 2, 3: 4, 5: 6})
+
+    assert (
+        capture.unordered
+        == """
+        2 : 3
+        4 : 5
+        6 : 7
+    """)
+
+

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1054,41 +1054,39 @@ def test_typevar(doc):
     not m.defined_PYBIND11_TEST_PYTYPES_HAS_RANGES,
     reason="<ranges> not available.",
 )
-def test_ranges(capture):
-    assert m.iterator_default_initialization
+@pytest.mark.parametrize(
+    ("tested_tuple", "expected"),
+    [((1,), [2]), ((3, 4), [4, 5]), ((7, 8, 9), [8, 9, 10])],
+)
+def test_tuple_ranges(tested_tuple, expected):
+    assert m.tuple_iterator_default_initialization()
+    assert m.transform_tuple_plus_one(tested_tuple) == expected
 
-    with capture:
-        m.transform_tuple_plus_one((1, 2, 3))
 
-    assert (
-        capture.unordered
-        == """
-        2
-        3
-        4
-    """
-    )
+@pytest.mark.skipif(
+    not m.defined_PYBIND11_TEST_PYTYPES_HAS_RANGES,
+    reason="<ranges> not available.",
+)
+@pytest.mark.parametrize(
+    ("tested_list", "expected"), [([1], [2]), ([3, 4], [4, 5]), ([7, 8, 9], [8, 9, 10])]
+)
+def test_list_ranges(tested_list, expected):
+    assert m.list_iterator_default_initialization()
+    assert m.transform_list_plus_one(tested_list) == expected
 
-    with capture:
-        m.transform_list_plus_one([1, 2, 3])
 
-    assert (
-        capture.unordered
-        == """
-        2
-        3
-        4
-    """
-    )
-
-    with capture:
-        m.transform_dict_plus_one({1: 2, 3: 4, 5: 6})
-
-    assert (
-        capture.unordered
-        == """
-        2 : 3
-        4 : 5
-        6 : 7
-    """
-    )
+@pytest.mark.skipif(
+    not m.defined_PYBIND11_TEST_PYTYPES_HAS_RANGES,
+    reason="<ranges> not available.",
+)
+@pytest.mark.parametrize(
+    ("tested_dict", "expected"),
+    [
+        ({1: 2}, [(2, 3)]),
+        ({3: 4, 5: 6}, [(4, 5), (6, 7)]),
+        ({7: 8, 9: 10, 11: 12}, [(8, 9), (10, 11), (12, 13)]),
+    ],
+)
+def test_dict_ranges(tested_dict, expected):
+    assert m.dict_iterator_default_initialization()
+    assert m.transform_dict_plus_one(tested_dict) == expected

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1051,7 +1051,8 @@ def test_typevar(doc):
 
 
 @pytest.mark.skipif(
-    not m.defined_PYBIND11_HAS_RANGES, reason="C++20 <ranges> not available."
+    not m.defined_PYBIND11_TEST_PYTYPES_HAS_RANGES,
+    reason="<ranges> not available.",
 )
 def test_ranges(capture):
     assert m.iterator_default_initialization


### PR DESCRIPTION
## Description
It seems that #4127 has made a mistake there: actually [p2325r3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2325r3.html) says nothing about C++ sentinels (which always requires `semiregular`), so it's necessary to add a default constructor for `iterator_policies` classes.

Moreover, [`forward_iterator` concept](http://eel.is/c++draft/iterator.concept.forward#2) requires that:
> Value-initialized iterators of the same type may be compared and shall compare equal to other value-initialized iterators of the same type.

and it's tested here:
https://github.com/ObeliskGate/pybind11/blob/74615a04105366647261da83f2980cd5df01b3cd/tests/test_pytypes.cpp#L932-L940
, together with other simple tests.

## Suggested changelog entry:
add `<ranges>` support for `py::tuple` and `py::list`