### PR TITLE
[smart_holder] Add and use `instance::is_alias` (to clean up `struct smart_holder`)

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -858,8 +858,12 @@ public:
     using base::value;
 
     bool load(handle src, bool convert) {
-        return base::template load_impl<copyable_holder_caster<type, std::shared_ptr<type>>>(
-            src, convert);
+        if (base::template load_impl<copyable_holder_caster<type, std::shared_ptr<type>>>(
+                src, convert)) {
+            sh_load_helper.maybe_set_python_instance_is_alias(src);
+            return true;
+        }
+        return false;
     }
 
     explicit operator std::shared_ptr<type> *() {
@@ -914,6 +918,7 @@ protected:
     void load_value(value_and_holder &&v_h) {
         if (typeinfo->holder_enum_v == detail::holder_enum_t::smart_holder) {
             sh_load_helper.loaded_v_h = v_h;
+            sh_load_helper.was_populated = true;
             value = sh_load_helper.get_void_ptr_or_nullptr();
             return;
         }
@@ -1041,14 +1046,19 @@ public:
     }
 
     bool load(handle src, bool convert) {
-        return base::template load_impl<
-            move_only_holder_caster<type, std::unique_ptr<type, deleter>>>(src, convert);
+        if (base::template load_impl<
+                move_only_holder_caster<type, std::unique_ptr<type, deleter>>>(src, convert)) {
+            sh_load_helper.maybe_set_python_instance_is_alias(src);
+            return true;
+        }
+        return false;
     }
 
     void load_value(value_and_holder &&v_h) {
         if (typeinfo->holder_enum_v == detail::holder_enum_t::smart_holder) {
             sh_load_helper.loaded_v_h = v_h;
             sh_load_helper.loaded_v_h.type = typeinfo;
+            sh_load_helper.was_populated = true;
             value = sh_load_helper.get_void_ptr_or_nullptr();
             return;
         }

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -637,6 +637,11 @@ struct instance {
     bool simple_instance_registered : 1;
     /// If true, get_internals().patients has an entry for this object
     bool has_patients : 1;
+// Cannot use PYBIND11_INTERNALS_VERSION >= 6 here without refactoring.
+#if PYBIND11_VERSION_MAJOR >= 3
+    /// If true, this Python object needs to be kept alive for the lifetime of the C++ value.
+    bool is_alias : 1;
+#endif
 
     /// Initializes all of the above type/values/holders data (but not the instance values
     /// themselves)

--- a/include/pybind11/detail/struct_smart_holder.h
+++ b/include/pybind11/detail/struct_smart_holder.h
@@ -136,7 +136,6 @@ struct smart_holder {
     bool vptr_is_external_shared_ptr : 1;
     bool is_populated : 1;
     bool is_disowned : 1;
-    bool pointee_depends_on_holder_owner : 1; // SMART_HOLDER_WIP: See PR #2839.
 
     // Design choice: smart_holder is movable but not copyable.
     smart_holder(smart_holder &&) = default;
@@ -146,8 +145,7 @@ struct smart_holder {
 
     smart_holder()
         : vptr_is_using_noop_deleter{false}, vptr_is_using_builtin_delete{false},
-          vptr_is_external_shared_ptr{false}, is_populated{false}, is_disowned{false},
-          pointee_depends_on_holder_owner{false} {}
+          vptr_is_external_shared_ptr{false}, is_populated{false}, is_disowned{false} {}
 
     bool has_pointee() const { return vptr != nullptr; }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2267,7 +2267,8 @@ private:
         }
         auto *uninitialized_location = std::addressof(v_h.holder<holder_type>());
         auto *value_ptr_w_t = v_h.value_ptr<type>();
-        bool pointee_depends_on_holder_owner
+        // Try downcast from `type` to `type_alias`:
+        inst->is_alias
             = detail::dynamic_raw_ptr_cast_if_possible<type_alias>(value_ptr_w_t) != nullptr;
         if (holder_void_ptr) {
             // Note: inst->owned ignored.
@@ -2277,14 +2278,12 @@ private:
                        uninitialized_location, value_ptr_w_t, value_ptr_w_t)) {
             if (inst->owned) {
                 new (uninitialized_location) holder_type(holder_type::from_raw_ptr_take_ownership(
-                    value_ptr_w_t, /*void_cast_raw_ptr*/ pointee_depends_on_holder_owner));
+                    value_ptr_w_t, /*void_cast_raw_ptr*/ inst->is_alias));
             } else {
                 new (uninitialized_location)
                     holder_type(holder_type::from_raw_ptr_unowned(value_ptr_w_t));
             }
         }
-        v_h.holder<holder_type>().pointee_depends_on_holder_owner
-            = pointee_depends_on_holder_owner;
         v_h.set_holder_constructed();
     }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Clean up `struct smart_holder`:

* Add `instance::is_alias` (similar to #2839, but everything else here is different).
* Migrate from using `smart_holder::pointee_depends_on_holder_owner` to `instance::is_alias`.
* Remove `smart_holder::pointee_depends_on_holder_owner`.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
