### PR TITLE
fix: never use `..` in a header include

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include "../attr.h"
-#include "../options.h"
+#include <pybind11/attr.h>
+#include <pybind11/options.h>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -12,7 +12,7 @@
 #include "common.h"
 
 #if defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
-#    include "../gil.h"
+#    include <pybind11/gil.h>
 #endif
 
 #include <pybind11/pytypes.h>

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -15,7 +15,7 @@
 #    include "../gil.h"
 #endif
 
-#include "../pytypes.h"
+#include <pybind11/pytypes.h>
 
 #include <exception>
 #include <mutex>

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -9,7 +9,8 @@
 
 #pragma once
 
-#include "../pytypes.h"
+#include <pybind11/pytypes.h>
+
 #include "common.h"
 #include "descr.h"
 #include "internals.h"

--- a/include/pybind11/eigen/matrix.h
+++ b/include/pybind11/eigen/matrix.h
@@ -9,7 +9,8 @@
 
 #pragma once
 
-#include "../numpy.h"
+#include <pybind11/numpy.h>
+
 #include "common.h"
 
 /* HINT: To suppress warnings originating from the Eigen headers, use -isystem.

--- a/include/pybind11/eigen/tensor.h
+++ b/include/pybind11/eigen/tensor.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include "../numpy.h"
+#include <pybind11/numpy.h>
+
 #include "common.h"
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include "../pybind11.h"
-#include "../detail/common.h"
-#include "../detail/descr.h"
-#include "../cast.h"
-#include "../pytypes.h"
+#include <pybind11/cast.h>
+#include <pybind11/detail/common.h>
+#include <pybind11/detail/descr.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
 
 #include <string>
 


### PR DESCRIPTION
## Description

You are not allowed to use `..` in a current-directory `""` include. This style of include is really designed to allow local files in the same directory (like `.inl` files) to be injected into the current location. `<>` includes are designed for headers. It's currently working in most cases due to implementation details.

This is currently broken, however, if you use a long path prefix on Windows (`\\?\`). For example, if you pass the include as `/I:system \\?\C:\pybind11\include`, then the compiler constructs the path as `\\?\C:\pybind11\include\pybind11\detail\../thing.h` - but that's invalid, as `..` is not processed as a "up one" in a Windows long path, but as a directory named `..`. Long paths are being used in specific situations (https://github.com/pypa/cibuildwheel/issues/1975), breaking pybind11 usage.

This is the minimum to fix that. Ideally, files should never include something from a parent folder, and (at least) public includes should be included via the public include path, but this is the minimum to fix pybind11 for MSVC.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fix includes when using Windows long paths (`\\?\` prefix)
```

<!-- If the upgrade guide needs updating, note that here too -->
