### PR TITLE
Properly translate C++ exception to Python exception when creating Python buffer from wrapped object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(PYBIND11_HEADERS
     include/pybind11/detail/type_caster_base.h
     include/pybind11/detail/typeid.h
     include/pybind11/detail/value_and_holder.h
+    include/pybind11/detail/exception_translation.h
     include/pybind11/attr.h
     include/pybind11/buffer_info.h
     include/pybind11/cast.h

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -591,6 +591,9 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
         raise_from(PyExc_BufferError, "Error getting buffer");
         return -1;
     }
+    if (info == nullptr) {
+        pybind11_fail("FATAL UNEXPECTED SITUATION: tinfo->get_buffer() returned nullptr.");
+    }
 
     if ((flags & PyBUF_WRITABLE) == PyBUF_WRITABLE && info->readonly) {
         delete info;

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -581,7 +581,15 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
         return -1;
     }
     std::memset(view, 0, sizeof(Py_buffer));
-    buffer_info *info = tinfo->get_buffer(obj, tinfo->get_buffer_data);
+    buffer_info *info = nullptr;
+    try {
+        info = tinfo->get_buffer(obj, tinfo->get_buffer_data);
+    } catch (...) {
+        try_translate_exceptions();
+        raise_from(PyExc_BufferError, "Error getting buffer");
+        return -1;
+    }
+
     if ((flags & PyBUF_WRITABLE) == PyBUF_WRITABLE && info->readonly) {
         delete info;
         // view->obj = nullptr;  // Was just memset to 0, so not necessary

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -11,6 +11,7 @@
 
 #include "../attr.h"
 #include "../options.h"
+#include "exception_translation.h"
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/exception_translation.h
+++ b/include/pybind11/detail/exception_translation.h
@@ -1,7 +1,7 @@
 /*
-    pybind11/detail/exception_translation.h: means to translate C++ exceptions to Python exception
+    pybind11/detail/exception_translation.h: means to translate C++ exceptions to Python exceptions
 
-    Copyright (c) 2024-2024 The Pybind Development Team.
+    Copyright (c) 2024 The Pybind Development Team.
 
     All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file.

--- a/include/pybind11/detail/exception_translation.h
+++ b/include/pybind11/detail/exception_translation.h
@@ -33,7 +33,6 @@ inline bool apply_exception_translators(std::forward_list<ExceptionTranslator> &
     return false;
 }
 
-
 inline void try_translate_exceptions() {
     /* When an exception is caught, give each registered exception
         translator a chance to translate it to a Python exception. First

--- a/include/pybind11/detail/exception_translation.h
+++ b/include/pybind11/detail/exception_translation.h
@@ -1,0 +1,72 @@
+/*
+    pybind11/detail/exception_translation.h: means to translate C++ exceptions to Python exception
+
+    Copyright (c) 2024-2024 The Pybind Development Team.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include "common.h"
+#include "internals.h"
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+// Apply all the extensions translators from a list
+// Return true if one of the translators completed without raising an exception
+// itself. Return of false indicates that if there are other translators
+// available, they should be tried.
+inline bool apply_exception_translators(std::forward_list<ExceptionTranslator> &translators) {
+    auto last_exception = std::current_exception();
+
+    for (auto &translator : translators) {
+        try {
+            translator(last_exception);
+            return true;
+        } catch (...) {
+            last_exception = std::current_exception();
+        }
+    }
+    return false;
+}
+
+
+inline void try_translate_exceptions() {
+    /* When an exception is caught, give each registered exception
+        translator a chance to translate it to a Python exception. First
+        all module-local translators will be tried in reverse order of
+        registration. If none of the module-locale translators handle
+        the exception (or there are no module-locale translators) then
+        the global translators will be tried, also in reverse order of
+        registration.
+
+        A translator may choose to do one of the following:
+
+        - catch the exception and call py::set_error()
+            to set a standard (or custom) Python exception, or
+        - do nothing and let the exception fall through to the next translator, or
+        - delegate translation to the next translator by throwing a new type of exception.
+        */
+
+    bool handled = with_internals([&](internals &internals) {
+        auto &local_exception_translators = get_local_internals().registered_exception_translators;
+        if (detail::apply_exception_translators(local_exception_translators)) {
+            return true;
+        }
+        auto &exception_translators = internals.registered_exception_translators;
+        if (detail::apply_exception_translators(exception_translators)) {
+            return true;
+        }
+        return false;
+    });
+
+    if (!handled) {
+        set_error(PyExc_SystemError, "Exception escaped from default exception translator!");
+    }
+}
+
+PYBIND11_NAMESPACE_END(detail)
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -761,8 +761,7 @@ inline void try_translate_exceptions() {
         */
 
     bool handled = with_internals([&](internals &internals) {
-        auto &local_exception_translators
-            = get_local_internals().registered_exception_translators;
+        auto &local_exception_translators = get_local_internals().registered_exception_translators;
         if (detail::apply_exception_translators(local_exception_translators)) {
             return true;
         }

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -338,6 +338,24 @@ inline internals **&get_internals_pp() {
     return internals_pp;
 }
 
+// Apply all the extensions translators from a list
+// Return true if one of the translators completed without raising an exception
+// itself. Return of false indicates that if there are other translators
+// available, they should be tried.
+inline bool apply_exception_translators(std::forward_list<ExceptionTranslator> &translators) {
+    auto last_exception = std::current_exception();
+
+    for (auto &translator : translators) {
+        try {
+            translator(last_exception);
+            return true;
+        } catch (...) {
+            last_exception = std::current_exception();
+        }
+    }
+    return false;
+}
+
 // forward decl
 inline void translate_exception(std::exception_ptr);
 
@@ -723,6 +741,41 @@ inline const char *get_function_record_capsule_name() {
 inline bool is_function_record_capsule(const capsule &cap) {
     // Pointer equality as we rely on internals() to ensure unique pointers
     return cap.name() == get_function_record_capsule_name();
+}
+
+inline void try_translate_exceptions() {
+    /* When an exception is caught, give each registered exception
+        translator a chance to translate it to a Python exception. First
+        all module-local translators will be tried in reverse order of
+        registration. If none of the module-locale translators handle
+        the exception (or there are no module-locale translators) then
+        the global translators will be tried, also in reverse order of
+        registration.
+
+        A translator may choose to do one of the following:
+
+        - catch the exception and call py::set_error()
+            to set a standard (or custom) Python exception, or
+        - do nothing and let the exception fall through to the next translator, or
+        - delegate translation to the next translator by throwing a new type of exception.
+        */
+
+    bool handled = with_internals([&](internals &internals) {
+        auto &local_exception_translators
+            = get_local_internals().registered_exception_translators;
+        if (detail::apply_exception_translators(local_exception_translators)) {
+            return true;
+        }
+        auto &exception_translators = internals.registered_exception_translators;
+        if (detail::apply_exception_translators(exception_translators)) {
+            return true;
+        }
+        return false;
+    });
+
+    if (!handled) {
+        set_error(PyExc_SystemError, "Exception escaped from default exception translator!");
+    }
 }
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -9,6 +9,7 @@
 */
 
 #pragma once
+#include "detail/exception_translation.h"
 
 #include "detail/class.h"
 #include "detail/init.h"

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -9,9 +9,8 @@
 */
 
 #pragma once
-#include "detail/exception_translation.h"
-
 #include "detail/class.h"
+#include "detail/exception_translation.h"
 #include "detail/init.h"
 #include "attr.h"
 #include "gil.h"

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -95,24 +95,6 @@ inline std::string replace_newlines_and_squash(const char *text) {
     return result.substr(str_begin, str_range);
 }
 
-// Apply all the extensions translators from a list
-// Return true if one of the translators completed without raising an exception
-// itself. Return of false indicates that if there are other translators
-// available, they should be tried.
-inline bool apply_exception_translators(std::forward_list<ExceptionTranslator> &translators) {
-    auto last_exception = std::current_exception();
-
-    for (auto &translator : translators) {
-        try {
-            translator(last_exception);
-            return true;
-        } catch (...) {
-            last_exception = std::current_exception();
-        }
-    }
-    return false;
-}
-
 #if defined(_MSC_VER)
 #    define PYBIND11_COMPAT_STRDUP _strdup
 #else
@@ -1038,40 +1020,7 @@ protected:
             throw;
 #endif
         } catch (...) {
-            /* When an exception is caught, give each registered exception
-               translator a chance to translate it to a Python exception. First
-               all module-local translators will be tried in reverse order of
-               registration. If none of the module-locale translators handle
-               the exception (or there are no module-locale translators) then
-               the global translators will be tried, also in reverse order of
-               registration.
-
-               A translator may choose to do one of the following:
-
-                - catch the exception and call py::set_error()
-                  to set a standard (or custom) Python exception, or
-                - do nothing and let the exception fall through to the next translator, or
-                - delegate translation to the next translator by throwing a new type of exception.
-             */
-
-            bool handled = with_internals([&](internals &internals) {
-                auto &local_exception_translators
-                    = get_local_internals().registered_exception_translators;
-                if (detail::apply_exception_translators(local_exception_translators)) {
-                    return true;
-                }
-                auto &exception_translators = internals.registered_exception_translators;
-                if (detail::apply_exception_translators(exception_translators)) {
-                    return true;
-                }
-                return false;
-            });
-
-            if (handled) {
-                return nullptr;
-            }
-
-            set_error(PyExc_SystemError, "Exception escaped from default exception translator!");
+            try_translate_exceptions();
             return nullptr;
         }
 

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -58,6 +58,7 @@ detail_headers = {
     "include/pybind11/detail/type_caster_base.h",
     "include/pybind11/detail/typeid.h",
     "include/pybind11/detail/value_and_holder.h",
+    "include/pybind11/detail/exception_translation.h",
 }
 
 eigen_headers = {

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -167,15 +167,14 @@ TEST_SUBMODULE(buffers, m) {
                  sizeof(float)});
         });
 
-    class BrokenMatrix: public Matrix {
+    class BrokenMatrix : public Matrix {
     public:
         BrokenMatrix(py::ssize_t rows, py::ssize_t cols) : Matrix(rows, cols) {}
     };
     py::class_<BrokenMatrix>(m, "BrokenMatrix", py::buffer_protocol())
         .def(py::init<py::ssize_t, py::ssize_t>())
-        .def_buffer([](BrokenMatrix &m) -> py::buffer_info {
-            throw std::runtime_error("I am broken");
-        });
+        .def_buffer(
+            [](BrokenMatrix &m) -> py::buffer_info { throw std::runtime_error("I am broken"); });
 
     // test_inherited_protocol
     class SquareMatrix : public Matrix {

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -170,12 +170,12 @@ TEST_SUBMODULE(buffers, m) {
     class BrokenMatrix : public Matrix {
     public:
         BrokenMatrix(py::ssize_t rows, py::ssize_t cols) : Matrix(rows, cols) {}
-        void blowUp() { throw std::runtime_error("I am broken"); }
+        void throw_runtime_error() { throw std::runtime_error("See PR #5324 for context."); }
     };
     py::class_<BrokenMatrix>(m, "BrokenMatrix", py::buffer_protocol())
         .def(py::init<py::ssize_t, py::ssize_t>())
-        .def_buffer([](BrokenMatrix &m) -> py::buffer_info {
-            m.blowUp();
+        .def_buffer([](BrokenMatrix &m) {
+            m.throw_runtime_error();
             return py::buffer_info();
         });
 

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -170,11 +170,14 @@ TEST_SUBMODULE(buffers, m) {
     class BrokenMatrix : public Matrix {
     public:
         BrokenMatrix(py::ssize_t rows, py::ssize_t cols) : Matrix(rows, cols) {}
+        void blowUp() { throw std::runtime_error("I am broken"); }
     };
     py::class_<BrokenMatrix>(m, "BrokenMatrix", py::buffer_protocol())
         .def(py::init<py::ssize_t, py::ssize_t>())
-        .def_buffer(
-            [](BrokenMatrix &m) -> py::buffer_info { throw std::runtime_error("I am broken"); });
+        .def_buffer([](BrokenMatrix &m) -> py::buffer_info {
+            m.blowUp();
+            return py::buffer_info();
+        });
 
     // test_inherited_protocol
     class SquareMatrix : public Matrix {

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -167,6 +167,16 @@ TEST_SUBMODULE(buffers, m) {
                  sizeof(float)});
         });
 
+    class BrokenMatrix: public Matrix {
+    public:
+        BrokenMatrix(py::ssize_t rows, py::ssize_t cols) : Matrix(rows, cols) {}
+    };
+    py::class_<BrokenMatrix>(m, "BrokenMatrix", py::buffer_protocol())
+        .def(py::init<py::ssize_t, py::ssize_t>())
+        .def_buffer([](BrokenMatrix &m) -> py::buffer_info {
+            throw std::runtime_error("I am broken");
+        });
+
     // test_inherited_protocol
     class SquareMatrix : public Matrix {
     public:

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -228,3 +228,9 @@ def test_buffer_docstring():
         m.get_buffer_info.__doc__.strip()
         == "get_buffer_info(arg0: Buffer) -> pybind11_tests.buffers.buffer_info"
     )
+
+def test_buffer_exception():
+    with pytest.raises(BufferError, match="Error getting buffer") as excinfo:
+        memoryview(m.BrokenMatrix(1, 1))
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert str(excinfo.value.__cause__) == "I am broken"

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -229,6 +229,7 @@ def test_buffer_docstring():
         == "get_buffer_info(arg0: Buffer) -> pybind11_tests.buffers.buffer_info"
     )
 
+
 def test_buffer_exception():
     with pytest.raises(BufferError, match="Error getting buffer") as excinfo:
         memoryview(m.BrokenMatrix(1, 1))

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -234,4 +234,4 @@ def test_buffer_exception():
     with pytest.raises(BufferError, match="Error getting buffer") as excinfo:
         memoryview(m.BrokenMatrix(1, 1))
     assert isinstance(excinfo.value.__cause__, RuntimeError)
-    assert str(excinfo.value.__cause__) == "I am broken"
+    assert "for context" in str(excinfo.value.__cause__)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

* Refactor exception translation a little - extract inline translation to a callable helper;
* Call the helper if an exception occurs when trying to get a buffer from wrapped object;
* Added the test, which crashes with `Fatal Python error` without the fix (unhandlable from within Python) and passes after it is done.
<!-- Include relevant issues or PRs here, describe what changed and why -->

Closes: #2764, #3336

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Properly translate C++ exception to Python exception when creating Python buffer from wrapped object
```

<!-- If the upgrade guide needs updating, note that here too -->
