### PR TITLE
DOC: Clarify requirements for including pybind11

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -78,6 +78,13 @@ For brevity, all code examples assume that the following two lines are present:
 
     namespace py = pybind11;
 
+.. note::
+
+    ``pybind11/pybind11.h`` includes ``Python.h``, as such it must be the first file 
+    included in any source file or header for `the same reasons as Python.h`_.
+
+.. _`the same reasons as Python.h`: https://docs.python.org/3/extending/extending.html#a-simple-example
+
 Some features may require additional headers, but those will be specified as needed.
 
 .. _simple_example:

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -80,7 +80,7 @@ For brevity, all code examples assume that the following two lines are present:
 
 .. note::
 
-    ``pybind11/pybind11.h`` includes ``Python.h``, as such it must be the first file 
+    ``pybind11/pybind11.h`` includes ``Python.h``, as such it must be the first file
     included in any source file or header for `the same reasons as Python.h`_.
 
 .. _`the same reasons as Python.h`: https://docs.python.org/3/extending/extending.html#a-simple-example


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Clarify requirements for including `pybind11/pybind11.h` inherited from [requirements for including `Python.h`](https://docs.python.org/3/extending/extending.html#a-simple-example)

Closes #4999



## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
