### PR TITLE
fix: using `__cpp_nontype_template_args` instead of `__cpp_nontype_template_parameter_class`

### DIFF
--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -100,9 +100,7 @@ class Never : public none {
     using none::none;
 };
 
-#if defined(__cpp_nontype_template_parameter_class)                                               \
-    && (/* See #5201 */ !defined(__GNUC__)                                                        \
-        || (__GNUC__ > 10 || (__GNUC__ == 10 && __GNUC_MINOR__ >= 3)))
+#if defined(__cpp_nontype_template_args)
 #    define PYBIND11_TYPING_H_HAS_STRING_LITERAL
 template <size_t N>
 struct StringLiteral {

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -100,7 +100,7 @@ class Never : public none {
     using none::none;
 };
 
-#if defined(__cpp_nontype_template_args)
+#if defined(__cpp_nontype_template_args) && __cpp_nontype_template_args >= 201911L
 #    define PYBIND11_TYPING_H_HAS_STRING_LITERAL
 template <size_t N>
 struct StringLiteral {

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1026,7 +1026,7 @@ def test_optional_object_annotations(doc):
 
 @pytest.mark.skipif(
     not m.defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL,
-    reason="C++20 feature not available.",
+    reason="C++20 non-type template args feature not available.",
 )
 def test_literal(doc):
     assert (
@@ -1037,7 +1037,7 @@ def test_literal(doc):
 
 @pytest.mark.skipif(
     not m.defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL,
-    reason="C++20 feature not available.",
+    reason="C++20 non-type template args feature not available.",
 )
 def test_typevar(doc):
     assert (


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Since macro `__cpp_nontype_template_parameter_class` is an GNU extension which has never been mentioned at [cppreference](https://en.cppreference.com/w/cpp/feature_test), This PR use the standard `__cpp_nontype_template_args` instead to enable all compilers (currently MSVC) to use `py::typing::StringLiteral`. By the way, this macro does't satisfy the feature-testing value at gcc-10 so it can provide a more standardized fix to #5201. 


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
fix: using `__cpp_nontype_template_args` instead of `__cpp_nontype_template_parameter_class`

```

<!-- If the upgrade guide needs updating, note that here too -->
