### PR TITLE
[smart_holder] Fix handling of `const unique_ptr<T, D> &` (do not disown).

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1101,8 +1101,8 @@ public:
 
         void operator()(std::unique_ptr<type, deleter> *ptr) {
             if (!ptr) {
-                pybind11_fail("Expected to be UNREACHABLE: " __FILE__
-                              ":" PYBIND11_TOSTRING(__LINE__));
+                pybind11_fail("FATAL: `const std::unique_ptr<T, D> &` was disowned (EXPECT "
+                              "UNDEFINED BEHAVIOR).");
             }
             (void) ptr->release();
             delete ptr;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1040,7 +1040,7 @@ public:
             policy = return_value_policy::reference_internal;
         }
         if (policy != return_value_policy::reference_internal) {
-            throw cast_error("Invalid return_value_policy for unique_ptr&");
+            throw cast_error("Invalid return_value_policy for const unique_ptr&");
         }
         return type_caster_base<type>::cast(src.get(), policy, parent);
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1085,7 +1085,9 @@ public:
 
     explicit operator const std::unique_ptr<type, deleter> &() {
         if (typeinfo->holder_enum_v == detail::holder_enum_t::smart_holder) {
+            // Get shared_ptr to ensure that the Python object is not disowned elsewhere.
             shared_ptr_storage = sh_load_helper.load_as_shared_ptr(value);
+            // Build a temporary unique_ptr that is meant to never expire.
             unique_ptr_storage = std::shared_ptr<std::unique_ptr<type, deleter>>(
                 new std::unique_ptr<type, deleter>{
                     sh_load_helper.template load_as_const_unique_ptr<deleter>(
@@ -1123,7 +1125,7 @@ public:
     static bool try_direct_conversions(handle) { return false; }
 
     smart_holder_type_caster_support::load_helper<remove_cv_t<type>> sh_load_helper; // Const2Mutbl
-    std::shared_ptr<type> shared_ptr_storage;
+    std::shared_ptr<type> shared_ptr_storage; // Serves as a pseudo lock.
     std::shared_ptr<std::unique_ptr<type, deleter>> unique_ptr_storage;
 };
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1088,7 +1088,8 @@ public:
             shared_ptr_storage = sh_load_helper.load_as_shared_ptr(value);
             unique_ptr_storage = std::shared_ptr<std::unique_ptr<type, deleter>>(
                 new std::unique_ptr<type, deleter>{
-                    sh_load_helper.template load_as_unique_ptr<deleter>(value)},
+                    sh_load_helper.template load_as_const_unique_ptr<deleter>(
+                        shared_ptr_storage.get())},
                 unique_ptr_storage_deleter());
             return *unique_ptr_storage;
         }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1104,7 +1104,7 @@ public:
                 pybind11_fail("Expected to be UNREACHABLE: " __FILE__
                               ":" PYBIND11_TOSTRING(__LINE__));
             }
-            ptr->release();
+            (void) ptr->release();
             delete ptr;
         }
     };

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1085,35 +1085,27 @@ public:
 
     explicit operator const std::unique_ptr<type, deleter> &() {
         if (typeinfo->holder_enum_v == detail::holder_enum_t::smart_holder) {
+            shared_ptr_storage = sh_load_helper.load_as_shared_ptr(value);
             unique_ptr_storage = std::shared_ptr<std::unique_ptr<type, deleter>>(
                 new std::unique_ptr<type, deleter>{
                     sh_load_helper.template load_as_unique_ptr<deleter>(value)},
-                unique_ptr_storage_deleter(&sh_load_helper.holder()));
+                unique_ptr_storage_deleter());
             return *unique_ptr_storage;
         }
         pybind11_fail("Expected to be UNREACHABLE: " __FILE__ ":" PYBIND11_TOSTRING(__LINE__));
     }
 
     struct unique_ptr_storage_deleter {
-        unique_ptr_storage_deleter(smart_holder *hld) : hld{hld} {}
+        unique_ptr_storage_deleter() {}
 
         void operator()(std::unique_ptr<type, deleter> *ptr) {
-            if (*ptr) {
-                if (hld->is_disowned) {
-                    hld->reclaim_disowned();
-                    ptr->release();
-                } else if (hld->is_populated) {
-                    hld->populate_from_unique_ptr(std::move(*ptr));
-                    ptr->release();
-                } else {
-                    pybind11_fail("Expected to be UNREACHABLE: " __FILE__
-                                  ":" PYBIND11_TOSTRING(__LINE__));
-                }
+            if (!ptr) {
+                pybind11_fail("Expected to be UNREACHABLE: " __FILE__
+                              ":" PYBIND11_TOSTRING(__LINE__));
             }
+            ptr->release();
             delete ptr;
         }
-
-        smart_holder *hld;
     };
 
     bool try_implicit_casts(handle src, bool convert) {
@@ -1136,6 +1128,7 @@ public:
     static bool try_direct_conversions(handle) { return false; }
 
     std::shared_ptr<std::unique_ptr<type, deleter>> unique_ptr_storage;
+    std::shared_ptr<type> shared_ptr_storage;
     smart_holder_type_caster_support::load_helper<remove_cv_t<type>> sh_load_helper; // Const2Mutbl
 };
 

--- a/include/pybind11/detail/struct_smart_holder.h
+++ b/include/pybind11/detail/struct_smart_holder.h
@@ -234,7 +234,7 @@ struct smart_holder {
     // Caller is responsible for precondition: ensure_compatible_rtti_uqp_del<T, D>() must succeed.
     template <typename T, typename D>
     std::unique_ptr<D> extract_deleter(const char *context) const {
-        auto *gd = std::get_deleter<guarded_delete>(vptr);
+        const auto *gd = std::get_deleter<guarded_delete>(vptr);
         if (gd && gd->use_del_fun) {
             const auto &custom_deleter_ptr = gd->del_fun.template target<custom_deleter<T, D>>();
             if (custom_deleter_ptr == nullptr) {

--- a/include/pybind11/detail/struct_smart_holder.h
+++ b/include/pybind11/detail/struct_smart_holder.h
@@ -287,30 +287,24 @@ struct smart_holder {
         release_disowned();
     }
 
-    // Caller is responsible for ensuring preconditions (SMART_HOLDER_WIP: details).
     template <typename T, typename D>
-    void populate_from_unique_ptr(std::unique_ptr<T, D> &&unq_ptr, void *void_ptr = nullptr) {
-        rtti_uqp_del = &typeid(D);
-        vptr_is_using_builtin_delete = is_std_default_delete<T>(*rtti_uqp_del);
+    static smart_holder from_unique_ptr(std::unique_ptr<T, D> &&unq_ptr,
+                                        void *void_ptr = nullptr) {
+        smart_holder hld;
+        hld.rtti_uqp_del = &typeid(D);
+        hld.vptr_is_using_builtin_delete = is_std_default_delete<T>(*hld.rtti_uqp_del);
         guarded_delete gd{nullptr, false};
-        if (vptr_is_using_builtin_delete) {
+        if (hld.vptr_is_using_builtin_delete) {
             gd = make_guarded_builtin_delete<T>(true);
         } else {
             gd = make_guarded_custom_deleter<T, D>(std::move(unq_ptr.get_deleter()), true);
         }
         if (void_ptr != nullptr) {
-            vptr.reset(void_ptr, std::move(gd));
+            hld.vptr.reset(void_ptr, std::move(gd));
         } else {
-            vptr.reset(unq_ptr.get(), std::move(gd));
+            hld.vptr.reset(unq_ptr.get(), std::move(gd));
         }
         (void) unq_ptr.release();
-    }
-
-    template <typename T, typename D>
-    static smart_holder from_unique_ptr(std::unique_ptr<T, D> &&unq_ptr,
-                                        void *void_ptr = nullptr) {
-        smart_holder hld;
-        hld.populate_from_unique_ptr(std::move(unq_ptr), void_ptr);
         hld.is_populated = true;
         return hld;
     }

--- a/include/pybind11/detail/struct_smart_holder.h
+++ b/include/pybind11/detail/struct_smart_holder.h
@@ -242,7 +242,7 @@ struct smart_holder {
                     std::string("smart_holder::extract_deleter() precondition failure (") + context
                     + ").");
             }
-            return std::unique_ptr<D>(new D(std::move(custom_deleter_ptr->deleter)));
+            return std::unique_ptr<D>(new D(custom_deleter_ptr->deleter)); // D must be copyable.
         }
         return nullptr;
     }

--- a/include/pybind11/detail/struct_smart_holder.h
+++ b/include/pybind11/detail/struct_smart_holder.h
@@ -242,7 +242,9 @@ struct smart_holder {
                     std::string("smart_holder::extract_deleter() precondition failure (") + context
                     + ").");
             }
-            return std::unique_ptr<D>(new D(custom_deleter_ptr->deleter)); // D must be copyable.
+            static_assert(std::is_copy_constructible<D>::value,
+                          "Required for compatibility with smart_holder functionality.");
+            return std::unique_ptr<D>(new D(custom_deleter_ptr->deleter));
         }
         return nullptr;
     }

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -794,22 +794,7 @@ struct load_helper : value_and_holder_helper {
                               "instance cannot safely be transferred to C++.");
         }
 
-        // Temporary variable to store the extracted deleter in.
-        std::unique_ptr<D> extracted_deleter;
-
-        auto *gd = std::get_deleter<pybindit::memory::guarded_delete>(holder().vptr);
-        if (gd && gd->use_del_fun) { // Note the ensure_compatible_rtti_uqp_del<T, D>() call above.
-            // In struct_smart_holder, a custom  deleter is always stored in a guarded delete.
-            // The guarded delete's std::function<void(void*)> actually points at the
-            // custom_deleter type, so we can verify it is of the custom deleter type and
-            // finally extract its deleter.
-            using custom_deleter_D = pybindit::memory::custom_deleter<T, D>;
-            const auto &custom_deleter_ptr = gd->del_fun.template target<custom_deleter_D>();
-            assert(custom_deleter_ptr != nullptr);
-            // Now that we have confirmed the type of the deleter matches the desired return
-            // value we can extract the function.
-            extracted_deleter = std::unique_ptr<D>(new D(std::move(custom_deleter_ptr->deleter)));
-        }
+        std::unique_ptr<D> extracted_deleter = holder().extract_deleter<T, D>(context);
 
         // Critical transfer-of-ownership section. This must stay together.
         if (self_life_support != nullptr) {
@@ -830,32 +815,17 @@ struct load_helper : value_and_holder_helper {
         return result;
     }
 
-    // This assumes load_as_shared_ptr succeeded, and the returned shared_ptr is still alive.
-    // The returned unique_ptr is meant to never expire.
+    // This assumes load_as_shared_ptr succeeded(), and the returned shared_ptr is still alive.
+    // The returned unique_ptr is meant to never expire (the behavior is undefined otherwise).
     template <typename D>
-    std::unique_ptr<T, D> load_as_const_unique_ptr(T *raw_type_ptr) {
+    std::unique_ptr<T, D>
+    load_as_const_unique_ptr(T *raw_type_ptr, const char *context = "load_as_const_unique_ptr") {
         if (!have_holder()) {
             return unique_with_deleter<T, D>(nullptr, std::unique_ptr<D>());
         }
-
-        // Temporary variable to store the extracted deleter in.
-        std::unique_ptr<D> extracted_deleter;
-
-        auto *gd = std::get_deleter<pybindit::memory::guarded_delete>(holder().vptr);
-        if (gd && gd->use_del_fun) { // Note the ensure_compatible_rtti_uqp_del<T, D>() call above.
-            // In struct_smart_holder, a custom  deleter is always stored in a guarded delete.
-            // The guarded delete's std::function<void(void*)> actually points at the
-            // custom_deleter type, so we can verify it is of the custom deleter type and
-            // finally extract its deleter.
-            using custom_deleter_D = pybindit::memory::custom_deleter<T, D>;
-            const auto &custom_deleter_ptr = gd->del_fun.template target<custom_deleter_D>();
-            assert(custom_deleter_ptr != nullptr);
-            // Now that we have confirmed the type of the deleter matches the desired return
-            // value we can extract the function.
-            extracted_deleter = std::unique_ptr<D>(new D(std::move(custom_deleter_ptr->deleter)));
-        }
-
-        return unique_with_deleter<T, D>(raw_type_ptr, std::move(extracted_deleter));
+        holder().template ensure_compatible_rtti_uqp_del<T, D>(context);
+        return unique_with_deleter<T, D>(raw_type_ptr,
+                                         std::move(holder().extract_deleter<T, D>(context)));
     }
 };
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -794,7 +794,7 @@ struct load_helper : value_and_holder_helper {
                               "instance cannot safely be transferred to C++.");
         }
 
-        std::unique_ptr<D> extracted_deleter = holder().extract_deleter<T, D>(context);
+        std::unique_ptr<D> extracted_deleter = holder().template extract_deleter<T, D>(context);
 
         // Critical transfer-of-ownership section. This must stay together.
         if (self_life_support != nullptr) {
@@ -824,8 +824,8 @@ struct load_helper : value_and_holder_helper {
             return unique_with_deleter<T, D>(nullptr, std::unique_ptr<D>());
         }
         holder().template ensure_compatible_rtti_uqp_del<T, D>(context);
-        return unique_with_deleter<T, D>(raw_type_ptr,
-                                         std::move(holder().extract_deleter<T, D>(context)));
+        return unique_with_deleter<T, D>(
+            raw_type_ptr, std::move(holder().template extract_deleter<T, D>(context)));
     }
 };
 

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -120,7 +120,14 @@ std::string get_mtxt(atyp const &obj) { return obj.mtxt; }
 std::ptrdiff_t get_ptr(atyp const &obj) { return reinterpret_cast<std::ptrdiff_t>(&obj); }
 
 std::unique_ptr<atyp> unique_ptr_roundtrip(std::unique_ptr<atyp> obj) { return obj; }
-const std::unique_ptr<atyp> &unique_ptr_cref_roundtrip(const std::unique_ptr<atyp> &obj) {
+
+std::string pass_unique_ptr_cref(const std::unique_ptr<atyp> &obj) { return obj->mtxt; }
+
+const std::unique_ptr<atyp> &rtrn_unique_ptr_cref(const std::string &mtxt) {
+    static std::unique_ptr<atyp> obj{new atyp{"static_ctor_arg"}};
+    if (!mtxt.empty()) {
+        obj->mtxt = mtxt;
+    }
     return obj;
 }
 
@@ -217,7 +224,9 @@ TEST_SUBMODULE(class_sh_basic, m) {
     m.def("get_ptr", get_ptr);   // pass_cref
 
     m.def("unique_ptr_roundtrip", unique_ptr_roundtrip); // pass_uqmp, rtrn_uqmp
-    m.def("unique_ptr_cref_roundtrip", unique_ptr_cref_roundtrip);
+
+    m.def("pass_unique_ptr_cref", pass_unique_ptr_cref);
+    m.def("rtrn_unique_ptr_cref", rtrn_unique_ptr_cref);
 
     py::classh<SharedPtrStash>(m, "SharedPtrStash")
         .def(py::init<>())

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -131,6 +131,10 @@ const std::unique_ptr<atyp> &rtrn_unique_ptr_cref(const std::string &mtxt) {
     return obj;
 }
 
+const std::unique_ptr<atyp> &unique_ptr_cref_roundtrip(const std::unique_ptr<atyp> &obj) {
+    return obj;
+}
+
 struct SharedPtrStash {
     std::vector<std::shared_ptr<const atyp>> stash;
     void Add(const std::shared_ptr<const atyp> &obj) { stash.push_back(obj); }
@@ -227,6 +231,7 @@ TEST_SUBMODULE(class_sh_basic, m) {
 
     m.def("pass_unique_ptr_cref", pass_unique_ptr_cref);
     m.def("rtrn_unique_ptr_cref", rtrn_unique_ptr_cref);
+    m.def("unique_ptr_cref_roundtrip", unique_ptr_cref_roundtrip);
 
     py::classh<SharedPtrStash>(m, "SharedPtrStash")
         .def(py::init<>())

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -151,19 +151,21 @@ def test_unique_ptr_roundtrip(num_round_trips=1000):
         id_orig = id_rtrn
 
 
-# This currently fails, because a unique_ptr is always loaded by value
-# due to pybind11/detail/smart_holder_type_casters.h:689
-# I think, we need to provide more cast operators.
-@pytest.mark.skip()
-def test_unique_ptr_cref_roundtrip():
-    orig = m.atyp("passenger")
-    id_orig = id(orig)
-    mtxt_orig = m.get_mtxt(orig)
+def test_pass_unique_ptr_cref():
+    obj = m.atyp("ctor_arg")
+    assert m.get_mtxt(obj) == "ctor_arg_MvCtor"
+    assert m.pass_unique_ptr_cref(obj) == "ctor_arg_MvCtor"
+    with pytest.raises(ValueError, match="Python instance was disowned"):
+        m.get_mtxt(obj)
 
-    recycled = m.unique_ptr_cref_roundtrip(orig)
-    assert m.get_mtxt(orig) == mtxt_orig
-    assert m.get_mtxt(recycled) == mtxt_orig
-    assert id(recycled) == id_orig
+
+def test_rtrn_unique_ptr_cref():
+    obj0 = m.rtrn_unique_ptr_cref("")
+    assert m.get_mtxt(obj0) == "static_ctor_arg"
+    obj1 = m.rtrn_unique_ptr_cref("passed_mtxt_1")
+    assert m.get_mtxt(obj1) == "passed_mtxt_1"
+    assert m.get_mtxt(obj0) == "passed_mtxt_1"
+    assert obj0 is obj1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -153,9 +153,9 @@ def test_unique_ptr_roundtrip(num_round_trips=1000):
 
 def test_pass_unique_ptr_cref():
     obj = m.atyp("ctor_arg")
-    assert m.get_mtxt(obj) == "ctor_arg_MvCtor"
-    assert m.pass_unique_ptr_cref(obj) == "ctor_arg_MvCtor"
-    assert m.get_mtxt(obj) == "ctor_arg_MvCtor"
+    assert re.match("ctor_arg(_MvCtor)*_MvCtor", m.get_mtxt(obj))
+    assert re.match("ctor_arg(_MvCtor)*_MvCtor", m.pass_unique_ptr_cref(obj))
+    assert re.match("ctor_arg(_MvCtor)*_MvCtor", m.get_mtxt(obj))
 
 
 def test_rtrn_unique_ptr_cref():

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -155,8 +155,7 @@ def test_pass_unique_ptr_cref():
     obj = m.atyp("ctor_arg")
     assert m.get_mtxt(obj) == "ctor_arg_MvCtor"
     assert m.pass_unique_ptr_cref(obj) == "ctor_arg_MvCtor"
-    with pytest.raises(ValueError, match="Python instance was disowned"):
-        m.get_mtxt(obj)
+    assert m.get_mtxt(obj) == "ctor_arg_MvCtor"
 
 
 def test_rtrn_unique_ptr_cref():
@@ -166,6 +165,17 @@ def test_rtrn_unique_ptr_cref():
     assert m.get_mtxt(obj1) == "passed_mtxt_1"
     assert m.get_mtxt(obj0) == "passed_mtxt_1"
     assert obj0 is obj1
+
+
+def test_unique_ptr_cref_roundtrip(num_round_trips=1000):
+    # Multiple roundtrips to stress-test implementation.
+    orig = m.atyp("passenger")
+    mtxt_orig = m.get_mtxt(orig)
+    recycled = orig
+    for _ in range(num_round_trips):
+        recycled = m.unique_ptr_cref_roundtrip(recycled)
+        assert recycled is orig
+        assert m.get_mtxt(recycled) == mtxt_orig
 
 
 @pytest.mark.parametrize(

--- a/tests/test_class_sh_trampoline_shared_from_this.cpp
+++ b/tests/test_class_sh_trampoline_shared_from_this.cpp
@@ -87,7 +87,12 @@ long pass_shared_ptr(const std::shared_ptr<Sft> &obj) {
     return sft.use_count();
 }
 
-void pass_unique_ptr(const std::unique_ptr<Sft> &) {}
+std::string pass_unique_ptr_cref(const std::unique_ptr<Sft> &obj) {
+    return obj ? obj->history : "<NULLPTR>";
+}
+std::string pass_unique_ptr_rref(std::unique_ptr<Sft> &&) {
+    throw std::runtime_error("Expected to not be reached.");
+}
 
 Sft *make_pure_cpp_sft_raw_ptr(const std::string &history_seed) { return new Sft{history_seed}; }
 
@@ -135,7 +140,8 @@ TEST_SUBMODULE(class_sh_trampoline_shared_from_this, m) {
 
     m.def("use_count", use_count);
     m.def("pass_shared_ptr", pass_shared_ptr);
-    m.def("pass_unique_ptr", pass_unique_ptr);
+    m.def("pass_unique_ptr_cref", pass_unique_ptr_cref);
+    m.def("pass_unique_ptr_rref", pass_unique_ptr_rref);
     m.def("make_pure_cpp_sft_raw_ptr", make_pure_cpp_sft_raw_ptr);
     m.def("make_pure_cpp_sft_unq_ptr", make_pure_cpp_sft_unq_ptr);
     m.def("make_pure_cpp_sft_shd_ptr", make_pure_cpp_sft_shd_ptr);

--- a/tests/test_class_sh_trampoline_shared_from_this.cpp
+++ b/tests/test_class_sh_trampoline_shared_from_this.cpp
@@ -90,7 +90,7 @@ long pass_shared_ptr(const std::shared_ptr<Sft> &obj) {
 std::string pass_unique_ptr_cref(const std::unique_ptr<Sft> &obj) {
     return obj ? obj->history : "<NULLPTR>";
 }
-std::string pass_unique_ptr_rref(std::unique_ptr<Sft> &&) {
+void pass_unique_ptr_rref(std::unique_ptr<Sft> &&) {
     throw std::runtime_error("Expected to not be reached.");
 }
 

--- a/tests/test_class_sh_trampoline_shared_from_this.py
+++ b/tests/test_class_sh_trampoline_shared_from_this.py
@@ -137,11 +137,14 @@ def test_pass_released_shared_ptr_as_unique_ptr():
     obj = PySft("PySft")
     stash1 = m.SftSharedPtrStash(1)
     stash1.Add(obj)  # Releases shared_ptr to C++.
+    assert m.pass_unique_ptr_cref(obj) == "PySft_Stash1Add"
+    assert obj.history == "PySft_Stash1Add"
     with pytest.raises(ValueError) as exc_info:
-        m.pass_unique_ptr(obj)
+        m.pass_unique_ptr_rref(obj)
     assert str(exc_info.value) == (
         "Python instance is currently owned by a std::shared_ptr."
     )
+    assert obj.history == "PySft_Stash1Add"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
TODO: PR Description

TODO: Split out pure refactoring into a separate PR.

@rhaschke FYI

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
