### PR TITLE
[smart_holder] Introduce `PYBIND11_SMART_HOLDER_DISABLE` option.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
           # Extra ubuntu latest job
           - runs-on: ubuntu-latest
             python: '3.11'
+          # Exercise PYBIND11_USE_SMART_HOLDER_AS_DEFAULT
+          # with recent (or ideally latest) released Python version.
           - runs-on: ubuntu-latest
             python: '3.12'
             args: >
@@ -80,6 +82,20 @@ jobs:
             python: '3.12'
             args: >
               -DCMAKE_CXX_FLAGS="/DPYBIND11_USE_SMART_HOLDER_AS_DEFAULT /GR /EHsc"
+          # Exercise PYBIND11_SMART_HOLDER_DISABLE
+          # with recent (or ideally latest) released Python version.
+          - runs-on: ubuntu-latest
+            python: '3.12'
+            args: >
+              -DCMAKE_CXX_FLAGS="-DPYBIND11_SMART_HOLDER_DISABLE"
+          - runs-on: macos-13
+            python: '3.12'
+            args: >
+              -DCMAKE_CXX_FLAGS="-DPYBIND11_SMART_HOLDER_DISABLE"
+          - runs-on: windows-2022
+            python: '3.12'
+            args: >
+              -DCMAKE_CXX_FLAGS="/DPYBIND11_SMART_HOLDER_DISABLE /GR /EHsc"
 
     name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -836,7 +836,7 @@ protected:
     holder_type holder;
 };
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 
 template <typename, typename SFINAE = void>
 struct copyable_holder_caster_shared_ptr_with_smart_holder_support_enabled : std::true_type {};
@@ -968,7 +968,7 @@ protected:
     std::shared_ptr<type> shared_ptr_storage;
 };
 
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 
 /// Specialize for the common std::shared_ptr, so users don't need to
 template <typename T>
@@ -990,7 +990,7 @@ struct move_only_holder_caster {
     static constexpr auto name = type_caster_base<type>::name;
 };
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 
 template <typename, typename SFINAE = void>
 struct move_only_holder_caster_unique_ptr_with_smart_holder_support_enabled : std::true_type {};
@@ -1129,7 +1129,7 @@ public:
     std::shared_ptr<std::unique_ptr<type, deleter>> unique_ptr_storage;
 };
 
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 
 template <typename type, typename deleter>
 class type_caster<std::unique_ptr<type, deleter>>
@@ -1167,7 +1167,7 @@ struct is_holder_type
 template <typename base, typename deleter>
 struct is_holder_type<base, std::unique_ptr<base, deleter>> : std::true_type {};
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 template <typename base>
 struct is_holder_type<base, smart_holder> : std::true_type {};
 #endif

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -198,7 +198,7 @@ void construct(value_and_holder &v_h, Alias<Class> &&result, bool) {
     v_h.value_ptr() = new Alias<Class>(std::move(result));
 }
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 
 template <typename T, typename D>
 smart_holder init_smart_holder_from_unique_ptr(std::unique_ptr<T, D> &&unq_ptr,
@@ -268,7 +268,7 @@ void construct(value_and_holder &v_h,
     v_h.type->init_instance(v_h.inst, &smhldr);
 }
 
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 
 // Implementing class for py::init<...>()
 template <typename... Args>

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -252,6 +252,10 @@ enum class holder_enum_t : uint8_t {
 
 #endif
 
+#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#    define PYBIND11_SMART_HOLDER_ENABLED
+#endif
+
 /// Additional type information which does not fit into the PyTypeObject.
 /// Changes to this struct also require bumping `PYBIND11_INTERNALS_VERSION`.
 struct type_info {

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -252,7 +252,8 @@ enum class holder_enum_t : uint8_t {
 
 #endif
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#if defined(PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT)                                     \
+    && !defined(PYBIND11_SMART_HOLDER_DISABLE)
 #    define PYBIND11_SMART_HOLDER_ENABLED
 #endif
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -473,7 +473,7 @@ inline PyThreadState *get_thread_state_unchecked() {
 void keep_alive_impl(handle nurse, handle patient);
 inline PyObject *make_new_instance(PyTypeObject *type);
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 
 // PYBIND11:REMINDER: Needs refactoring of existing pybind11 code.
 inline bool deregister_instance(instance *self, void *valptr, const type_info *tinfo);
@@ -830,7 +830,7 @@ struct load_helper : value_and_holder_helper {
 
 PYBIND11_NAMESPACE_END(smart_holder_type_caster_support)
 
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 
 class type_caster_generic {
 public:
@@ -936,7 +936,7 @@ public:
 
     // Base methods for generic caster; there are overridden in copyable_holder_caster
     void load_value(value_and_holder &&v_h) {
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
         if (typeinfo->holder_enum_v == detail::holder_enum_t::smart_holder) {
             smart_holder_type_caster_support::value_and_holder_helper v_h_helper;
             v_h_helper.loaded_v_h = v_h;

--- a/include/pybind11/detail/using_smart_holder.h
+++ b/include/pybind11/detail/using_smart_holder.h
@@ -9,19 +9,19 @@
 
 #include <type_traits>
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 #    include "struct_smart_holder.h"
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 using pybindit::memory::smart_holder;
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 template <typename H>
 using is_smart_holder = std::is_same<H, smart_holder>;
 #else

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1631,7 +1631,7 @@ PYBIND11_NAMESPACE_END(detail)
 template <typename T, typename D, typename SFINAE = void>
 struct property_cpp_function : detail::property_cpp_function_classic<T, D> {};
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
@@ -1810,10 +1810,9 @@ struct property_cpp_function<
         detail::both_t_and_d_use_type_caster_base<T, typename D::element_type>>::value>>
     : detail::property_cpp_function_sh_unique_ptr_member<T, D> {};
 
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 
-#if defined(PYBIND11_USE_SMART_HOLDER_AS_DEFAULT)                                                 \
-    && defined(PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT)
+#if defined(PYBIND11_USE_SMART_HOLDER_AS_DEFAULT) && defined(PYBIND11_SMART_HOLDER_ENABLED)
 // NOTE: THIS IS MEANT FOR STRESS-TESTING ONLY!
 //       As of PR #5257, for production use, there is no longer a strong reason to make
 //       smart_holder the default holder:
@@ -1881,7 +1880,7 @@ public:
         // A more fitting name would be uses_unique_ptr_holder.
         record.default_holder = detail::is_instantiation<std::unique_ptr, holder_type>::value;
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
         if (detail::is_instantiation<std::unique_ptr, holder_type>::value) {
             record.holder_enum_v = detail::holder_enum_t::std_unique_ptr;
         } else if (detail::is_instantiation<std::shared_ptr, holder_type>::value) {
@@ -2226,7 +2225,7 @@ private:
         init_holder(inst, v_h, (const holder_type *) holder_ptr, v_h.value_ptr<type>());
     }
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 
     template <typename WrappedType>
     static bool try_initialization_using_shared_from_this(holder_type *, WrappedType *, ...) {
@@ -2287,7 +2286,7 @@ private:
         v_h.set_holder_constructed();
     }
 
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 
     /// Deallocates an instance; via holder, if constructed; otherwise via operator delete.
     static void dealloc(detail::value_and_holder &v_h) {
@@ -2329,7 +2328,7 @@ private:
     }
 };
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 
 // Supports easier switching between py::class_<T> and py::class_<T, py::smart_holder>:
 // users can simply replace the `_` in `class_` with `h` or vice versa.

--- a/include/pybind11/trampoline_self_life_support.h
+++ b/include/pybind11/trampoline_self_life_support.h
@@ -6,7 +6,7 @@
 
 #include "detail/internals.h"
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 
 #    include "detail/common.h"
 #    include "detail/using_smart_holder.h"
@@ -63,4 +63,4 @@ struct trampoline_self_life_support {
 
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
 
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -93,7 +93,7 @@ TEST_SUBMODULE(class_, m) {
     struct ToBeHeldByUniquePtr {};
     py::class_<ToBeHeldByUniquePtr, std::unique_ptr<ToBeHeldByUniquePtr>>(m, "ToBeHeldByUniquePtr")
         .def(py::init<>());
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
     m.def("pass_unique_ptr", [](std::unique_ptr<ToBeHeldByUniquePtr> &&) {});
 #else
     m.attr("pass_unique_ptr") = py::none();

--- a/tests/test_class_sh_basic.cpp
+++ b/tests/test_class_sh_basic.cpp
@@ -156,8 +156,8 @@ namespace pybind11_tests {
 namespace class_sh_basic {
 
 TEST_SUBMODULE(class_sh_basic, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -260,7 +260,7 @@ TEST_SUBMODULE(class_sh_basic, m) {
           []() { return CastUnusualOpRefConstRef(LocalUnusualOpRef()); });
     m.def("CallCastUnusualOpRefMovable",
           []() { return CastUnusualOpRefMovable(LocalUnusualOpRef()); });
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }
 
 } // namespace class_sh_basic

--- a/tests/test_class_sh_basic.py
+++ b/tests/test_class_sh_basic.py
@@ -7,7 +7,7 @@ import pytest
 
 from pybind11_tests import class_sh_basic as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_disowning.cpp
+++ b/tests/test_class_sh_disowning.cpp
@@ -32,8 +32,8 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_disowning::Atype<1>)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_disowning::Atype<2>)
 
 TEST_SUBMODULE(class_sh_disowning, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -49,5 +49,5 @@ TEST_SUBMODULE(class_sh_disowning, m) {
 
     m.def("overloaded", (int (*)(std::unique_ptr<Atype<1>>, int)) & overloaded);
     m.def("overloaded", (int (*)(std::unique_ptr<Atype<2>>, int)) & overloaded);
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_disowning.py
+++ b/tests/test_class_sh_disowning.py
@@ -4,7 +4,7 @@ import pytest
 
 from pybind11_tests import class_sh_disowning as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_disowning_mi.cpp
+++ b/tests/test_class_sh_disowning_mi.cpp
@@ -57,8 +57,8 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_disowning_mi::Base1)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_disowning_mi::Base2)
 
 TEST_SUBMODULE(class_sh_disowning_mi, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -98,5 +98,5 @@ TEST_SUBMODULE(class_sh_disowning_mi, m) {
     py::classh<Base2>(m, "Base2").def(py::init<int>()).def("bar", &Base2::bar);
     m.def("disown_base1", disown_base1);
     m.def("disown_base2", disown_base2);
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_disowning_mi.py
+++ b/tests/test_class_sh_disowning_mi.py
@@ -5,7 +5,7 @@ import pytest
 import env  # noqa: F401
 from pybind11_tests import class_sh_disowning_mi as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_factory_constructors.cpp
+++ b/tests/test_class_sh_factory_constructors.cpp
@@ -87,8 +87,8 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_factory_constructors::with_alias)
 
 TEST_SUBMODULE(class_sh_factory_constructors, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -183,5 +183,5 @@ TEST_SUBMODULE(class_sh_factory_constructors, m) {
                       [](int, int, int, int, int) {
                           return std::make_shared<with_alias>(); // Invalid alias factory.
                       }));
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_factory_constructors.py
+++ b/tests/test_class_sh_factory_constructors.py
@@ -4,7 +4,7 @@ import pytest
 
 from pybind11_tests import class_sh_factory_constructors as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_inheritance.cpp
+++ b/tests/test_class_sh_inheritance.cpp
@@ -73,8 +73,8 @@ namespace pybind11_tests {
 namespace class_sh_inheritance {
 
 TEST_SUBMODULE(class_sh_inheritance, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -105,7 +105,7 @@ TEST_SUBMODULE(class_sh_inheritance, m) {
     m.def("pass_cptr_base1", pass_cptr_base1);
     m.def("pass_cptr_base2", pass_cptr_base2);
     m.def("pass_cptr_drvd2", pass_cptr_drvd2);
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }
 
 } // namespace class_sh_inheritance

--- a/tests/test_class_sh_inheritance.py
+++ b/tests/test_class_sh_inheritance.py
@@ -4,7 +4,7 @@ import pytest
 
 from pybind11_tests import class_sh_inheritance as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_mi_thunks.cpp
+++ b/tests/test_class_sh_mi_thunks.cpp
@@ -40,8 +40,8 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(test_class_sh_mi_thunks::Base1)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(test_class_sh_mi_thunks::Derived)
 
 TEST_SUBMODULE(class_sh_mi_thunks, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -103,5 +103,5 @@ TEST_SUBMODULE(class_sh_mi_thunks, m) {
         }
         return obj_der->vec.size();
     });
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_mi_thunks.py
+++ b/tests/test_class_sh_mi_thunks.py
@@ -4,7 +4,7 @@ import pytest
 
 from pybind11_tests import class_sh_mi_thunks as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_property.cpp
+++ b/tests/test_class_sh_property.cpp
@@ -58,8 +58,8 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(test_class_sh_property::WithCharArrayMember)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(test_class_sh_property::WithConstCharPtrMember)
 
 TEST_SUBMODULE(class_sh_property, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -109,5 +109,5 @@ TEST_SUBMODULE(class_sh_property, m) {
     py::classh<WithConstCharPtrMember>(m, "WithConstCharPtrMember")
         .def(py::init<>())
         .def_readonly("const_char_ptr_member", &WithConstCharPtrMember::const_char_ptr_member);
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_property.py
+++ b/tests/test_class_sh_property.py
@@ -7,7 +7,7 @@ import pytest
 import env  # noqa: F401
 from pybind11_tests import class_sh_property as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_property_non_owning.cpp
+++ b/tests/test_class_sh_property_non_owning.cpp
@@ -51,8 +51,8 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(DataField)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(DataFieldsHolder)
 
 TEST_SUBMODULE(class_sh_property_non_owning, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -71,5 +71,5 @@ TEST_SUBMODULE(class_sh_property_non_owning, m) {
     py::classh<DataFieldsHolder>(m, "DataFieldsHolder")
         .def(py::init<std::size_t>())
         .def("vec_at", &DataFieldsHolder::vec_at, py::return_value_policy::reference_internal);
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_property_non_owning.py
+++ b/tests/test_class_sh_property_non_owning.py
@@ -4,7 +4,7 @@ import pytest
 
 from pybind11_tests import class_sh_property_non_owning as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_shared_ptr_copy_move.cpp
+++ b/tests/test_class_sh_shared_ptr_copy_move.cpp
@@ -50,8 +50,8 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::FooSmHld)
 namespace pybind11_tests {
 
 TEST_SUBMODULE(class_sh_shared_ptr_copy_move, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -113,7 +113,7 @@ TEST_SUBMODULE(class_sh_shared_ptr_copy_move, m) {
         l.append(std::move(o));
         return l;
     });
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }
 
 } // namespace pybind11_tests

--- a/tests/test_class_sh_shared_ptr_copy_move.py
+++ b/tests/test_class_sh_shared_ptr_copy_move.py
@@ -4,7 +4,7 @@ import pytest
 
 from pybind11_tests import class_sh_shared_ptr_copy_move as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_trampoline_basic.cpp
+++ b/tests/test_class_sh_trampoline_basic.cpp
@@ -34,7 +34,7 @@ struct AbaseAlias : Abase<SerNo> {
     }
 };
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 template <>
 struct AbaseAlias<1> : Abase<1>, py::trampoline_self_life_support {
     using Abase<1>::Abase;
@@ -46,7 +46,7 @@ struct AbaseAlias<1> : Abase<1>, py::trampoline_self_life_support {
                                other_val);
     }
 };
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 
 template <int SerNo>
 int AddInCppRawPtr(const Abase<SerNo> *obj, int other_val) {
@@ -65,7 +65,7 @@ int AddInCppUniquePtr(std::unique_ptr<Abase<SerNo>> obj, int other_val) {
 
 template <int SerNo>
 void wrap(py::module_ m, const char *py_class_name) {
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
     py::classh<Abase<SerNo>, AbaseAlias<SerNo>>(m, py_class_name)
         .def(py::init<int>(), py::arg("val"))
         .def("Get", &Abase<SerNo>::Get)
@@ -86,13 +86,13 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(Abase<0>)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(Abase<1>)
 
 TEST_SUBMODULE(class_sh_trampoline_basic, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
 
     wrap<0>(m, "Abase0");
     wrap<1>(m, "Abase1");
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_trampoline_basic.cpp
+++ b/tests/test_class_sh_trampoline_basic.cpp
@@ -63,9 +63,9 @@ int AddInCppUniquePtr(std::unique_ptr<Abase<SerNo>> obj, int other_val) {
     return obj->Add(other_val) * 100 + 13;
 }
 
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 template <int SerNo>
 void wrap(py::module_ m, const char *py_class_name) {
-#ifdef PYBIND11_SMART_HOLDER_ENABLED
     py::classh<Abase<SerNo>, AbaseAlias<SerNo>>(m, py_class_name)
         .def(py::init<int>(), py::arg("val"))
         .def("Get", &Abase<SerNo>::Get)
@@ -74,8 +74,8 @@ void wrap(py::module_ m, const char *py_class_name) {
     m.def("AddInCppRawPtr", AddInCppRawPtr<SerNo>, py::arg("obj"), py::arg("other_val"));
     m.def("AddInCppSharedPtr", AddInCppSharedPtr<SerNo>, py::arg("obj"), py::arg("other_val"));
     m.def("AddInCppUniquePtr", AddInCppUniquePtr<SerNo>, py::arg("obj"), py::arg("other_val"));
-#endif
 }
+#endif
 
 } // namespace class_sh_trampoline_basic
 } // namespace pybind11_tests

--- a/tests/test_class_sh_trampoline_basic.py
+++ b/tests/test_class_sh_trampoline_basic.py
@@ -4,7 +4,7 @@ import pytest
 
 from pybind11_tests import class_sh_trampoline_basic as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_trampoline_self_life_support.cpp
+++ b/tests/test_class_sh_trampoline_self_life_support.cpp
@@ -38,7 +38,7 @@ protected:
     Big5() : history{"DefaultConstructor"} {}
 };
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 struct Big5Trampoline : Big5, py::trampoline_self_life_support {
     using Big5::Big5;
 };
@@ -52,8 +52,8 @@ using namespace pybind11_tests::class_sh_trampoline_self_life_support;
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(Big5)
 
 TEST_SUBMODULE(class_sh_trampoline_self_life_support, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -94,5 +94,5 @@ TEST_SUBMODULE(class_sh_trampoline_self_life_support, m) {
         py::object o1 = py::cast(std::move(obj));
         return py::make_tuple(o1, o2);
     });
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_trampoline_self_life_support.py
+++ b/tests/test_class_sh_trampoline_self_life_support.py
@@ -4,7 +4,7 @@ import pytest
 
 import pybind11_tests.class_sh_trampoline_self_life_support as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_trampoline_shared_from_this.cpp
+++ b/tests/test_class_sh_trampoline_shared_from_this.cpp
@@ -71,7 +71,7 @@ struct SftSharedPtrStash {
     }
 };
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 struct SftTrampoline : Sft, py::trampoline_self_life_support {
     using Sft::Sft;
 };
@@ -115,8 +115,8 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(Sft)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(SftSharedPtrStash)
 
 TEST_SUBMODULE(class_sh_trampoline_shared_from_this, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -146,5 +146,5 @@ TEST_SUBMODULE(class_sh_trampoline_shared_from_this, m) {
     m.def("make_pure_cpp_sft_unq_ptr", make_pure_cpp_sft_unq_ptr);
     m.def("make_pure_cpp_sft_shd_ptr", make_pure_cpp_sft_shd_ptr);
     m.def("pass_through_shd_ptr", pass_through_shd_ptr);
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_trampoline_shared_from_this.py
+++ b/tests/test_class_sh_trampoline_shared_from_this.py
@@ -8,7 +8,7 @@ import pytest
 import env
 import pybind11_tests.class_sh_trampoline_shared_from_this as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.cpp
+++ b/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.cpp
@@ -63,8 +63,8 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(SpGoAway)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(SpGoAwayTester)
 
 TEST_SUBMODULE(class_sh_trampoline_shared_ptr_cpp_arg, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -101,5 +101,5 @@ TEST_SUBMODULE(class_sh_trampoline_shared_ptr_cpp_arg, m) {
     py::classh<SpGoAwayTester>(m, "SpGoAwayTester")
         .def(py::init<>())
         .def_readwrite("obj", &SpGoAwayTester::m_obj);
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.py
+++ b/tests/test_class_sh_trampoline_shared_ptr_cpp_arg.py
@@ -4,7 +4,7 @@ import pytest
 
 import pybind11_tests.class_sh_trampoline_shared_ptr_cpp_arg as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_trampoline_unique_ptr.cpp
+++ b/tests/test_class_sh_trampoline_unique_ptr.cpp
@@ -39,7 +39,7 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(pybind11_tests::class_sh_trampoline_unique_pt
 namespace pybind11_tests {
 namespace class_sh_trampoline_unique_ptr {
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 class PyClass : public Class, public py::trampoline_self_life_support {
 public:
     std::unique_ptr<Class> clone() const override {
@@ -54,8 +54,8 @@ public:
 } // namespace pybind11_tests
 
 TEST_SUBMODULE(class_sh_trampoline_unique_ptr, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -71,5 +71,5 @@ TEST_SUBMODULE(class_sh_trampoline_unique_ptr, m) {
 
     m.def("clone", [](const Class &obj) { return obj.clone(); });
     m.def("clone_and_foo", [](const Class &obj) { return obj.clone()->foo(); });
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_trampoline_unique_ptr.py
+++ b/tests/test_class_sh_trampoline_unique_ptr.py
@@ -4,7 +4,7 @@ import pytest
 
 import pybind11_tests.class_sh_trampoline_unique_ptr as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_unique_ptr_custom_deleter.cpp
+++ b/tests/test_class_sh_unique_ptr_custom_deleter.cpp
@@ -31,8 +31,8 @@ namespace pybind11_tests {
 namespace class_sh_unique_ptr_custom_deleter {
 
 TEST_SUBMODULE(class_sh_unique_ptr_custom_deleter, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -40,7 +40,7 @@ TEST_SUBMODULE(class_sh_unique_ptr_custom_deleter, m) {
     py::classh<Pet>(m, "Pet").def_readwrite("name", &Pet::name);
 
     m.def("create", &Pet::New);
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }
 
 } // namespace class_sh_unique_ptr_custom_deleter

--- a/tests/test_class_sh_unique_ptr_custom_deleter.py
+++ b/tests/test_class_sh_unique_ptr_custom_deleter.py
@@ -4,7 +4,7 @@ import pytest
 
 from pybind11_tests import class_sh_unique_ptr_custom_deleter as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_unique_ptr_member.cpp
+++ b/tests/test_class_sh_unique_ptr_member.cpp
@@ -45,8 +45,8 @@ namespace pybind11_tests {
 namespace class_sh_unique_ptr_member {
 
 TEST_SUBMODULE(class_sh_unique_ptr_member, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -60,7 +60,7 @@ TEST_SUBMODULE(class_sh_unique_ptr_member, m) {
         .def("is_owner", &ptr_owner::is_owner)
         .def("give_up_ownership_via_unique_ptr", &ptr_owner::give_up_ownership_via_unique_ptr)
         .def("give_up_ownership_via_shared_ptr", &ptr_owner::give_up_ownership_via_shared_ptr);
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }
 
 } // namespace class_sh_unique_ptr_member

--- a/tests/test_class_sh_unique_ptr_member.py
+++ b/tests/test_class_sh_unique_ptr_member.py
@@ -4,7 +4,7 @@ import pytest
 
 from pybind11_tests import class_sh_unique_ptr_member as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/tests/test_class_sh_virtual_py_cpp_mix.cpp
+++ b/tests/test_class_sh_virtual_py_cpp_mix.cpp
@@ -31,7 +31,7 @@ int get_from_cpp_plainc_ptr(const Base *b) { return b->get() + 4000; }
 
 int get_from_cpp_unique_ptr(std::unique_ptr<Base> b) { return b->get() + 5000; }
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 
 struct BaseVirtualOverrider : Base, py::trampoline_self_life_support {
     using Base::Base;
@@ -57,8 +57,8 @@ PYBIND11_SMART_HOLDER_TYPE_CASTERS(CppDerivedPlain)
 PYBIND11_SMART_HOLDER_TYPE_CASTERS(CppDerived)
 
 TEST_SUBMODULE(class_sh_virtual_py_cpp_mix, m) {
-    m.attr("defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT") =
-#ifndef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+    m.attr("defined_PYBIND11_SMART_HOLDER_ENABLED") =
+#ifndef PYBIND11_SMART_HOLDER_ENABLED
         false;
 #else
         true;
@@ -71,5 +71,5 @@ TEST_SUBMODULE(class_sh_virtual_py_cpp_mix, m) {
 
     m.def("get_from_cpp_plainc_ptr", get_from_cpp_plainc_ptr, py::arg("b"));
     m.def("get_from_cpp_unique_ptr", get_from_cpp_unique_ptr, py::arg("b"));
-#endif // PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#endif // PYBIND11_SMART_HOLDER_ENABLED
 }

--- a/tests/test_class_sh_virtual_py_cpp_mix.py
+++ b/tests/test_class_sh_virtual_py_cpp_mix.py
@@ -4,7 +4,7 @@ import pytest
 
 from pybind11_tests import class_sh_virtual_py_cpp_mix as m
 
-if not m.defined_PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT:
+if not m.defined_PYBIND11_SMART_HOLDER_ENABLED:
     pytest.skip("smart_holder not available.", allow_module_level=True)
 
 

--- a/ubench/holder_comparison.cpp
+++ b/ubench/holder_comparison.cpp
@@ -22,7 +22,7 @@ void wrap_number_bucket(py::module m, const char *class_name) {
         .def("add", &WrappedType::add, py::arg("other"));
 }
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 
 template <typename T>
 class padded_unique_ptr {
@@ -41,7 +41,7 @@ static_assert(sizeof(padded_unique_ptr<nb_pu>) == sizeof(py::smart_holder),
 
 } // namespace hc
 
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
 PYBIND11_DECLARE_HOLDER_TYPE(T, hc::padded_unique_ptr<T>);
 #endif
 
@@ -49,7 +49,7 @@ PYBIND11_MODULE(pybind11_ubench_holder_comparison, m) {
     using namespace hc;
     wrap_number_bucket<nb_up, std::unique_ptr<nb_up>>(m, "number_bucket_up");
     wrap_number_bucket<nb_sp, std::shared_ptr<nb_sp>>(m, "number_bucket_sp");
-#ifdef PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
+#ifdef PYBIND11_SMART_HOLDER_ENABLED
     m.def("sizeof_smart_holder", []() { return sizeof(py::smart_holder); });
     wrap_number_bucket<nb_pu, padded_unique_ptr<nb_pu>>(m, "number_bucket_pu");
     wrap_number_bucket<nb_sh, py::smart_holder>(m, "number_bucket_sh");


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Introduce a `PYBIND11_SMART_HOLDER_DISABLE` macro.

**Note that the `PYBIND11_INTERNALS_ID` is identical with and without that define.**

That way the smart_holder feature is available by default, but users concerned about compile-time or runtime overhead can use the macro to essentially eliminate the overhead completely, without breaking full internals-compatibility with pybind11 extensions that have the smart_holder feature enabled.

Probably, the extra time the preprocessor needs to strip out the smart_holder code is virtually unmeasurable. The extra compile time for the tiny internals addition is probably also unmeasurable.

See also: https://github.com/pybind/pybind11/pull/5339#issuecomment-2323409413

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
