### PR TITLE
Fixed array_t type hint

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -2090,7 +2090,7 @@ vectorize_helper<Func, Return, Args...> vectorize_extractor(const Func &f, Retur
 template <typename T, int Flags>
 struct handle_type_name<array_t<T, Flags>> {
     static constexpr auto name
-        = const_name("numpy.ndarray[") + npy_format_descriptor<T>::name + const_name("]");
+        = const_name("numpy.typing.NDArray[") + npy_format_descriptor<T>::name + const_name("]");
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -320,13 +320,13 @@ def test_overload_resolution(msg):
         msg(excinfo.value)
         == """
         overloaded(): incompatible function arguments. The following argument types are supported:
-            1. (arg0: numpy.ndarray[numpy.float64]) -> str
-            2. (arg0: numpy.ndarray[numpy.float32]) -> str
-            3. (arg0: numpy.ndarray[numpy.int32]) -> str
-            4. (arg0: numpy.ndarray[numpy.uint16]) -> str
-            5. (arg0: numpy.ndarray[numpy.int64]) -> str
-            6. (arg0: numpy.ndarray[numpy.complex128]) -> str
-            7. (arg0: numpy.ndarray[numpy.complex64]) -> str
+            1. (arg0: numpy.typing.NDArray[numpy.float64]) -> str
+            2. (arg0: numpy.typing.NDArray[numpy.float32]) -> str
+            3. (arg0: numpy.typing.NDArray[numpy.int32]) -> str
+            4. (arg0: numpy.typing.NDArray[numpy.uint16]) -> str
+            5. (arg0: numpy.typing.NDArray[numpy.int64]) -> str
+            6. (arg0: numpy.typing.NDArray[numpy.complex128]) -> str
+            7. (arg0: numpy.typing.NDArray[numpy.complex64]) -> str
 
         Invoked with: 'not an array'
     """
@@ -342,8 +342,8 @@ def test_overload_resolution(msg):
     assert m.overloaded3(np.array([1], dtype="intc")) == "int"
     expected_exc = """
         overloaded3(): incompatible function arguments. The following argument types are supported:
-            1. (arg0: numpy.ndarray[numpy.int32]) -> str
-            2. (arg0: numpy.ndarray[numpy.float64]) -> str
+            1. (arg0: numpy.typing.NDArray[numpy.int32]) -> str
+            2. (arg0: numpy.typing.NDArray[numpy.float64]) -> str
 
         Invoked with: """
 
@@ -527,7 +527,7 @@ def test_index_using_ellipsis():
     ],
 )
 def test_format_descriptors_for_floating_point_types(test_func):
-    assert "numpy.ndarray[numpy.float" in test_func.__doc__
+    assert "numpy.typing.NDArray[numpy.float" in test_func.__doc__
 
 
 @pytest.mark.parametrize("forcecast", [False, True])

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -351,7 +351,7 @@ def test_complex_array():
 def test_signature(doc):
     assert (
         doc(m.create_rec_nested)
-        == "create_rec_nested(arg0: int) -> numpy.ndarray[NestedStruct]"
+        == "create_rec_nested(arg0: int) -> numpy.typing.NDArray[NestedStruct]"
     )
 
 

--- a/tests/test_numpy_vectorize.py
+++ b/tests/test_numpy_vectorize.py
@@ -150,7 +150,7 @@ def test_docs(doc):
     assert (
         doc(m.vectorized_func)
         == """
-        vectorized_func(arg0: numpy.ndarray[numpy.int32], arg1: numpy.ndarray[numpy.float32], arg2: numpy.ndarray[numpy.float64]) -> object
+        vectorized_func(arg0: numpy.typing.NDArray[numpy.int32], arg1: numpy.typing.NDArray[numpy.float32], arg2: numpy.typing.NDArray[numpy.float64]) -> object
     """
     )
 
@@ -212,12 +212,12 @@ def test_passthrough_arguments(doc):
         + ", ".join(
             [
                 "arg0: float",
-                "arg1: numpy.ndarray[numpy.float64]",
-                "arg2: numpy.ndarray[numpy.float64]",
-                "arg3: numpy.ndarray[numpy.int32]",
+                "arg1: numpy.typing.NDArray[numpy.float64]",
+                "arg2: numpy.typing.NDArray[numpy.float64]",
+                "arg3: numpy.typing.NDArray[numpy.int32]",
                 "arg4: int",
                 "arg5: m.numpy_vectorize.NonPODClass",
-                "arg6: numpy.ndarray[numpy.float64]",
+                "arg6: numpy.typing.NDArray[numpy.float64]",
             ]
         )
         + ") -> object"


### PR DESCRIPTION
## Description

Fixed type hint for `pybind11::array_t`
Fixes #5352 


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Fixed type hint for `pybind11::array_t`
```

<!-- If the upgrade guide needs updating, note that here too -->
