### PR TITLE
Add warn disable for GGC 12 bound checking error

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1380,7 +1380,17 @@ protected:
             } else {
                 internals.registered_types_cpp[tindex] = tinfo;
             }
+
+            PYBIND11_WARNING_PUSH
+#if defined(__GNUC__) && __GNUC__ == 12
+            // When using GCC 12 these warnings are disabled as they trigger
+            // false positive warnings.  Discussed here:
+            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115824.
+            PYBIND11_WARNING_DISABLE_GCC("-Warray-bounds")
+            PYBIND11_WARNING_DISABLE_GCC("-Wstringop-overread")
+#endif
             internals.registered_types_py[(PyTypeObject *) m_ptr] = {tinfo};
+            PYBIND11_WARNING_POP
         });
 
         if (rec.bases.size() > 1 || rec.multiple_inheritance) {


### PR DESCRIPTION
Issue: [#5224](https://github.com/pybind/pybind11/issues/5224)

The `internals.registered_types_py...` line in pybind11.h triggers a
false-positive bounds checking warning in GCC 12.

This is discussed in
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115824.

The workaround implemented is taken from suggestions then refactored to
use the `PYBIND11_WARNING_PUSH` and `PYBIND11_WARNING_POP` MACROS.