### PR TITLE
Add type hints for args and kwargs

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1570,9 +1570,9 @@ class argument_loader {
     using indices = make_index_sequence<sizeof...(Args)>;
 
     template <typename Arg>
-    using argument_is_args = std::is_same<intrinsic_t<Arg>, args>;
+    using argument_is_args = std::is_base_of<args, intrinsic_t<Arg>>;
     template <typename Arg>
-    using argument_is_kwargs = std::is_same<intrinsic_t<Arg>, kwargs>;
+    using argument_is_kwargs = std::is_base_of<kwargs, intrinsic_t<Arg>>;
     // Get kwargs argument position, or -1 if not present:
     static constexpr auto kwargs_pos = constexpr_last<argument_is_kwargs, Args...>();
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1010,11 +1010,13 @@ struct handle_type_name<weakref> {
 };
 template <>
 struct handle_type_name<args> {
-    static constexpr auto name = const_name("*args");
+    static constexpr auto name = const_name("*args: ") + make_caster<object>::name;
+};
 };
 template <>
 struct handle_type_name<kwargs> {
-    static constexpr auto name = const_name("**kwargs");
+    static constexpr auto name = const_name("**kwargs: ") + make_caster<object>::name;
+};
 };
 template <>
 struct handle_type_name<obj_attr_accessor> {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1012,11 +1012,17 @@ template <>
 struct handle_type_name<args> {
     static constexpr auto name = const_name("*args: ") + make_caster<object>::name;
 };
+template <typename T>
+struct handle_type_name<Args<T>> {
+    static constexpr auto name = const_name("*args: ") + make_caster<T>::name;
 };
 template <>
 struct handle_type_name<kwargs> {
     static constexpr auto name = const_name("**kwargs: ") + make_caster<object>::name;
 };
+template <typename T>
+struct handle_type_name<KWArgs<T>> {
+    static constexpr auto name = const_name("**kwargs: ") + make_caster<T>::name;
 };
 template <>
 struct handle_type_name<obj_attr_accessor> {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1010,7 +1010,7 @@ struct handle_type_name<weakref> {
 };
 template <>
 struct handle_type_name<args> {
-    static constexpr auto name = const_name("*args: ") + make_caster<object>::name;
+    static constexpr auto name = const_name("*args: typing.Any");
 };
 template <typename T>
 struct handle_type_name<Args<T>> {
@@ -1018,7 +1018,7 @@ struct handle_type_name<Args<T>> {
 };
 template <>
 struct handle_type_name<kwargs> {
-    static constexpr auto name = const_name("**kwargs: ") + make_caster<object>::name;
+    static constexpr auto name = const_name("**kwargs: typing.Any");
 };
 template <typename T>
 struct handle_type_name<KWArgs<T>> {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1010,7 +1010,7 @@ struct handle_type_name<weakref> {
 };
 template <>
 struct handle_type_name<args> {
-    static constexpr auto name = const_name("*args: typing.Any");
+    static constexpr auto name = const_name("*args");
 };
 template <typename T>
 struct handle_type_name<Args<T>> {
@@ -1018,7 +1018,7 @@ struct handle_type_name<Args<T>> {
 };
 template <>
 struct handle_type_name<kwargs> {
-    static constexpr auto name = const_name("**kwargs: typing.Any");
+    static constexpr auto name = const_name("**kwargs");
 };
 template <typename T>
 struct handle_type_name<KWArgs<T>> {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2226,6 +2226,8 @@ class kwargs : public dict {
     PYBIND11_OBJECT_DEFAULT(kwargs, dict, PyDict_Check)
 };
 
+// Subclasses of args and kwargs to support type hinting
+// as defined in PEP 484. See #5357 for more info.
 template <typename T>
 class Args : public args {
     using args::args;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2216,6 +2216,16 @@ class kwargs : public dict {
     PYBIND11_OBJECT_DEFAULT(kwargs, dict, PyDict_Check)
 };
 
+template <typename T>
+class Args : public args {
+    using args::args;
+};
+
+template <typename T>
+class KWArgs : public kwargs {
+    using kwargs::kwargs;
+};
+
 class anyset : public object {
 public:
     PYBIND11_OBJECT(anyset, object, PyAnySet_Check)

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -14,26 +14,6 @@
 
 #include <utility>
 
-// Classes needed for subclass test.
-class ArgsSubclass : public py::args {
-    using py::args::args;
-};
-class KWArgsSubclass : public py::kwargs {
-    using py::kwargs::kwargs;
-};
-namespace pybind11 {
-namespace detail {
-template <>
-struct handle_type_name<ArgsSubclass> {
-    static constexpr auto name = const_name("*Args");
-};
-template <>
-struct handle_type_name<KWArgsSubclass> {
-    static constexpr auto name = const_name("**KWArgs");
-};
-} // namespace detail
-} // namespace pybind11
-
 TEST_SUBMODULE(kwargs_and_defaults, m) {
     auto kw_func
         = [](int x, int y) { return "x=" + std::to_string(x) + ", y=" + std::to_string(y); };
@@ -345,7 +325,7 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
 
     // Test support for args and kwargs subclasses
     m.def("args_kwargs_subclass_function",
-          [](const ArgsSubclass &args, const KWArgsSubclass &kwargs) {
+          [](const py::Args<std::string> &args, const py::KWArgs<std::string> &kwargs) {
               return py::make_tuple(args, kwargs);
           });
 }

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -20,7 +20,7 @@ def test_function_signatures(doc):
     )
     assert (
         doc(m.args_kwargs_subclass_function)
-        == "args_kwargs_subclass_function(*Args, **KWArgs) -> tuple"
+        == "args_kwargs_subclass_function(*args: str, **kwargs: str) -> tuple"
     )
     assert (
         doc(m.KWClass.foo0)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

The stubs generated by pybind11 do not contain any type hints for `*args` or `**kwargs` which makes static type checkers like mypy sad.

This pull request adds templated classes `py::Args` and `py::KWArgs` which can be used in place of `py::args` and `py::kwargs` to add custom type hints for `*args` and `**kwargs` as described in [PEP 484](https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values)


## Examples

```cpp
#include <pybind11/pybind11.h>

void init_module(py::module m){
    m.def("test", [](py::args args, py::kwargs kwargs){});
}
```

This will generate stub files that look like this
```
def test(*args, **kwargs) -> None: ...
```

If this is used with mypy it will generate this error.
`error: Function is missing a type annotation for one or more arguments`

The `py::Args` and `py::KWArgs` classes can be used instead to add type hints in the same vein as pybind11 does typing.
```cpp
#include <pybind11/pybind11.h>

void init_module(py::module m){
    m.def("test", [](py::Args<int> args, py::KWArgs<float> kwargs){});
}
```

This generates the following stub.
```
def test(*args: int, **kwargs: float) -> None: ...
```

This can also be used with anything pybind11 supports including custom classes added through pybind11.

## Alternatives

The only alternative solution I am currently aware of is to manually write the definition in a doc like this.
```cpp
#include <pybind11/pybind11.h>

void init_module(py::module m){
    py::options options;
    options.disable_function_signatures();
    m.def("test", [](py::args args, py::kwargs kwargs){},
    py::doc("test(*args: int, **kwargs: float) -> None")
    );
    options.enable_function_signatures();
}
```


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Added `py::Args` and `py::KWArgs` to enable custom type hinting of `*args` and `**kwargs` (see PEP 484).
```

<!-- If the upgrade guide needs updating, note that here too -->
