### PR TITLE
Added option for different arg/return type hints to type_caster

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -120,7 +120,8 @@ struct as_return_type {
 };
 
 template <typename T>
-struct as_return_type<T, typename std::enable_if<is_descr<decltype(T::return_name)>::value>::type> {
+struct as_return_type<T,
+                      typename std::enable_if<is_descr<decltype(T::return_name)>::value>::type> {
     static constexpr auto name = T::return_name;
 };
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -120,7 +120,7 @@ struct as_return_type {
 };
 
 template <typename T>
-struct as_return_type<T, typename std::enable_if_t<is_descr<decltype(T::return_name)>::value>> {
+struct as_return_type<T, typename std::enable_if<is_descr<decltype(T::return_name)>::value>::type> {
     static constexpr auto name = T::return_name;
 };
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -101,6 +101,31 @@ inline std::string replace_newlines_and_squash(const char *text) {
 #    define PYBIND11_COMPAT_STRDUP strdup
 #endif
 
+/// Type trait checker for `descr`.
+template<typename>
+struct is_descr : std::false_type {};
+
+template<size_t N, typename... Ts>
+struct is_descr<descr<N, Ts...>> : std::true_type {};
+
+template<size_t N, typename... Ts>
+struct is_descr<const descr<N, Ts...>> : std::true_type {};
+
+/// Checks for `return_name` in `type_caster` to replace `name` for return type hints.
+/// this is useful for having a different python type hint for args vs return value,
+/// e.g., `std::filesystem::path` -> Arg: `Union[os.PathLike, str, bytes]`, return: `Path`.
+template<typename T, typename Enable = void>
+struct as_return_type
+{
+    static constexpr auto name = T::name;
+};
+
+template <typename T>
+struct as_return_type<T, typename std::enable_if_t<is_descr<decltype(T::return_name)>::value>>
+{
+    static constexpr auto name = T::return_name;
+};
+
 PYBIND11_NAMESPACE_END(detail)
 
 /// Wraps an arbitrary C++ function/method/lambda function/.. into a callable Python object
@@ -320,7 +345,8 @@ protected:
         /* Generate a readable signature describing the function's arguments and return
            value types */
         static constexpr auto signature
-            = const_name("(") + cast_in::arg_names + const_name(") -> ") + cast_out::name;
+            = const_name("(") + cast_in::arg_names + const_name(") -> ")
+            + as_return_type<cast_out>::name;
         PYBIND11_DESCR_CONSTEXPR auto types = decltype(signature)::types();
 
         /* Register the function with Python from generic (non-templated) code */

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -102,27 +102,25 @@ inline std::string replace_newlines_and_squash(const char *text) {
 #endif
 
 /// Type trait checker for `descr`.
-template<typename>
+template <typename>
 struct is_descr : std::false_type {};
 
-template<size_t N, typename... Ts>
+template <size_t N, typename... Ts>
 struct is_descr<descr<N, Ts...>> : std::true_type {};
 
-template<size_t N, typename... Ts>
+template <size_t N, typename... Ts>
 struct is_descr<const descr<N, Ts...>> : std::true_type {};
 
 /// Checks for `return_name` in `type_caster` to replace `name` for return type hints.
 /// this is useful for having a different python type hint for args vs return value,
 /// e.g., `std::filesystem::path` -> Arg: `Union[os.PathLike, str, bytes]`, return: `Path`.
-template<typename T, typename Enable = void>
-struct as_return_type
-{
+template <typename T, typename Enable = void>
+struct as_return_type {
     static constexpr auto name = T::name;
 };
 
 template <typename T>
-struct as_return_type<T, typename std::enable_if_t<is_descr<decltype(T::return_name)>::value>>
-{
+struct as_return_type<T, typename std::enable_if_t<is_descr<decltype(T::return_name)>::value>> {
     static constexpr auto name = T::return_name;
 };
 
@@ -344,9 +342,8 @@ protected:
 
         /* Generate a readable signature describing the function's arguments and return
            value types */
-        static constexpr auto signature
-            = const_name("(") + cast_in::arg_names + const_name(") -> ")
-            + as_return_type<cast_out>::name;
+        static constexpr auto signature = const_name("(") + cast_in::arg_names
+                                          + const_name(") -> ") + as_return_type<cast_out>::name;
         PYBIND11_DESCR_CONSTEXPR auto types = decltype(signature)::types();
 
         /* Register the function with Python from generic (non-templated) code */

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -106,7 +106,8 @@ public:
         return true;
     }
 
-    PYBIND11_TYPE_CASTER(T, const_name("os.PathLike"));
+    PYBIND11_TYPE_CASTER(T, const_name("Union[os.PathLike, str, bytes]"));
+    static constexpr auto return_name = const_name("Path");
 };
 
 #endif // PYBIND11_HAS_FILESYSTEM || defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -454,6 +454,13 @@ TEST_SUBMODULE(stl, m) {
     // test_fs_path
     m.attr("has_filesystem") = true;
     m.def("parent_path", [](const std::filesystem::path &p) { return p.parent_path(); });
+    m.def("parent_paths", [](const std::vector<std::filesystem::path> &p) {
+        std::vector<std::filesystem::path> result;
+        for (const auto &i : p) {
+            result.push_back(i.parent_path());
+        }
+        return result;
+    });
 #endif
 
 #ifdef PYBIND11_TEST_VARIANT

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -265,6 +265,11 @@ def test_fs_path(doc):
         doc(m.parent_path)
         == "parent_path(arg0: Union[os.PathLike, str, bytes]) -> Path"
     )
+    assert m.parent_paths(["foo/bar", "foo/baz"]) == [Path("foo"), Path("foo")]
+    assert (
+        doc(m.parent_paths)
+        == "parent_paths(arg0: list[Union[os.PathLike, str, bytes]]) -> list[Path]"
+    )
 
 
 @pytest.mark.skipif(not hasattr(m, "load_variant"), reason="no <variant>")

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -245,7 +245,7 @@ def test_reference_sensitive_optional():
 
 
 @pytest.mark.skipif(not hasattr(m, "has_filesystem"), reason="no <filesystem>")
-def test_fs_path():
+def test_fs_path(doc):
     from pathlib import Path
 
     class PseudoStrPath:
@@ -261,6 +261,7 @@ def test_fs_path():
     assert m.parent_path(b"foo/bar") == Path("foo")
     assert m.parent_path(PseudoStrPath()) == Path("foo")
     assert m.parent_path(PseudoBytesPath()) == Path("foo")
+    assert doc(m.parent_path) == "parent_path(arg0: Union[os.PathLike, str, bytes]) -> Path"
 
 
 @pytest.mark.skipif(not hasattr(m, "load_variant"), reason="no <variant>")

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -261,7 +261,10 @@ def test_fs_path(doc):
     assert m.parent_path(b"foo/bar") == Path("foo")
     assert m.parent_path(PseudoStrPath()) == Path("foo")
     assert m.parent_path(PseudoBytesPath()) == Path("foo")
-    assert doc(m.parent_path) == "parent_path(arg0: Union[os.PathLike, str, bytes]) -> Path"
+    assert (
+        doc(m.parent_path)
+        == "parent_path(arg0: Union[os.PathLike, str, bytes]) -> Path"
+    )
 
 
 @pytest.mark.skipif(not hasattr(m, "load_variant"), reason="no <variant>")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
This PR adds the option for defining `return_name` in a custom `type_caster`, which allows to have different python type hints for arguments and return value. The check if `return_name` is available or `name` should be used as fallback is implemented using the template class `as_return_type`.

This is entirely optional and should not impact any existing `type_caster`.
One exception is the `type_caster` for `std::filesystem::path`, which was modified to support this new feature.
Here, `Union[os.PathLike, str, bytes]` is the argument type hint and `Path` is the return type hint.
This is more accurate than the previous usage of `os.PathLike` for both argument and return type hint.
I have updated the unit test to check for the new signature.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Added option for different arg/return type hints to type_caster.
Updated stl/filesystem to use correct arg/return type hints.
```

<!-- If the upgrade guide needs updating, note that here too -->

## Possible TODOs
* [ ] Update `Custom type casters` documentation
* [x] Test if it works in containers like `list[Path]` -> does not work
* [ ] Fix for all `handle_type_name` (maybe some recursive template magic adding `as_return_type` to subtypes)
* [ ] Update type hints for Eigen (currently uses `np.ndarray` as arg type hint but also takes lists and tuples (should probably be `numpy.typing.ArrayLike` + maybe `typing.Annotated` for shape/dtype annotation


I would love to get feedback on this!
Especially on the "Possible TODO" regarding Eigen. Should I implement that here in this PR or should I open a separate PR later?

Currently I am working on adding typing stubs to Open3D (isl-org/Open3D#6917) using `pybind11-stubgen`.
Applying mypy/pyright on existing example code showed that a lot of type checks failed, which could be fixed by this PR.
