### PR TITLE
fix docs build command on different global and venv python versions

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -142,7 +142,7 @@ On Linux, the above example can be compiled using the following command:
 
 .. code-block:: bash
 
-    $ c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) example.cpp -o example$(python3-config --extension-suffix)
+    $ c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) example.cpp -o example$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')
 
 .. note::
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -142,7 +142,7 @@ On Linux, the above example can be compiled using the following command:
 
 .. code-block:: bash
 
-    $ c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) example.cpp -o example$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')
+    $ c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) example.cpp -o example$(python3 -m pybind11 --extension-suffix)
 
 .. note::
 

--- a/pybind11/__main__.py
+++ b/pybind11/__main__.py
@@ -71,6 +71,11 @@ def main() -> None:
         action="store_true",
         help="Print the pkgconfig directory, ideal for setting $PKG_CONFIG_PATH.",
     )
+    parser.add_argument(
+        "--extension-suffix",
+        action="store_true",
+        help="Print the extension for a Python module",
+    )
     args = parser.parse_args()
     if not sys.argv[1:]:
         parser.print_help()
@@ -80,6 +85,8 @@ def main() -> None:
         print(quote(get_cmake_dir()))
     if args.pkgconfigdir:
         print(quote(get_pkgconfig_dir()))
+    if args.extension_suffix:
+        print(sysconfig.get_config_var("EXT_SUFFIX"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

The build command in the [docs](https://pybind11.readthedocs.io/en/stable/basics.html#creating-bindings-for-a-simple-function) fails when using a python venv with a different version to the global installation as python3-config will use the global one.

For example on a machine with global python 3.12 in a venv using python 3.11:

```bash
(venv) $ python3-config --extension-suffix  # .cpython-311-x86_64-linux-gnu.so

(venv) $ python3 -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))'  # .cpython-312-x86_64-linux-gnu.so
```

This silently causes a 'ModuleNotFound' error as the venv cannot import the generated pybind module.

## Suggested changelog entry:

``rst
Support ``--extension-suffix` on the pybind11 command
```
