### PR TITLE
Added exception translator specific mutex used with try_translate_exceptions

### DIFF
--- a/include/pybind11/detail/exception_translation.h
+++ b/include/pybind11/detail/exception_translation.h
@@ -50,17 +50,17 @@ inline void try_translate_exceptions() {
         - delegate translation to the next translator by throwing a new type of exception.
         */
 
-    bool handled = with_internals_for_exception_translator([&](internals &internals) {
-        auto &local_exception_translators = get_local_internals().registered_exception_translators;
-        if (detail::apply_exception_translators(local_exception_translators)) {
-            return true;
-        }
-        auto &exception_translators = internals.registered_exception_translators;
-        if (detail::apply_exception_translators(exception_translators)) {
-            return true;
-        }
-        return false;
-    });
+    bool handled = with_exception_translators(
+        [&](std::forward_list<ExceptionTranslator> &exception_translators,
+            std::forward_list<ExceptionTranslator> &local_exception_translators) {
+            if (detail::apply_exception_translators(local_exception_translators)) {
+                return true;
+            }
+            if (detail::apply_exception_translators(exception_translators)) {
+                return true;
+            }
+            return false;
+        });
 
     if (!handled) {
         set_error(PyExc_SystemError, "Exception escaped from default exception translator!");

--- a/include/pybind11/detail/exception_translation.h
+++ b/include/pybind11/detail/exception_translation.h
@@ -50,7 +50,7 @@ inline void try_translate_exceptions() {
         - delegate translation to the next translator by throwing a new type of exception.
         */
 
-    bool handled = with_internals([&](internals &internals) {
+    bool handled = with_internals_for_exception_translator([&](internals &internals) {
         auto &local_exception_translators = get_local_internals().registered_exception_translators;
         if (detail::apply_exception_translators(local_exception_translators)) {
             return true;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2586,7 +2586,7 @@ void implicitly_convertible() {
 }
 
 inline void register_exception_translator(ExceptionTranslator &&translator) {
-    detail::with_internals([&](detail::internals &internals) {
+    detail::with_internals_for_exception_translator([&](detail::internals &internals) {
         internals.registered_exception_translators.push_front(
             std::forward<ExceptionTranslator>(translator));
     });
@@ -2599,7 +2599,7 @@ inline void register_exception_translator(ExceptionTranslator &&translator) {
  * the exception.
  */
 inline void register_local_exception_translator(ExceptionTranslator &&translator) {
-    detail::with_internals([&](detail::internals &internals) {
+    detail::with_internals_for_exception_translator([&](detail::internals &internals) {
         (void) internals;
         detail::get_local_internals().registered_exception_translators.push_front(
             std::forward<ExceptionTranslator>(translator));

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2586,10 +2586,12 @@ void implicitly_convertible() {
 }
 
 inline void register_exception_translator(ExceptionTranslator &&translator) {
-    detail::with_internals_for_exception_translator([&](detail::internals &internals) {
-        internals.registered_exception_translators.push_front(
-            std::forward<ExceptionTranslator>(translator));
-    });
+    detail::with_exception_translators(
+        [&](std::forward_list<ExceptionTranslator> &exception_translators,
+            std::forward_list<ExceptionTranslator> &local_exception_translators) {
+            (void) local_exception_translators;
+            exception_translators.push_front(std::forward<ExceptionTranslator>(translator));
+        });
 }
 
 /**
@@ -2599,11 +2601,12 @@ inline void register_exception_translator(ExceptionTranslator &&translator) {
  * the exception.
  */
 inline void register_local_exception_translator(ExceptionTranslator &&translator) {
-    detail::with_internals_for_exception_translator([&](detail::internals &internals) {
-        (void) internals;
-        detail::get_local_internals().registered_exception_translators.push_front(
-            std::forward<ExceptionTranslator>(translator));
-    });
+    detail::with_exception_translators(
+        [&](std::forward_list<ExceptionTranslator> &exception_translators,
+            std::forward_list<ExceptionTranslator> &local_exception_translators) {
+            (void) exception_translators;
+            local_exception_translators.push_front(std::forward<ExceptionTranslator>(translator));
+        });
 }
 
 /**

--- a/tests/custom_exceptions.py
+++ b/tests/custom_exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 
 class PythonMyException7(Exception):
     def __init__(self, message):

--- a/tests/custom_exceptions.py
+++ b/tests/custom_exceptions.py
@@ -1,0 +1,9 @@
+
+class PythonMyException7(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(message)
+
+    def __str__(self):
+        s = "[PythonMyException7]: " + self.message.a
+        return s

--- a/tests/custom_exceptions.py
+++ b/tests/custom_exceptions.py
@@ -7,5 +7,4 @@ class PythonMyException7(Exception):
         super().__init__(message)
 
     def __str__(self):
-        s = "[PythonMyException7]: " + self.message.a
-        return s
+        return "[PythonMyException7]: " + self.message.a

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -405,8 +405,9 @@ TEST_SUBMODULE(exceptions, m) {
         .def(py::init<const std::string &>())
         .def_readwrite("a", &CustomData::a);
 
-    PYBIND11_CONSTINIT static py::gil_safe_call_once_and_store<py::object> storage;
-    storage.call_once_and_store_result([&]() {
+    PYBIND11_CONSTINIT static py::gil_safe_call_once_and_store<py::object>
+        PythonMyException7_storage;
+    PythonMyException7_storage.call_once_and_store_result([&]() {
         auto mod = py::module_::import("custom_exceptions");
         py::object obj = mod.attr("PythonMyException7");
         return obj;
@@ -418,9 +419,9 @@ TEST_SUBMODULE(exceptions, m) {
                 std::rethrow_exception(p);
             }
         } catch (const MyException7 &e) {
-            auto obj = storage.get_stored();
-            py::object obj2 = obj(e.message);
-            PyErr_SetObject(PyExc_Exception, obj2.ptr());
+            auto exc_type = PythonMyException7_storage.get_stored();
+            py::object exc_inst = exc_type(e.message);
+            PyErr_SetObject(PyExc_Exception, exc_inst.ptr());
         }
     });
 }

--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -112,12 +112,12 @@ struct PythonAlreadySetInDestructor {
 };
 
 struct CustomData {
-    CustomData(const std::string &a) : a(a) {}
+    explicit CustomData(const std::string &a) : a(a) {}
     std::string a;
 };
 
 struct MyException7 {
-    MyException7(const CustomData &message) : message(message) {}
+    explicit MyException7(const CustomData &message) : message(message) {}
     CustomData message;
 };
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 
 import pytest
+from custom_exceptions import PythonMyException7
 
 import env
 import pybind11_cross_module_tests as cm
@@ -194,6 +195,10 @@ def test_custom(msg):
         except m.MyException5_1 as err:
             raise RuntimeError("Exception error: caught child from parent") from err
     assert msg(excinfo.value) == "this is a helper-defined translated exception"
+
+    with pytest.raises(PythonMyException7) as excinfo:
+        m.throws7()
+    assert msg(excinfo.value) == "[PythonMyException7]: abc"
 
 
 def test_nested_throws(capture):


### PR DESCRIPTION
## Description

- Added exception translator specific mutex in the internals to lock it when with `try_translate_exceptions` and `register_exception_translator`, `register_local_exception_translator`.

Fixes #5346


cc @colesbury 



<!-- 
## Suggested changelog entry:

Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script.
```rst
...
```
-->
<!-- If the upgrade guide needs updating, note that here too -->
