### PR TITLE
[v2.11] Backport: Enable type-safe interoperability between different independent Python/C++ bindings systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ cmake_dependent_option(PYBIND11_FINDPYTHON "Force new FindPython" OFF
 set(PYBIND11_HEADERS
     include/pybind11/detail/class.h
     include/pybind11/detail/common.h
+    include/pybind11/detail/cpp_conduit.h
     include/pybind11/detail/descr.h
     include/pybind11/detail/init.h
     include/pybind11/detail/internals.h

--- a/include/pybind11/detail/cpp_conduit.h
+++ b/include/pybind11/detail/cpp_conduit.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2024 The pybind Community.
+
+#pragma once
+
+#include <pybind11/pytypes.h>
+
+#include "common.h"
+#include "internals.h"
+
+#include <typeinfo>
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+// Forward declaration needed here: Refactoring opportunity.
+extern "C" inline PyObject *pybind11_object_new(PyTypeObject *type, PyObject *, PyObject *);
+
+inline bool type_is_managed_by_our_internals(PyTypeObject *type_obj) {
+#if defined(PYPY_VERSION)
+    auto &internals = get_internals();
+    return bool(internals.registered_types_py.find(type_obj)
+                != internals.registered_types_py.end());
+#else
+    return bool(type_obj->tp_new == pybind11_object_new);
+#endif
+}
+
+inline bool is_instance_method_of_type(PyTypeObject *type_obj, PyObject *attr_name) {
+    PyObject *descr = _PyType_Lookup(type_obj, attr_name);
+    return bool((descr != nullptr) && PyInstanceMethod_Check(descr));
+}
+
+inline object try_get_cpp_conduit_method(PyObject *obj) {
+    if (PyType_Check(obj)) {
+        return object();
+    }
+    PyTypeObject *type_obj = Py_TYPE(obj);
+    str attr_name("_pybind11_conduit_v1_");
+    bool assumed_to_be_callable = false;
+    if (type_is_managed_by_our_internals(type_obj)) {
+        if (!is_instance_method_of_type(type_obj, attr_name.ptr())) {
+            return object();
+        }
+        assumed_to_be_callable = true;
+    }
+    PyObject *method = PyObject_GetAttr(obj, attr_name.ptr());
+    if (method == nullptr) {
+        PyErr_Clear();
+        return object();
+    }
+    if (!assumed_to_be_callable && PyCallable_Check(method) == 0) {
+        Py_DECREF(method);
+        return object();
+    }
+    return reinterpret_steal<object>(method);
+}
+
+inline void *try_raw_pointer_ephemeral_from_cpp_conduit(handle src,
+                                                        const std::type_info *cpp_type_info) {
+    object method = try_get_cpp_conduit_method(src.ptr());
+    if (method) {
+        capsule cpp_type_info_capsule(const_cast<void *>(static_cast<const void *>(cpp_type_info)),
+                                      typeid(std::type_info).name());
+        object cpp_conduit = method(bytes(PYBIND11_PLATFORM_ABI_ID),
+                                    cpp_type_info_capsule,
+                                    bytes("raw_pointer_ephemeral"));
+        if (isinstance<capsule>(cpp_conduit)) {
+            return reinterpret_borrow<capsule>(cpp_conduit).get_pointer();
+        }
+    }
+    return nullptr;
+}
+
+#define PYBIND11_HAS_CPP_CONDUIT 1
+
+PYBIND11_NAMESPACE_END(detail)
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -307,15 +307,17 @@ struct type_info {
 #    endif
 #endif
 
+#define PYBIND11_PLATFORM_ABI_ID                                                                  \
+    PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI             \
+        PYBIND11_BUILD_TYPE
+
 #define PYBIND11_INTERNALS_ID                                                                     \
     "__pybind11_internals_v" PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION)                        \
-        PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI         \
-            PYBIND11_BUILD_TYPE "__"
+        PYBIND11_PLATFORM_ABI_ID "__"
 
 #define PYBIND11_MODULE_LOCAL_ID                                                                  \
     "__pybind11_module_local_v" PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION)                     \
-        PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI         \
-            PYBIND11_BUILD_TYPE "__"
+        PYBIND11_PLATFORM_ABI_ID "__"
 
 /// Each module locally stores a pointer to the `internals` data. The data
 /// itself is shared among modules with the same `PYBIND11_INTERNALS_ID`.

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -11,13 +11,16 @@
 
 #include "../pytypes.h"
 #include "common.h"
+#include "cpp_conduit.h"
 #include "descr.h"
 #include "internals.h"
 #include "typeid.h"
 
 #include <cstdint>
+#include <cstring>
 #include <iterator>
 #include <new>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <typeindex>
@@ -637,6 +640,13 @@ public:
         }
         return false;
     }
+    bool try_cpp_conduit(handle src) {
+        value = try_raw_pointer_ephemeral_from_cpp_conduit(src, cpptype);
+        if (value != nullptr) {
+            return true;
+        }
+        return false;
+    }
     void check_holder_compat() {}
 
     PYBIND11_NOINLINE static void *local_load(PyObject *src, const type_info *ti) {
@@ -768,6 +778,10 @@ public:
             return true;
         }
 
+        if (convert && cpptype && this_.try_cpp_conduit(src)) {
+            return true;
+        }
+
         return false;
     }
 
@@ -794,6 +808,32 @@ public:
     const std::type_info *cpptype = nullptr;
     void *value = nullptr;
 };
+
+inline object cpp_conduit_method(handle self,
+                                 const bytes &pybind11_platform_abi_id,
+                                 const capsule &cpp_type_info_capsule,
+                                 const bytes &pointer_kind) {
+#ifdef PYBIND11_HAS_STRING_VIEW
+    using cpp_str = std::string_view;
+#else
+    using cpp_str = std::string;
+#endif
+    if (cpp_str(pybind11_platform_abi_id) != PYBIND11_PLATFORM_ABI_ID) {
+        return none();
+    }
+    if (std::strcmp(cpp_type_info_capsule.name(), typeid(std::type_info).name()) != 0) {
+        return none();
+    }
+    if (cpp_str(pointer_kind) != "raw_pointer_ephemeral") {
+        throw std::runtime_error("Invalid pointer_kind: \"" + std::string(pointer_kind) + "\"");
+    }
+    const auto *cpp_type_info = cpp_type_info_capsule.get_pointer<const std::type_info>();
+    type_caster_generic caster(*cpp_type_info);
+    if (!caster.load(self, false)) {
+        return none();
+    }
+    return capsule(caster.value, cpp_type_info->name());
+}
 
 /**
  * Determine suitable casting operator for pointer-or-lvalue-casting type casters.  The type caster

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -569,7 +569,8 @@ protected:
         int index = 0;
         /* Create a nice pydoc rec including all signatures and
            docstrings of the functions in the overload chain */
-        if (chain && options::show_function_signatures()) {
+        if (chain && options::show_function_signatures()
+            && std::strcmp(rec->name, "_pybind11_conduit_v1_") != 0) {
             // First a generic signature
             signatures += rec->name;
             signatures += "(*args, **kwargs)\n";
@@ -578,7 +579,8 @@ protected:
         // Then specific overload signatures
         bool first_user_def = true;
         for (auto *it = chain_start; it != nullptr; it = it->next) {
-            if (options::show_function_signatures()) {
+            if (options::show_function_signatures()
+                && std::strcmp(rec->name, "_pybind11_conduit_v1_") != 0) {
                 if (index > 0) {
                     signatures += '\n';
                 }
@@ -1558,6 +1560,7 @@ public:
             instances[std::type_index(typeid(type_alias))]
                 = instances[std::type_index(typeid(type))];
         }
+        def("_pybind11_conduit_v1_", cpp_conduit_method);
     }
 
     template <typename Base, detail::enable_if_t<is_base<Base>::value, int> = 0>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,7 @@ set(PYBIND11_TEST_FILES
     test_const_name
     test_constants_and_functions
     test_copy_move
+    test_cpp_conduit
     test_custom_type_casters
     test_custom_type_setup
     test_docstring_options
@@ -219,6 +220,8 @@ tests_extra_targets("test_exceptions.py;test_local_bindings.py;test_stl.py;test_
 # And add additional targets for other tests.
 tests_extra_targets("test_exceptions.py" "cross_module_interleaved_error_already_set")
 tests_extra_targets("test_gil_scoped.py" "cross_module_gil_utils")
+tests_extra_targets("test_cpp_conduit.py"
+                    "exo_planet_pybind11;exo_planet_c_api;home_planet_very_lonely_traveler")
 
 set(PYBIND11_EIGEN_REPO
     "https://gitlab.com/libeigen/eigen.git"

--- a/tests/exo_planet_c_api.cpp
+++ b/tests/exo_planet_c_api.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2024 The pybind Community.
+
+// THIS MUST STAY AT THE TOP!
+#include <pybind11/pybind11.h> // EXCLUSIVELY for PYBIND11_PLATFORM_ABI_ID
+// Potential future direction to maximize reusability:
+// (e.g. for use from SWIG, Cython, PyCLIF, nanobind):
+//     #include <pybind11/compat/platform_abi_id.h>
+// This would only depend on:
+//     1. A C++ compiler, WITHOUT requiring -fexceptions.
+//     2. Python.h
+
+#include "test_cpp_conduit_traveler_types.h"
+
+#include <Python.h>
+#include <typeinfo>
+
+namespace {
+
+void *get_cpp_conduit_void_ptr(PyObject *py_obj, const std::type_info *cpp_type_info) {
+    PyObject *cpp_type_info_capsule
+        = PyCapsule_New(const_cast<void *>(static_cast<const void *>(cpp_type_info)),
+                        typeid(std::type_info).name(),
+                        nullptr);
+    if (cpp_type_info_capsule == nullptr) {
+        return nullptr;
+    }
+    PyObject *cpp_conduit = PyObject_CallMethod(py_obj,
+                                                "_pybind11_conduit_v1_",
+                                                "yOy",
+                                                PYBIND11_PLATFORM_ABI_ID,
+                                                cpp_type_info_capsule,
+                                                "raw_pointer_ephemeral");
+    Py_DECREF(cpp_type_info_capsule);
+    if (cpp_conduit == nullptr) {
+        return nullptr;
+    }
+    void *void_ptr = PyCapsule_GetPointer(cpp_conduit, cpp_type_info->name());
+    Py_DECREF(cpp_conduit);
+    if (PyErr_Occurred()) {
+        return nullptr;
+    }
+    return void_ptr;
+}
+
+template <typename T>
+T *get_cpp_conduit_type_ptr(PyObject *py_obj) {
+    void *void_ptr = get_cpp_conduit_void_ptr(py_obj, &typeid(T));
+    if (void_ptr == nullptr) {
+        return nullptr;
+    }
+    return static_cast<T *>(void_ptr);
+}
+
+extern "C" PyObject *wrapGetLuggage(PyObject * /*self*/, PyObject *traveler) {
+    const auto *cpp_traveler
+        = get_cpp_conduit_type_ptr<pybind11_tests::test_cpp_conduit::Traveler>(traveler);
+    if (cpp_traveler == nullptr) {
+        return nullptr;
+    }
+    return PyUnicode_FromString(cpp_traveler->luggage.c_str());
+}
+
+extern "C" PyObject *wrapGetPoints(PyObject * /*self*/, PyObject *premium_traveler) {
+    const auto *cpp_premium_traveler
+        = get_cpp_conduit_type_ptr<pybind11_tests::test_cpp_conduit::PremiumTraveler>(
+            premium_traveler);
+    if (cpp_premium_traveler == nullptr) {
+        return nullptr;
+    }
+    return PyLong_FromLong(static_cast<long>(cpp_premium_traveler->points));
+}
+
+PyMethodDef ThisMethodDef[] = {{"GetLuggage", wrapGetLuggage, METH_O, nullptr},
+                               {"GetPoints", wrapGetPoints, METH_O, nullptr},
+                               {nullptr, nullptr, 0, nullptr}};
+
+struct PyModuleDef ThisModuleDef = {
+    PyModuleDef_HEAD_INIT, // m_base
+    "exo_planet_c_api",    // m_name
+    nullptr,               // m_doc
+    -1,                    // m_size
+    ThisMethodDef,         // m_methods
+    nullptr,               // m_slots
+    nullptr,               // m_traverse
+    nullptr,               // m_clear
+    nullptr                // m_free
+};
+
+} // namespace
+
+#if defined(WIN32) || defined(_WIN32)
+#    define EXO_PLANET_C_API_EXPORT __declspec(dllexport)
+#else
+#    define EXO_PLANET_C_API_EXPORT __attribute__((visibility("default")))
+#endif
+
+extern "C" EXO_PLANET_C_API_EXPORT PyObject *PyInit_exo_planet_c_api() {
+    PyObject *m = PyModule_Create(&ThisModuleDef);
+    if (m == nullptr) {
+        return nullptr;
+    }
+    return m;
+}

--- a/tests/exo_planet_pybind11.cpp
+++ b/tests/exo_planet_pybind11.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 The pybind Community.
+
+#if defined(PYBIND11_INTERNALS_VERSION)
+#    undef PYBIND11_INTERNALS_VERSION
+#endif
+#define PYBIND11_INTERNALS_VERSION 900000001
+
+#include "test_cpp_conduit_traveler_bindings.h"
+
+namespace pybind11_tests {
+namespace test_cpp_conduit {
+
+PYBIND11_MODULE(exo_planet_pybind11, m) {
+    wrap_traveler(m);
+    m.def("wrap_very_lonely_traveler", [m]() { wrap_very_lonely_traveler(m); });
+}
+
+} // namespace test_cpp_conduit
+} // namespace pybind11_tests

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -49,6 +49,7 @@ main_headers = {
 detail_headers = {
     "include/pybind11/detail/class.h",
     "include/pybind11/detail/common.h",
+    "include/pybind11/detail/cpp_conduit.h",
     "include/pybind11/detail/descr.h",
     "include/pybind11/detail/init.h",
     "include/pybind11/detail/internals.h",

--- a/tests/home_planet_very_lonely_traveler.cpp
+++ b/tests/home_planet_very_lonely_traveler.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2024 The pybind Community.
+
+#include "test_cpp_conduit_traveler_bindings.h"
+
+namespace pybind11_tests {
+namespace test_cpp_conduit {
+
+PYBIND11_MODULE(home_planet_very_lonely_traveler, m) {
+    m.def("wrap_very_lonely_traveler", [m]() { wrap_very_lonely_traveler(m); });
+}
+
+} // namespace test_cpp_conduit
+} // namespace pybind11_tests

--- a/tests/test_cpp_conduit.cpp
+++ b/tests/test_cpp_conduit.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 The pybind Community.
+
+#include "pybind11_tests.h"
+#include "test_cpp_conduit_traveler_bindings.h"
+
+#include <typeinfo>
+
+namespace pybind11_tests {
+namespace test_cpp_conduit {
+
+TEST_SUBMODULE(cpp_conduit, m) {
+    m.attr("PYBIND11_PLATFORM_ABI_ID") = py::bytes(PYBIND11_PLATFORM_ABI_ID);
+    m.attr("cpp_type_info_capsule_Traveler")
+        = py::capsule(&typeid(Traveler), typeid(std::type_info).name());
+    m.attr("cpp_type_info_capsule_int") = py::capsule(&typeid(int), typeid(std::type_info).name());
+
+    wrap_traveler(m);
+    wrap_lonely_traveler(m);
+}
+
+} // namespace test_cpp_conduit
+} // namespace pybind11_tests

--- a/tests/test_cpp_conduit.py
+++ b/tests/test_cpp_conduit.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2024 The pybind Community.
+
+from __future__ import annotations
+
+import exo_planet_c_api
+import exo_planet_pybind11
+import home_planet_very_lonely_traveler
+import pytest
+
+from pybind11_tests import cpp_conduit as home_planet
+
+
+def test_traveler_getattr_actually_exists():
+    t_h = home_planet.Traveler("home")
+    assert t_h.any_name == "Traveler GetAttr: any_name luggage: home"
+
+
+def test_premium_traveler_getattr_actually_exists():
+    t_h = home_planet.PremiumTraveler("home", 7)
+    assert t_h.secret_name == "PremiumTraveler GetAttr: secret_name points: 7"
+
+
+def test_call_cpp_conduit_success():
+    t_h = home_planet.Traveler("home")
+    cap = t_h._pybind11_conduit_v1_(
+        home_planet.PYBIND11_PLATFORM_ABI_ID,
+        home_planet.cpp_type_info_capsule_Traveler,
+        b"raw_pointer_ephemeral",
+    )
+    assert cap.__class__.__name__ == "PyCapsule"
+
+
+def test_call_cpp_conduit_platform_abi_id_mismatch():
+    t_h = home_planet.Traveler("home")
+    cap = t_h._pybind11_conduit_v1_(
+        home_planet.PYBIND11_PLATFORM_ABI_ID + b"MISMATCH",
+        home_planet.cpp_type_info_capsule_Traveler,
+        b"raw_pointer_ephemeral",
+    )
+    assert cap is None
+
+
+def test_call_cpp_conduit_cpp_type_info_capsule_mismatch():
+    t_h = home_planet.Traveler("home")
+    cap = t_h._pybind11_conduit_v1_(
+        home_planet.PYBIND11_PLATFORM_ABI_ID,
+        home_planet.cpp_type_info_capsule_int,
+        b"raw_pointer_ephemeral",
+    )
+    assert cap is None
+
+
+def test_call_cpp_conduit_pointer_kind_invalid():
+    t_h = home_planet.Traveler("home")
+    with pytest.raises(
+        RuntimeError, match='^Invalid pointer_kind: "raw_pointer_ephemreal"$'
+    ):
+        t_h._pybind11_conduit_v1_(
+            home_planet.PYBIND11_PLATFORM_ABI_ID,
+            home_planet.cpp_type_info_capsule_Traveler,
+            b"raw_pointer_ephemreal",
+        )
+
+
+def test_home_only_basic():
+    t_h = home_planet.Traveler("home")
+    assert t_h.luggage == "home"
+    assert home_planet.get_luggage(t_h) == "home"
+
+
+def test_home_only_premium():
+    p_h = home_planet.PremiumTraveler("home", 2)
+    assert p_h.luggage == "home"
+    assert home_planet.get_luggage(p_h) == "home"
+    assert home_planet.get_points(p_h) == 2
+
+
+def test_exo_only_basic():
+    t_e = exo_planet_pybind11.Traveler("exo")
+    assert t_e.luggage == "exo"
+    assert exo_planet_pybind11.get_luggage(t_e) == "exo"
+
+
+def test_exo_only_premium():
+    p_e = exo_planet_pybind11.PremiumTraveler("exo", 3)
+    assert p_e.luggage == "exo"
+    assert exo_planet_pybind11.get_luggage(p_e) == "exo"
+    assert exo_planet_pybind11.get_points(p_e) == 3
+
+
+def test_home_passed_to_exo_basic():
+    t_h = home_planet.Traveler("home")
+    assert exo_planet_pybind11.get_luggage(t_h) == "home"
+
+
+def test_exo_passed_to_home_basic():
+    t_e = exo_planet_pybind11.Traveler("exo")
+    assert home_planet.get_luggage(t_e) == "exo"
+
+
+def test_home_passed_to_exo_premium():
+    p_h = home_planet.PremiumTraveler("home", 2)
+    assert exo_planet_pybind11.get_luggage(p_h) == "home"
+    assert exo_planet_pybind11.get_points(p_h) == 2
+
+
+def test_exo_passed_to_home_premium():
+    p_e = exo_planet_pybind11.PremiumTraveler("exo", 3)
+    assert home_planet.get_luggage(p_e) == "exo"
+    assert home_planet.get_points(p_e) == 3
+
+
+@pytest.mark.parametrize(
+    "traveler_type", [home_planet.Traveler, exo_planet_pybind11.Traveler]
+)
+def test_exo_planet_c_api_traveler(traveler_type):
+    t = traveler_type("socks")
+    assert exo_planet_c_api.GetLuggage(t) == "socks"
+
+
+@pytest.mark.parametrize(
+    "premium_traveler_type",
+    [home_planet.PremiumTraveler, exo_planet_pybind11.PremiumTraveler],
+)
+def test_exo_planet_c_api_premium_traveler(premium_traveler_type):
+    pt = premium_traveler_type("gucci", 5)
+    assert exo_planet_c_api.GetLuggage(pt) == "gucci"
+    assert exo_planet_c_api.GetPoints(pt) == 5
+
+
+def test_home_planet_wrap_very_lonely_traveler():
+    # This does not exercise the cpp_conduit feature, but is here to
+    # demonstrate that the cpp_conduit feature does not solve all
+    # cross-extension interoperability issues.
+    # Here is the proof that the following works for extensions with
+    # matching `PYBIND11_INTERNALS_ID`s:
+    #     test_cpp_conduit.cpp:
+    #         py::class_<LonelyTraveler>
+    #     home_planet_very_lonely_traveler.cpp:
+    #         py::class_<VeryLonelyTraveler, LonelyTraveler>
+    # See test_exo_planet_pybind11_wrap_very_lonely_traveler() for the negative
+    # test.
+    assert home_planet.LonelyTraveler is not None  # Verify that the base class exists.
+    home_planet_very_lonely_traveler.wrap_very_lonely_traveler()
+    # Ensure that the derived class exists.
+    assert home_planet_very_lonely_traveler.VeryLonelyTraveler is not None
+
+
+def test_exo_planet_pybind11_wrap_very_lonely_traveler():
+    # See comment under test_home_planet_wrap_very_lonely_traveler() first.
+    # Here the `PYBIND11_INTERNALS_ID`s don't match between:
+    #     test_cpp_conduit.cpp:
+    #         py::class_<LonelyTraveler>
+    #     exo_planet_pybind11.cpp:
+    #         py::class_<VeryLonelyTraveler, LonelyTraveler>
+    assert home_planet.LonelyTraveler is not None  # Verify that the base class exists.
+    with pytest.raises(
+        RuntimeError,
+        match='^generic_type: type "VeryLonelyTraveler" referenced unknown base type '
+        '"pybind11_tests::test_cpp_conduit::LonelyTraveler"$',
+    ):
+        exo_planet_pybind11.wrap_very_lonely_traveler()

--- a/tests/test_cpp_conduit.py
+++ b/tests/test_cpp_conduit.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2024 The pybind Community.
 
-from __future__ import annotations
-
 import exo_planet_c_api
 import exo_planet_pybind11
 import home_planet_very_lonely_traveler

--- a/tests/test_cpp_conduit_traveler_bindings.h
+++ b/tests/test_cpp_conduit_traveler_bindings.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2024 The pybind Community.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+#include "test_cpp_conduit_traveler_types.h"
+
+#include <string>
+
+namespace pybind11_tests {
+namespace test_cpp_conduit {
+
+namespace py = pybind11;
+
+inline void wrap_traveler(py::module_ m) {
+    py::class_<Traveler>(m, "Traveler")
+        .def(py::init<std::string>())
+        .def_readwrite("luggage", &Traveler::luggage)
+        // See issue #3788:
+        .def("__getattr__", [](const Traveler &self, const std::string &key) {
+            return "Traveler GetAttr: " + key + " luggage: " + self.luggage;
+        });
+
+    m.def("get_luggage", [](const Traveler &person) { return person.luggage; });
+
+    py::class_<PremiumTraveler, Traveler>(m, "PremiumTraveler")
+        .def(py::init<std::string, int>())
+        .def_readwrite("points", &PremiumTraveler::points)
+        // See issue #3788:
+        .def("__getattr__", [](const PremiumTraveler &self, const std::string &key) {
+            return "PremiumTraveler GetAttr: " + key + " points: " + std::to_string(self.points);
+        });
+
+    m.def("get_points", [](const PremiumTraveler &person) { return person.points; });
+}
+
+inline void wrap_lonely_traveler(py::module_ m) {
+    py::class_<LonelyTraveler>(std::move(m), "LonelyTraveler");
+}
+
+inline void wrap_very_lonely_traveler(py::module_ m) {
+    py::class_<VeryLonelyTraveler, LonelyTraveler>(std::move(m), "VeryLonelyTraveler");
+}
+
+} // namespace test_cpp_conduit
+} // namespace pybind11_tests

--- a/tests/test_cpp_conduit_traveler_types.h
+++ b/tests/test_cpp_conduit_traveler_types.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 The pybind Community.
+
+#pragma once
+
+#include <string>
+
+namespace pybind11_tests {
+namespace test_cpp_conduit {
+
+struct Traveler {
+    explicit Traveler(const std::string &luggage) : luggage(luggage) {}
+    std::string luggage;
+};
+
+struct PremiumTraveler : Traveler {
+    explicit PremiumTraveler(const std::string &luggage, int points)
+        : Traveler(luggage), points(points) {}
+    int points;
+};
+
+struct LonelyTraveler {};
+struct VeryLonelyTraveler : LonelyTraveler {};
+
+} // namespace test_cpp_conduit
+} // namespace pybind11_tests


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Backport of PR https://github.com/pybind/pybind11/pull/5296 to the pybind11 v2.11 series, to maximize the benefit of the new cross-version interoperability feature.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Backport of PR #5296: The pybind11 v2.11 series now interoperates with other pybind11 versions that include PR #5296. (See the description of PR #5296 for limitations.)
```

<!-- If the upgrade guide needs updating, note that here too -->
