### PR TITLE
fix(cmake): `NO_EXTRAS` in `pybind11_add_module` function partially working

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -274,10 +274,6 @@ function(pybind11_add_module target_name)
     target_link_libraries(${target_name} PRIVATE pybind11::embed)
   endif()
 
-  if(MSVC)
-    target_link_libraries(${target_name} PRIVATE pybind11::windows_extras)
-  endif()
-
   # -fvisibility=hidden is required to allow multiple modules compiled against
   # different pybind versions to work properly, and for some features (e.g.
   # py::module_local).  We force it on everything inside the `pybind11`


### PR DESCRIPTION
## Description

The `NO_EXTRAS` parameter in the `pybind11_add_module` function was not fully effective, resulting in incomplete application of the intended build configuration. After investigation, it was discovered that the `target_link_libraries(${target_name} PRIVATE pybind11::windows_extras)` command was included twice in the CMake script. [One of these](https://github.com/pybind/pybind11/blob/ad9fd39e143c8296a49a1b5b258cb6aa24e23889/tools/pybind11NewTools.cmake#L277-L279) instances occurred before the [`ARG_NO_EXTRAS`](https://github.com/pybind/pybind11/blob/ad9fd39e143c8296a49a1b5b258cb6aa24e23889/tools/pybind11NewTools.cmake#L299-L301) condition was checked, which caused `pybind11::windows_extras` to be linked even when `NO_EXTRAS` was set. Another occurrence of this call can be found [here](https://github.com/pybind/pybind11/blob/ad9fd39e143c8296a49a1b5b258cb6aa24e23889/tools/pybind11NewTools.cmake#L320-L322). This caused the function to work only partially as intended.
