### PR TITLE
Allow subclasses of py::args and py::kwargs

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1570,9 +1570,9 @@ class argument_loader {
     using indices = make_index_sequence<sizeof...(Args)>;
 
     template <typename Arg>
-    using argument_is_args = std::is_same<intrinsic_t<Arg>, args>;
+    using argument_is_args = std::is_base_of<args, intrinsic_t<Arg>>;
     template <typename Arg>
-    using argument_is_kwargs = std::is_same<intrinsic_t<Arg>, kwargs>;
+    using argument_is_kwargs = std::is_base_of<kwargs, intrinsic_t<Arg>>;
     // Get kwargs argument position, or -1 if not present:
     static constexpr auto kwargs_pos = constexpr_last<argument_is_kwargs, Args...>();
 

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -322,16 +322,14 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
             py::pos_only{},
             py::arg("i"),
             py::arg("j"));
-            
+
     // Test support for args and kwargs subclasses
-    class ArgsSubclass: public py::args{
+    class ArgsSubclass : public py::args {
         using py::args::args;
-    }
-    class KWArgsSubclass: public py::kwargs{
+    } class KWArgsSubclass : public py::kwargs {
         using py::kwargs::kwargs;
-    }
-    m.def("args_kwargs_subclass_function", [](const ArgsSubclass &args, const KWArgsSubclass &kwargs) {
-        return py::make_tuple(args, kwargs);
-    });
-    
+    } m.def("args_kwargs_subclass_function",
+            [](const ArgsSubclass &args, const KWArgsSubclass &kwargs) {
+                return py::make_tuple(args, kwargs);
+            });
 }

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -322,4 +322,16 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
             py::pos_only{},
             py::arg("i"),
             py::arg("j"));
+            
+    // Test support for args and kwargs subclasses
+    class ArgsSubclass: public py::args{
+        using py::args::args;
+    }
+    class KWArgsSubclass: public py::kwargs{
+        using py::kwargs::kwargs;
+    }
+    m.def("args_kwargs_subclass_function", [](const ArgsSubclass &args, const KWArgsSubclass &kwargs) {
+        return py::make_tuple(args, kwargs);
+    });
+    
 }

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -25,11 +25,11 @@ namespace pybind11 {
 namespace detail {
 template <>
 struct handle_type_name<ArgsSubclass> {
-    static constexpr auto name = const_name("*args");
+    static constexpr auto name = const_name("*Args");
 };
 template <>
 struct handle_type_name<KWArgsSubclass> {
-    static constexpr auto name = const_name("**kwargs");
+    static constexpr auto name = const_name("**KWArgs");
 };
 } // namespace detail
 } // namespace pybind11

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -324,13 +324,14 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
             py::arg("j"));
 
     // Test support for args and kwargs subclasses
-    class ArgsSubclass: public py::args{
+    class ArgsSubclass : public py::args {
         using py::args::args;
     };
-    class KWArgsSubclass: public py::kwargs{
+    class KWArgsSubclass : public py::kwargs {
         using py::kwargs::kwargs;
     };
-    m.def("args_kwargs_subclass_function", [](const ArgsSubclass &args, const KWArgsSubclass &kwargs) {
-        return py::make_tuple(args, kwargs);
-    });
+    m.def("args_kwargs_subclass_function",
+          [](const ArgsSubclass &args, const KWArgsSubclass &kwargs) {
+              return py::make_tuple(args, kwargs);
+          });
 }

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -14,6 +14,22 @@
 
 #include <utility>
 
+// Classes needed for subclass test.
+class ArgsSubclass : public py::args {
+    using py::args::args;
+};
+class KWArgsSubclass : public py::kwargs {
+    using py::kwargs::kwargs;
+};
+template <>
+struct handle_type_name<ArgsSubclass> {
+    static constexpr auto name = const_name("*args");
+};
+template <>
+struct handle_type_name<KWArgsSubclass> {
+    static constexpr auto name = const_name("**kwargs");
+};
+
 TEST_SUBMODULE(kwargs_and_defaults, m) {
     auto kw_func
         = [](int x, int y) { return "x=" + std::to_string(x) + ", y=" + std::to_string(y); };
@@ -324,20 +340,6 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
             py::arg("j"));
 
     // Test support for args and kwargs subclasses
-    class ArgsSubclass : public py::args {
-        using py::args::args;
-    };
-    class KWArgsSubclass : public py::kwargs {
-        using py::kwargs::kwargs;
-    };
-    template <>
-    struct handle_type_name<ArgsSubclass> {
-        static constexpr auto name = const_name("*args");
-    };
-    template <>
-    struct handle_type_name<KWArgsSubclass> {
-        static constexpr auto name = const_name("**kwargs");
-    };
     m.def("args_kwargs_subclass_function",
           [](const ArgsSubclass &args, const KWArgsSubclass &kwargs) {
               return py::make_tuple(args, kwargs);

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -21,14 +21,19 @@ class ArgsSubclass : public py::args {
 class KWArgsSubclass : public py::kwargs {
     using py::kwargs::kwargs;
 };
-template <>
-struct handle_type_name<ArgsSubclass> {
-    static constexpr auto name = const_name("*args");
-};
-template <>
-struct handle_type_name<KWArgsSubclass> {
-    static constexpr auto name = const_name("**kwargs");
-};
+namespace pybind11 {
+    namespace detail {
+        template <>
+        struct handle_type_name<ArgsSubclass> {
+            static constexpr auto name = const_name("*args");
+        };
+        template <>
+        struct handle_type_name<KWArgsSubclass> {
+            static constexpr auto name = const_name("**kwargs");
+        };
+    }
+}
+
 
 TEST_SUBMODULE(kwargs_and_defaults, m) {
     auto kw_func

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -324,12 +324,13 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
             py::arg("j"));
 
     // Test support for args and kwargs subclasses
-    class ArgsSubclass : public py::args {
+    class ArgsSubclass: public py::args{
         using py::args::args;
-    } class KWArgsSubclass : public py::kwargs {
+    };
+    class KWArgsSubclass: public py::kwargs{
         using py::kwargs::kwargs;
-    } m.def("args_kwargs_subclass_function",
-            [](const ArgsSubclass &args, const KWArgsSubclass &kwargs) {
-                return py::make_tuple(args, kwargs);
-            });
+    };
+    m.def("args_kwargs_subclass_function", [](const ArgsSubclass &args, const KWArgsSubclass &kwargs) {
+        return py::make_tuple(args, kwargs);
+    });
 }

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -330,6 +330,14 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
     class KWArgsSubclass : public py::kwargs {
         using py::kwargs::kwargs;
     };
+    template <>
+    struct handle_type_name<ArgsSubclass> {
+        static constexpr auto name = const_name("*args");
+    };
+    template <>
+    struct handle_type_name<KWArgsSubclass> {
+        static constexpr auto name = const_name("**kwargs");
+    };
     m.def("args_kwargs_subclass_function",
           [](const ArgsSubclass &args, const KWArgsSubclass &kwargs) {
               return py::make_tuple(args, kwargs);

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -22,18 +22,17 @@ class KWArgsSubclass : public py::kwargs {
     using py::kwargs::kwargs;
 };
 namespace pybind11 {
-    namespace detail {
-        template <>
-        struct handle_type_name<ArgsSubclass> {
-            static constexpr auto name = const_name("*args");
-        };
-        template <>
-        struct handle_type_name<KWArgsSubclass> {
-            static constexpr auto name = const_name("**kwargs");
-        };
-    }
-}
-
+namespace detail {
+template <>
+struct handle_type_name<ArgsSubclass> {
+    static constexpr auto name = const_name("*args");
+};
+template <>
+struct handle_type_name<KWArgsSubclass> {
+    static constexpr auto name = const_name("**kwargs");
+};
+} // namespace detail
+} // namespace pybind11
 
 TEST_SUBMODULE(kwargs_and_defaults, m) {
     auto kw_func

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -426,3 +426,8 @@ def test_args_refcount():
     assert m.mixed_args_refcount(myval, myval, myval) == (exp3_3, exp3_3, exp3_3)
 
     assert m.class_default_argument() == "<class 'decimal.Decimal'>"
+    
+    assert m.args_kwargs_subclass_function(7, 8, myval, a=1, b=myval) == (
+        (7, 8, myval),
+        {"a": 1, "b": myval},
+    )

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -18,7 +18,8 @@ def test_function_signatures(doc):
         doc(m.args_kwargs_function) == "args_kwargs_function(*args, **kwargs) -> tuple"
     )
     assert (
-        doc(m.args_kwargs_subclass_function) == "args_kwargs_subclass_function(*Args, **KWArgs) -> tuple"
+        doc(m.args_kwargs_subclass_function)
+        == "args_kwargs_subclass_function(*Args, **KWArgs) -> tuple"
     )
     assert (
         doc(m.KWClass.foo0)
@@ -416,7 +417,7 @@ def test_args_refcount():
         {"a": 1, "b": myval},
     )
     assert refcount(myval) == expected
-    
+
     assert m.args_kwargs_subclass_function(7, 8, myval, a=1, b=myval) == (
         (7, 8, myval),
         {"a": 1, "b": myval},

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -18,6 +18,9 @@ def test_function_signatures(doc):
         doc(m.args_kwargs_function) == "args_kwargs_function(*args, **kwargs) -> tuple"
     )
     assert (
+        doc(m.args_kwargs_subclass_function) == "args_kwargs_subclass_function(*Args, **KWArgs) -> tuple"
+    )
+    assert (
         doc(m.KWClass.foo0)
         == "foo0(self: m.kwargs_and_defaults.KWClass, arg0: int, arg1: float) -> None"
     )
@@ -98,6 +101,7 @@ def test_arg_and_kwargs():
     args = "a1", "a2"
     kwargs = {"arg3": "a3", "arg4": 4}
     assert m.args_kwargs_function(*args, **kwargs) == (args, kwargs)
+    assert m.args_kwargs_subclass_function(*args, **kwargs) == (args, kwargs)
 
 
 def test_mixed_args_and_kwargs(msg):
@@ -412,6 +416,12 @@ def test_args_refcount():
         {"a": 1, "b": myval},
     )
     assert refcount(myval) == expected
+    
+    assert m.args_kwargs_subclass_function(7, 8, myval, a=1, b=myval) == (
+        (7, 8, myval),
+        {"a": 1, "b": myval},
+    )
+    assert refcount(myval) == expected
 
     exp3 = refcount(myval, myval, myval)
     assert m.args_refcount(myval, myval, myval) == (exp3, exp3, exp3)
@@ -426,8 +436,3 @@ def test_args_refcount():
     assert m.mixed_args_refcount(myval, myval, myval) == (exp3_3, exp3_3, exp3_3)
 
     assert m.class_default_argument() == "<class 'decimal.Decimal'>"
-
-    assert m.args_kwargs_subclass_function(7, 8, myval, a=1, b=myval) == (
-        (7, 8, myval),
-        {"a": 1, "b": myval},
-    )

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -426,7 +426,7 @@ def test_args_refcount():
     assert m.mixed_args_refcount(myval, myval, myval) == (exp3_3, exp3_3, exp3_3)
 
     assert m.class_default_argument() == "<class 'decimal.Decimal'>"
-    
+
     assert m.args_kwargs_subclass_function(7, 8, myval, a=1, b=myval) == (
         (7, 8, myval),
         {"a": 1, "b": myval},


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

The current implementation does not allow subclasses of args or kwargs.
This change allows subclasses to be used.

This was originally submitted as part of #5357 but more discussion is required to solve it.
This is a very minor change which would allow me to implement my own workaround until it is solved.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Allow subclasses of `py::args` and `py::kwargs`.
```

<!-- If the upgrade guide needs updating, note that here too -->
