### PR TITLE
Export libc++ exceptions

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -323,6 +323,7 @@ PYBIND11_WARNING_POP
 
 // For libc++, the exceptions should be exported,
 // otherwise, the exception translation would be incorrect.
+// IMPORTANT: This code block must stay BELOW the #include <exception> above (see PR #5390).
 #if !defined(PYBIND11_EXPORT_EXCEPTION)
 #    if defined(_LIBCPP_EXCEPTION)
 #        define PYBIND11_EXPORT_EXCEPTION PYBIND11_EXPORT

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -324,7 +324,7 @@ PYBIND11_WARNING_POP
 // For libc++, the exceptions should be exported,
 // otherwise, the exception translation would be incorrect.
 #if !defined(PYBIND11_EXPORT_EXCEPTION)
-#    if defined(__apple_build_version__) || defined(_LIBCPP_EXCEPTION)
+#    if defined(_LIBCPP_EXCEPTION)
 #        define PYBIND11_EXPORT_EXCEPTION PYBIND11_EXPORT
 #    else
 #        define PYBIND11_EXPORT_EXCEPTION

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -164,14 +164,6 @@
 #    endif
 #endif
 
-#if !defined(PYBIND11_EXPORT_EXCEPTION)
-#    if defined(__apple_build_version__)
-#        define PYBIND11_EXPORT_EXCEPTION PYBIND11_EXPORT
-#    else
-#        define PYBIND11_EXPORT_EXCEPTION
-#    endif
-#endif
-
 // For CUDA, GCC7, GCC8:
 // PYBIND11_NOINLINE_FORCED is incompatible with `-Wattributes -Werror`.
 // When defining PYBIND11_NOINLINE_FORCED, it is best to also use `-Wno-attributes`.
@@ -326,6 +318,16 @@ PYBIND11_WARNING_POP
 #if defined(__has_include)
 #    if __has_include(<version>)
 #        include <version>
+#    endif
+#endif
+
+// For libc++, the exceptions should be exported,
+// otherwise, the exception translation would be incorrect.
+#if !defined(PYBIND11_EXPORT_EXCEPTION)
+#    if defined(__apple_build_version__) || defined(_LIBCPP_EXCEPTION)
+#        define PYBIND11_EXPORT_EXCEPTION PYBIND11_EXPORT
+#    else
+#        define PYBIND11_EXPORT_EXCEPTION
 #    endif
 #endif
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -76,7 +76,7 @@ def test_cross_module_exceptions(msg):
 
 # TODO: FIXME
 @pytest.mark.xfail(
-    "(env.MACOS and env.PYPY) or sys.platform.startswith('emscripten')",
+    "env.MACOS and env.PYPY",
     raises=RuntimeError,
     reason="See Issue #2847, PR #2999, PR #4324",
 )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -76,7 +76,7 @@ def test_cross_module_exceptions(msg):
 
 # TODO: FIXME
 @pytest.mark.xfail(
-    "env.MACOS and (env.PYPY or pybind11_tests.compiler_info.startswith('Homebrew Clang')) or sys.platform.startswith('emscripten')",
+    "(env.MACOS and env.PYPY) or sys.platform.startswith('emscripten')",
     raises=RuntimeError,
     reason="See Issue #2847, PR #2999, PR #4324",
 )


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Before this PR, exception translation was still failing on libc++. The failure reason is the visibility of exceptions, which was already discovered in #2999 and reverted by #4324.  This PR fixes it by detecting libc++ using the _LIBCPP_EXCEPTION macro and setting PYBIND11_EXPORT_EXCEPTION accordingly. The macro definition is moved below other C++ header inclusion to make sure that _LIBCPP_EXCEPTION is defined.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

 

```rst
``pybind11::builtin_exception`` is now explicitly exported when linked to libc++.
```

<!-- If the upgrade guide needs updating, note that here too -->
