### PR TITLE
fix: don't strip with BUILD_TYPE None

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -307,7 +307,7 @@ function(pybind11_add_module target_name)
   if(DEFINED CMAKE_BUILD_TYPE) # see https://github.com/pybind/pybind11/issues/4454
     # Use case-insensitive comparison to match the result of $<CONFIG:cfgs>
     string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
-    if(NOT MSVC AND NOT "${uppercase_CMAKE_BUILD_TYPE}" MATCHES DEBUG|RELWITHDEBINFO)
+    if(NOT MSVC AND NOT "${uppercase_CMAKE_BUILD_TYPE}" MATCHES DEBUG|RELWITHDEBINFO|NONE)
       # Strip unnecessary sections of the binary on Linux/macOS
       pybind11_strip(${target_name})
     endif()

--- a/tools/pybind11Tools.cmake
+++ b/tools/pybind11Tools.cmake
@@ -196,7 +196,7 @@ function(pybind11_add_module target_name)
   if(DEFINED CMAKE_BUILD_TYPE) # see https://github.com/pybind/pybind11/issues/4454
     # Use case-insensitive comparison to match the result of $<CONFIG:cfgs>
     string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
-    if(NOT MSVC AND NOT "${uppercase_CMAKE_BUILD_TYPE}" MATCHES DEBUG|RELWITHDEBINFO)
+    if(NOT MSVC AND NOT "${uppercase_CMAKE_BUILD_TYPE}" MATCHES DEBUG|RELWITHDEBINFO|NONE)
       pybind11_strip(${target_name})
     endif()
   endif()


### PR DESCRIPTION
## Description

Debian builds with None by default and takes care of stripping itself.
This allows building debug symbol packages.

## Suggested changelog entry:

```rst
Don't strip with CMAKE_BUILD_TYPE None

```