### PR TITLE
Print key in KeyError in map.__getitem__/__delitem__

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -785,7 +785,7 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args &&
         [](Map &m, const KeyType &k) -> MappedType & {
             auto it = m.find(k);
             if (it == m.end()) {
-                throw key_error();
+                throw key_error(str(cast(k)).cast<std::string>());
             }
             return it->second;
         },
@@ -808,7 +808,7 @@ class_<Map, holder_type> bind_map(handle scope, const std::string &name, Args &&
     cl.def("__delitem__", [](Map &m, const KeyType &k) {
         auto it = m.find(k);
         if (it == m.end()) {
-            throw key_error();
+            throw key_error(str(cast(k)).cast<std::string>());
         }
         m.erase(it);
     });

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -712,9 +712,10 @@ str format_message_key_error(const KeyType &key) {
             return message;
         }
     }
-    const size_t max_length = 80;
+    const size_t max_length = 200;
     if (len(message) > max_length) {
-        return str(message[slice(0, max_length, 1)]) + str("...");
+        return str(message[slice(0, max_length / 2, 1)]) + str("...")
+               + str(message[slice(len(message) - max_length / 2, len(message), 1)]);
     }
     return message;
 }

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -703,7 +703,7 @@ std::string format_message_key_error(const KeyType &k) {
         try {
             message = repr(cast(k));
         } catch (const std::exception &) {
-            // Leave the message empty.
+            return message;
         }
     }
     const size_t max_length = 80;

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -694,13 +694,9 @@ struct ItemsViewImpl : public detail::items_view {
     Map &map;
 };
 
-template <typename KeyType>
-str format_message_key_error(const KeyType &key) {
+inline str format_message_key_error_key_object(handle py_key) {
     str message = "pybind11::bind_map key";
-    object py_key;
-    try {
-        py_key = cast(key);
-    } catch (const std::exception &) {
+    if (!py_key) {
         return message;
     }
     try {
@@ -718,6 +714,18 @@ str format_message_key_error(const KeyType &key) {
                + str(message[slice(-half_max_length, static_cast<ssize_t>(len(message)), 1)]);
     }
     return message;
+}
+
+template <typename KeyType>
+str format_message_key_error(const KeyType &key) {
+    object py_key;
+    try {
+        py_key = cast(key);
+    } catch (const std::exception &) {
+        do { // Trick to avoid "empty catch" warning/error.
+        } while (false);
+    }
+    return format_message_key_error_key_object(py_key);
 }
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -712,10 +712,10 @@ str format_message_key_error(const KeyType &key) {
             return message;
         }
     }
-    const size_t max_length = 200;
-    if (len(message) > max_length) {
-        return str(message[slice(0, max_length / 2, 1)]) + str("...")
-               + str(message[slice(len(message) - max_length / 2, len(message), 1)]);
+    const ssize_t half_max_length = 100;
+    if (len(message) > half_max_length * 2) {
+        return str(message[slice(0, half_max_length, 1)]) + str("...")
+               + str(message[slice(-half_max_length, static_cast<ssize_t>(len(message)), 1)]);
     }
     return message;
 }

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -708,10 +708,10 @@ inline str format_message_key_error_key_object(handle py_key) {
             return message;
         }
     }
-    const ssize_t half_max_length = 100;
-    if (len(message) > half_max_length * 2) {
-        return str(message[slice(0, half_max_length, 1)]) + str("...")
-               + str(message[slice(-half_max_length, static_cast<ssize_t>(len(message)), 1)]);
+    const ssize_t cut_length = 100;
+    if (len(message) > 2 * cut_length + 3) {
+        return str(message[slice(0, cut_length, 1)]) + str("✄✄✄")
+               + str(message[slice(-cut_length, static_cast<ssize_t>(len(message)), 1)]);
     }
     return message;
 }

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -310,6 +310,11 @@ def test_map_delitem():
         del mm["a_long_key"]
     assert "a_long_key" in str(excinfo.value)
 
+    k = "".join(map(str, range(1000)))
+    with pytest.raises(KeyError) as excinfo:
+        del mm[k]
+    assert (k[:80] + "...") in str(excinfo.value)
+
     um = m.UnorderedMapStringDouble()
     um["ua"] = 1.1
     um["ub"] = 2.6

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -304,11 +304,11 @@ def test_map_delitem():
 
     with pytest.raises(KeyError) as excinfo:
         _ = mm["a_long_key"]
-    assert "a_long_key" in excinfo.value
+    assert "a_long_key" in str(excinfo.value)
 
     with pytest.raises(KeyError) as excinfo:
         del mm["a_long_key"]
-    assert "a_long_key" in excinfo.value
+    assert "a_long_key" in str(excinfo.value)
 
     um = m.UnorderedMapStringDouble()
     um["ua"] = 1.1

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -313,7 +313,9 @@ def test_map_delitem():
     k = "".join(map(str, range(1000)))
     with pytest.raises(KeyError) as excinfo:
         del mm[k]
-    assert (k[:80] + "...") in str(excinfo.value)
+    max_length = 200
+    k_repr = k[: max_length // 2] + "..." + k[-max_length // 2 :]
+    assert k_repr in str(excinfo.value)
 
     um = m.UnorderedMapStringDouble()
     um["ua"] = 1.1

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -303,18 +303,22 @@ def test_map_delitem():
     assert list(mm.items()) == [("b", 2.5)]
 
     with pytest.raises(KeyError) as excinfo:
-        _ = mm["a_long_key"]
+        mm["a_long_key"]
     assert "a_long_key" in str(excinfo.value)
 
     with pytest.raises(KeyError) as excinfo:
         del mm["a_long_key"]
     assert "a_long_key" in str(excinfo.value)
 
-    k = "".join(map(str, range(1000)))
+    cut_length = 100
+    k_very_long = "ab" * cut_length + "xyz"
     with pytest.raises(KeyError) as excinfo:
-        del mm[k]
-    max_length = 200
-    k_repr = k[: max_length // 2] + "..." + k[-max_length // 2 :]
+        mm[k_very_long]
+    assert k_very_long in str(excinfo.value)
+    k_very_long += "@"
+    with pytest.raises(KeyError) as excinfo:
+        mm[k_very_long]
+    k_repr = k_very_long[:cut_length] + "✄✄✄" + k_very_long[-cut_length:]
     assert k_repr in str(excinfo.value)
 
     um = m.UnorderedMapStringDouble()

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -302,6 +302,14 @@ def test_map_delitem():
     assert list(mm) == ["b"]
     assert list(mm.items()) == [("b", 2.5)]
 
+    with pytest.raises(KeyError) as excinfo:
+        _ = mm["a_long_key"]
+    assert "a_long_key" in excinfo.value
+
+    with pytest.raises(KeyError) as excinfo:
+        del mm["a_long_key"]
+    assert "a_long_key" in excinfo.value
+
     um = m.UnorderedMapStringDouble()
     um["ua"] = 1.1
     um["ub"] = 2.6


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

When a C++ container is bound by `bind_map` and one accesses or deletes an element that does not exist, pybind11 currently raises an empty, uninformative message: `KeyError: ''`. This PR prints the key, which is the behavior of Python's `dict`.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
When getting or deleting an element in a container bound by ``bind_map``, print the key in ``KeyError`` if it does not exist.
```

<!-- If the upgrade guide needs updating, note that here too -->
