### PR TITLE
Fix #5399: iterator increment operator does not skip first item

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1476,8 +1476,12 @@ public:
     }
 
     iterator operator++(int) {
-        auto rv = *this;
+        // Note: We must call init() first so that rv.value is
+        // the same as this->value just before calling advance().
+        // Otherwise, dereferencing the returned iterator may call
+        // advance() again and return the 3rd item instead of the 1st.
         init();
+        auto rv = *this;
         advance();
         return rv;
     }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1470,27 +1470,26 @@ public:
     PYBIND11_OBJECT_DEFAULT(iterator, object, PyIter_Check)
 
     iterator &operator++() {
+        init();
         advance();
         return *this;
     }
 
     iterator operator++(int) {
         auto rv = *this;
+        init();
         advance();
         return rv;
     }
 
     // NOLINTNEXTLINE(readability-const-return-type) // PR #3263
     reference operator*() const {
-        if (m_ptr && !value.ptr()) {
-            auto &self = const_cast<iterator &>(*this);
-            self.advance();
-        }
+        init();
         return value;
     }
 
     pointer operator->() const {
-        operator*();
+        init();
         return &value;
     }
 
@@ -1513,6 +1512,13 @@ public:
     friend bool operator!=(const iterator &a, const iterator &b) { return a->ptr() != b->ptr(); }
 
 private:
+    void init() const {
+        if (m_ptr && !value.ptr()) {
+            auto &self = const_cast<iterator &>(*this);
+            self.advance();
+        }
+    }
+
     void advance() {
         value = reinterpret_steal<object>(PyIter_Next(m_ptr));
         if (value.ptr() == nullptr && PyErr_Occurred()) {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -150,7 +150,14 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("get_iterator", [] { return py::iterator(); });
     // test_iterable
     m.def("get_iterable", [] { return py::iterable(); });
+    m.def("get_first_item_from_iterable", [](const py::iterable &iter) {
+        // This tests the postfix increment operator
+        py::iterator it = iter.begin();
+        py::iterator it2 = it++;
+        return *it2;
+    });
     m.def("get_second_item_from_iterable", [](const py::iterable &iter) {
+        // This tests the prefix increment operator
         py::iterator it = iter.begin();
         ++it;
         return *it;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -150,6 +150,11 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("get_iterator", [] { return py::iterator(); });
     // test_iterable
     m.def("get_iterable", [] { return py::iterable(); });
+    m.def("get_second_item_from_iterable", [](const py::iterable &iter) {
+        py::iterator it = iter.begin();
+        ++it;
+        return *it;
+    });
     m.def("get_frozenset_from_iterable",
           [](const py::iterable &iter) { return py::frozenset(iter); });
     m.def("get_list_from_iterable", [](const py::iterable &iter) { return py::list(iter); });

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -54,6 +54,12 @@ def test_iterable(doc):
     assert doc(m.get_iterable) == "get_iterable() -> Iterable"
 
 
+def test_get_second_item_from_iterable():
+    lins = [1, 2]
+    i = m.get_second_item_from_iterable(lins)
+    assert i == 2
+
+
 def test_float(doc):
     assert doc(m.get_float) == "get_float() -> float"
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -52,10 +52,9 @@ def test_from_iterable(pytype, from_iter_func):
 
 def test_iterable(doc):
     assert doc(m.get_iterable) == "get_iterable() -> Iterable"
-
-
-def test_get_second_item_from_iterable():
-    lins = [1, 2]
+    lins = [1, 2, 3]
+    i = m.get_first_item_from_iterable(lins)
+    assert i == 1
     i = m.get_second_item_from_iterable(lins)
     assert i == 2
 


### PR DESCRIPTION
## Description

Fixes #5399

I fixed this bug by ensuring that the increment operator calls `advance()` one more time if `advance()` had never been called before (like `operator*` and `operator->` already did). I encapsulated this logic in a helper function `init()`.

Alternatively, the `init()` function could directly be called in the constructor, which would make more sense and be more performant since it avoids the extra check on all operators. But I'm not sure how to do this since the constructor is defined via a macro. This is why I used the same method as `operator*` and `operator->` already did.

## Suggested changelog entry:

```rst
* Fix iterator increment operator does not skip first item
```
