### PR TITLE
Manually defining a class via attributes does not allow for passing kwargs

### DIFF
--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -554,6 +554,22 @@ TEST_SUBMODULE(class_, m) {
     });
 
     test_class::pr4220_tripped_over_this::bind_empty0(m);
+
+    py::object parent_metaclass = py::reinterpret_borrow<py::object>((PyObject *) &PyType_Type);
+    py::dict attributes;
+
+    attributes["test"] = py::cpp_function(
+        [](py::object self [[maybe_unused]], py::object x, py::object y) {
+            py::print(x, y);
+            return 0;
+        },
+        py::arg("x"),
+        py::kw_only(),
+        py::arg("y"),
+        py::is_method(py::none())
+    );
+
+    m.attr("KwOnlyMethod") = parent_metaclass("MwOnlyMethod", py::make_tuple(), attributes);
 }
 
 template <int N>

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -501,3 +501,7 @@ def test_pr4220_tripped_over_this():
         m.Empty0().get_msg()
         == "This is really only meant to exercise successful compilation."
     )
+
+
+def test_kw_only():
+    assert (m.KwOnlyMethod().test("x", y="y") == 0)


### PR DESCRIPTION
The recommended method of creating a subclass from https://github.com/pybind/pybind11/issues/1193#issuecomment-429451094 does not seem to allow for passing keyword arguments Demonstrate that using the method of defining a class recommended on https://github.com/pybind/pybind11/issues/1193 does not allow for passing kwargs.

This test fails with:
```
    def test_kw_only():
>       assert (m.KwOnlyMethod().test("x", y="y") == 0)
E       TypeError: (): incompatible function arguments. The following argument types are supported:
E           1. (x: object, *, y: object, arg1: object) -> int
E
E       Invoked with: <importlib._bootstrap.MwOnlyMethod object at 0x11029e900>, 'x'; kwargs: y='y'


../../../../tests/test_class.py:507: TypeError
```