### PR TITLE
Fix buffer protocol implementation

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -602,9 +602,9 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
         return -1;
     }
     view->obj = obj;
+    view->ndim = 1;  // See discussion on PR #5407.
     view->internal = info;
     view->buf = info->ptr;
-    view->ndim = (int) info->ndim;
     view->itemsize = info->itemsize;
     view->len = view->itemsize;
     for (auto s : info->shape) {
@@ -615,6 +615,7 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
         view->format = const_cast<char *>(info->format.c_str());
     }
     if ((flags & PyBUF_ND) == PyBUF_ND) {
+        view->ndim = (int) info->ndim;
         view->shape = info->shape.data();
     }
     if ((flags & PyBUF_STRIDES) == PyBUF_STRIDES) {

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -612,7 +612,7 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
     for (auto s : info->shape) {
         view->len *= s;
     }
-    view->ndim = (int) info->ndim;
+    view->ndim = static_cast<int>(info->ndim);
     view->shape = info->shape.data();
     view->strides = info->strides.data();
     view->readonly = static_cast<int>(info->readonly);
@@ -645,9 +645,9 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
             return -1;
         }
 
+    } else if ((flags & PyBUF_STRIDES) != PyBUF_STRIDES) {
         // If no strides are requested, the buffer must be C-contiguous.
         // https://docs.python.org/3/c-api/buffer.html#contiguity-requests
-    } else if ((flags & PyBUF_STRIDES) != PyBUF_STRIDES) {
         if (PyBuffer_IsContiguous(view, 'C') == 0) {
             std::memset(view, 0, sizeof(Py_buffer));
             delete info;
@@ -661,7 +661,7 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
         // Since this is a contiguous buffer, it can also pretend to be 1D.
         if ((flags & PyBUF_ND) != PyBUF_ND) {
             view->shape = nullptr;
-            view->ndim = 1;
+            view->ndim = 0;
         }
     }
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -602,9 +602,9 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
         return -1;
     }
     view->obj = obj;
-    view->ndim = 1;
     view->internal = info;
     view->buf = info->ptr;
+    view->ndim = (int) info->ndim;
     view->itemsize = info->itemsize;
     view->len = view->itemsize;
     for (auto s : info->shape) {
@@ -614,10 +614,11 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
     if ((flags & PyBUF_FORMAT) == PyBUF_FORMAT) {
         view->format = const_cast<char *>(info->format.c_str());
     }
-    if ((flags & PyBUF_STRIDES) == PyBUF_STRIDES) {
-        view->ndim = (int) info->ndim;
-        view->strides = info->strides.data();
+    if ((flags & PyBUF_ND) == PyBUF_ND) {
         view->shape = info->shape.data();
+    }
+    if ((flags & PyBUF_STRIDES) == PyBUF_STRIDES) {
+        view->strides = info->strides.data();
     }
     Py_INCREF(view->obj);
     return 0;

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -601,8 +601,10 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
         set_error(PyExc_BufferError, "Writable buffer requested for readonly storage");
         return -1;
     }
+
+    // Fill in all the information, and then downgrade as requested by the caller, or raise an
+    // error if that's not possible.
     view->obj = obj;
-    view->ndim = 1;  // See discussion on PR #5407.
     view->internal = info;
     view->buf = info->ptr;
     view->itemsize = info->itemsize;
@@ -610,17 +612,59 @@ extern "C" inline int pybind11_getbuffer(PyObject *obj, Py_buffer *view, int fla
     for (auto s : info->shape) {
         view->len *= s;
     }
+    view->ndim = (int) info->ndim;
+    view->shape = info->shape.data();
+    view->strides = info->strides.data();
     view->readonly = static_cast<int>(info->readonly);
     if ((flags & PyBUF_FORMAT) == PyBUF_FORMAT) {
         view->format = const_cast<char *>(info->format.c_str());
     }
-    if ((flags & PyBUF_ND) == PyBUF_ND) {
-        view->ndim = (int) info->ndim;
-        view->shape = info->shape.data();
+
+    // Note, all contiguity flags imply PyBUF_STRIDES and lower.
+    if ((flags & PyBUF_C_CONTIGUOUS) == PyBUF_C_CONTIGUOUS) {
+        if (PyBuffer_IsContiguous(view, 'C') == 0) {
+            std::memset(view, 0, sizeof(Py_buffer));
+            delete info;
+            set_error(PyExc_BufferError,
+                      "C-contiguous buffer requested for discontiguous storage");
+            return -1;
+        }
+    } else if ((flags & PyBUF_F_CONTIGUOUS) == PyBUF_F_CONTIGUOUS) {
+        if (PyBuffer_IsContiguous(view, 'F') == 0) {
+            std::memset(view, 0, sizeof(Py_buffer));
+            delete info;
+            set_error(PyExc_BufferError,
+                      "Fortran-contiguous buffer requested for discontiguous storage");
+            return -1;
+        }
+    } else if ((flags & PyBUF_ANY_CONTIGUOUS) == PyBUF_ANY_CONTIGUOUS) {
+        if (PyBuffer_IsContiguous(view, 'A') == 0) {
+            std::memset(view, 0, sizeof(Py_buffer));
+            delete info;
+            set_error(PyExc_BufferError, "Contiguous buffer requested for discontiguous storage");
+            return -1;
+        }
+
+        // If no strides are requested, the buffer must be C-contiguous.
+        // https://docs.python.org/3/c-api/buffer.html#contiguity-requests
+    } else if ((flags & PyBUF_STRIDES) != PyBUF_STRIDES) {
+        if (PyBuffer_IsContiguous(view, 'C') == 0) {
+            std::memset(view, 0, sizeof(Py_buffer));
+            delete info;
+            set_error(PyExc_BufferError,
+                      "C-contiguous buffer requested for discontiguous storage");
+            return -1;
+        }
+
+        view->strides = nullptr;
+
+        // Since this is a contiguous buffer, it can also pretend to be 1D.
+        if ((flags & PyBUF_ND) != PyBUF_ND) {
+            view->shape = nullptr;
+            view->ndim = 1;
+        }
     }
-    if ((flags & PyBUF_STRIDES) == PyBUF_STRIDES) {
-        view->strides = info->strides.data();
-    }
+
     Py_INCREF(view->obj);
     return 0;
 }

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -167,6 +167,125 @@ TEST_SUBMODULE(buffers, m) {
                  sizeof(float)});
         });
 
+    // A matrix that uses Fortran storage order.
+    class FortranMatrix : public Matrix {
+    public:
+        FortranMatrix(py::ssize_t rows, py::ssize_t cols) : Matrix(cols, rows) {
+            print_created(this,
+                          std::to_string(rows) + "x" + std::to_string(cols) + " Fortran matrix");
+        }
+
+        float operator()(py::ssize_t i, py::ssize_t j) const { return Matrix::operator()(j, i); }
+
+        float &operator()(py::ssize_t i, py::ssize_t j) { return Matrix::operator()(j, i); }
+
+        using Matrix::data;
+
+        py::ssize_t rows() const { return Matrix::cols(); }
+        py::ssize_t cols() const { return Matrix::rows(); }
+    };
+    py::class_<FortranMatrix, Matrix>(m, "FortranMatrix", py::buffer_protocol())
+        .def(py::init<py::ssize_t, py::ssize_t>())
+
+        .def("rows", &FortranMatrix::rows)
+        .def("cols", &FortranMatrix::cols)
+
+        /// Bare bones interface
+        .def("__getitem__",
+             [](const FortranMatrix &m, std::pair<py::ssize_t, py::ssize_t> i) {
+                 if (i.first >= m.rows() || i.second >= m.cols()) {
+                     throw py::index_error();
+                 }
+                 return m(i.first, i.second);
+             })
+        .def("__setitem__",
+             [](FortranMatrix &m, std::pair<py::ssize_t, py::ssize_t> i, float v) {
+                 if (i.first >= m.rows() || i.second >= m.cols()) {
+                     throw py::index_error();
+                 }
+                 m(i.first, i.second) = v;
+             })
+        /// Provide buffer access
+        .def_buffer([](FortranMatrix &m) -> py::buffer_info {
+            return py::buffer_info(m.data(),             /* Pointer to buffer */
+                                   {m.rows(), m.cols()}, /* Buffer dimensions */
+                                   /* Strides (in bytes) for each index */
+                                   {sizeof(float), sizeof(float) * size_t(m.rows())});
+        });
+
+    // A matrix that uses a discontiguous underlying memory block.
+    class DiscontiguousMatrix : public Matrix {
+    public:
+        DiscontiguousMatrix(py::ssize_t rows,
+                            py::ssize_t cols,
+                            py::ssize_t row_factor,
+                            py::ssize_t col_factor)
+            : Matrix(rows * row_factor, cols * col_factor), m_row_factor(row_factor),
+              m_col_factor(col_factor) {
+            print_created(this,
+                          std::to_string(rows) + "(*" + std::to_string(row_factor) + ")x"
+                              + std::to_string(cols) + "(*" + std::to_string(col_factor)
+                              + ") matrix");
+        }
+
+        ~DiscontiguousMatrix() {
+            print_destroyed(this,
+                            std::to_string(rows() / m_row_factor) + "(*"
+                                + std::to_string(m_row_factor) + ")x"
+                                + std::to_string(cols() / m_col_factor) + "(*"
+                                + std::to_string(m_col_factor) + ") matrix");
+        }
+
+        float operator()(py::ssize_t i, py::ssize_t j) const {
+            return Matrix::operator()(i * m_row_factor, j * m_col_factor);
+        }
+
+        float &operator()(py::ssize_t i, py::ssize_t j) {
+            return Matrix::operator()(i * m_row_factor, j * m_col_factor);
+        }
+
+        using Matrix::data;
+
+        py::ssize_t rows() const { return Matrix::rows() / m_row_factor; }
+        py::ssize_t cols() const { return Matrix::cols() / m_col_factor; }
+        py::ssize_t row_factor() const { return m_row_factor; }
+        py::ssize_t col_factor() const { return m_col_factor; }
+
+    private:
+        py::ssize_t m_row_factor;
+        py::ssize_t m_col_factor;
+    };
+    py::class_<DiscontiguousMatrix, Matrix>(m, "DiscontiguousMatrix", py::buffer_protocol())
+        .def(py::init<py::ssize_t, py::ssize_t, py::ssize_t, py::ssize_t>())
+
+        .def("rows", &DiscontiguousMatrix::rows)
+        .def("cols", &DiscontiguousMatrix::cols)
+
+        /// Bare bones interface
+        .def("__getitem__",
+             [](const DiscontiguousMatrix &m, std::pair<py::ssize_t, py::ssize_t> i) {
+                 if (i.first >= m.rows() || i.second >= m.cols()) {
+                     throw py::index_error();
+                 }
+                 return m(i.first, i.second);
+             })
+        .def("__setitem__",
+             [](DiscontiguousMatrix &m, std::pair<py::ssize_t, py::ssize_t> i, float v) {
+                 if (i.first >= m.rows() || i.second >= m.cols()) {
+                     throw py::index_error();
+                 }
+                 m(i.first, i.second) = v;
+             })
+        /// Provide buffer access
+        .def_buffer([](DiscontiguousMatrix &m) -> py::buffer_info {
+            return py::buffer_info(m.data(),             /* Pointer to buffer */
+                                   {m.rows(), m.cols()}, /* Buffer dimensions */
+                                   /* Strides (in bytes) for each index */
+                                   {size_t(m.col_factor()) * sizeof(float) * size_t(m.cols())
+                                        * size_t(m.row_factor()),
+                                    size_t(m.col_factor()) * sizeof(float)});
+        });
+
     class BrokenMatrix : public Matrix {
     public:
         BrokenMatrix(py::ssize_t rows, py::ssize_t cols) : Matrix(rows, cols) {}
@@ -274,6 +393,9 @@ TEST_SUBMODULE(buffers, m) {
     m.attr("PyBUF_ND") = PyBUF_ND;
     m.attr("PyBUF_STRIDES") = PyBUF_STRIDES;
     m.attr("PyBUF_INDIRECT") = PyBUF_INDIRECT;
+    m.attr("PyBUF_C_CONTIGUOUS") = PyBUF_C_CONTIGUOUS;
+    m.attr("PyBUF_F_CONTIGUOUS") = PyBUF_F_CONTIGUOUS;
+    m.attr("PyBUF_ANY_CONTIGUOUS") = PyBUF_ANY_CONTIGUOUS;
 
     m.def("get_py_buffer", [](const py::object &object, int flags) {
         Py_buffer buffer;

--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -389,6 +389,7 @@ TEST_SUBMODULE(buffers, m) {
     m.def("get_buffer_info", [](const py::buffer &buffer) { return buffer.request(); });
 
     // Expose Py_buffer for testing.
+    m.attr("PyBUF_FORMAT") = PyBUF_FORMAT;
     m.attr("PyBUF_SIMPLE") = PyBUF_SIMPLE;
     m.attr("PyBUF_ND") = PyBUF_ND;
     m.attr("PyBUF_STRIDES") = PyBUF_STRIDES;

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -247,7 +247,7 @@ def test_to_pybuffer():
     info = m.get_py_buffer(mat, m.PyBUF_SIMPLE)
     assert info.itemsize == ctypes.sizeof(ctypes.c_float)
     assert info.len == mat.rows() * mat.cols() * info.itemsize
-    assert info.ndim == 2
+    assert info.ndim == 1  # See discussion on PR #5407.
     assert info.shape is None
     assert info.strides is None
     assert info.suboffsets is None

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -247,7 +247,7 @@ def test_to_pybuffer():
     info = m.get_py_buffer(mat, m.PyBUF_SIMPLE)
     assert info.itemsize == ctypes.sizeof(ctypes.c_float)
     assert info.len == mat.rows() * mat.cols() * info.itemsize
-    assert info.ndim == 1  # See discussion on PR #5407.
+    assert info.ndim == 0  # See discussion on PR #5407.
     assert info.shape is None
     assert info.strides is None
     assert info.suboffsets is None

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -251,6 +251,16 @@ def test_c_contiguous_to_pybuffer(type):
         raise ValueError(f"Unknown parametrization {type}")
 
     info = m.get_py_buffer(mat, m.PyBUF_SIMPLE)
+    assert info.format is None
+    assert info.itemsize == ctypes.sizeof(ctypes.c_float)
+    assert info.len == 5 * 4 * info.itemsize
+    assert info.ndim == 0  # See discussion on PR #5407.
+    assert info.shape is None
+    assert info.strides is None
+    assert info.suboffsets is None
+    assert not info.readonly
+    info = m.get_py_buffer(mat, m.PyBUF_SIMPLE | m.PyBUF_FORMAT)
+    assert info.format == "f"
     assert info.itemsize == ctypes.sizeof(ctypes.c_float)
     assert info.len == 5 * 4 * info.itemsize
     assert info.ndim == 0  # See discussion on PR #5407.

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -239,3 +239,40 @@ def test_buffer_exception():
         memoryview(m.BrokenMatrix(1, 1))
     assert isinstance(excinfo.value.__cause__, RuntimeError)
     assert "for context" in str(excinfo.value.__cause__)
+
+
+def test_to_pybuffer():
+    mat = m.Matrix(5, 4)
+
+    info = m.get_py_buffer(mat, m.PyBUF_SIMPLE)
+    assert info.itemsize == ctypes.sizeof(ctypes.c_float)
+    assert info.len == mat.rows() * mat.cols() * info.itemsize
+    assert info.ndim == 2
+    assert info.shape is None
+    assert info.strides is None
+    assert info.suboffsets is None
+    assert not info.readonly
+    info = m.get_py_buffer(mat, m.PyBUF_ND)
+    assert info.itemsize == ctypes.sizeof(ctypes.c_float)
+    assert info.len == mat.rows() * mat.cols() * info.itemsize
+    assert info.ndim == 2
+    assert info.shape == [5, 4]
+    assert info.strides is None
+    assert info.suboffsets is None
+    assert not info.readonly
+    info = m.get_py_buffer(mat, m.PyBUF_STRIDES)
+    assert info.itemsize == ctypes.sizeof(ctypes.c_float)
+    assert info.len == mat.rows() * mat.cols() * info.itemsize
+    assert info.ndim == 2
+    assert info.shape == [5, 4]
+    assert info.strides == [4 * info.itemsize, info.itemsize]
+    assert info.suboffsets is None
+    assert not info.readonly
+    info = m.get_py_buffer(mat, m.PyBUF_INDIRECT)
+    assert info.itemsize == ctypes.sizeof(ctypes.c_float)
+    assert info.len == mat.rows() * mat.cols() * info.itemsize
+    assert info.ndim == 2
+    assert info.shape == [5, 4]
+    assert info.strides == [4 * info.itemsize, info.itemsize]
+    assert info.suboffsets is None  # Should be filled in here, but we don't use it.
+    assert not info.readonly


### PR DESCRIPTION
## Description

According to the buffer protocol, `ndim` is a _required_ field [1], and should always be set correctly. Additionally, `shape` should be set if flags includes `PyBUF_ND` or higher [2]. The current implementation only set those fields if flags was `PyBUF_STRIDES`.

~~**Note, the tests currently leak**, since they don't call `PyBuffer_Release`, as figuring out how to make a custom deleter work there is not something I've understood. Should I just immediately convert to a `SimpleNamespace` or similar instead or wrapping the struct?~~ I changed it to a `SimpleNamespace`.

[1] https://docs.python.org/3/c-api/buffer.html#request-independent-fields
[2] https://docs.python.org/3/c-api/buffer.html#shape-strides-suboffsets

## Suggested changelog entry:

```rst
* Fix buffer protocol implementation
```

PS, conventional commits are only mentioned in the PR template; they should be mentioned in https://github.com/pybind/pybind11/blob/af67e87393b0f867ccffc2702885eea12de063fc/.github/CONTRIBUTING.md so one knows that before committing...