### PR TITLE
docs: fix error condition in custom type caster example

### DIFF
--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -64,7 +64,7 @@ type is explicitly allowed.
                 value.long_value = PyLong_AsLong(tmp);
                 Py_DECREF(tmp);
                 /* Ensure return code was OK (to avoid out-of-range errors etc) */
-                return !(value.long_value == -1 && !PyErr_Occurred());
+                return !(value.long_value == -1 && PyErr_Occurred());
             }
 
             /**


### PR DESCRIPTION
## Description

I found a mistake in the documentation for custom [type_casters](https://github.com/pybind/pybind11/blob/f7e14e985be167ca158fd3ee2fe5d8a4f175fa87/docs/advanced/cast/custom.rst), which I believe hasn't been covered by an open issue or PR yet. The `load` function of a type caster struct is supposed to return `true` upon success. However, the condition
```cpp
!(value.long_value == -1 && !PyErr_Occurred())
```
whose value is returned, also evaluates to true if no error occurred and the Python float value is `-1`. The negation of the result of `PyErr_Occurred()` needs to be removed.


## Suggested changelog entry:

```rst
* Fixed the return value in the custom type caster example
```

<!-- If the upgrade guide needs updating, note that here too -->
