### PR TITLE
Systematically skip `ConstructorStats` tests on GraalPy

### DIFF
--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -190,6 +190,7 @@ def test_alive_gc_multi_derived(capture):
     )
 
 
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
 def test_return_none(capture):
     n_inst = ConstructorStats.detail_reg_inst()
     with capture:
@@ -217,6 +218,7 @@ def test_return_none(capture):
     assert capture == "Releasing parent."
 
 
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
 def test_keep_alive_constructor(capture):
     n_inst = ConstructorStats.detail_reg_inst()
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -27,6 +27,9 @@ def test_instance(msg):
 
     instance = m.NoConstructor.new_instance()
 
+    if env.GRAALPY:
+        pytest.skip("ConstructorStats is incompatible with GraalPy.")
+
     cstats = ConstructorStats.get(m.NoConstructor)
     assert cstats.alive() == 1
     del instance
@@ -35,6 +38,10 @@ def test_instance(msg):
 
 def test_instance_new():
     instance = m.NoConstructorNew()  # .__new__(m.NoConstructor.__class__)
+
+    if env.GRAALPY:
+        pytest.skip("ConstructorStats is incompatible with GraalPy.")
+
     cstats = ConstructorStats.get(m.NoConstructorNew)
     assert cstats.alive() == 1
     del instance

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import copy_move_policies as m
 
 
@@ -17,6 +18,7 @@ def test_lacking_move_ctor():
     assert "is neither movable nor copyable!" in str(excinfo.value)
 
 
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
 def test_move_and_copy_casts():
     """Cast some values in C++ via custom type casters and count the number of moves/copies."""
 
@@ -44,6 +46,7 @@ def test_move_and_copy_casts():
     assert c_m.alive() + c_mc.alive() + c_c.alive() == 0
 
 
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
 def test_move_and_copy_loads():
     """Call some functions that load arguments via custom type casters and count the number of
     moves/copies."""
@@ -77,6 +80,7 @@ def test_move_and_copy_loads():
 
 
 @pytest.mark.skipif(not m.has_optional, reason="no <optional>")
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
 def test_move_and_copy_load_optional():
     """Tests move/copy loads of std::optional arguments"""
 

--- a/tests/test_custom_type_casters.py
+++ b/tests/test_custom_type_casters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import custom_type_casters as m
 
 
@@ -94,6 +95,7 @@ def test_noconvert_args(msg):
     )
 
 
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
 def test_custom_caster_destruction():
     """Tests that returning a pointer to a type that gets converted with a custom type caster gets
     destroyed when the function has py::return_value_policy::take_ownership policy applied.

--- a/tests/test_eigen_matrix.py
+++ b/tests/test_eigen_matrix.py
@@ -395,6 +395,7 @@ def test_eigen_return_references():
     np.testing.assert_array_equal(a_copy5, c5want)
 
 
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
 def assert_keeps_alive(cl, method, *args):
     cstats = ConstructorStats.get(cl)
     start_with = cstats.alive()

--- a/tests/test_opaque_types.py
+++ b/tests/test_opaque_types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import env
 from pybind11_tests import ConstructorStats, UserType
 from pybind11_tests import opaque_types as m
 
@@ -30,7 +31,9 @@ def test_pointers(msg):
     living_before = ConstructorStats.get(UserType).alive()
     assert m.get_void_ptr_value(m.return_void_ptr()) == 0x1234
     assert m.get_void_ptr_value(UserType())  # Should also work for other C++ types
-    assert ConstructorStats.get(UserType).alive() == living_before
+
+    if not env.GRAALPY:
+        assert ConstructorStats.get(UserType).alive() == living_before
 
     with pytest.raises(TypeError) as excinfo:
         m.get_void_ptr_value([1, 2, 3])  # This should not work

--- a/tests/test_operator_overloading.py
+++ b/tests/test_operator_overloading.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-import env  # noqa: F401
+import env
 from pybind11_tests import ConstructorStats
 from pybind11_tests import operators as m
 
@@ -50,6 +50,9 @@ def test_operator_overloading():
     assert str(v1) == "[1.500000, -0.125000]"
     v2 /= v1
     assert str(v2) == "[2.000000, 8.000000]"
+
+    if env.GRAALPY:
+        pytest.skip("ConstructorStats is incompatible with GraalPy.")
 
     cstats = ConstructorStats.get(m.Vector2)
     assert cstats.alive() == 3


### PR DESCRIPTION
I went through all the tests that use `ConstructorStats` and skipped them on GraalPy, because they all have potential to fail transiently.

Example flakes seen recently:
* https://github.com/pybind/pybind11/actions/runs/11499093534/job/32006334677?pr=4953
* https://github.com/pybind/pybind11/actions/runs/11508384818/job/32036495838?pr=4953