### PR TITLE
Add support for array_t<handle> and array_t<object>

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1428,25 +1428,11 @@ public:
 };
 
 template <typename T>
-struct npy_format_descriptor<T, enable_if_t<is_same_ignoring_cvref<T, PyObject *>::value>> {
-    static constexpr auto name = const_name("object");
-
-    static constexpr int value = npy_api::NPY_OBJECT_;
-
-    static pybind11::dtype dtype() { return pybind11::dtype(/*typenum*/ value); }
-};
-
-template <>
-struct npy_format_descriptor<handle, enable_if_t<sizeof(handle) == sizeof(PyObject *)>> {
-    static constexpr auto name = const_name("object");
-
-    static constexpr int value = npy_api::NPY_OBJECT_;
-
-    static pybind11::dtype dtype() { return pybind11::dtype(/*typenum*/ value); }
-};
-
-template <>
-struct npy_format_descriptor<object, enable_if_t<sizeof(object) == sizeof(PyObject *)>> {
+struct npy_format_descriptor<
+    T,
+    enable_if_t<is_same_ignoring_cvref<T, PyObject *>::value
+                || ((std::is_same<T, handle>::value || std::is_same<T, object>::value)
+                    && sizeof(T) == sizeof(PyObject *))>> {
     static constexpr auto name = const_name("object");
 
     static constexpr int value = npy_api::NPY_OBJECT_;

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1437,7 +1437,7 @@ struct npy_format_descriptor<T, enable_if_t<is_same_ignoring_cvref<T, PyObject *
 };
 
 template <>
-struct npy_format_descriptor<handle, enable_if_t<sizeof(handle) == sizeof(PyObject*)>> {
+struct npy_format_descriptor<handle, enable_if_t<sizeof(handle) == sizeof(PyObject *)>> {
     static constexpr auto name = const_name("object");
 
     static constexpr int value = npy_api::NPY_OBJECT_;
@@ -1446,7 +1446,7 @@ struct npy_format_descriptor<handle, enable_if_t<sizeof(handle) == sizeof(PyObje
 };
 
 template <>
-struct npy_format_descriptor<object, enable_if_t<sizeof(object) == sizeof(PyObject*)>> {
+struct npy_format_descriptor<object, enable_if_t<sizeof(object) == sizeof(PyObject *)>> {
     static constexpr auto name = const_name("object");
 
     static constexpr int value = npy_api::NPY_OBJECT_;

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1436,6 +1436,24 @@ struct npy_format_descriptor<T, enable_if_t<is_same_ignoring_cvref<T, PyObject *
     static pybind11::dtype dtype() { return pybind11::dtype(/*typenum*/ value); }
 };
 
+template <>
+struct npy_format_descriptor<handle, enable_if_t<sizeof(handle) == sizeof(PyObject*)>> {
+    static constexpr auto name = const_name("object");
+
+    static constexpr int value = npy_api::NPY_OBJECT_;
+
+    static pybind11::dtype dtype() { return pybind11::dtype(/*typenum*/ value); }
+};
+
+template <>
+struct npy_format_descriptor<object, enable_if_t<sizeof(object) == sizeof(PyObject*)>> {
+    static constexpr auto name = const_name("object");
+
+    static constexpr int value = npy_api::NPY_OBJECT_;
+
+    static pybind11::dtype dtype() { return pybind11::dtype(/*typenum*/ value); }
+};
+
 #define PYBIND11_DECL_CHAR_FMT                                                                    \
     static constexpr auto name = const_name("S") + const_name<N>();                               \
     static pybind11::dtype dtype() {                                                              \

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -528,23 +528,21 @@ TEST_SUBMODULE(numpy_array, sm) {
                return sum_str_values;
            });
 
-    sm.def("pass_array_handle_return_sum_str_values",
-           [](const py::array_t<py::handle> &objs) {
-               std::string sum_str_values;
-               for (const auto &obj : objs) {
-                   sum_str_values += py::str(obj.attr("value"));
-               }
-               return sum_str_values;
-           });
+    sm.def("pass_array_handle_return_sum_str_values", [](const py::array_t<py::handle> &objs) {
+        std::string sum_str_values;
+        for (const auto &obj : objs) {
+            sum_str_values += py::str(obj.attr("value"));
+        }
+        return sum_str_values;
+    });
 
-    sm.def("pass_array_object_return_sum_str_values",
-           [](const py::array_t<py::object> &objs) {
-               std::string sum_str_values;
-               for (const auto &obj : objs) {
-                   sum_str_values += py::str(obj.attr("value"));
-               }
-               return sum_str_values;
-           });
+    sm.def("pass_array_object_return_sum_str_values", [](const py::array_t<py::object> &objs) {
+        std::string sum_str_values;
+        for (const auto &obj : objs) {
+            sum_str_values += py::str(obj.attr("value"));
+        }
+        return sum_str_values;
+    });
 
     sm.def("pass_array_pyobject_ptr_return_as_list",
            [](const py::array_t<PyObject *> &objs) -> py::list { return objs; });

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -160,7 +160,7 @@ template <typename PyObjectType>
 PyObjectType convert_to_pyobjecttype(py::object obj);
 
 template <>
-PyObject * convert_to_pyobjecttype<PyObject *>(py::object obj) {
+PyObject *convert_to_pyobjecttype<PyObject *>(py::object obj) {
     return obj.release().ptr();
 }
 
@@ -568,9 +568,12 @@ TEST_SUBMODULE(numpy_array, sm) {
 
     sm.def("round_trip_float", [](double d) { return d; });
 
-    sm.def("pass_array_pyobject_ptr_return_sum_str_values", pass_array_return_sum_str_values<PyObject *>);
-    sm.def("pass_array_handle_return_sum_str_values", pass_array_return_sum_str_values<py::handle>);
-    sm.def("pass_array_object_return_sum_str_values", pass_array_return_sum_str_values<py::object>);
+    sm.def("pass_array_pyobject_ptr_return_sum_str_values",
+           pass_array_return_sum_str_values<PyObject *>);
+    sm.def("pass_array_handle_return_sum_str_values",
+           pass_array_return_sum_str_values<py::handle>);
+    sm.def("pass_array_object_return_sum_str_values",
+           pass_array_return_sum_str_values<py::object>);
 
     sm.def("pass_array_pyobject_ptr_return_as_list", pass_array_return_as_list<PyObject *>);
     sm.def("pass_array_handle_return_as_list", pass_array_return_as_list<py::handle>);

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -569,7 +569,7 @@ TEST_SUBMODULE(numpy_array, sm) {
         py::array_t<py::handle> arr_from_list(static_cast<py::ssize_t>(arr_size));
         py::handle *data = arr_from_list.mutable_data();
         for (py::size_t i = 0; i < arr_size; i++) {
-            assert(data[i] == nullptr);
+            assert(!data[i]);
             data[i] = py::object(objs[i]).release();
         }
         return arr_from_list;

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -195,7 +195,7 @@ py::array_t<PyObjectType> return_array_cpp_loop(const py::list &objs) {
     PyObjectType *data = arr_from_list.mutable_data();
     for (py::size_t i = 0; i < arr_size; i++) {
         assert(!data[i]);
-        data[i] = convert_to_pyobjecttype<PyObjectType>(objs[i]);
+        data[i] = convert_to_pyobjecttype<PyObjectType>(objs[i].attr("value"));
     }
     return arr_from_list;
 }

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -156,6 +156,55 @@ py::handle auxiliaries(T &&r, T2 &&r2) {
     return l.release();
 }
 
+template <typename PyObjectType>
+PyObjectType convert_to_pyobjecttype(py::object obj);
+
+template <>
+PyObject * convert_to_pyobjecttype<PyObject *>(py::object obj) {
+    return obj.release().ptr();
+}
+
+template <>
+py::handle convert_to_pyobjecttype<py::handle>(py::object obj) {
+    return obj.release();
+}
+
+template <>
+py::object convert_to_pyobjecttype<py::object>(py::object obj) {
+    return obj;
+}
+
+template <typename PyObjectType>
+std::string pass_array_return_sum_str_values(const py::array_t<PyObjectType> &objs) {
+    std::string sum_str_values;
+    for (const auto &obj : objs) {
+        sum_str_values += py::str(obj.attr("value"));
+    }
+    return sum_str_values;
+}
+
+template <typename PyObjectType>
+py::list pass_array_return_as_list(const py::array_t<PyObjectType> &objs) {
+    return objs;
+}
+
+template <typename PyObjectType>
+py::array_t<PyObjectType> return_array_cpp_loop(const py::list &objs) {
+    py::size_t arr_size = py::len(objs);
+    py::array_t<PyObjectType> arr_from_list(static_cast<py::ssize_t>(arr_size));
+    PyObjectType *data = arr_from_list.mutable_data();
+    for (py::size_t i = 0; i < arr_size; i++) {
+        assert(!data[i]);
+        data[i] = convert_to_pyobjecttype<PyObjectType>(objs[i]);
+    }
+    return arr_from_list;
+}
+
+template <typename PyObjectType>
+py::array_t<PyObjectType> return_array_from_list(const py::list &objs) {
+    return objs;
+}
+
 // note: declaration at local scope would create a dangling reference!
 static int data_i = 42;
 
@@ -519,78 +568,19 @@ TEST_SUBMODULE(numpy_array, sm) {
 
     sm.def("round_trip_float", [](double d) { return d; });
 
-    sm.def("pass_array_pyobject_ptr_return_sum_str_values",
-           [](const py::array_t<PyObject *> &objs) {
-               std::string sum_str_values;
-               for (const auto &obj : objs) {
-                   sum_str_values += py::str(obj.attr("value"));
-               }
-               return sum_str_values;
-           });
+    sm.def("pass_array_pyobject_ptr_return_sum_str_values", pass_array_return_sum_str_values<PyObject *>);
+    sm.def("pass_array_handle_return_sum_str_values", pass_array_return_sum_str_values<py::handle>);
+    sm.def("pass_array_object_return_sum_str_values", pass_array_return_sum_str_values<py::object>);
 
-    sm.def("pass_array_handle_return_sum_str_values", [](const py::array_t<py::handle> &objs) {
-        std::string sum_str_values;
-        for (const auto &obj : objs) {
-            sum_str_values += py::str(obj.attr("value"));
-        }
-        return sum_str_values;
-    });
+    sm.def("pass_array_pyobject_ptr_return_as_list", pass_array_return_as_list<PyObject *>);
+    sm.def("pass_array_handle_return_as_list", pass_array_return_as_list<py::handle>);
+    sm.def("pass_array_object_return_as_list", pass_array_return_as_list<py::object>);
 
-    sm.def("pass_array_object_return_sum_str_values", [](const py::array_t<py::object> &objs) {
-        std::string sum_str_values;
-        for (const auto &obj : objs) {
-            sum_str_values += py::str(obj.attr("value"));
-        }
-        return sum_str_values;
-    });
+    sm.def("return_array_pyobject_ptr_cpp_loop", return_array_cpp_loop<PyObject *>);
+    sm.def("return_array_handle_cpp_loop", return_array_cpp_loop<py::handle>);
+    sm.def("return_array_object_cpp_loop", return_array_cpp_loop<py::object>);
 
-    sm.def("pass_array_pyobject_ptr_return_as_list",
-           [](const py::array_t<PyObject *> &objs) -> py::list { return objs; });
-
-    sm.def("pass_array_handle_return_as_list",
-           [](const py::array_t<py::handle> &objs) -> py::list { return objs; });
-
-    sm.def("pass_array_object_return_as_list",
-           [](const py::array_t<py::object> &objs) -> py::list { return objs; });
-
-    sm.def("return_array_pyobject_ptr_cpp_loop", [](const py::list &objs) {
-        py::size_t arr_size = py::len(objs);
-        py::array_t<PyObject *> arr_from_list(static_cast<py::ssize_t>(arr_size));
-        PyObject **data = arr_from_list.mutable_data();
-        for (py::size_t i = 0; i < arr_size; i++) {
-            assert(data[i] == nullptr);
-            data[i] = py::cast<PyObject *>(objs[i]);
-        }
-        return arr_from_list;
-    });
-
-    sm.def("return_array_handle_cpp_loop", [](const py::list &objs) {
-        py::size_t arr_size = py::len(objs);
-        py::array_t<py::handle> arr_from_list(static_cast<py::ssize_t>(arr_size));
-        py::handle *data = arr_from_list.mutable_data();
-        for (py::size_t i = 0; i < arr_size; i++) {
-            assert(!data[i]);
-            data[i] = py::object(objs[i]).release();
-        }
-        return arr_from_list;
-    });
-
-    sm.def("return_array_object_cpp_loop", [](const py::list &objs) {
-        py::size_t arr_size = py::len(objs);
-        py::array_t<py::object> arr_from_list(static_cast<py::ssize_t>(arr_size));
-        py::object *data = arr_from_list.mutable_data();
-        for (py::size_t i = 0; i < arr_size; i++) {
-            data[i] = objs[i];
-        }
-        return arr_from_list;
-    });
-
-    sm.def("return_array_pyobject_ptr_from_list",
-           [](const py::list &objs) -> py::array_t<PyObject *> { return objs; });
-
-    sm.def("return_array_handle_from_list",
-           [](const py::list &objs) -> py::array_t<py::handle> { return objs; });
-
-    sm.def("return_array_object_from_list",
-           [](const py::list &objs) -> py::array_t<py::object> { return objs; });
+    sm.def("return_array_pyobject_ptr_from_list", return_array_from_list<PyObject *>);
+    sm.def("return_array_handle_from_list", return_array_from_list<py::handle>);
+    sm.def("return_array_object_from_list", return_array_from_list<py::object>);
 }

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -528,8 +528,32 @@ TEST_SUBMODULE(numpy_array, sm) {
                return sum_str_values;
            });
 
+    sm.def("pass_array_handle_return_sum_str_values",
+           [](const py::array_t<py::handle> &objs) {
+               std::string sum_str_values;
+               for (const auto &obj : objs) {
+                   sum_str_values += py::str(obj.attr("value"));
+               }
+               return sum_str_values;
+           });
+
+    sm.def("pass_array_object_return_sum_str_values",
+           [](const py::array_t<py::object> &objs) {
+               std::string sum_str_values;
+               for (const auto &obj : objs) {
+                   sum_str_values += py::str(obj.attr("value"));
+               }
+               return sum_str_values;
+           });
+
     sm.def("pass_array_pyobject_ptr_return_as_list",
            [](const py::array_t<PyObject *> &objs) -> py::list { return objs; });
+
+    sm.def("pass_array_handle_return_as_list",
+           [](const py::array_t<py::handle> &objs) -> py::list { return objs; });
+
+    sm.def("pass_array_object_return_as_list",
+           [](const py::array_t<py::object> &objs) -> py::list { return objs; });
 
     sm.def("return_array_pyobject_ptr_cpp_loop", [](const py::list &objs) {
         py::size_t arr_size = py::len(objs);
@@ -537,11 +561,38 @@ TEST_SUBMODULE(numpy_array, sm) {
         PyObject **data = arr_from_list.mutable_data();
         for (py::size_t i = 0; i < arr_size; i++) {
             assert(data[i] == nullptr);
-            data[i] = py::cast<PyObject *>(objs[i].attr("value"));
+            data[i] = py::cast<PyObject *>(objs[i]);
+        }
+        return arr_from_list;
+    });
+
+    sm.def("return_array_handle_cpp_loop", [](const py::list &objs) {
+        py::size_t arr_size = py::len(objs);
+        py::array_t<py::handle> arr_from_list(static_cast<py::ssize_t>(arr_size));
+        py::handle *data = arr_from_list.mutable_data();
+        for (py::size_t i = 0; i < arr_size; i++) {
+            assert(data[i] == nullptr);
+            data[i] = py::object(objs[i]).release();
+        }
+        return arr_from_list;
+    });
+
+    sm.def("return_array_object_cpp_loop", [](const py::list &objs) {
+        py::size_t arr_size = py::len(objs);
+        py::array_t<py::object> arr_from_list(static_cast<py::ssize_t>(arr_size));
+        py::object *data = arr_from_list.mutable_data();
+        for (py::size_t i = 0; i < arr_size; i++) {
+            data[i] = objs[i];
         }
         return arr_from_list;
     });
 
     sm.def("return_array_pyobject_ptr_from_list",
            [](const py::list &objs) -> py::array_t<PyObject *> { return objs; });
+
+    sm.def("return_array_handle_from_list",
+           [](const py::list &objs) -> py::array_t<py::handle> { return objs; });
+
+    sm.def("return_array_object_from_list",
+           [](const py::list &objs) -> py::array_t<py::object> { return objs; });
 }

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import env  # noqa: F401
 from pybind11_tests import numpy_array as m
 
 np = pytest.importorskip("numpy")

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -645,12 +645,11 @@ def UnwrapPyValueHolder(vhs):
 )
 def test_pass_array_object_return_sum_str_values_ndarray(func):
     initial_counter = PyValueHolder.counter
-    for loop in range(100):
-        # Intentionally all temporaries, do not change.
-        assert (
-            func(np.array(WrapWithPyValueHolder(-3, "four", 5.0), dtype=object))
-            == "-3four5.0"
-        )
+    # Intentionally all temporaries, do not change.
+    assert (
+        func(np.array(WrapWithPyValueHolder(-3, "four", 5.0), dtype=object))
+        == "-3four5.0"
+    )
     assert PyValueHolder.counter == initial_counter
 
 
@@ -664,9 +663,8 @@ def test_pass_array_object_return_sum_str_values_ndarray(func):
 )
 def test_pass_array_object_return_sum_str_values_list(func):
     initial_counter = PyValueHolder.counter
-    for loop in range(100):
-        # Intentionally all temporaries, do not change.
-        assert func(WrapWithPyValueHolder(2, "three", -4.0)) == "2three-4.0"
+    # Intentionally all temporaries, do not change.
+    assert func(WrapWithPyValueHolder(2, "three", -4.0)) == "2three-4.0"
     assert PyValueHolder.counter == initial_counter
 
 
@@ -680,11 +678,10 @@ def test_pass_array_object_return_sum_str_values_list(func):
 )
 def test_pass_array_object_return_as_list(func):
     initial_counter = PyValueHolder.counter
-    for loop in range(100):
-        # Intentionally all temporaries, do not change.
-        assert UnwrapPyValueHolder(
-            func(np.array(WrapWithPyValueHolder(-1, "two", 3.0), dtype=object))
-        ) == [-1, "two", 3.0]
+    # Intentionally all temporaries, do not change.
+    assert UnwrapPyValueHolder(
+        func(np.array(WrapWithPyValueHolder(-1, "two", 3.0), dtype=object))
+    ) == [-1, "two", 3.0]
     assert PyValueHolder.counter == initial_counter
 
 
@@ -701,11 +698,10 @@ def test_pass_array_object_return_as_list(func):
 )
 def test_return_array_object_cpp_loop(func):
     initial_counter = PyValueHolder.counter
-    for loop in range(100):
-        # Intentionally all temporaries, do not change.
-        arr_from_list = func(WrapWithPyValueHolder(6, "seven", -8.0))
-        assert isinstance(arr_from_list, np.ndarray)
-        assert arr_from_list.dtype == np.dtype("O")
-        assert UnwrapPyValueHolder(arr_from_list) == [6, "seven", -8.0]
+    # Intentionally all temporaries, do not change.
+    arr_from_list = func(WrapWithPyValueHolder(6, "seven", -8.0))
+    assert isinstance(arr_from_list, np.ndarray)
+    assert arr_from_list.dtype == np.dtype("O")
+    assert UnwrapPyValueHolder(arr_from_list) == [6, "seven", -8.0]
     del arr_from_list
     assert PyValueHolder.counter == initial_counter

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-import env
 from pybind11_tests import numpy_array as m
 
 np = pytest.importorskip("numpy")

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -617,14 +617,8 @@ def test_round_trip_float():
 #     * Sanitizers are much more likely to detect heap-use-after-free due to
 #       other ref-count bugs.
 class PyValueHolder:
-    counter = 0
-
     def __init__(self, value):
         self.value = value
-        PyValueHolder.counter += 1
-
-    def __del__(self):
-        PyValueHolder.counter -= 1
 
 
 def WrapWithPyValueHolder(*values):
@@ -644,14 +638,11 @@ def UnwrapPyValueHolder(vhs):
     ],
 )
 def test_pass_array_object_return_sum_str_values_ndarray(func):
-    initial_counter = PyValueHolder.counter
     # Intentionally all temporaries, do not change.
     assert (
         func(np.array(WrapWithPyValueHolder(-3, "four", 5.0), dtype=object))
         == "-3four5.0"
     )
-    if not env.PYPY and not env.GRAALPY:
-        assert PyValueHolder.counter == initial_counter
 
 
 @pytest.mark.parametrize(
@@ -663,11 +654,8 @@ def test_pass_array_object_return_sum_str_values_ndarray(func):
     ],
 )
 def test_pass_array_object_return_sum_str_values_list(func):
-    initial_counter = PyValueHolder.counter
     # Intentionally all temporaries, do not change.
     assert func(WrapWithPyValueHolder(2, "three", -4.0)) == "2three-4.0"
-    if not env.PYPY and not env.GRAALPY:
-        assert PyValueHolder.counter == initial_counter
 
 
 @pytest.mark.parametrize(
@@ -679,13 +667,10 @@ def test_pass_array_object_return_sum_str_values_list(func):
     ],
 )
 def test_pass_array_object_return_as_list(func):
-    initial_counter = PyValueHolder.counter
     # Intentionally all temporaries, do not change.
     assert UnwrapPyValueHolder(
         func(np.array(WrapWithPyValueHolder(-1, "two", 3.0), dtype=object))
     ) == [-1, "two", 3.0]
-    if not env.PYPY and not env.GRAALPY:
-        assert PyValueHolder.counter == initial_counter
 
 
 @pytest.mark.parametrize(
@@ -700,12 +685,8 @@ def test_pass_array_object_return_as_list(func):
     ],
 )
 def test_return_array_object_cpp_loop(func):
-    initial_counter = PyValueHolder.counter
     # Intentionally all temporaries, do not change.
     arr_from_list = func(WrapWithPyValueHolder(6, "seven", -8.0))
     assert isinstance(arr_from_list, np.ndarray)
     assert arr_from_list.dtype == np.dtype("O")
     assert UnwrapPyValueHolder(arr_from_list) == [6, "seven", -8.0]
-    del arr_from_list
-    if not env.PYPY and not env.GRAALPY:
-        assert PyValueHolder.counter == initial_counter

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -650,7 +650,8 @@ def test_pass_array_object_return_sum_str_values_ndarray(func):
         func(np.array(WrapWithPyValueHolder(-3, "four", 5.0), dtype=object))
         == "-3four5.0"
     )
-    assert PyValueHolder.counter == initial_counter
+    if not env.PYPY and not env.GRAALPY:
+        assert PyValueHolder.counter == initial_counter
 
 
 @pytest.mark.parametrize(
@@ -665,7 +666,8 @@ def test_pass_array_object_return_sum_str_values_list(func):
     initial_counter = PyValueHolder.counter
     # Intentionally all temporaries, do not change.
     assert func(WrapWithPyValueHolder(2, "three", -4.0)) == "2three-4.0"
-    assert PyValueHolder.counter == initial_counter
+    if not env.PYPY and not env.GRAALPY:
+        assert PyValueHolder.counter == initial_counter
 
 
 @pytest.mark.parametrize(
@@ -682,7 +684,8 @@ def test_pass_array_object_return_as_list(func):
     assert UnwrapPyValueHolder(
         func(np.array(WrapWithPyValueHolder(-1, "two", 3.0), dtype=object))
     ) == [-1, "two", 3.0]
-    assert PyValueHolder.counter == initial_counter
+    if not env.PYPY and not env.GRAALPY:
+        assert PyValueHolder.counter == initial_counter
 
 
 @pytest.mark.parametrize(
@@ -704,4 +707,5 @@ def test_return_array_object_cpp_loop(func):
     assert arr_from_list.dtype == np.dtype("O")
     assert UnwrapPyValueHolder(arr_from_list) == [6, "seven", -8.0]
     del arr_from_list
-    assert PyValueHolder.counter == initial_counter
+    if not env.PYPY and not env.GRAALPY:
+        assert PyValueHolder.counter == initial_counter

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -618,9 +618,11 @@ def test_round_trip_float():
 #       other ref-count bugs.
 class PyValueHolder:
     counter = 0
+
     def __init__(self, value):
         self.value = value
         PyValueHolder.counter += 1
+
     def __del__(self):
         PyValueHolder.counter -= 1
 
@@ -646,9 +648,7 @@ def test_pass_array_object_return_sum_str_values_ndarray(func):
     for loop in range(100):
         # Intentionally all temporaries, do not change.
         assert (
-            func(
-                np.array(WrapWithPyValueHolder(-3, "four", 5.0), dtype=object)
-            )
+            func(np.array(WrapWithPyValueHolder(-3, "four", 5.0), dtype=object))
             == "-3four5.0"
         )
     assert PyValueHolder.counter == initial_counter
@@ -666,12 +666,7 @@ def test_pass_array_object_return_sum_str_values_list(func):
     initial_counter = PyValueHolder.counter
     for loop in range(100):
         # Intentionally all temporaries, do not change.
-        assert (
-            func(
-                WrapWithPyValueHolder(2, "three", -4.0)
-            )
-            == "2three-4.0"
-        )
+        assert func(WrapWithPyValueHolder(2, "three", -4.0)) == "2three-4.0"
     assert PyValueHolder.counter == initial_counter
 
 
@@ -688,9 +683,7 @@ def test_pass_array_object_return_as_list(func):
     for loop in range(100):
         # Intentionally all temporaries, do not change.
         assert UnwrapPyValueHolder(
-            func(
-                np.array(WrapWithPyValueHolder(-1, "two", 3.0), dtype=object)
-            )
+            func(np.array(WrapWithPyValueHolder(-1, "two", 3.0), dtype=object))
         ) == [-1, "two", 3.0]
     assert PyValueHolder.counter == initial_counter
 

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -629,64 +629,61 @@ def UnwrapPyValueHolder(vhs):
     return [vh.value for vh in vhs]
 
 
+PASS_ARRAY_PYOBJECT_RETURN_SUM_STR_VALUES_FUNCTIONS = [
+    m.pass_array_pyobject_ptr_return_sum_str_values,
+    m.pass_array_handle_return_sum_str_values,
+    m.pass_array_object_return_sum_str_values,
+]
+
+
 @pytest.mark.parametrize(
-    "func",
-    [
-        m.pass_array_pyobject_ptr_return_sum_str_values,
-        m.pass_array_handle_return_sum_str_values,
-        m.pass_array_object_return_sum_str_values,
-    ],
+    "pass_array", PASS_ARRAY_PYOBJECT_RETURN_SUM_STR_VALUES_FUNCTIONS
 )
-def test_pass_array_object_return_sum_str_values_ndarray(func):
+def test_pass_array_object_return_sum_str_values_ndarray(pass_array):
     # Intentionally all temporaries, do not change.
     assert (
-        func(np.array(WrapWithPyValueHolder(-3, "four", 5.0), dtype=object))
+        pass_array(np.array(WrapWithPyValueHolder(-3, "four", 5.0), dtype=object))
         == "-3four5.0"
     )
 
 
 @pytest.mark.parametrize(
-    "func",
-    [
-        m.pass_array_pyobject_ptr_return_sum_str_values,
-        m.pass_array_handle_return_sum_str_values,
-        m.pass_array_object_return_sum_str_values,
-    ],
+    "pass_array", PASS_ARRAY_PYOBJECT_RETURN_SUM_STR_VALUES_FUNCTIONS
 )
-def test_pass_array_object_return_sum_str_values_list(func):
+def test_pass_array_object_return_sum_str_values_list(pass_array):
     # Intentionally all temporaries, do not change.
-    assert func(WrapWithPyValueHolder(2, "three", -4.0)) == "2three-4.0"
+    assert pass_array(WrapWithPyValueHolder(2, "three", -4.0)) == "2three-4.0"
 
 
 @pytest.mark.parametrize(
-    "func",
+    "pass_array",
     [
         m.pass_array_pyobject_ptr_return_as_list,
         m.pass_array_handle_return_as_list,
         m.pass_array_object_return_as_list,
     ],
 )
-def test_pass_array_object_return_as_list(func):
+def test_pass_array_object_return_as_list(pass_array):
     # Intentionally all temporaries, do not change.
     assert UnwrapPyValueHolder(
-        func(np.array(WrapWithPyValueHolder(-1, "two", 3.0), dtype=object))
+        pass_array(np.array(WrapWithPyValueHolder(-1, "two", 3.0), dtype=object))
     ) == [-1, "two", 3.0]
 
 
 @pytest.mark.parametrize(
-    "func",
+    ("return_array", "unwrap"),
     [
-        m.return_array_pyobject_ptr_cpp_loop,
-        m.return_array_handle_cpp_loop,
-        m.return_array_object_cpp_loop,
-        m.return_array_pyobject_ptr_from_list,
-        m.return_array_handle_from_list,
-        m.return_array_object_from_list,
+        (m.return_array_pyobject_ptr_cpp_loop, list),
+        (m.return_array_handle_cpp_loop, list),
+        (m.return_array_object_cpp_loop, list),
+        (m.return_array_pyobject_ptr_from_list, UnwrapPyValueHolder),
+        (m.return_array_handle_from_list, UnwrapPyValueHolder),
+        (m.return_array_object_from_list, UnwrapPyValueHolder),
     ],
 )
-def test_return_array_object_cpp_loop(func):
+def test_return_array_object_cpp_loop(return_array, unwrap):
     # Intentionally all temporaries, do not change.
-    arr_from_list = func(WrapWithPyValueHolder(6, "seven", -8.0))
+    arr_from_list = return_array(WrapWithPyValueHolder(6, "seven", -8.0))
     assert isinstance(arr_from_list, np.ndarray)
     assert arr_from_list.dtype == np.dtype("O")
-    assert UnwrapPyValueHolder(arr_from_list) == [6, "seven", -8.0]
+    assert unwrap(arr_from_list) == [6, "seven", -8.0]

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-import env  # noqa: F401
+import env
 from pybind11_tests import numpy_array as m
 
 np = pytest.importorskip("numpy")


### PR DESCRIPTION
## Description

This commit adds improved support for NumPy arrays with object dtype, by allowing users to access such arrays as `array_t<handle>` or `array_t<object>`, which are more convenient than `array_t<PyObject*>` (which was introduced in PR #4674). In particular, `array_t<object>` provides automatic memory management.

This feature relies on the fact that `object` and `handle` have the same memory layout as `PyObject*`, i.e. `sizeof(object) == sizeof(handle) == sizeof(PyObject*)`. If this is somehow not the case, the `enable_if_t` test should automatically disable this feature.

I have also extended and improved the tests related to this feature with additional tests to detect memory leaks due to incorrect refcounts.

## Suggested changelog entry:

```rst
Add support for array_t<handle> and array_t<object>
```