### PR TITLE
Fix incorrect link syntax in upgrade guide

### DIFF
--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -24,7 +24,8 @@ changes are that:
   function is not available anymore.
 
 Due to NumPy changes, you may experience difficulties updating to NumPy 2.
-Please see the [NumPy 2 migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html) for details.
+Please see the `NumPy 2 migration guide <https://numpy.org/devdocs/numpy_2_0_migration_guide.html>`_
+for details.
 For example, a more direct change could be that the default integer ``"int_"``
 (and ``"uint"``) is now ``ssize_t`` and not ``long`` (affects 64bit windows).
 


### PR DESCRIPTION
Looks like some markdown spilled into our restructured text