### PR TITLE
Build platform ABI tag improvements

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -324,12 +324,12 @@ struct type_info {
 #    define PYBIND11_BUILD_LIB ""
 #  endif
 #  if (_MSC_VER) / 100 == 19
-#    define PYBIND11_BUILD_ABI NB_BUILD_LIB "_19"
+#    define PYBIND11_BUILD_ABI PYBIND11_BUILD_LIB "_19"
 #  else
-#    define PYBIND11_BUILD_ABI NB_BUILD_LIB "_unknown"
+#    define PYBIND11_BUILD_ABI PYBIND11_BUILD_LIB "_unknown"
 #  endif
 #elif defined(_LIBCPP_ABI_VERSION)
-#  define PYBIND11_BUILD_ABI "_abi" NB_TOSTRING(_LIBCPP_ABI_VERSION)
+#  define PYBIND11_BUILD_ABI "_abi" PYBIND11_TOSTRING(_LIBCPP_ABI_VERSION)
 #elif defined(__GLIBCXX__)
 #  if _GLIBCXX_USE_CXX11_ABI
 #    define PYBIND11_BUILD_ABI ""


### PR DESCRIPTION
With pybind11 and nanobind considering changes to the platform ABI tag, there is a nice opportunity to make them consistent with each other. This would make it potentially possible to later use that ABI tag to safely dispatch function calls between the two libraries.

This commit adapts the ABI tag as follows:

- It removes ``PYBIND11_INTERNALS_KIND`` that was neither used nor documented.
- It adapts the MSVC ABI tag to be less stringent (see PR #4953)
- It adapts the GCC ABI tag to be less stringent.
- It adds a check for a Clang/libc++ ABI tag that wasn't present before
