### PR TITLE
`PYBIND11_PLATFORM_ABI_ID` Modernization Continued (platforms other than MSVC)

### DIFF
--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -25,6 +25,8 @@
 #        define PYBIND11_COMPILER_TYPE "msvc"
 #    elif defined(__APPLE__)
 #        define PYBIND11_COMPILER_TYPE "macos"
+#    elif defined(__EMSCRIPTEN__)
+#        define PYBIND11_COMPILER_TYPE "emscripten"
 #    elif defined(__GLIBC__) || defined(_GLIBCXX_USE_CXX11_ABI)
 #        define PYBIND11_COMPILER_TYPE "glibc"
 #    else

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -12,13 +12,6 @@
 #define PYBIND11_PLATFORM_ABI_ID_STRINGIFY(x) #x
 #define PYBIND11_PLATFORM_ABI_ID_TOSTRING(x) PYBIND11_PLATFORM_ABI_ID_STRINGIFY(x)
 
-// On MSVC, debug and release builds are not ABI-compatible!
-#if defined(_MSC_VER) && defined(_DEBUG)
-#    define PYBIND11_BUILD_TYPE "_debug"
-#else
-#    define PYBIND11_BUILD_TYPE ""
-#endif
-
 // Let's assume that different compilers are ABI-incompatible.
 // A user can manually set this string if they know their
 // compiler is compatible.
@@ -82,6 +75,14 @@
 #    endif
 #endif
 
+// On MSVC, debug and release builds are not ABI-compatible!
+#if defined(_MSC_VER) && defined(_DEBUG)
+#    define PYBIND11_BUILD_TYPE "_debug"
+#else
+#    define PYBIND11_BUILD_TYPE ""
+#endif
+
+// Obsolete and slated for removal. DO NOT USE!
 #ifndef PYBIND11_INTERNALS_KIND
 #    define PYBIND11_INTERNALS_KIND ""
 #endif

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -23,7 +23,7 @@
 #        define PYBIND11_COMPILER_TYPE "gcc_cygwin"
 #    elif defined(_MSC_VER)
 #        define PYBIND11_COMPILER_TYPE "msvc"
-#    elif defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__)
+#    elif defined(__clang__) || defined(__GNUC__)
 #        define PYBIND11_COMPILER_TYPE "system" // Assumed compatible with system compiler.
 #    else
 #        error "Unknown PYBIND11_COMPILER_TYPE: PLEASE REVISE THIS CODE."

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -23,22 +23,18 @@
 // A user can manually set this string if they know their
 // compiler is compatible.
 #ifndef PYBIND11_COMPILER_TYPE
-#    if defined(_MSC_VER)
-#        define PYBIND11_COMPILER_TYPE "_msvc"
-#    elif defined(__INTEL_COMPILER)
-#        define PYBIND11_COMPILER_TYPE "_icc"
-#    elif defined(__clang__)
-#        define PYBIND11_COMPILER_TYPE "_clang"
-#    elif defined(__PGI)
-#        define PYBIND11_COMPILER_TYPE "_pgi"
-#    elif defined(__MINGW32__)
+#    if defined(__MINGW32__)
 #        define PYBIND11_COMPILER_TYPE "_mingw"
 #    elif defined(__CYGWIN__)
 #        define PYBIND11_COMPILER_TYPE "_gcc_cygwin"
-#    elif defined(__GNUC__)
-#        define PYBIND11_COMPILER_TYPE "_gcc"
+#    elif defined(_MSC_VER)
+#        define PYBIND11_COMPILER_TYPE "_msvc"
+#    elif defined(__PGI)
+#        define PYBIND11_COMPILER_TYPE "_pgi"
+#    elif defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__)
+#        define PYBIND11_COMPILER_TYPE "_system" // Assumed compatible with system compiler.
 #    else
-#        define PYBIND11_COMPILER_TYPE "_unknown"
+#        error "Unknown PYBIND11_COMPILER_TYPE: PLEASE REVISE THIS CODE."
 #    endif
 #endif
 

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -25,8 +25,6 @@
 #        define PYBIND11_COMPILER_TYPE "msvc"
 #    elif defined(__APPLE__)
 #        define PYBIND11_COMPILER_TYPE "macos"
-#    elif defined(__EMSCRIPTEN__)
-#        define PYBIND11_COMPILER_TYPE "emscripten"
 #    elif defined(__GLIBC__) || defined(_GLIBCXX_USE_CXX11_ABI)
 #        define PYBIND11_COMPILER_TYPE "glibc"
 #    else

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -27,8 +27,6 @@
 #        define PYBIND11_COMPILER_TYPE "macos"
 #    elif defined(__EMSCRIPTEN__)
 #        define PYBIND11_COMPILER_TYPE "emscripten"
-#    elif defined(GRAALVM_PYTHON)
-#        define PYBIND11_COMPILER_TYPE "graalvm"
 #    elif defined(__GLIBC__) || defined(_GLIBCXX_USE_CXX11_ABI)
 #        define PYBIND11_COMPILER_TYPE "glibc"
 #    else

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -54,9 +54,7 @@
 #endif
 
 #ifndef PYBIND11_BUILD_ABI
-#    if defined(__GXX_ABI_VERSION) // Linux/OSX.
-#        define PYBIND11_BUILD_ABI "_cxxabi" PYBIND11_PLATFORM_ABI_ID_TOSTRING(__GXX_ABI_VERSION)
-#    elif defined(_MSC_VER)               // See PR #4953.
+#    if defined(_MSC_VER)                 // See PR #4953.
 #        if defined(_MT) && defined(_DLL) // Corresponding to CL command line options /MD or /MDd.
 #            if (_MSC_VER) / 100 == 19
 #                define PYBIND11_BUILD_ABI "_md_mscver19"
@@ -72,8 +70,17 @@
 #                error "Unknown major version for MSC_VER: PLEASE REVISE THIS CODE."
 #            endif
 #        endif
-#    elif defined(__NVCOMPILER)       // NVHPC (PGI-based).
-#        define PYBIND11_BUILD_ABI "" // TODO: What should be here, to prevent UB?
+#    elif defined(__NVCOMPILER)        // NVHPC (PGI-based).
+#        define PYBIND11_BUILD_ABI ""  // TODO: What should be here, to prevent UB?
+#    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
+#        define PYBIND11_BUILD_ABI "_libcpp" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
+#    elif defined(__GXX_ABI_VERSION)
+#        if __GXX_ABI_VERSION >= 1002 && defined(_GLIBCXX_USE_CXX11_ABI)
+#            define PYBIND11_BUILD_ABI                                                            \
+                "_usecxx11" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_GLIBCXX_USE_CXX11_ABI)
+#        else
+#            error "Unknown platform or compiler (__GXX_ABI_VERSION): PLEASE REVISE THIS CODE."
+#        endif
 #    else
 #        error "Unknown platform or compiler: PLEASE REVISE THIS CODE."
 #    endif

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -29,9 +29,7 @@
 #        define PYBIND11_COMPILER_TYPE "_gcc_cygwin"
 #    elif defined(_MSC_VER)
 #        define PYBIND11_COMPILER_TYPE "_msvc"
-#    elif defined(__PGI)
-#        define PYBIND11_COMPILER_TYPE "_pgi"
-#    elif defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__)
+#    elif defined(__INTEL_COMPILER) || defined(__PGI) || defined(__clang__) || defined(__GNUC__)
 #        define PYBIND11_COMPILER_TYPE "_system" // Assumed compatible with system compiler.
 #    else
 #        error "Unknown PYBIND11_COMPILER_TYPE: PLEASE REVISE THIS CODE."

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -23,8 +23,14 @@
 #        define PYBIND11_COMPILER_TYPE "gcc_cygwin"
 #    elif defined(_MSC_VER)
 #        define PYBIND11_COMPILER_TYPE "msvc"
-#    elif defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__)
-#        define PYBIND11_COMPILER_TYPE "system" // Assumed compatible with system compiler.
+#    elif defined(__GLIBC__)                                                                      \
+        && (defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__))
+//       // Compatibility is determined based on libstdc++ or libc++ ABI version (below).
+#        define PYBIND11_COMPILER_TYPE "glibc"
+#    elif defined(__APPLE__)                                                                      \
+        && (defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__))
+//       // Compatibility is (usually) determined based on libc++ ABI version (below).
+#        define PYBIND11_COMPILER_TYPE "macos"
 #    else
 #        error "Unknown PYBIND11_COMPILER_TYPE: PLEASE REVISE THIS CODE."
 #    endif

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -23,14 +23,8 @@
 #        define PYBIND11_COMPILER_TYPE "gcc_cygwin"
 #    elif defined(_MSC_VER)
 #        define PYBIND11_COMPILER_TYPE "msvc"
-#    elif defined(__GLIBC__)                                                                      \
-        && (defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__))
-//       // Compatibility is determined based on libstdc++ or libc++ ABI version (below).
-#        define PYBIND11_COMPILER_TYPE "glibc"
-#    elif defined(__APPLE__)                                                                      \
-        && (defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__))
-//       // Compatibility is (usually) determined based on libc++ ABI version (below).
-#        define PYBIND11_COMPILER_TYPE "macos"
+#    elif defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__)
+#        define PYBIND11_COMPILER_TYPE "system" // Assumed compatible with system compiler.
 #    else
 #        error "Unknown PYBIND11_COMPILER_TYPE: PLEASE REVISE THIS CODE."
 #    endif

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -66,8 +66,10 @@
 #                error "Unknown major version for MSC_VER: PLEASE REVISE THIS CODE."
 #            endif
 #        endif
-#    elif defined(__NVCOMPILER)        // NVHPC (PGI-based).
-#        define PYBIND11_BUILD_ABI ""  // TODO: What should be here, to prevent UB?
+#    elif defined(__NVCOMPILER) // NVHPC (PGI-based).
+#        define PYBIND11_BUILD_ABI                                                                      \
+            "_gnuc_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(__GNUC__) "_" PYBIND11_PLATFORM_ABI_ID_TOSTRING( \
+                __GNUC_MINOR__) "_use_cxx11_abi_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_GLIBCXX_USE_CXX11_ABI)
 #    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
 #        define PYBIND11_BUILD_ABI "_abi" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
 #    elif defined(__GXX_ABI_VERSION)

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -29,8 +29,6 @@
 #        define PYBIND11_COMPILER_TYPE "_gcc_cygwin"
 #    elif defined(_MSC_VER)
 #        define PYBIND11_COMPILER_TYPE "_msvc"
-#    elif defined(__PGI)
-#        define PYBIND11_COMPILER_TYPE "_pgi"
 #    elif defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__)
 #        define PYBIND11_COMPILER_TYPE "_system" // Assumed compatible with system compiler.
 #    else
@@ -66,23 +64,17 @@
 #                error "Unknown major version for MSC_VER: PLEASE REVISE THIS CODE."
 #            endif
 #        endif
-#    elif defined(__NVCOMPILER) // NVHPC (PGI-based).
-#        define PYBIND11_BUILD_ABI                                                                      \
-            "_gnuc_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(__GNUC__) "_" PYBIND11_PLATFORM_ABI_ID_TOSTRING( \
-                __GNUC_MINOR__) "_use_cxx11_abi_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_GLIBCXX_USE_CXX11_ABI)
 #    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
 #        define PYBIND11_BUILD_ABI "_abi" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
-#    elif defined(__GXX_ABI_VERSION)
-#        if __GXX_ABI_VERSION >= 1002 && __GXX_ABI_VERSION < 2000
-#            if !defined(_GLIBCXX_USE_CXX11_ABI)
-#                error "UNEXPECTED: _GLIBCXX_USE_CXX11_ABI not defined: PLEASE REVISE THIS CODE."
-#            endif
-#            define PYBIND11_BUILD_ABI                                                            \
-                "_gxx_abi_1xxx_use_cxx11_abi_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(                 \
-                    _GLIBCXX_USE_CXX11_ABI)
-#        else
+#    elif defined(_GLIBCXX_USE_CXX11_ABI) // See PR #5439.
+#        if defined(__GXX_ABI_VERSION) && __GXX_ABI_VERSION < 1002 || __GXX_ABI_VERSION >= 2000
 #            error "Unknown platform or compiler (__GXX_ABI_VERSION): PLEASE REVISE THIS CODE."
 #        endif
+//       // Assume NVHPC it is in the 1xxx ABI family. THIS ASSUMPTION IS NOT FUTURE PROOF,
+//       // but on balance the best we can do.
+#        define PYBIND11_BUILD_ABI                                                                \
+            "_gxx_abi_1xxx_use_cxx11_abi_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(                     \
+                _GLIBCXX_USE_CXX11_ABI)
 #    else
 #        error "Unknown platform or compiler: PLEASE REVISE THIS CODE."
 #    endif

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -12,18 +12,19 @@
 #define PYBIND11_PLATFORM_ABI_ID_STRINGIFY(x) #x
 #define PYBIND11_PLATFORM_ABI_ID_TOSTRING(x) PYBIND11_PLATFORM_ABI_ID_STRINGIFY(x)
 
-// Let's assume that different compilers are ABI-incompatible.
-// A user can manually set this string if they know their
-// compiler is compatible.
-#ifndef PYBIND11_COMPILER_TYPE
+#ifdef PYBIND11_COMPILER_TYPE
+//   // To maintain backward compatibility (see PR #5439).
+#    define PYBIND11_COMPILER_TYPE_LEADING_UNDERSCORE ""
+#else
+#    define PYBIND11_COMPILER_TYPE_LEADING_UNDERSCORE "_"
 #    if defined(__MINGW32__)
-#        define PYBIND11_COMPILER_TYPE "_mingw"
+#        define PYBIND11_COMPILER_TYPE "mingw"
 #    elif defined(__CYGWIN__)
-#        define PYBIND11_COMPILER_TYPE "_gcc_cygwin"
+#        define PYBIND11_COMPILER_TYPE "gcc_cygwin"
 #    elif defined(_MSC_VER)
-#        define PYBIND11_COMPILER_TYPE "_msvc"
+#        define PYBIND11_COMPILER_TYPE "msvc"
 #    elif defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__)
-#        define PYBIND11_COMPILER_TYPE "_system" // Assumed compatible with system compiler.
+#        define PYBIND11_COMPILER_TYPE "system" // Assumed compatible with system compiler.
 #    else
 #        error "Unknown PYBIND11_COMPILER_TYPE: PLEASE REVISE THIS CODE."
 #    endif
@@ -82,11 +83,5 @@
 #    define PYBIND11_BUILD_TYPE ""
 #endif
 
-// Obsolete and slated for removal. DO NOT USE!
-#ifndef PYBIND11_INTERNALS_KIND
-#    define PYBIND11_INTERNALS_KIND ""
-#endif
-
 #define PYBIND11_PLATFORM_ABI_ID                                                                  \
-    PYBIND11_INTERNALS_KIND PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI             \
-        PYBIND11_BUILD_TYPE
+    PYBIND11_COMPILER_TYPE PYBIND11_STDLIB PYBIND11_BUILD_ABI PYBIND11_BUILD_TYPE

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -67,11 +67,17 @@
 #    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
 #        define PYBIND11_BUILD_ABI "_abi" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
 #    elif defined(_GLIBCXX_USE_CXX11_ABI) // See PR #5439.
+#        if defined(__NVCOMPILER)
+//           // Assume that NVHPC is in the 1xxx ABI family.
+//           // THIS ASSUMPTION IS NOT FUTURE PROOF but apparently the best we can do.
+//           // Please let us know if there is a way to validate the assumption here.
+#        elif !defined(__GXX_ABI_VERSION)
+#            error                                                                                \
+                "Unknown platform or compiler (_GLIBCXX_USE_CXX11_ABI): PLEASE REVISE THIS CODE."
+#        endif
 #        if defined(__GXX_ABI_VERSION) && __GXX_ABI_VERSION < 1002 || __GXX_ABI_VERSION >= 2000
 #            error "Unknown platform or compiler (__GXX_ABI_VERSION): PLEASE REVISE THIS CODE."
 #        endif
-//       // Assume NVHPC it is in the 1xxx ABI family. THIS ASSUMPTION IS NOT FUTURE PROOF,
-//       // but on balance the best we can do.
 #        define PYBIND11_BUILD_ABI                                                                \
             "_gxx_abi_1xxx_use_cxx11_abi_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(                     \
                 _GLIBCXX_USE_CXX11_ABI)

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -64,9 +64,11 @@
 #                error "Unknown major version for MSC_VER: PLEASE REVISE THIS CODE."
 #            endif
 #        endif
+#    elif defined(__NVCOMPILER)        // NVHPC (PGI-based).
+#        define PYBIND11_BUILD_ABI ""  // TODO: What should be here, to prevent UB?
 #    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
 #        define PYBIND11_BUILD_ABI "_abi" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
-#    elif defined(__GXX_ABI_VERSION) // See PR #5439.
+#    elif defined(__GXX_ABI_VERSION)
 #        if __GXX_ABI_VERSION >= 1002 && __GXX_ABI_VERSION < 2000
 #            if !defined(_GLIBCXX_USE_CXX11_ABI)
 #                error "UNEXPECTED: _GLIBCXX_USE_CXX11_ABI not defined: PLEASE REVISE THIS CODE."

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -27,6 +27,8 @@
 #        define PYBIND11_COMPILER_TYPE "macos"
 #    elif defined(__EMSCRIPTEN__)
 #        define PYBIND11_COMPILER_TYPE "emscripten"
+#    elif defined(GRAALVM_PYTHON)
+#        define PYBIND11_COMPILER_TYPE "graalvm"
 #    elif defined(__GLIBC__) || defined(_GLIBCXX_USE_CXX11_ABI)
 #        define PYBIND11_COMPILER_TYPE "glibc"
 #    else

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -29,7 +29,9 @@
 #        define PYBIND11_COMPILER_TYPE "_gcc_cygwin"
 #    elif defined(_MSC_VER)
 #        define PYBIND11_COMPILER_TYPE "_msvc"
-#    elif defined(__INTEL_COMPILER) || defined(__PGI) || defined(__clang__) || defined(__GNUC__)
+#    elif defined(__PGI)
+#        define PYBIND11_COMPILER_TYPE "_pgi"
+#    elif defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__)
 #        define PYBIND11_COMPILER_TYPE "_system" // Assumed compatible with system compiler.
 #    else
 #        error "Unknown PYBIND11_COMPILER_TYPE: PLEASE REVISE THIS CODE."

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -75,7 +75,8 @@
 #    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
 #        define PYBIND11_BUILD_ABI "_libcpp" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
 #    elif defined(__GXX_ABI_VERSION)
-#        if __GXX_ABI_VERSION >= 1002 && __GXX_ABI_VERSION < 2000 && defined(_GLIBCXX_USE_CXX11_ABI)
+#        if __GXX_ABI_VERSION >= 1002 && __GXX_ABI_VERSION < 2000                                 \
+            && defined(_GLIBCXX_USE_CXX11_ABI)
 #            define PYBIND11_BUILD_ABI                                                            \
                 "_gxx_abi_1_usecxx11_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_GLIBCXX_USE_CXX11_ABI)
 #        else

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -36,15 +36,10 @@
 #    endif
 #endif
 
-// Also standard libs
+// PR #5439 made this macro obsolete. However, there are many manipulations of this macro in the
+// wild. Therefore, to maintain backward compatibility, it is kept around.
 #ifndef PYBIND11_STDLIB
-#    if defined(_LIBCPP_VERSION)
-#        define PYBIND11_STDLIB "_libcpp"
-#    elif defined(__GLIBCXX__) || defined(__GLIBCPP__)
-#        define PYBIND11_STDLIB "_libstdcpp"
-#    else
-#        define PYBIND11_STDLIB ""
-#    endif
+#    define PYBIND11_STDLIB ""
 #endif
 
 #ifndef PYBIND11_BUILD_ABI
@@ -65,7 +60,8 @@
 #            endif
 #        endif
 #    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
-#        define PYBIND11_BUILD_ABI "_abi" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
+#        define PYBIND11_BUILD_ABI                                                                \
+            "_libcpp_abi" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
 #    elif defined(_GLIBCXX_USE_CXX11_ABI) // See PR #5439.
 #        if defined(__NVCOMPILER)
 //           // Assume that NVHPC is in the 1xxx ABI family.
@@ -79,7 +75,7 @@
 #            error "Unknown platform or compiler (__GXX_ABI_VERSION): PLEASE REVISE THIS CODE."
 #        endif
 #        define PYBIND11_BUILD_ABI                                                                \
-            "_gxx_abi_1xxx_use_cxx11_abi_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(                     \
+            "_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(           \
                 _GLIBCXX_USE_CXX11_ABI)
 #    else
 #        error "Unknown platform or compiler: PLEASE REVISE THIS CODE."

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -23,10 +23,14 @@
 #        define PYBIND11_COMPILER_TYPE "gcc_cygwin"
 #    elif defined(_MSC_VER)
 #        define PYBIND11_COMPILER_TYPE "msvc"
-#    elif defined(__APPLE__)
-#        define PYBIND11_COMPILER_TYPE "macos"
-#    elif defined(__GLIBC__) || defined(_GLIBCXX_USE_CXX11_ABI)
+#    elif defined(__GLIBC__)                                                                      \
+        && (defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__))
+//       // Compatibility is determined based on libstdc++ or libc++ ABI version (below).
 #        define PYBIND11_COMPILER_TYPE "glibc"
+#    elif defined(__APPLE__)                                                                      \
+        && (defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__))
+//       // Compatibility is (usually) determined based on libc++ ABI version (below).
+#        define PYBIND11_COMPILER_TYPE "macos"
 #    else
 #        error "Unknown PYBIND11_COMPILER_TYPE: PLEASE REVISE THIS CODE."
 #    endif

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -64,11 +64,9 @@
 #                error "Unknown major version for MSC_VER: PLEASE REVISE THIS CODE."
 #            endif
 #        endif
-#    elif defined(__NVCOMPILER)        // NVHPC (PGI-based).
-#        define PYBIND11_BUILD_ABI ""  // TODO: What should be here, to prevent UB?
 #    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
 #        define PYBIND11_BUILD_ABI "_abi" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
-#    elif defined(__GXX_ABI_VERSION)
+#    elif defined(__GXX_ABI_VERSION) // See PR #5439.
 #        if __GXX_ABI_VERSION >= 1002 && __GXX_ABI_VERSION < 2000
 #            if !defined(_GLIBCXX_USE_CXX11_ABI)
 #                error "UNEXPECTED: _GLIBCXX_USE_CXX11_ABI not defined: PLEASE REVISE THIS CODE."

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -75,9 +75,9 @@
 #    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
 #        define PYBIND11_BUILD_ABI "_libcpp" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
 #    elif defined(__GXX_ABI_VERSION)
-#        if __GXX_ABI_VERSION >= 1002 && defined(_GLIBCXX_USE_CXX11_ABI)
+#        if __GXX_ABI_VERSION >= 1002 && __GXX_ABI_VERSION < 2000 && defined(_GLIBCXX_USE_CXX11_ABI)
 #            define PYBIND11_BUILD_ABI                                                            \
-                "_usecxx11" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_GLIBCXX_USE_CXX11_ABI)
+                "_gxx_abi_1_usecxx11_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_GLIBCXX_USE_CXX11_ABI)
 #        else
 #            error "Unknown platform or compiler (__GXX_ABI_VERSION): PLEASE REVISE THIS CODE."
 #        endif

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -23,14 +23,10 @@
 #        define PYBIND11_COMPILER_TYPE "gcc_cygwin"
 #    elif defined(_MSC_VER)
 #        define PYBIND11_COMPILER_TYPE "msvc"
-#    elif defined(__GLIBC__)                                                                      \
-        && (defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__))
-//       // Compatibility is determined based on libstdc++ or libc++ ABI version (below).
-#        define PYBIND11_COMPILER_TYPE "glibc"
-#    elif defined(__APPLE__)                                                                      \
-        && (defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__))
-//       // Compatibility is (usually) determined based on libc++ ABI version (below).
+#    elif defined(__APPLE__)
 #        define PYBIND11_COMPILER_TYPE "macos"
+#    elif defined(__GLIBC__) || defined(_GLIBCXX_USE_CXX11_ABI)
+#        define PYBIND11_COMPILER_TYPE "glibc"
 #    else
 #        error "Unknown PYBIND11_COMPILER_TYPE: PLEASE REVISE THIS CODE."
 #    endif

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -77,10 +77,11 @@
 #    elif defined(__GXX_ABI_VERSION)
 #        if __GXX_ABI_VERSION >= 1002 && __GXX_ABI_VERSION < 2000
 #            if !defined(_GLIBCXX_USE_CXX11_ABI)
-#                error "UNEXPECTED: _GLIBCXX_USE_CXX11_ABI not defined"
+#                error "UNEXPECTED: _GLIBCXX_USE_CXX11_ABI not defined: PLEASE REVISE THIS CODE."
 #            endif
 #            define PYBIND11_BUILD_ABI                                                            \
-                "_gxx_abi_1xxx_usecxx11_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_GLIBCXX_USE_CXX11_ABI)
+                "_gxx_abi_1xxx_use_cxx11_abi_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(                 \
+                    _GLIBCXX_USE_CXX11_ABI)
 #        else
 #            error "Unknown platform or compiler (__GXX_ABI_VERSION): PLEASE REVISE THIS CODE."
 #        endif

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -75,8 +75,10 @@
 #    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
 #        define PYBIND11_BUILD_ABI "_abi" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
 #    elif defined(__GXX_ABI_VERSION)
-#        if __GXX_ABI_VERSION >= 1002 && __GXX_ABI_VERSION < 2000                                 \
-            && defined(_GLIBCXX_USE_CXX11_ABI)
+#        if __GXX_ABI_VERSION >= 1002 && __GXX_ABI_VERSION < 2000
+#            if !defined(_GLIBCXX_USE_CXX11_ABI)
+#                error "UNEXPECTED: _GLIBCXX_USE_CXX11_ABI not defined"
+#            endif
 #            define PYBIND11_BUILD_ABI                                                            \
                 "_gxx_abi_1xxx_usecxx11_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_GLIBCXX_USE_CXX11_ABI)
 #        else

--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -73,12 +73,12 @@
 #    elif defined(__NVCOMPILER)        // NVHPC (PGI-based).
 #        define PYBIND11_BUILD_ABI ""  // TODO: What should be here, to prevent UB?
 #    elif defined(_LIBCPP_ABI_VERSION) // https://libcxx.llvm.org/DesignDocs/ABIVersioning.html
-#        define PYBIND11_BUILD_ABI "_libcpp" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
+#        define PYBIND11_BUILD_ABI "_abi" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_LIBCPP_ABI_VERSION)
 #    elif defined(__GXX_ABI_VERSION)
 #        if __GXX_ABI_VERSION >= 1002 && __GXX_ABI_VERSION < 2000                                 \
             && defined(_GLIBCXX_USE_CXX11_ABI)
 #            define PYBIND11_BUILD_ABI                                                            \
-                "_gxx_abi_1_usecxx11_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_GLIBCXX_USE_CXX11_ABI)
+                "_gxx_abi_1xxx_usecxx11_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(_GLIBCXX_USE_CXX11_ABI)
 #        else
 #            error "Unknown platform or compiler (__GXX_ABI_VERSION): PLEASE REVISE THIS CODE."
 #        endif

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -272,11 +272,11 @@ struct type_info {
 
 #define PYBIND11_INTERNALS_ID                                                                     \
     "__pybind11_internals_v" PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION)                        \
-        PYBIND11_PLATFORM_ABI_ID "__"
+        PYBIND11_COMPILER_TYPE_LEADING_UNDERSCORE PYBIND11_PLATFORM_ABI_ID "__"
 
 #define PYBIND11_MODULE_LOCAL_ID                                                                  \
     "__pybind11_module_local_v" PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION)                     \
-        PYBIND11_PLATFORM_ABI_ID "__"
+        PYBIND11_COMPILER_TYPE_LEADING_UNDERSCORE PYBIND11_PLATFORM_ABI_ID "__"
 
 /// Each module locally stores a pointer to the `internals` data. The data
 /// itself is shared among modules with the same `PYBIND11_INTERNALS_ID`.


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This PR updates `PYBIND11_PLATFORM_ABI_ID`, which determines cross-extension ABI compatibility, to improve accuracy across all platforms other than MSVC (which was modernized previously in #4953). For context on the importance of `PYBIND11_PLATFORM_ABI_ID`, please refer to PRs #5296 and #5375.

The accuracy improvements can be seen by comparing the `PYBIND11_INTERNALS_ID` summaries before and after: 

master @ 741d86f2e3527b667ba85d273a5eea19a0978ef5 (logs_32284154734.zip, logs_32284154873.zip):

```bash
cat *.txt | grep 'C.. Info: .* __pybind11_internals_v' | sed 's/.* __pybind11_internals_v[0-9]*/__pybind11_internals_vX/' | cut -d' ' -f1 | sort | uniq -c
```

```
     27 __pybind11_internals_vX_clang_libcpp_cxxabi1002__
      5 __pybind11_internals_vX_clang_libstdcpp_cxxabi1002__
     27 __pybind11_internals_vX_gcc_libstdcpp_cxxabi1013__
      3 __pybind11_internals_vX_gcc_libstdcpp_cxxabi1014__
      3 __pybind11_internals_vX_gcc_libstdcpp_cxxabi1016__
      2 __pybind11_internals_vX_gcc_libstdcpp_cxxabi1017__
      5 __pybind11_internals_vX_gcc_libstdcpp_cxxabi1018__
      2 __pybind11_internals_vX_icc_libstdcpp_cxxabi1010__
      6 __pybind11_internals_vX_mingw_libstdcpp_cxxabi1019__
      1 __pybind11_internals_vX_pgi_libstdcpp__
```

This PR (pr5439_logs_32281771697.zip, pr5439_logs_32281771739.zip):

```
      6 __pybind11_internals_vX_mingw_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1__
     26 __pybind11_internals_vX_system_libcpp_abi1__
      1 __pybind11_internals_vX_system_libcpp_abi2__
     48 __pybind11_internals_vX_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1__
```
Note that the compiler-specific identifiers `clang`, `gcc`, `icc`, `pgi` no longer appear. **ABI compatibility is now determined primarily by `libstdcpp` (gcc) or `libcpp` (clang) ABI preprocessor macros.**

It is expected that overrides like [those in pytorch](https://github.com/pytorch/pytorch/blob/7dd9b5fc4343d101294dbbab4b4172f2859460bc/torch/utils/cpp_extension.py#L1372-L1390) will not be needed anymore. However, this PR ensures that existing overrides will still function, allowing for gradual community adoption.

Similar to #4953, silent fallbacks for unexpected situations have been replaced with `#error ... PLEASE REVISE THIS CODE.` directives. For such cases, command-line overrides for the affected macros can serve as temporary workarounds. To eliminate the need for such workarounds, users are encouraged to contribute updates to `pybind11/conduit/pybind11_platform_abi_id.h` as needed.

For completeness, the counts for MSVC (unchanged):

```
      3 __pybind11_internals_vX_msvc_md_mscver19__
     34 __pybind11_internals_vX_msvc_md_mscver19_debug__
      3 __pybind11_internals_vX_msvc_mt_mscver1942__
```

The work on this PR was informed by:

* https://github.com/pybind/pybind11/pull/4953#discussion_r1819513219
* https://github.com/pybind/pybind11/pull/4953#discussion_r1819571321
* #5437

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
``PYBIND11_PLATFORM_ABI_ID`` (which is used in composing ``PYBIND11_INTERNALS_ID``) was modernized to reflect actual ABI compatibility more accurately.
```

<!-- If the upgrade guide needs updating, note that here too -->
