### PR TITLE
Remove `mingw-w64-i686-python-numpy` from `mingw32` build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1019,7 +1019,6 @@ jobs:
           git
           mingw-w64-${{matrix.env}}-gcc
           mingw-w64-${{matrix.env}}-python-pip
-          mingw-w64-${{matrix.env}}-python-numpy
           mingw-w64-${{matrix.env}}-cmake
           mingw-w64-${{matrix.env}}-make
           mingw-w64-${{matrix.env}}-python-pytest
@@ -1031,7 +1030,7 @@ jobs:
       with:
         msystem: ${{matrix.sys}}
         install: >-
-          git
+          mingw-w64-${{matrix.env}}-python-numpy
           mingw-w64-${{matrix.env}}-python-scipy
           mingw-w64-${{matrix.env}}-eigen3
 


### PR DESCRIPTION
`mingw-w64-i686-python-numpy` does not seem to exist anymore:

[Last successful](https://github.com/pybind/pybind11/actions/runs/11872299852/job/33085849640): Sat, 16 Nov 2024 18:25:21 GMT

[First failure](https://github.com/pybind/pybind11/actions/runs/11873312507/job/33088302602): Sat, 16 Nov 2024 21:43:28 GMT

```
Installing additional packages through pacman...
  C:\Windows\system32\cmd.exe /D /S /C D:\a\_temp\setup-msys2\msys2.cmd -c "'pacman' '--noconfirm' '-S' '--needed' '--overwrite' '*' 'git' 'mingw-w64-i686-gcc' 'mingw-w64-i686-python-pip' 'mingw-w64-i686-python-numpy' 'mingw-w64-i686-cmake' 'mingw-w64-i686-make' 'mingw-w64-i686-python-pytest' 'mingw-w64-i686-boost' 'mingw-w64-i686-catch'"
  error: target not found: mingw-w64-i686-python-numpy
  Error: The process 'C:\Windows\system32\cmd.exe' failed with exit code 1
```

Minor collateral fix (`mingw64`): `warning: git-2.47.0-1 is up to date -- skipping` 

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
