### PR TITLE
Try to fix reentrant write transient failures in tests

### DIFF
--- a/tests/constructor_stats.h
+++ b/tests/constructor_stats.h
@@ -312,8 +312,16 @@ void print_created(T *inst, Values &&...values) {
 }
 template <class T, typename... Values>
 void print_destroyed(T *inst, Values &&...values) { // Prints but doesn't store given values
+    /*
+     * On GraalPy, destructors can trigger anywhere and this can cause random
+     * failures in unrelated tests.
+     */
+#if !defined(GRAALVM_PYTHON)
     print_constr_details(inst, "destroyed", values...);
     track_destroyed(inst);
+#else
+    py::detail::silence_unused_warnings(inst, values...);
+#endif
 }
 template <class T, typename... Values>
 void print_values(T *inst, Values &&...values) {

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -6,13 +6,7 @@ from io import StringIO
 
 import pytest
 
-import env  # noqa: F401
 from pybind11_tests import iostream as m
-
-pytestmark = pytest.mark.skipif(
-    "env.GRAALPY",
-    reason="Delayed prints from finalizers from other tests can end up in the output",
-)
 
 
 def test_captured(capsys):


### PR DESCRIPTION
Disable `print_destroyed` in tests on GraalPy. It can trigger within and ongoing print, causing reentrancy errors. The prints have no value on GraalPy anyway, because they trigger in random places, so they cannot be tested. I also try to reenable `test_iostream` because that one was failing because the random prints could end up in the output capture.