### PR TITLE
feat(types) Allow setting types for attributes

### DIFF
--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -22,7 +22,7 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - uses: pypa/cibuildwheel@v2.21
+    - uses: pypa/cibuildwheel@v2.22
       env:
         PYODIDE_BUILD_EXPORTS: whole_archive
       with:

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1373,6 +1373,22 @@ using py_str = str;
 // Written here so make_caster<T> can be used
 template <typename D>
 template <typename T>
+str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
+#if !defined(__cpp_inline_variables)
+    static_assert(!std::is_same<T, T>::value,
+                  "C++17 feature __cpp_inline_variables not available: "
+                  "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
+#endif
+    object ann = annotations();
+    if (ann.contains(key)) {
+        throw std::runtime_error("__annotations__[\"" + std::string(key) + "\"] was set already.");
+    }
+    ann[key] = make_caster<T>::name.text;
+    return {derived(), key};
+}
+
+template <typename D>
+template <typename T>
 obj_attr_accessor object_api<D>::attr_with_type_hint(handle key) const {
 #if !defined(__cpp_inline_variables)
     static_assert(!std::is_same<T, T>::value,
@@ -1387,22 +1403,6 @@ obj_attr_accessor object_api<D>::attr_with_type_hint(handle key) const {
     }
     ann[key] = make_caster<T>::name.text;
     return {derived(), reinterpreted_key};
-}
-
-template <typename D>
-template <typename T>
-str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
-#if !defined(__cpp_inline_variables)
-    static_assert(!std::is_same<T, T>::value,
-                  "C++17 feature __cpp_inline_variables not available: "
-                  "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
-#endif
-    object ann = annotations();
-    if (ann.contains(key)) {
-        throw std::runtime_error("__annotations__[\"" + std::string(key) + "\"] was set already.");
-    }
-    ann[key] = make_caster<T>::name.text;
-    return {derived(), key};
 }
 
 // Placeholder type for the unneeded (and dead code) static variable in the

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1329,14 +1329,18 @@ object object_or_cast(T &&o) {
     return pybind11::cast(std::forward<T>(o));
 }
 
+
+#if defined(PYBIND11_CPP17)
 // Declared in pytypes.h:
 // Written here so make_caster<T> can be used
 template <typename D>
 template <typename T>
 str_attr_accessor object_api<D>::attr_with_type(const char *key) const {
-    annotations()[key] = make_caster<T>::name.text;
+    static constexpr auto name = make_caster<T>::name;
+    annotations()[key] = name.text;
     return {derived(), key};
 }
+#endif
 
 // Placeholder type for the unneeded (and dead code) static variable in the
 // PYBIND11_OVERRIDE_OVERRIDE macro

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1329,7 +1329,6 @@ object object_or_cast(T &&o) {
     return pybind11::cast(std::forward<T>(o));
 }
 
-
 #if defined(PYBIND11_CPP17)
 // Declared in pytypes.h:
 // Written here so make_caster<T> can be used

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1372,7 +1372,7 @@ template <typename D>
 template <typename T>
 str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
 #if !defined(__cpp_inline_variables)
-    static_assert(always_false<T>::value,
+    static_assert(std::false_type::value,
                   "C++17 feature __cpp_inline_variables not available: "
                   "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
 #endif

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1335,8 +1335,7 @@ object object_or_cast(T &&o) {
 template <typename D>
 template <typename T>
 str_attr_accessor object_api<D>::attr_with_type(const char *key) const {
-    static constexpr auto name = make_caster<T>::name;
-    annotations()[key] = name.text;
+    annotations()[key] = make_caster<T>::name.text;
     return {derived(), key};
 }
 #endif

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1379,7 +1379,7 @@ obj_attr_accessor object_api<D>::attr_with_type_hint(handle key) const {
     object ann = annotations();
     object reinterpreted_key = reinterpret_borrow<object>(key);
     if (ann.contains(reinterpreted_key)) {
-        throw std::runtime_error("__annotations__[\"" + std::string(py::str(reinterpreted_key))
+        throw std::runtime_error("__annotations__[\"" + std::string(str(reinterpreted_key))
                                  + "\"] was set already.");
     }
     ann[key] = make_caster<T>::name.text;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1379,7 +1379,8 @@ obj_attr_accessor object_api<D>::attr_with_type_hint(handle key) const {
     object ann = annotations();
     object reinterpreted_key = reinterpret_borrow<object>(key);
     if (ann.contains(reinterpreted_key)) {
-        throw std::runtime_error("__annotations__[\"" + std::string(py::str(reinterpreted_key)) + "\"] was set already.");
+        throw std::runtime_error("__annotations__[\"" + std::string(py::str(reinterpreted_key))
+                                 + "\"] was set already.");
     }
     ann[key] = make_caster<T>::name.text;
     return {derived(), reinterpreted_key};

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1370,6 +1370,22 @@ object object_or_cast(T &&o) {
 // Written here so make_caster<T> can be used
 template <typename D>
 template <typename T>
+obj_attr_accessor object_api<D>::attr_with_type_hint(handle key) const {
+#if !defined(__cpp_inline_variables)
+    static_assert(!std::is_same<T, T>::value,
+                  "C++17 feature __cpp_inline_variables not available: "
+                  "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
+#endif
+    object ann = annotations();
+    if (ann.contains(key)) {
+        throw std::runtime_error("__annotations__[\"" + std::string(key) + "\"] was set already.");
+    }
+    ann[key] = make_caster<T>::name.text;
+    return {derived(), reinterpret_borrow<object>(key)};
+}
+
+template <typename D>
+template <typename T>
 str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
 #if !defined(__cpp_inline_variables)
     static_assert(!std::is_same<T, T>::value,

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1329,6 +1329,15 @@ object object_or_cast(T &&o) {
     return pybind11::cast(std::forward<T>(o));
 }
 
+// Declared in pytypes.h:
+// Written here so make_caster<T> can be used
+template <typename D>
+template <typename T>
+str_attr_accessor object_api<D>::attr_with_type(const char *key) const {
+    annotations()[key] = make_caster<T>::name.text;
+    return {derived(), key};
+};
+
 // Placeholder type for the unneeded (and dead code) static variable in the
 // PYBIND11_OVERRIDE_OVERRIDE macro
 struct override_unused {};

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1334,7 +1334,7 @@ object object_or_cast(T &&o) {
 // Written here so make_caster<T> can be used
 template <typename D>
 template <typename T>
-str_attr_accessor object_api<D>::attr_with_type(const char *key) const {
+str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
     annotations()[key] = make_caster<T>::name.text;
     return {derived(), key};
 }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1372,7 +1372,7 @@ template <typename D>
 template <typename T>
 str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
 #if !defined(__cpp_inline_variables)
-    static_assert(std::false_type::value,
+    static_assert(always_false<T>::value,
                   "C++17 feature __cpp_inline_variables not available: "
                   "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
 #endif

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1367,7 +1367,7 @@ object object_or_cast(T &&o) {
 }
 
 // This is being used to get around the conflict with the deprecated str() function on object_api
-typedef str py_str;
+using py_str = str;
 
 // Declared in pytypes.h:
 // Written here so make_caster<T> can be used
@@ -1380,7 +1380,7 @@ obj_attr_accessor object_api<D>::attr_with_type_hint(handle key) const {
                   "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
 #endif
     object ann = annotations();
-    object reinterpreted_key = reinterpret_borrow<object>(key);
+    auto reinterpreted_key = reinterpret_borrow<object>(key);
     if (ann.contains(reinterpreted_key)) {
         throw std::runtime_error("__annotations__[\"" + std::string(py_str(reinterpreted_key))
                                  + "\"] was set already.");

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1336,7 +1336,7 @@ template <typename T>
 str_attr_accessor object_api<D>::attr_with_type(const char *key) const {
     annotations()[key] = make_caster<T>::name.text;
     return {derived(), key};
-};
+}
 
 // Placeholder type for the unneeded (and dead code) static variable in the
 // PYBIND11_OVERRIDE_OVERRIDE macro

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1377,11 +1377,12 @@ obj_attr_accessor object_api<D>::attr_with_type_hint(handle key) const {
                   "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
 #endif
     object ann = annotations();
-    if (ann.contains(key)) {
-        throw std::runtime_error("__annotations__[\"" + std::string(key) + "\"] was set already.");
+    object reinterpreted_key = reinterpret_borrow<object>(key);
+    if (ann.contains(reinterpreted_key)) {
+        throw std::runtime_error("__annotations__[\"" + std::string(py::str(reinterpreted_key)) + "\"] was set already.");
     }
     ann[key] = make_caster<T>::name.text;
-    return {derived(), reinterpret_borrow<object>(key)};
+    return {derived(), reinterpreted_key};
 }
 
 template <typename D>

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1366,6 +1366,9 @@ object object_or_cast(T &&o) {
     return pybind11::cast(std::forward<T>(o));
 }
 
+// This is being used to get around the conflict with the deprecated str() function on object_api
+typedef str py_str;
+
 // Declared in pytypes.h:
 // Written here so make_caster<T> can be used
 template <typename D>
@@ -1379,7 +1382,7 @@ obj_attr_accessor object_api<D>::attr_with_type_hint(handle key) const {
     object ann = annotations();
     object reinterpreted_key = reinterpret_borrow<object>(key);
     if (ann.contains(reinterpreted_key)) {
-        throw std::runtime_error("__annotations__[\"" + std::string(str(reinterpreted_key))
+        throw std::runtime_error("__annotations__[\"" + py_str(reinterpreted_key)
                                  + "\"] was set already.");
     }
     ann[key] = make_caster<T>::name.text;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1372,7 +1372,7 @@ template <typename D>
 template <typename T>
 str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
 #if !defined(__cpp_inline_variables)
-    static_assert(false,
+    static_assert(!std::is_same<T, T>::value,
                   "C++17 feature __cpp_inline_variables not available: "
                   "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
 #endif

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1372,7 +1372,7 @@ template <typename D>
 template <typename T>
 str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
 #if !defined(__cpp_inline_variables)
-    static_assert(!std::is_same<T, T>::value,
+    static_assert(always_false<T>::value,
                   "C++17 feature __cpp_inline_variables not available: "
                   "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
 #endif

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1382,7 +1382,7 @@ obj_attr_accessor object_api<D>::attr_with_type_hint(handle key) const {
     object ann = annotations();
     object reinterpreted_key = reinterpret_borrow<object>(key);
     if (ann.contains(reinterpreted_key)) {
-        throw std::runtime_error("__annotations__[\"" + py_str(reinterpreted_key)
+        throw std::runtime_error("__annotations__[\"" + std::string(py_str(reinterpreted_key))
                                  + "\"] was set already.");
     }
     ann[key] = make_caster<T>::name.text;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1376,7 +1376,11 @@ str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
                   "C++17 feature __cpp_inline_variables not available: "
                   "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
 #endif
-    annotations()[key] = make_caster<T>::name.text;
+    object ann = annotations();
+    if (ann.contains(key)) {
+        throw std::runtime_error("__annotations__[\"" + std::string(key) + "\"] was set already.");
+    }
+    ann[key] = make_caster<T>::name.text;
     return {derived(), key};
 }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1366,16 +1366,19 @@ object object_or_cast(T &&o) {
     return pybind11::cast(std::forward<T>(o));
 }
 
-#if defined(PYBIND11_CPP17)
 // Declared in pytypes.h:
 // Written here so make_caster<T> can be used
 template <typename D>
 template <typename T>
 str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
+#if !defined(__cpp_inline_variables)
+    static_assert(false,
+                  "C++17 feature __cpp_inline_variables not available: "
+                  "https://en.cppreference.com/w/cpp/language/static#Static_data_members");
+#endif
     annotations()[key] = make_caster<T>::name.text;
     return {derived(), key};
 }
-#endif
 
 // Placeholder type for the unneeded (and dead code) static variable in the
 // PYBIND11_OVERRIDE_OVERRIDE macro

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -627,6 +627,11 @@ struct instance {
 static_assert(std::is_standard_layout<instance>::value,
               "Internal error: `pybind11::detail::instance` is not standard layout!");
 
+// Some older compilers (e.g. gcc 9.4.0) require
+//     static_assert(always_false<T>::value, "...");
+// instead of
+//     static_assert(false, "...");
+// to trigger the static_assert() in a template only if it is actually instantiated.
 template <typename>
 struct always_false : std::false_type {};
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -627,6 +627,9 @@ struct instance {
 static_assert(std::is_standard_layout<instance>::value,
               "Internal error: `pybind11::detail::instance` is not standard layout!");
 
+template <typename>
+struct always_false : std::false_type {};
+
 /// from __cpp_future__ import (convenient aliases from C++14/17)
 #if defined(PYBIND11_CPP14)
 using std::conditional_t;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2572,7 +2572,7 @@ object object_api<D>::annotations() const {
 // Python 3.8, 3.9
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
     if (isinstance<type>(derived())) {
-        return getattr(derived(), "__dict__").get("__annotations__", dict());
+        return getattr(getattr(derived(), "__dict__"), "__annotations__", dict());
     } else {
         return getattr(derived(), "__annotations__", dict());
     }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2569,18 +2569,17 @@ template <typename D>
 // Always a dict
 // https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
 object object_api<D>::annotations() const {
-    // Python 3.8, 3.9 
-    #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
-        if (isinstance<type>(derived())){
-            return getattr(derived(), "__dict__").get("__annotations__", dict());
-        }
-        else{
-            return getattr(derived(), "__annotations__", dict());
-        }
-    // Python 3.10+
-    #else
+// Python 3.8, 3.9
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
+    if (isinstance<type>(derived())) {
+        return getattr(derived(), "__dict__").get("__annotations__", dict());
+    } else {
         return getattr(derived(), "__annotations__", dict());
-    #endif
+    }
+// Python 3.10+
+#else
+    return getattr(derived(), "__annotations__", dict());
+#endif
 }
 
 template <typename D>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2567,8 +2567,14 @@ str_attr_accessor object_api<D>::doc() const {
 
 template <typename D>
 // Always a dict
+// https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
 object object_api<D>::annotations() const {
-    return getattr(derived(), "__annotations__", dict());
+    if (isinstance<type>(derived())){
+        return getattr(getattr(derived(), "__dict__"), "__annotations__", dict());
+    }
+    else{
+        return getattr(derived(), "__annotations__", dict());
+    }
 }
 
 template <typename D>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2569,12 +2569,18 @@ template <typename D>
 // Always a dict
 // https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
 object object_api<D>::annotations() const {
-    if (isinstance<type>(derived())){
-        return getattr(getattr(derived(), "__dict__"), "__annotations__", dict());
-    }
-    else{
+    // Python 3.8, 3.9 
+    #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
+        if (isinstance<type>(derived())){
+            return getattr(derived(), "__dict__").get("__annotations__", dict());
+        }
+        else{
+            return getattr(derived(), "__annotations__", dict());
+        }
+    // Python 3.10+
+    #else
         return getattr(derived(), "__annotations__", dict());
-    }
+    #endif
 }
 
 template <typename D>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -116,7 +116,7 @@ public:
     /** \rst
          Similar to the above attr functions with the difference that the templated Type
          is used to set the `__annotations__` dict value to the corresponding key. Worth noting
-         that attr_with_type_hint is implemented in cast.h
+         that attr_with_type_hint is implemented in cast.h.
     \endrst */
     template <typename T>
     obj_attr_accessor attr_with_type_hint(handle key) const;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -115,7 +115,7 @@ public:
 
     /** \rst
          Similar to the above attr functions with the difference that the templated Type
-         is used to set the `__annotations__` dict value to the corresponding key. Worth nothing
+         is used to set the `__annotations__` dict value to the corresponding key. Worth noting
          that attr_with_type_hint is implemented in cast.h
     \endrst */
     template <typename T>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2567,7 +2567,13 @@ str_attr_accessor object_api<D>::doc() const {
 
 template <typename D>
 str_attr_accessor object_api<D>::annotations() const {
-    str_attr_accessor annotations_dict = attr("__annotations__");
+    // Create dict automatically
+
+    #if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
+        str_attr_accessor annotations_dict = attr("__dict__").attr("__annotations__");
+    #else
+        str_attr_accessor annotations_dict = attr("__annotations__");
+    #endif
     // Create dict automatically
     if (!isinstance<dict>(annotations_dict)) {
         annotations_dict = dict();

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2571,7 +2571,7 @@ template <typename D>
 object object_api<D>::annotations() const {
 // Python 3.8, 3.9
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
-    if (isinstance<type>(derived())) {
+    if (hasattr(derived(), "__dict__")) {
         return getattr(getattr(derived(), "__dict__"), "__annotations__", dict());
     } else {
         return getattr(derived(), "__annotations__", dict());

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -120,6 +120,7 @@ public:
     \endrst */
     template <typename T>
     obj_attr_accessor attr_with_type_hint(handle key) const;
+    /// See above (the only difference is that the key is provided as a string literal)
     template <typename T>
     str_attr_accessor attr_with_type_hint(const char *key) const;
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -113,6 +113,10 @@ public:
     /// See above (the only difference is that the key is provided as a string literal)
     str_attr_accessor attr(const char *key) const;
 
+    // attr_with_type is implemented in cast.h:
+    template <typename T>
+    str_attr_accessor attr_with_type(const char *key) const;
+
     /** \rst
         Matches * unpacking in Python, e.g. to unpack arguments out of a ``tuple``
         or ``list`` for a function call. Applying another * to the result yields
@@ -181,6 +185,9 @@ public:
 
     /// Get or set the object's docstring, i.e. ``obj.__doc__``.
     str_attr_accessor doc() const;
+
+    // TODO: Make read only?
+    str_attr_accessor annotations() const;
 
     /// Return the object's current reference count
     ssize_t ref_count() const {
@@ -2556,6 +2563,16 @@ pybind11::str object_api<D>::str() const {
 template <typename D>
 str_attr_accessor object_api<D>::doc() const {
     return attr("__doc__");
+}
+
+template <typename D>
+str_attr_accessor object_api<D>::annotations() const {
+     str_attr_accessor annotations_dict = attr("__annotations__");
+    // Create dict automatically
+    if (!isinstance<dict>(annotations_dict)){
+        annotations_dict = dict();
+    }
+    return annotations_dict;
 }
 
 template <typename D>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2568,8 +2568,7 @@ str_attr_accessor object_api<D>::doc() const {
 template <typename D>
 // Always a dict
 object object_api<D>::annotations() const {
-    dict annotations_dict = getattr(derived(), "__annotations__", dict());
-    return std::move(annotations_dict);
+    return getattr(derived(), "__annotations__", dict());
 }
 
 template <typename D>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -186,7 +186,7 @@ public:
     /// Get or set the object's docstring, i.e. ``obj.__doc__``.
     str_attr_accessor doc() const;
 
-    // TODO: Make read only?
+    /// Get or set the object's annotations, i.e. ``obj.__annotations``.
     str_attr_accessor annotations() const;
 
     /// Return the object's current reference count

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -116,7 +116,6 @@ public:
     // attr_with_type_hint is implemented in cast.h:
     template <typename T>
     obj_attr_accessor attr_with_type_hint(handle key) const;
-
     template <typename T>
     str_attr_accessor attr_with_type_hint(const char *key) const;
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -113,7 +113,11 @@ public:
     /// See above (the only difference is that the key is provided as a string literal)
     str_attr_accessor attr(const char *key) const;
 
-    // attr_with_type_hint is implemented in cast.h:
+    /** \rst 
+         Similar to the above attr functions with the difference that the templated Type
+         is used to set the `__annotations__` dict value to the corresponding key. Worth nothing that
+         attr_with_type_hint is implemented in cast.h
+     \endrst */ 
     template <typename T>
     obj_attr_accessor attr_with_type_hint(handle key) const;
     template <typename T>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -116,8 +116,8 @@ public:
     /** \rst
          Similar to the above attr functions with the difference that the templated Type
          is used to set the `__annotations__` dict value to the corresponding key. Worth nothing
-     that attr_with_type_hint is implemented in cast.h
-     \endrst */
+         that attr_with_type_hint is implemented in cast.h
+    \endrst */
     template <typename T>
     obj_attr_accessor attr_with_type_hint(handle key) const;
     template <typename T>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2569,7 +2569,7 @@ str_attr_accessor object_api<D>::doc() const {
 template <typename D>
 object object_api<D>::annotations() const {
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
-// https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
+    // https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
     if (!hasattr(derived(), "__annotations__")) {
         setattr(derived(), "__annotations__", dict());
     }

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2569,7 +2569,7 @@ template <typename D>
 // Always a dict
 object object_api<D>::annotations() const {
     dict annotations_dict = getattr(derived(), "__annotations__", dict());
-    return annotations_dict;
+    return std::move(annotations_dict);
 }
 
 template <typename D>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -113,11 +113,10 @@ public:
     /// See above (the only difference is that the key is provided as a string literal)
     str_attr_accessor attr(const char *key) const;
 
-#if defined(PYBIND11_CPP17)
     // attr_with_type_hint is implemented in cast.h:
     template <typename T>
     str_attr_accessor attr_with_type_hint(const char *key) const;
-#endif
+
     /** \rst
         Matches * unpacking in Python, e.g. to unpack arguments out of a ``tuple``
         or ``list`` for a function call. Applying another * to the result yields

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2571,11 +2571,10 @@ template <typename D>
 object object_api<D>::annotations() const {
 // Python 3.8, 3.9
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
-    if (hasattr(derived(), "__dict__")) {
-        return getattr(getattr(derived(), "__dict__"), "__annotations__", dict());
-    } else {
-        return getattr(derived(), "__annotations__", dict());
+    if (!hasattr(derived(), "__annotations__")) {
+        setattr(derived(), "__annotations__", dict());
     }
+    return attr("__annotations__");
 // Python 3.10+
 #else
     return getattr(derived(), "__annotations__", dict());

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -113,10 +113,11 @@ public:
     /// See above (the only difference is that the key is provided as a string literal)
     str_attr_accessor attr(const char *key) const;
 
+#if defined(PYBIND11_CPP17)
     // attr_with_type is implemented in cast.h:
     template <typename T>
     str_attr_accessor attr_with_type(const char *key) const;
-
+#endif
     /** \rst
         Matches * unpacking in Python, e.g. to unpack arguments out of a ``tuple``
         or ``list`` for a function call. Applying another * to the result yields

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -113,11 +113,11 @@ public:
     /// See above (the only difference is that the key is provided as a string literal)
     str_attr_accessor attr(const char *key) const;
 
-    /** \rst 
+    /** \rst
          Similar to the above attr functions with the difference that the templated Type
-         is used to set the `__annotations__` dict value to the corresponding key. Worth nothing that
-         attr_with_type_hint is implemented in cast.h
-     \endrst */ 
+         is used to set the `__annotations__` dict value to the corresponding key. Worth nothing
+     that attr_with_type_hint is implemented in cast.h
+     \endrst */
     template <typename T>
     obj_attr_accessor attr_with_type_hint(handle key) const;
     template <typename T>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -114,9 +114,9 @@ public:
     str_attr_accessor attr(const char *key) const;
 
 #if defined(PYBIND11_CPP17)
-    // attr_with_type is implemented in cast.h:
+    // attr_with_type_hint is implemented in cast.h:
     template <typename T>
-    str_attr_accessor attr_with_type(const char *key) const;
+    str_attr_accessor attr_with_type_hint(const char *key) const;
 #endif
     /** \rst
         Matches * unpacking in Python, e.g. to unpack arguments out of a ``tuple``
@@ -2567,16 +2567,13 @@ str_attr_accessor object_api<D>::doc() const {
 }
 
 template <typename D>
-// Always a dict
-// https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
 object object_api<D>::annotations() const {
-// Python 3.8, 3.9
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
+// https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
     if (!hasattr(derived(), "__annotations__")) {
         setattr(derived(), "__annotations__", dict());
     }
     return attr("__annotations__");
-// Python 3.10+
 #else
     return getattr(derived(), "__annotations__", dict());
 #endif

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -186,8 +186,8 @@ public:
     /// Get or set the object's docstring, i.e. ``obj.__doc__``.
     str_attr_accessor doc() const;
 
-    /// Get or set the object's annotations, i.e. ``obj.__annotations``.
-    str_attr_accessor annotations() const;
+    /// Get or set the object's annotations, i.e. ``obj.__annotations__``.
+    object annotations() const;
 
     /// Return the object's current reference count
     ssize_t ref_count() const {
@@ -2566,12 +2566,9 @@ str_attr_accessor object_api<D>::doc() const {
 }
 
 template <typename D>
-str_attr_accessor object_api<D>::annotations() const {
-    str_attr_accessor annotations_dict = attr("__annotations__");
-    // Create dict automatically
-    if (!isinstance<dict>(annotations_dict)) {
-        annotations_dict = dict();
-    }
+// Always a dict
+object object_api<D>::annotations() const {
+    dict annotations_dict = getattr(derived(), "__annotations__", dict());
     return annotations_dict;
 }
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2569,11 +2569,11 @@ template <typename D>
 str_attr_accessor object_api<D>::annotations() const {
     // Create dict automatically
 
-    #if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
-        str_attr_accessor annotations_dict = attr("__dict__").attr("__annotations__");
-    #else
-        str_attr_accessor annotations_dict = attr("__annotations__");
-    #endif
+#if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
+    str_attr_accessor annotations_dict = attr("__dict__").attr("__annotations__");
+#else
+    str_attr_accessor annotations_dict = attr("__annotations__");
+#endif
     // Create dict automatically
     if (!isinstance<dict>(annotations_dict)) {
         annotations_dict = dict();

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2567,9 +2567,9 @@ str_attr_accessor object_api<D>::doc() const {
 
 template <typename D>
 str_attr_accessor object_api<D>::annotations() const {
-     str_attr_accessor annotations_dict = attr("__annotations__");
+    str_attr_accessor annotations_dict = attr("__annotations__");
     // Create dict automatically
-    if (!isinstance<dict>(annotations_dict)){
+    if (!isinstance<dict>(annotations_dict)) {
         annotations_dict = dict();
     }
     return annotations_dict;

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -115,6 +115,9 @@ public:
 
     // attr_with_type_hint is implemented in cast.h:
     template <typename T>
+    obj_attr_accessor attr_with_type_hint(handle key) const;
+
+    template <typename T>
     str_attr_accessor attr_with_type_hint(const char *key) const;
 
     /** \rst

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2567,13 +2567,7 @@ str_attr_accessor object_api<D>::doc() const {
 
 template <typename D>
 str_attr_accessor object_api<D>::annotations() const {
-    // Create dict automatically
-
-#if !defined(PYPY_VERSION) && PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 9
-    str_attr_accessor annotations_dict = attr("__dict__").attr("__annotations__");
-#else
     str_attr_accessor annotations_dict = attr("__annotations__");
-#endif
     // Create dict automatically
     if (!isinstance<dict>(annotations_dict)) {
         annotations_dict = dict();

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -89,6 +89,12 @@ class Final : public object {
 };
 
 template <typename T>
+class ClassVar : public object {
+    PYBIND11_OBJECT_DEFAULT(ClassVar, object, PyObject_Type)
+    using object::object;
+};
+
+template <typename T>
 class TypeGuard : public bool_ {
     using bool_::bool_;
 };
@@ -257,13 +263,18 @@ struct handle_type_name<typing::Optional<T>> {
         = const_name("Optional[") + as_return_type<make_caster<T>>::name + const_name("]");
 };
 
-// TypeGuard and TypeIs use as_return_type to use the return type if available, which is usually
-// the narrower type.
-
 template <typename T>
 struct handle_type_name<typing::Final<T>> {
     static constexpr auto name = const_name("Final[") + make_caster<T>::name + const_name("]");
 };
+
+template <typename T>
+struct handle_type_name<typing::ClassVar<T>> {
+    static constexpr auto name = const_name("ClassVar[") + make_caster<T>::name + const_name("]");
+};
+
+// TypeGuard and TypeIs use as_return_type to use the return type if available, which is usually
+// the narrower type.
 
 template <typename T>
 struct handle_type_name<typing::TypeGuard<T>> {

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -83,6 +83,12 @@ class Optional : public object {
 };
 
 template <typename T>
+class Final : public object {
+    PYBIND11_OBJECT_DEFAULT(Final, object, PyObject_Type)
+    using object::object;
+};
+
+template <typename T>
 class TypeGuard : public bool_ {
     using bool_::bool_;
 };
@@ -203,6 +209,11 @@ struct handle_type_name<typing::Union<Types...>> {
 template <typename T>
 struct handle_type_name<typing::Optional<T>> {
     static constexpr auto name = const_name("Optional[") + make_caster<T>::name + const_name("]");
+};
+
+template <typename T>
+struct handle_type_name<typing::Final<T>> {
+    static constexpr auto name = const_name("Final[") + make_caster<T>::name + const_name("]");
 };
 
 template <typename T>

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1039,8 +1039,10 @@ TEST_SUBMODULE(pytypes, m) {
 #endif
 
 #if defined(__cpp_inline_variables)
+    // Exercises const char* overload:
     m.attr_with_type_hint<py::typing::List<int>>("list_int") = py::list();
-    m.attr_with_type_hint<py::typing::Set<py::str>>("set_str") = py::set();
+    // Exercises py::handle overload:
+    m.attr_with_type_hint<py::typing::Set<py::str>>(py::str("set_str")) = py::set();
 
     struct Empty {};
     py::class_<Empty>(m, "EmptyAnnotationClass");

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1045,12 +1045,17 @@ TEST_SUBMODULE(pytypes, m) {
     struct Empty {};
     py::class_<Empty>(m, "EmptyAnnotationClass");
 
-    struct Point {};
-    auto point = py::class_<Point>(m, "Point");
-    point.def(py::init());
-    point.attr_with_type_hint<py::typing::ClassVar<float>>("x");
-    point.attr_with_type_hint<py::typing::ClassVar<py::typing::Dict<py::str, int>>>("dict_str_int")
+    struct Static {};
+    auto static_class = py::class_<Static>(m, "Static");
+    static_class.def(py::init());
+    static_class.attr_with_type_hint<py::typing::ClassVar<float>>("x") = 1.0;
+    static_class.attr_with_type_hint<py::typing::ClassVar<py::typing::Dict<py::str, int>>>("dict_str_int")
         = py::dict();
+
+    struct Instance {};
+    auto instance = py::class_<Instance>(m, "Instance", py::dynamic_attr());
+    instance.def(py::init());
+    instance.attr_with_type_hint<float>("y");
 
     m.attr_with_type_hint<py::typing::Final<int>>("CONST_INT") = 3;
     m.attr("defined_PYBIND11_CPP17") = true;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1049,7 +1049,8 @@ TEST_SUBMODULE(pytypes, m) {
     auto static_class = py::class_<Static>(m, "Static");
     static_class.def(py::init());
     static_class.attr_with_type_hint<py::typing::ClassVar<float>>("x") = 1.0;
-    static_class.attr_with_type_hint<py::typing::ClassVar<py::typing::Dict<py::str, int>>>("dict_str_int")
+    static_class.attr_with_type_hint<py::typing::ClassVar<py::typing::Dict<py::str, int>>>(
+        "dict_str_int")
         = py::dict();
 
     struct Instance {};

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1058,7 +1058,12 @@ TEST_SUBMODULE(pytypes, m) {
     instance.def(py::init());
     instance.attr_with_type_hint<float>("y");
 
+    m.def("attr_with_type_hint_float_x", [](py::handle obj) {
+        obj.attr_with_type_hint<float>("x");
+    });
+
     m.attr_with_type_hint<py::typing::Final<int>>("CONST_INT") = 3;
+    
     m.attr("defined___cpp_inline_variables") = true;
 #else
     m.attr("defined___cpp_inline_variables") = false;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1000,8 +1000,8 @@ TEST_SUBMODULE(pytypes, m) {
 #endif
 
 #if defined(PYBIND11_CPP17)
-    m.attr_with_type<py::typing::List<int>>("list_int") = py::list();
-    m.attr_with_type<py::typing::Set<py::str>>("set_str") = py::set();
+    m.attr_with_type_hint<py::typing::List<int>>("list_int") = py::list();
+    m.attr_with_type_hint<py::typing::Set<py::str>>("set_str") = py::set();
 
     struct Empty {};
     py::class_<Empty>(m, "EmptyAnnotationClass");
@@ -1011,10 +1011,10 @@ TEST_SUBMODULE(pytypes, m) {
         py::dict dict_str_int;
     };
     auto point = py::class_<Point>(m, "Point");
-    point.attr_with_type<float>("x");
-    point.attr_with_type<py::typing::Dict<py::str, int>>("dict_str_int") = py::dict();
+    point.attr_with_type_hint<float>("x");
+    point.attr_with_type_hint<py::typing::Dict<py::str, int>>("dict_str_int") = py::dict();
 
-    m.attr_with_type<py::typing::Final<int>>("CONST_INT") = 3;
+    m.attr_with_type_hint<py::typing::Final<int>>("CONST_INT") = 3;
     m.attr("defined_PYBIND11_CPP17") = true;
 #else
     m.attr("defined_PYBIND11_CPP17") = false;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1002,7 +1002,6 @@ TEST_SUBMODULE(pytypes, m) {
     m.attr_with_type<py::typing::List<int>>("list_int") = py::list();
     m.attr_with_type<py::typing::Set<py::str>>("set_str") = py::set();
 
-
     struct Empty {};
     py::class_<Empty>(m, "EmptyAnnotationClass");
 
@@ -1015,5 +1014,4 @@ TEST_SUBMODULE(pytypes, m) {
     point.attr_with_type<py::typing::Dict<py::str, int>>("dict_str_int") = py::dict();
 
     m.attr_with_type<py::typing::Final<int>>("CONST_INT") = 3;
-
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -999,6 +999,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.attr("defined_PYBIND11_TEST_PYTYPES_HAS_RANGES") = false;
 #endif
 
+#if defined(PYBIND11_CPP17)
     m.attr_with_type<py::typing::List<int>>("list_int") = py::list();
     m.attr_with_type<py::typing::Set<py::str>>("set_str") = py::set();
 
@@ -1014,4 +1015,8 @@ TEST_SUBMODULE(pytypes, m) {
     point.attr_with_type<py::typing::Dict<py::str, int>>("dict_str_int") = py::dict();
 
     m.attr_with_type<py::typing::Final<int>>("CONST_INT") = 3;
+    m.attr("defined_PYBIND11_CPP17") = true;
+#else
+    m.attr("defined_PYBIND11_CPP17") = false;
+#endif
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1049,7 +1049,8 @@ TEST_SUBMODULE(pytypes, m) {
     auto point = py::class_<Point>(m, "Point");
     point.def(py::init());
     point.attr_with_type_hint<py::typing::ClassVar<float>>("x");
-    point.attr_with_type_hint<py::typing::ClassVar<py::typing::Dict<py::str, int>>>("dict_str_int") = py::dict();
+    point.attr_with_type_hint<py::typing::ClassVar<py::typing::Dict<py::str, int>>>("dict_str_int")
+        = py::dict();
 
     m.attr_with_type_hint<py::typing::Final<int>>("CONST_INT") = 3;
     m.attr("defined_PYBIND11_CPP17") = true;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1045,13 +1045,11 @@ TEST_SUBMODULE(pytypes, m) {
     struct Empty {};
     py::class_<Empty>(m, "EmptyAnnotationClass");
 
-    struct Point {
-        float x;
-        py::dict dict_str_int;
-    };
+    struct Point {};
     auto point = py::class_<Point>(m, "Point");
-    point.attr_with_type_hint<float>("x");
-    point.attr_with_type_hint<py::typing::Dict<py::str, int>>("dict_str_int") = py::dict();
+    point.def(py::init());
+    point.attr_with_type_hint<py::typing::ClassVar<float>>("x");
+    point.attr_with_type_hint<py::typing::ClassVar<py::typing::Dict<py::str, int>>>("dict_str_int") = py::dict();
 
     m.attr_with_type_hint<py::typing::Final<int>>("CONST_INT") = 3;
     m.attr("defined_PYBIND11_CPP17") = true;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1058,12 +1058,11 @@ TEST_SUBMODULE(pytypes, m) {
     instance.def(py::init());
     instance.attr_with_type_hint<float>("y");
 
-    m.def("attr_with_type_hint_float_x", [](py::handle obj) {
-        obj.attr_with_type_hint<float>("x");
-    });
+    m.def("attr_with_type_hint_float_x",
+          [](py::handle obj) { obj.attr_with_type_hint<float>("x"); });
 
     m.attr_with_type_hint<py::typing::Final<int>>("CONST_INT") = 3;
-    
+
     m.attr("defined___cpp_inline_variables") = true;
 #else
     m.attr("defined___cpp_inline_variables") = false;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1038,7 +1038,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.attr("defined_PYBIND11_TEST_PYTYPES_HAS_RANGES") = false;
 #endif
 
-#if defined(PYBIND11_CPP17)
+#if defined(__cpp_inline_variables)
     m.attr_with_type_hint<py::typing::List<int>>("list_int") = py::list();
     m.attr_with_type_hint<py::typing::Set<py::str>>("set_str") = py::set();
 
@@ -1059,9 +1059,9 @@ TEST_SUBMODULE(pytypes, m) {
     instance.attr_with_type_hint<float>("y");
 
     m.attr_with_type_hint<py::typing::Final<int>>("CONST_INT") = 3;
-    m.attr("defined_PYBIND11_CPP17") = true;
+    m.attr("defined___cpp_inline_variables") = true;
 #else
-    m.attr("defined_PYBIND11_CPP17") = false;
+    m.attr("defined___cpp_inline_variables") = false;
 #endif
     m.def("half_of_number", [](const RealNumber &x) { return RealNumber{x.value / 2}; });
     // std::vector<T>

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -998,4 +998,22 @@ TEST_SUBMODULE(pytypes, m) {
 #else
     m.attr("defined_PYBIND11_TEST_PYTYPES_HAS_RANGES") = false;
 #endif
+
+    m.attr_with_type<py::typing::List<int>>("list_int") = py::list();
+    m.attr_with_type<py::typing::Set<py::str>>("set_str") = py::set();
+
+
+    struct Empty {};
+    py::class_<Empty>(m, "EmptyAnnotationClass");
+
+    struct Point {
+        float x;
+        py::dict dict_str_int;
+    };
+    auto point = py::class_<Point>(m, "Point");
+    point.attr_with_type<float>("x");
+    point.attr_with_type<py::typing::Dict<py::str, int>>("dict_str_int") = py::dict();
+
+    m.attr_with_type<py::typing::Final<int>>("CONST_INT") = 3;
+
 }

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1104,13 +1104,7 @@ def test_dict_ranges(tested_dict, expected):
 
 
 def get_annotations_helper(o):
-    # Taken from __annotations__ docs
-    # https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
-    if isinstance(o, type):
-        ann = o.__dict__.get("__annotations__", None)
-    else:
-        ann = getattr(o, "__annotations__", None)
-    return ann
+    return getattr(o, "__annotations__", None)
 
 
 def test_module_attribute_types() -> None:
@@ -1124,7 +1118,7 @@ def test_class_attribute_types() -> None:
     empty_annotations = get_annotations_helper(m.EmptyAnnotationClass)
     annotations = get_annotations_helper(m.Point)
 
-    assert empty_annotations is None
+    assert empty_annotations == {}
     assert annotations["x"] == "float"
     assert annotations["dict_str_int"] == "dict[str, int]"
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1105,19 +1105,24 @@ def test_dict_ranges(tested_dict, expected):
 
 # https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
 def get_annotations_helper(o):
-    print(dir(o))
     if isinstance(o, type):
         return o.__dict__.get("__annotations__", {})
     return getattr(o, "__annotations__", {})
 
-
+@pytest.mark.skipif(
+    not m.defined_PYBIND11_CPP17,
+    reason="C++17 Position Independent Code not available",
+)
 def test_module_attribute_types() -> None:
     module_annotations = get_annotations_helper(m)
 
     assert module_annotations["list_int"] == "list[int]"
     assert module_annotations["set_str"] == "set[str]"
 
-
+@pytest.mark.skipif(
+    not m.defined_PYBIND11_CPP17,
+    reason="C++17 Position Independent Code not available",
+)
 def test_class_attribute_types() -> None:
     empty_annotations = get_annotations_helper(m.EmptyAnnotationClass)
     annotations = get_annotations_helper(m.Point)
@@ -1126,7 +1131,10 @@ def test_class_attribute_types() -> None:
     assert annotations["x"] == "float"
     assert annotations["dict_str_int"] == "dict[str, int]"
 
-
+@pytest.mark.skipif(
+    not m.defined_PYBIND11_CPP17,
+    reason="C++17 Position Independent Code not available",
+)
 def test_final_annotation() -> None:
     module_annotations = get_annotations_helper(m)
     assert module_annotations["CONST_INT"] == "Final[int]"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1106,18 +1106,19 @@ def test_dict_ranges(tested_dict, expected):
 def test_module_attribute_types() -> None:
     module_annotations = m.__annotations__
 
-    assert module_annotations['list_int'] == 'list[int]'
-    assert module_annotations['set_str'] == 'set[str]'
+    assert module_annotations["list_int"] == "list[int]"
+    assert module_annotations["set_str"] == "set[str]"
 
 
 def test_class_attribute_types() -> None:
     empty_annotations = m.EmptyAnnotationClass.__annotations__
     annotations = m.Point.__annotations__
-    
+
     assert empty_annotations == {}
-    assert annotations['x'] == 'float'
-    assert annotations['dict_str_int'] == 'dict[str, int]'
+    assert annotations["x"] == "float"
+    assert annotations["dict_str_int"] == "dict[str, int]"
+
 
 def test_final_annotation() -> None:
     module_annotations = m.__annotations__
-    assert module_annotations['CONST_INT'] == 'Final[int]'
+    assert module_annotations["CONST_INT"] == "Final[int]"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1101,3 +1101,23 @@ def test_list_ranges(tested_list, expected):
 def test_dict_ranges(tested_dict, expected):
     assert m.dict_iterator_default_initialization()
     assert m.transform_dict_plus_one(tested_dict) == expected
+
+
+def test_module_attribute_types() -> None:
+    module_annotations = m.__annotations__
+
+    assert module_annotations['list_int'] == 'list[int]'
+    assert module_annotations['set_str'] == 'set[str]'
+
+
+def test_class_attribute_types() -> None:
+    empty_annotations = m.EmptyAnnotationClass.__annotations__
+    annotations = m.Point.__annotations__
+    
+    assert empty_annotations == {}
+    assert annotations['x'] == 'float'
+    assert annotations['dict_str_int'] == 'dict[str, int]'
+
+def test_final_annotation() -> None:
+    module_annotations = m.__annotations__
+    assert module_annotations['CONST_INT'] == 'Final[int]'

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1125,7 +1125,6 @@ def test_class_attribute_types() -> None:
     assert empty_annotations == {}
     assert annotations["x"] == "float"
     assert annotations["dict_str_int"] == "dict[str, int]"
-    assert False
 
 
 def test_final_annotation() -> None:

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1105,6 +1105,7 @@ def test_dict_ranges(tested_dict, expected):
 
 # https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
 def get_annotations_helper(o):
+    dir(o)
     if isinstance(o, type):
         return o.__dict__.get("__annotations__", {})
     return getattr(o, "__annotations__", {})

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1111,8 +1111,8 @@ def get_annotations_helper(o):
 
 
 @pytest.mark.skipif(
-    not m.defined_PYBIND11_CPP17,
-    reason="C++17 Position Independent Code not available",
+    not m.defined___cpp_inline_variables,
+    reason="C++17 feature __cpp_inline_variables not available.",
 )
 def test_module_attribute_types() -> None:
     module_annotations = get_annotations_helper(m)
@@ -1122,8 +1122,8 @@ def test_module_attribute_types() -> None:
 
 
 @pytest.mark.skipif(
-    not m.defined_PYBIND11_CPP17,
-    reason="C++17 Position Independent Code not available",
+    not m.defined___cpp_inline_variables,
+    reason="C++17 feature __cpp_inline_variables not available.",
 )
 def test_class_attribute_types() -> None:
     empty_annotations = get_annotations_helper(m.EmptyAnnotationClass)
@@ -1154,8 +1154,8 @@ def test_class_attribute_types() -> None:
 
 
 @pytest.mark.skipif(
-    not m.defined_PYBIND11_CPP17,
-    reason="C++17 Position Independent Code not available",
+    not m.defined___cpp_inline_variables,
+    reason="C++17 feature __cpp_inline_variables not available.",
 )
 def test_final_annotation() -> None:
     module_annotations = get_annotations_helper(m)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1136,8 +1136,9 @@ def test_class_attribute_types() -> None:
     m.Point.x = 1.0
     assert m.Point.x == 1.0
 
+    m.Point.x = 3.0
     point = m.Point()
-    assert point.x == 1.0
+    assert point.x == 3.0
 
     point.dict_str_int["hi"] = 3
     assert m.Point().dict_str_int == {"hi": 3}

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1162,8 +1162,11 @@ def test_redeclaration_attr_with_type_hint() -> None:
     m.attr_with_type_hint_float_x(obj)
     help(obj)
     assert get_annotations_helper(obj)["x"] == "float"
-    with pytest.raises(RuntimeError, match=r'^__annotations__\["x"\] was set already\.$'):
+    with pytest.raises(
+        RuntimeError, match=r'^__annotations__\["x"\] was set already\.$'
+    ):
         m.attr_with_type_hint_float_x(obj)
+
 
 @pytest.mark.skipif(
     not m.defined___cpp_inline_variables,

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1106,8 +1106,8 @@ def test_dict_ranges(tested_dict, expected):
 # https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
 def get_annotations_helper(o):
     if isinstance(o, type):
-        return o.__dict__.get("__annotations__", {})
-    return getattr(o, "__annotations__", {})
+        return o.__dict__.get("__annotations__", None)
+    return getattr(o, "__annotations__", None)
 
 
 @pytest.mark.skipif(
@@ -1129,9 +1129,19 @@ def test_class_attribute_types() -> None:
     empty_annotations = get_annotations_helper(m.EmptyAnnotationClass)
     annotations = get_annotations_helper(m.Point)
 
-    assert empty_annotations == {}
-    assert annotations["x"] == "float"
-    assert annotations["dict_str_int"] == "dict[str, int]"
+    assert empty_annotations is None
+    assert annotations["x"] == "ClassVar[float]"
+    assert annotations["dict_str_int"] == "ClassVar[dict[str, int]]"
+
+    m.Point.x = 1.0
+    assert m.Point.x == 1.0
+
+    point = m.Point()
+    assert point.x == 1.0
+
+    point.dict_str_int["hi"] = 3
+    assert m.Point().dict_str_int == {"hi": 3}
+
 
 
 @pytest.mark.skipif(

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1120,6 +1120,18 @@ def test_module_attribute_types() -> None:
     assert module_annotations["list_int"] == "list[int]"
     assert module_annotations["set_str"] == "set[str]"
 
+@pytest.mark.skipif(
+    not m.defined___cpp_inline_variables,
+    reason="C++17 feature __cpp_inline_variables not available.",
+)
+@pytest.mark.skipif(sys.version_info < (3, 10),
+                    reason="get_annotations function does not exist until Python3.10")
+def test_get_annotations_compliance() -> None:
+    from inspect import get_annotations
+    module_annotations = get_annotations(m)
+
+    assert module_annotations["list_int"] == "list[int]"
+    assert module_annotations["set_str"] == "set[str]"
 
 @pytest.mark.skipif(
     not m.defined___cpp_inline_variables,

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1102,13 +1102,14 @@ def test_dict_ranges(tested_dict, expected):
     assert m.dict_iterator_default_initialization()
     assert m.transform_dict_plus_one(tested_dict) == expected
 
+
 def get_annotations_helper(o):
     # Taken from __annotations__ docs
     # https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
     if isinstance(o, type):
-        ann = o.__dict__.get('__annotations__', None)
+        ann = o.__dict__.get("__annotations__", None)
     else:
-        ann = getattr(o, '__annotations__', None)
+        ann = getattr(o, "__annotations__", None)
     return ann
 
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1160,7 +1160,6 @@ def test_class_attribute_types() -> None:
 def test_redeclaration_attr_with_type_hint() -> None:
     obj = m.Instance()
     m.attr_with_type_hint_float_x(obj)
-    help(obj)
     assert get_annotations_helper(obj)["x"] == "float"
     with pytest.raises(
         RuntimeError, match=r'^__annotations__\["x"\] was set already\.$'

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1105,7 +1105,7 @@ def test_dict_ranges(tested_dict, expected):
 
 # https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
 def get_annotations_helper(o):
-    dir(o)
+    print(dir(o))
     if isinstance(o, type):
         return o.__dict__.get("__annotations__", {})
     return getattr(o, "__annotations__", {})
@@ -1125,6 +1125,7 @@ def test_class_attribute_types() -> None:
     assert empty_annotations == {}
     assert annotations["x"] == "float"
     assert annotations["dict_str_int"] == "dict[str, int]"
+    assert False
 
 
 def test_final_annotation() -> None:

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1127,21 +1127,30 @@ def test_module_attribute_types() -> None:
 )
 def test_class_attribute_types() -> None:
     empty_annotations = get_annotations_helper(m.EmptyAnnotationClass)
-    annotations = get_annotations_helper(m.Point)
+    static_annotations = get_annotations_helper(m.Static)
+    instance_annotations = get_annotations_helper(m.Instance)
 
     assert empty_annotations is None
-    assert annotations["x"] == "ClassVar[float]"
-    assert annotations["dict_str_int"] == "ClassVar[dict[str, int]]"
+    assert static_annotations["x"] == "ClassVar[float]"
+    assert static_annotations["dict_str_int"] == "ClassVar[dict[str, int]]"
 
-    m.Point.x = 1.0
-    assert m.Point.x == 1.0
+    assert m.Static.x == 1.0
 
-    m.Point.x = 3.0
-    point = m.Point()
-    assert point.x == 3.0
+    m.Static.x = 3.0
+    static = m.Static()
+    assert static.x == 3.0
 
-    point.dict_str_int["hi"] = 3
-    assert m.Point().dict_str_int == {"hi": 3}
+    static.dict_str_int["hi"] = 3
+    assert m.Static().dict_str_int == {"hi": 3}
+
+    assert instance_annotations["y"] == "float"
+    instance1 = m.Instance()
+    instance1.y = 4.0
+
+    instance2 = m.Instance()
+    instance2.y = 5.0
+
+    assert instance1.y != instance2.y
 
 
 @pytest.mark.skipif(

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1120,18 +1120,23 @@ def test_module_attribute_types() -> None:
     assert module_annotations["list_int"] == "list[int]"
     assert module_annotations["set_str"] == "set[str]"
 
+
 @pytest.mark.skipif(
     not m.defined___cpp_inline_variables,
     reason="C++17 feature __cpp_inline_variables not available.",
 )
-@pytest.mark.skipif(sys.version_info < (3, 10),
-                    reason="get_annotations function does not exist until Python3.10")
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="get_annotations function does not exist until Python3.10",
+)
 def test_get_annotations_compliance() -> None:
     from inspect import get_annotations
+
     module_annotations = get_annotations(m)
 
     assert module_annotations["list_int"] == "list[int]"
     assert module_annotations["set_str"] == "set[str]"
+
 
 @pytest.mark.skipif(
     not m.defined___cpp_inline_variables,

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1102,12 +1102,12 @@ def test_dict_ranges(tested_dict, expected):
     assert m.dict_iterator_default_initialization()
     assert m.transform_dict_plus_one(tested_dict) == expected
 
+
 # https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
 def get_annotations_helper(o):
     if isinstance(o, type):
-        return o.__dict__.get('__annotations__', {})
-    else:
-        return getattr(o, '__annotations__', {})
+        return o.__dict__.get("__annotations__", {})
+    return getattr(o, "__annotations__", {})
 
 
 def test_module_attribute_types() -> None:

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1143,7 +1143,6 @@ def test_class_attribute_types() -> None:
     assert m.Point().dict_str_int == {"hi": 3}
 
 
-
 @pytest.mark.skipif(
     not m.defined_PYBIND11_CPP17,
     reason="C++17 Position Independent Code not available",

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1104,6 +1104,7 @@ def test_dict_ranges(tested_dict, expected):
 
 
 def get_annotations_helper(o):
+    print(help(o))
     return getattr(o, "__annotations__", None)
 
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1102,23 +1102,32 @@ def test_dict_ranges(tested_dict, expected):
     assert m.dict_iterator_default_initialization()
     assert m.transform_dict_plus_one(tested_dict) == expected
 
+def get_annotations_helper(o):
+    # Taken from __annotations__ docs
+    # https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
+    if isinstance(o, type):
+        ann = o.__dict__.get('__annotations__', None)
+    else:
+        ann = getattr(o, '__annotations__', None)
+    return ann
+
 
 def test_module_attribute_types() -> None:
-    module_annotations = m.__annotations__
+    module_annotations = get_annotations_helper(m)
 
     assert module_annotations["list_int"] == "list[int]"
     assert module_annotations["set_str"] == "set[str]"
 
 
 def test_class_attribute_types() -> None:
-    empty_annotations = m.EmptyAnnotationClass.__annotations__
-    annotations = m.Point.__annotations__
+    empty_annotations = get_annotations_helper(m.EmptyAnnotationClass)
+    annotations = get_annotations_helper(m.Point)
 
-    assert empty_annotations == {}
+    assert empty_annotations is None
     assert annotations["x"] == "float"
     assert annotations["dict_str_int"] == "dict[str, int]"
 
 
 def test_final_annotation() -> None:
-    module_annotations = m.__annotations__
+    module_annotations = get_annotations_helper(m)
     assert module_annotations["CONST_INT"] == "Final[int]"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1157,6 +1157,18 @@ def test_class_attribute_types() -> None:
     not m.defined___cpp_inline_variables,
     reason="C++17 feature __cpp_inline_variables not available.",
 )
+def test_redeclaration_attr_with_type_hint() -> None:
+    obj = m.Instance()
+    m.attr_with_type_hint_float_x(obj)
+    help(obj)
+    assert get_annotations_helper(obj)["x"] == "float"
+    with pytest.raises(RuntimeError, match=r'^__annotations__\["x"\] was set already\.$'):
+        m.attr_with_type_hint_float_x(obj)
+
+@pytest.mark.skipif(
+    not m.defined___cpp_inline_variables,
+    reason="C++17 feature __cpp_inline_variables not available.",
+)
 def test_final_annotation() -> None:
     module_annotations = get_annotations_helper(m)
     assert module_annotations["CONST_INT"] == "Final[int]"

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1102,10 +1102,12 @@ def test_dict_ranges(tested_dict, expected):
     assert m.dict_iterator_default_initialization()
     assert m.transform_dict_plus_one(tested_dict) == expected
 
-
+# https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
 def get_annotations_helper(o):
-    print(help(o))
-    return getattr(o, "__annotations__", None)
+    if isinstance(o, type):
+        return o.__dict__.get('__annotations__', {})
+    else:
+        return getattr(o, '__annotations__', {})
 
 
 def test_module_attribute_types() -> None:

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1109,6 +1109,7 @@ def get_annotations_helper(o):
         return o.__dict__.get("__annotations__", {})
     return getattr(o, "__annotations__", {})
 
+
 @pytest.mark.skipif(
     not m.defined_PYBIND11_CPP17,
     reason="C++17 Position Independent Code not available",
@@ -1118,6 +1119,7 @@ def test_module_attribute_types() -> None:
 
     assert module_annotations["list_int"] == "list[int]"
     assert module_annotations["set_str"] == "set[str]"
+
 
 @pytest.mark.skipif(
     not m.defined_PYBIND11_CPP17,
@@ -1130,6 +1132,7 @@ def test_class_attribute_types() -> None:
     assert empty_annotations == {}
     assert annotations["x"] == "float"
     assert annotations["dict_str_int"] == "dict[str, int]"
+
 
 @pytest.mark.skipif(
     not m.defined_PYBIND11_CPP17,


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Until now setting specific type annotation on module or class attributes has been impossible. By using `__annotations__` we can automatically store that information for stub generators to use and be more accurate in their definitions. Also add the `Final` type to mark attributes as Final.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
add `attr_with_type` for declaring attribute types and `Final`, `ClassVar` type annotations.
```
