### PR TITLE
feat(types) C++ int and bool Literals in Python Literal Type

### DIFF
--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -138,7 +138,7 @@ constexpr enable_if_t<!B, T2> _(const T1 &d1, const T2 &d2) {
     return const_name<B, T1, T2>(d1, d2);
 }
 
-#if defined(PYBIND11_CPP17)
+#    if defined(PYBIND11_CPP17)
 
 template <auto Bool,
           typename std::enable_if<std::is_same<decltype(Bool), bool>::value, int>::type = 0>
@@ -148,9 +148,9 @@ auto constexpr _() {
 
 template <auto Size,
           typename std::enable_if<!std::is_same<decltype(Size), bool>::value, int>::type = 0>
-#else
+#    else
 template <size_t Size>
-#endif
+#    endif
 auto constexpr _() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
     return const_name<Size>();
 }

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -89,7 +89,12 @@ constexpr enable_if_t<!B, T2> const_name(const T1 &, const T2 &d) {
     return d;
 }
 
-template <size_t Size>
+template <auto Bool, typename std::enable_if<std::is_same<decltype(Bool), bool>::value, int>::type = 0>
+auto constexpr const_name() {
+    return const_name<Bool>("True", "False");
+}
+
+template <auto Size, typename std::enable_if<std::is_same<decltype(Size), int>::value, int>::type = 0>
 auto constexpr const_name() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
     return int_to_str<Size / 10, Size % 10>::digits;
 }
@@ -126,7 +131,7 @@ constexpr enable_if_t<!B, T2> _(const T1 &d1, const T2 &d2) {
     return const_name<B, T1, T2>(d1, d2);
 }
 
-template <size_t Size>
+template <auto Size>
 auto constexpr _() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
     return const_name<Size>();
 }

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -89,6 +89,8 @@ constexpr enable_if_t<!B, T2> const_name(const T1 &, const T2 &d) {
     return d;
 }
 
+#if defined(PYBIND11_CPP17)
+
 template <auto Bool,
           typename std::enable_if<std::is_same<decltype(Bool), bool>::value, int>::type = 0>
 auto constexpr const_name() {
@@ -97,6 +99,9 @@ auto constexpr const_name() {
 
 template <auto Size,
           typename std::enable_if<!std::is_same<decltype(Size), bool>::value, int>::type = 0>
+#elif
+template <size_t Size>
+#endif
 auto constexpr const_name() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
     return int_to_str<Size / 10, Size % 10>::digits;
 }

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -99,7 +99,7 @@ auto constexpr const_name() {
 
 template <auto Size,
           typename std::enable_if<!std::is_same<decltype(Size), bool>::value, int>::type = 0>
-#elif
+#else
 template <size_t Size>
 #endif
 auto constexpr const_name() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -138,10 +138,23 @@ constexpr enable_if_t<!B, T2> _(const T1 &d1, const T2 &d2) {
     return const_name<B, T1, T2>(d1, d2);
 }
 
-template <auto Size>
+#if defined(PYBIND11_CPP17)
+
+template <auto Bool,
+          typename std::enable_if<std::is_same<decltype(Bool), bool>::value, int>::type = 0>
+auto constexpr _() {
+    return const_name<Bool>();
+}
+
+template <auto Size,
+          typename std::enable_if<!std::is_same<decltype(Size), bool>::value, int>::type = 0>
+#else
+template <size_t Size>
+#endif
 auto constexpr _() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
     return const_name<Size>();
 }
+
 template <typename Type>
 constexpr descr<1, Type> _() {
     return const_name<Type>();

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -89,12 +89,14 @@ constexpr enable_if_t<!B, T2> const_name(const T1 &, const T2 &d) {
     return d;
 }
 
-template <auto Bool, typename std::enable_if<std::is_same<decltype(Bool), bool>::value, int>::type = 0>
+template <auto Bool,
+          typename std::enable_if<std::is_same<decltype(Bool), bool>::value, int>::type = 0>
 auto constexpr const_name() {
     return const_name<Bool>("True", "False");
 }
 
-template <auto Size, typename std::enable_if<std::is_same<decltype(Size), int>::value, int>::type = 0>
+template <auto Size,
+          typename std::enable_if<std::is_same<decltype(Size), int>::value, int>::type = 0>
 auto constexpr const_name() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
     return int_to_str<Size / 10, Size % 10>::digits;
 }

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -96,7 +96,7 @@ auto constexpr const_name() {
 }
 
 template <auto Size,
-          typename std::enable_if<std::is_same<decltype(Size), int>::value, int>::type = 0>
+          typename std::enable_if<!std::is_same<decltype(Size), bool>::value, int>::type = 0>
 auto constexpr const_name() -> remove_cv_t<decltype(int_to_str<Size / 10, Size % 10>::digits)> {
     return int_to_str<Size / 10, Size % 10>::digits;
 }

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -281,11 +281,13 @@ struct handle_type_name<typing::Never> {
 };
 
 #if defined(PYBIND11_TYPING_H_HAS_STRING_LITERAL)
-template <auto StrLit, typename std::enable_if<std::is_same<decltype(StrLit), typing::StringLiteral>::value, int>::type = 0>
+template <auto StrLit,
+          typename std::enable_if<std::is_same<decltype(StrLit), typing::StringLiteral>::value,
+                                  int>::type
+          = 0>
 auto constexpr const_name() {
     return const_name(StrLit.name);
 }
-
 
 template <typing::StringLiteral StrLit>
 struct handle_type_name<typing::TypeVar<StrLit>> {

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -281,10 +281,7 @@ struct handle_type_name<typing::Never> {
 };
 
 #if defined(PYBIND11_TYPING_H_HAS_STRING_LITERAL)
-template <auto StrLit,
-          typename std::enable_if<std::is_same<decltype(StrLit), typing::StringLiteral>::value,
-                                  int>::type
-          = 0>
+template <typing::StringLiteral StrLit>
 auto constexpr const_name() {
     return const_name(StrLit.name);
 }

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -281,7 +281,10 @@ struct handle_type_name<typing::Never> {
 };
 
 #if defined(PYBIND11_TYPING_H_HAS_STRING_LITERAL)
-template <typing::StringLiteral StrLit>
+template <auto StrLit,
+          typename std::enable_if<std::is_same<decltype(StrLit), typing::StringLiteral>::value,
+                                  int>::type
+          = 0>
 auto constexpr const_name() {
     return const_name(StrLit.name);
 }

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -282,7 +282,7 @@ struct handle_type_name<typing::Never> {
 
 #if defined(PYBIND11_TYPING_H_HAS_STRING_LITERAL)
 template <auto StrLit,
-          typename std::enable_if<std::is_same<decltype(StrLit), typing::StringLiteral>::value,
+          typename std::enable_if<!std::is_integral<decltype(StrLit)>::value,
                                   int>::type
           = 0>
 auto constexpr const_name() {

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -282,9 +282,7 @@ struct handle_type_name<typing::Never> {
 
 #if defined(PYBIND11_TYPING_H_HAS_STRING_LITERAL)
 template <auto StrLit,
-          typename std::enable_if<!std::is_integral<decltype(StrLit)>::value,
-                                  int>::type
-          = 0>
+          typename std::enable_if<!std::is_integral<decltype(StrLit)>::value, int>::type = 0>
 auto constexpr const_name() {
     return const_name(StrLit.name);
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -123,7 +123,7 @@ namespace literals {
 enum Color { RED = 0, BLUE = 1 };
 
 typedef py::typing::Literal<26,
-                            0x1A,
+                            0x14,
                             py::typing::StringLiteral("\"hello world\""),
                             py::typing::StringLiteral("b\"hello world\""),
                             py::typing::StringLiteral("u\"hello world\""),

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -984,7 +984,8 @@ TEST_SUBMODULE(pytypes, m) {
 #endif
 
 #if defined(PYBIND11_CPP17)
-    m.def("annotate_literal", [](py::typing::Literal<3, 6, 1, 0, true, false> &o) -> py::object { return o; });
+    m.def("annotate_literal",
+          [](py::typing::Literal<3, 6, 1, 0, true, false> &o) -> py::object { return o; });
 
     m.attr("PYBIND11_CPP17") = true;
 #else

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -124,12 +124,12 @@ enum Color { RED = 0, BLUE = 1 };
 
 typedef py::typing::Literal<26,
                             0x1A,
-                            "\"hello world\"",
-                            "b\"hello world\"",
-                            "u\"hello world\"",
+                            py::typing::StringLiteral("\"hello world\""),
+                            py::typing::StringLiteral("b\"hello world\""),
+                            py::typing::StringLiteral("u\"hello world\""),
                             true,
-                            "Color.RED",
-                            "None">
+                            py::typing::StringLiteral("Color.RED"),
+                            py::typing::StringLiteral("None")>
     LiteralFoo;
 } // namespace literals
 namespace typevar {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -970,6 +970,9 @@ TEST_SUBMODULE(pytypes, m) {
         .value("BLUE", literals::Color::BLUE);
 
     m.def("annotate_complete_literal", [](literals::LiteralFoo &o) -> py::object { return o; });
+    
+    m.def("literal_test", [](py::typing::Literal<"hi"> &o) -> py::object { return o; })
+    
     m.def("annotate_generic_containers",
           [](const py::typing::List<typevar::TypeVarT> &l) -> py::typing::List<typevar::TypeVarV> {
               return l;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -972,8 +972,9 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("annotate_complete_literal", [](literals::LiteralFoo &o) -> py::object { return o; });
 
     m.def("annotate_generic_containers",
-            [](const py::typing::List<typevar::TypeVarT> &l)
-                -> py::typing::List<typevar::TypeVarV> { return l; });
+          [](const py::typing::List<typevar::TypeVarT> &l) -> py::typing::List<typevar::TypeVarV> {
+              return l;
+          });
 
     m.def("annotate_listT_to_T",
           [](const py::typing::List<typevar::TypeVarT> &l) -> typevar::TypeVarT { return l[0]; });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -124,17 +124,17 @@ enum Color { RED = 0, BLUE = 1 };
 
 typedef py::typing::Literal<26,
                             0x1A,
-                            "\"hello world\"",
-                            "b\"hello world\"",
-                            "u\"hello world\"",
+                            py::typing::StringLiteral("\"hello world\""),
+                            py::typing::StringLiteral("b\"hello world\""),
+                            py::typing::StringLiteral("u\"hello world\""),
                             true,
-                            "Color.RED",
-                            "None">
+                            py::typing::StringLiteral("Color.RED"),
+                            py::typing::StringLiteral("None")>
     LiteralFoo;
 } // namespace literals
 namespace typevar {
 typedef py::typing::TypeVar<"T"> TypeVarT;
-typedef py::typing::TypeVar<"V"> TypeVarV;
+typedef py::typing::TypeVar<py::typing::StringLiteral("V")> TypeVarV;
 } // namespace typevar
 #endif
 
@@ -971,11 +971,9 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.def("annotate_complete_literal", [](literals::LiteralFoo &o) -> py::object { return o; });
 
-    m.def("literal_test", [](py::typing::Literal<"hi"> &o) -> py::object { return o; })
-
-        m.def("annotate_generic_containers",
-              [](const py::typing::List<typevar::TypeVarT> &l)
-                  -> py::typing::List<typevar::TypeVarV> { return l; });
+    m.def("annotate_generic_containers",
+            [](const py::typing::List<typevar::TypeVarT> &l)
+                -> py::typing::List<typevar::TypeVarV> { return l; });
 
     m.def("annotate_listT_to_T",
           [](const py::typing::List<typevar::TypeVarT> &l) -> typevar::TypeVarT { return l[0]; });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -122,12 +122,12 @@ void m_defs(py::module_ &m) {
 namespace literals {
 enum Color { RED = 0, BLUE = 1 };
 
-typedef py::typing::Literal<"26",
+typedef py::typing::Literal<26,
                             "0x1A",
                             "\"hello world\"",
                             "b\"hello world\"",
                             "u\"hello world\"",
-                            "True",
+                            true,
                             "Color.RED",
                             "None">
     LiteralFoo;
@@ -969,7 +969,7 @@ TEST_SUBMODULE(pytypes, m) {
         .value("RED", literals::Color::RED)
         .value("BLUE", literals::Color::BLUE);
 
-    m.def("annotate_literal", [](literals::LiteralFoo &o) -> py::object { return o; });
+    m.def("annotate_complete_literal", [](literals::LiteralFoo &o) -> py::object { return o; });
     m.def("annotate_generic_containers",
           [](const py::typing::List<typevar::TypeVarT> &l) -> py::typing::List<typevar::TypeVarV> {
               return l;
@@ -981,6 +981,14 @@ TEST_SUBMODULE(pytypes, m) {
     m.attr("defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL") = true;
 #else
     m.attr("defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL") = false;
+#endif
+
+#if defined(PYBIND11_CPP17)
+    m.def("annotate_literal", [](py::typing::Literal<3, 6, 1, 0, true, false> &o) -> py::object { return o; });
+
+    m.attr("PYBIND11_CPP17") = true;
+#else
+    m.attr("PYBIND11_CPP17") = false;
 #endif
 
 #if defined(PYBIND11_TEST_PYTYPES_HAS_RANGES)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -123,7 +123,7 @@ namespace literals {
 enum Color { RED = 0, BLUE = 1 };
 
 typedef py::typing::Literal<26,
-                            "0x1A",
+                            0x1A,
                             "\"hello world\"",
                             "b\"hello world\"",
                             "u\"hello world\"",
@@ -985,7 +985,7 @@ TEST_SUBMODULE(pytypes, m) {
 
 #if defined(PYBIND11_CPP17)
     m.def("annotate_literal",
-          [](py::typing::Literal<3, 6, 1, 0, true, false> &o) -> py::object { return o; });
+          [](py::typing::Literal<3, 6, 1, 0, true, false, 0x14> &o) -> py::object { return o; });
 
     m.attr("PYBIND11_CPP17") = true;
 #else

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -970,13 +970,12 @@ TEST_SUBMODULE(pytypes, m) {
         .value("BLUE", literals::Color::BLUE);
 
     m.def("annotate_complete_literal", [](literals::LiteralFoo &o) -> py::object { return o; });
-    
+
     m.def("literal_test", [](py::typing::Literal<"hi"> &o) -> py::object { return o; })
-    
-    m.def("annotate_generic_containers",
-          [](const py::typing::List<typevar::TypeVarT> &l) -> py::typing::List<typevar::TypeVarV> {
-              return l;
-          });
+
+        m.def("annotate_generic_containers",
+              [](const py::typing::List<typevar::TypeVarT> &l)
+                  -> py::typing::List<typevar::TypeVarV> { return l; });
 
     m.def("annotate_listT_to_T",
           [](const py::typing::List<typevar::TypeVarT> &l) -> typevar::TypeVarT { return l[0]; });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -124,17 +124,17 @@ enum Color { RED = 0, BLUE = 1 };
 
 typedef py::typing::Literal<26,
                             0x1A,
-                            py::typing::StringLiteral("\"hello world\""),
-                            py::typing::StringLiteral("b\"hello world\""),
-                            py::typing::StringLiteral("u\"hello world\""),
+                            "\"hello world\"",
+                            "b\"hello world\"",
+                            "u\"hello world\"",
                             true,
-                            py::typing::StringLiteral("Color.RED"),
-                            py::typing::StringLiteral("None")>
+                            "Color.RED",
+                            "None">
     LiteralFoo;
 } // namespace literals
 namespace typevar {
 typedef py::typing::TypeVar<"T"> TypeVarT;
-typedef py::typing::TypeVar<py::typing::StringLiteral("V")> TypeVarV;
+typedef py::typing::TypeVar<"V"> TypeVarV;
 } // namespace typevar
 #endif
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1036,12 +1036,22 @@ def test_optional_object_annotations(doc):
 
 
 @pytest.mark.skipif(
-    not m.defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL,
-    reason="C++20 non-type template args feature not available.",
+    not m.PYBIND11_CPP17,
+    reason="C++17 auto template args feature not available.",
 )
 def test_literal(doc):
     assert (
         doc(m.annotate_literal)
+        == 'annotate_literal(arg0: Literal[3, 6, 1, 0, True, False]) -> object'
+    )
+
+@pytest.mark.skipif(
+    not m.defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL,
+    reason="C++20 non-type template args feature not available.",
+)
+def test_complete_literal(doc):
+    assert (
+        doc(m.annotate_complete_literal)
         == 'annotate_literal(arg0: Literal[26, 0x1A, "hello world", b"hello world", u"hello world", True, Color.RED, None]) -> object'
     )
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1042,8 +1042,9 @@ def test_optional_object_annotations(doc):
 def test_literal(doc):
     assert (
         doc(m.annotate_literal)
-        == 'annotate_literal(arg0: Literal[3, 6, 1, 0, True, False]) -> object'
+        == "annotate_literal(arg0: Literal[3, 6, 1, 0, True, False]) -> object"
     )
+
 
 @pytest.mark.skipif(
     not m.defined_PYBIND11_TYPING_H_HAS_STRING_LITERAL,

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1042,7 +1042,7 @@ def test_optional_object_annotations(doc):
 def test_literal(doc):
     assert (
         doc(m.annotate_literal)
-        == "annotate_literal(arg0: Literal[3, 6, 1, 0, True, False]) -> object"
+        == "annotate_literal(arg0: Literal[3, 6, 1, 0, True, False, 20]) -> object"
     )
 
 
@@ -1053,7 +1053,7 @@ def test_literal(doc):
 def test_complete_literal(doc):
     assert (
         doc(m.annotate_complete_literal)
-        == 'annotate_literal(arg0: Literal[26, 0x1A, "hello world", b"hello world", u"hello world", True, Color.RED, None]) -> object'
+        == 'annotate_literal(arg0: Literal[26, 20 "hello world", b"hello world", u"hello world", True, Color.RED, None]) -> object'
     )
 
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1053,7 +1053,7 @@ def test_literal(doc):
 def test_complete_literal(doc):
     assert (
         doc(m.annotate_complete_literal)
-        == 'annotate_literal(arg0: Literal[26, 20 "hello world", b"hello world", u"hello world", True, Color.RED, None]) -> object'
+        == 'annotate_complete_literal(arg0: Literal[26, 20, "hello world", b"hello world", u"hello world", True, Color.RED, None]) -> object'
     )
 
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

`typing.Literal` now can accept straight ints and bools, rather than only string Literals previously. For more information check out the python pep [here](https://peps.python.org/pep-0586/).

<!-- Include relevant issues or PRs here, describe what changed and why -->
## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Update `typing.Literal` type to support C++ ints and bools
```

<!-- If the upgrade guide needs updating, note that here too -->
