### PR TITLE
Drop  Clang dev CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
         clang:
           - dev
         std:
-          - 11
+          - 17
         container_suffix:
           - ""
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,10 +336,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang:
-          - dev
-        std:
-          - 17
         container_suffix:
           - ""
         include:


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Dropping the "🐍 3 • Clang dev • C++11 • x64" job because it started failing.

I don't have the free bandwidth to debug. **Help welcome.**

For "last successful" and "first failing" information see comments below.

Changing from C++11 to C++17 did not help.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
