### PR TITLE
Introducing pybind11 Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 
 **pybind11 — Seamless operability between C++11 and Python**
 
-|Latest Documentation Status| |Stable Documentation Status| |Gitter chat| |GitHub Discussions| |CI| |Build status|
+|Latest Documentation Status| |Stable Documentation Status| |Gitter chat| |GitHub Discussions| |CI| |Build status| |Gurubase|
 
 |Repology| |PyPI package| |Conda-forge| |Python Versions|
 
@@ -179,3 +179,5 @@ to the terms and conditions of this license.
    :target: https://pypi.org/project/pybind11/
 .. |GitHub Discussions| image:: https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github
    :target: https://github.com/pybind/pybind11/discussions
+.. |Gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20pybind11%20Guru-006BFF
+   :target: https://gurubase.io/g/pybind11


### PR DESCRIPTION
Hello Team,

This PR is a friendly notification that the [pybind11 Guru](https://gurubase.io/g/pybind11) has been added to Gurubase. The pybind11 Guru uses data from this repository and the [documentation](https://pybind11.readthedocs.io/en/latest) to answer questions by leveraging the LLM.

Gurubase is a centralized, RAG-based learning and troubleshooting assistant platform. Each "Guru" is equipped with custom knowledge to answer user questions based on data collected for that tool. More information can be found in [this repo](https://github.com/getanteon/gurubase).

This PR updates the README to indicate that pybind11 users can now ask questions to pybind11 Guru. As shown in the [Used By](https://github.com/getanteon/gurubase?tab=readme-ov-file#used-by) section, over 100 open-source repositories currently showcase their Guru in their README.md.

By default, there are three possible actions:
1. If you dislike it, we can immediately disable pybind11 Guru in Gurubase and remove this PR.
2. If you like it but don’t want to add it to the README, we can remove this PR or include it in another place you prefer.
3. If you’re happy with it, we can keep it as is and merge the PR.

Although this PR is created by the Gurubase Notifier account, the team monitors it and will answer any questions you may have.

**Note:** If you consider this PR a time-waster, apologize for the inconvenience. Developers often request us to create a Guru for the tools they use. Once we create it, we notify the maintainers to inform them and seek their approval.
