### PR TITLE
Fix module type hint

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1322,7 +1322,7 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 
 template <>
 struct handle_type_name<module_> {
-    static constexpr auto name = const_name("module");
+    static constexpr auto name = const_name("types.ModuleType");
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -83,8 +83,8 @@ def test_pydoc():
 
 def test_module_handle_type_name():
     assert (
-        doc(m.def_submodule)
-        == "def_submodule(arg0: module, arg1: str) -> types.ModuleType"
+        m.def_submodule.__doc__
+        == "def_submodule(arg0: module, arg1: str) -> types.ModuleType\n"
     )
 
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -81,6 +81,10 @@ def test_pydoc():
     assert pydoc.text.docmodule(pybind11_tests)
 
 
+def test_module_handle_type_name():
+    assert doc(m.def_submodule) == "def_submodule(arg0: module, arg1: str) -> types.ModuleType"
+
+
 def test_duplicate_registration():
     """Registering two things with the same name"""
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -82,7 +82,10 @@ def test_pydoc():
 
 
 def test_module_handle_type_name():
-    assert doc(m.def_submodule) == "def_submodule(arg0: module, arg1: str) -> types.ModuleType"
+    assert (
+        doc(m.def_submodule)
+        == "def_submodule(arg0: module, arg1: str) -> types.ModuleType"
+    )
 
 
 def test_duplicate_registration():

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -84,7 +84,7 @@ def test_pydoc():
 def test_module_handle_type_name():
     assert (
         m.def_submodule.__doc__
-        == "def_submodule(arg0: module, arg1: str) -> types.ModuleType\n"
+        == "def_submodule(arg0: types.ModuleType, arg1: str) -> types.ModuleType\n"
     )
 
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

"module" is not a valid python value.
The correct type hint for a module object is "types.ModuleType" which has existed since at least Python 2.6


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Fix module type hint
```

<!-- If the upgrade guide needs updating, note that here too -->
