### PR TITLE
Rework of arg/return type hints to support .noconvert()

### DIFF
--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -61,19 +61,16 @@ type is explicitly allowed.
 
     template <>
     struct type_caster<user_space::Point2D> {
-        // This macro inserts a lot of boilerplate code and sets the default type hint to `tuple`
-        PYBIND11_TYPE_CASTER(user_space::Point2D, const_name("tuple"));
-        // `arg_name` and `return_name` may optionally be used to specify type hints separately for
-        // arguments and return values.
+        // This macro inserts a lot of boilerplate code and sets the type hint.
+        // `io_name` is used to specify different type hints for arguments and return values.
         // The signature of our negate function would then look like:
         // `negate(Sequence[float]) -> tuple[float, float]`
-        static constexpr auto arg_name = const_name("Sequence[float]");
-        static constexpr auto return_name = const_name("tuple[float, float]");
+        PYBIND11_TYPE_CASTER(user_space::Point2D, io_name("Sequence[float]", "tuple[float, float]"));
 
         // C++ -> Python: convert `Point2D` to `tuple[float, float]`. The second and third arguments
         // are used to indicate the return value policy and parent object (for
         // return_value_policy::reference_internal) and are often ignored by custom casters.
-        // The return value should reflect the type hint specified by `return_name`.
+        // The return value should reflect the type hint specified by the second argument of `io_name`.
         static handle
         cast(const user_space::Point2D &number, return_value_policy /*policy*/, handle /*parent*/) {
             return py::make_tuple(number.x, number.y).release();
@@ -81,7 +78,8 @@ type is explicitly allowed.
 
         // Python -> C++: convert a `PyObject` into a `Point2D` and return false upon failure. The
         // second argument indicates whether implicit conversions should be allowed.
-        // The accepted types should reflect the type hint specified by `arg_name`.
+        // The accepted types should reflect the type hint specified by the first argument of
+        // `io_name`.
         bool load(handle src, bool /*convert*/) {
             // Check if handle is a Sequence
             if (!py::isinstance<py::sequence>(src)) {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -34,39 +34,6 @@ PYBIND11_WARNING_DISABLE_MSVC(4127)
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-// Type trait checker for `descr`
-template <typename>
-struct is_descr : std::false_type {};
-
-template <size_t N, typename... Ts>
-struct is_descr<descr<N, Ts...>> : std::true_type {};
-
-template <size_t N, typename... Ts>
-struct is_descr<const descr<N, Ts...>> : std::true_type {};
-
-// Use arg_name instead of name when available
-template <typename T, typename SFINAE = void>
-struct as_arg_type {
-    static constexpr auto name = T::name;
-};
-
-template <typename T>
-struct as_arg_type<T, typename std::enable_if<is_descr<decltype(T::arg_name)>::value>::type> {
-    static constexpr auto name = T::arg_name;
-};
-
-// Use return_name instead of name when available
-template <typename T, typename SFINAE = void>
-struct as_return_type {
-    static constexpr auto name = T::name;
-};
-
-template <typename T>
-struct as_return_type<T,
-                      typename std::enable_if<is_descr<decltype(T::return_name)>::value>::type> {
-    static constexpr auto name = T::return_name;
-};
-
 template <typename type, typename SFINAE = void>
 class type_caster : public type_caster_base<type> {};
 template <typename type>
@@ -1113,8 +1080,6 @@ struct pyobject_caster {
         return src.inc_ref();
     }
     PYBIND11_TYPE_CASTER(type, handle_type_name<type>::name);
-    static constexpr auto arg_name = as_arg_type<handle_type_name<type>>::name;
-    static constexpr auto return_name = as_return_type<handle_type_name<type>>::name;
 };
 
 template <typename T>
@@ -1668,7 +1633,7 @@ public:
                   "py::args cannot be specified more than once");
 
     static constexpr auto arg_names
-        = ::pybind11::detail::concat(type_descr(as_arg_type<make_caster<Args>>::name)...);
+        = ::pybind11::detail::concat(type_descr(make_caster<Args>::name)...);
 
     bool load_args(function_call &call) { return load_impl_sequence(call, indices{}); }
 

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -101,7 +101,7 @@ constexpr descr<1, Type> const_name() {
 
 // Use a different name based on whether the parameter is used as input or output
 template <size_t N1, size_t N2>
-constexpr auto io_name(char const (&text1)[N1], char const (&text2)[N2]) {
+constexpr descr<N1 + N2 + 1> io_name(char const (&text1)[N1], char const (&text2)[N2]) {
     return const_name("@") + const_name(text1) + const_name("@") + const_name(text2)
            + const_name("@");
 }
@@ -163,8 +163,9 @@ constexpr auto concat(const descr<N, Ts...> &d, const Args &...args) {
 }
 #else
 template <size_t N, typename... Ts, typename... Args>
-constexpr auto concat(const descr<N, Ts...> &d, const Args &...args)
-    -> decltype(std::declval<descr<N + 2, Ts...>>() + concat(args...)) {
+constexpr auto concat(const descr<N, Ts...> &d,
+                      const Args &...args) -> decltype(std::declval<descr<N + 2, Ts...>>()
+                                                       + concat(args...)) {
     return d + const_name(", ") + concat(args...);
 }
 #endif

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -176,12 +176,12 @@ constexpr descr<N + 2, Ts...> type_descr(const descr<N, Ts...> &descr) {
 
 template <size_t N, typename... Ts>
 constexpr descr<N + 4, Ts...> arg_descr(const descr<N, Ts...> &descr) {
-    return const_name("@^") + descr + const_name("@^");
+    return const_name("@^") + descr + const_name("@!");
 }
 
 template <size_t N, typename... Ts>
 constexpr descr<N + 4, Ts...> return_descr(const descr<N, Ts...> &descr) {
-    return const_name("@$") + descr + const_name("@$");
+    return const_name("@$") + descr + const_name("@!");
 }
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -174,5 +174,15 @@ constexpr descr<N + 2, Ts...> type_descr(const descr<N, Ts...> &descr) {
     return const_name("{") + descr + const_name("}");
 }
 
+template <size_t N, typename... Ts>
+constexpr descr<N + 4, Ts...> arg_descr(const descr<N, Ts...> &descr) {
+    return const_name("@^") + descr + const_name("@^");
+}
+
+template <size_t N, typename... Ts>
+constexpr descr<N + 4, Ts...> return_descr(const descr<N, Ts...> &descr) {
+    return const_name("@$") + descr + const_name("@$");
+}
+
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -99,6 +99,13 @@ constexpr descr<1, Type> const_name() {
     return {'%'};
 }
 
+// Use a different name based on whether the parameter is used as input or output
+template <size_t N1, size_t N2>
+constexpr auto io_name(char const (&text1)[N1], char const (&text2)[N2]) {
+    return const_name("@") + const_name(text1) + const_name("@") + const_name(text2)
+           + const_name("@");
+}
+
 // If "_" is defined as a macro, py::detail::_ cannot be provided.
 // It is therefore best to use py::detail::const_name universally.
 // This block is for backward compatibility only.

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -163,9 +163,8 @@ constexpr auto concat(const descr<N, Ts...> &d, const Args &...args) {
 }
 #else
 template <size_t N, typename... Ts, typename... Args>
-constexpr auto concat(const descr<N, Ts...> &d,
-                      const Args &...args) -> decltype(std::declval<descr<N + 2, Ts...>>()
-                                                       + concat(args...)) {
+constexpr auto concat(const descr<N, Ts...> &d, const Args &...args)
+    -> decltype(std::declval<descr<N + 2, Ts...>>() + concat(args...)) {
     return d + const_name(", ") + concat(args...);
 }
 #endif

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -515,19 +515,25 @@ protected:
                 ++pc;
                 if (!use_return_value
                     && !(arg_index < rec->args.size() && !rec->args[arg_index].convert)) {
-                    while (*pc && *pc != '@')
+                    while (*pc != '\0' && *pc != '@') {
                         signature += *pc++;
-                    if (*pc == '@')
+                    }
+                    if (*pc == '@') {
                         ++pc;
-                    while (*pc && *pc != '@')
+                    }
+                    while (*pc != '\0' && *pc != '@') {
                         ++pc;
+                    }
                 } else {
-                    while (*pc && *pc != '@')
+                    while (*pc != '\0' && *pc != '@') {
                         ++pc;
-                    if (*pc == '@')
+                    }
+                    if (*pc == '@') {
                         ++pc;
-                    while (*pc && *pc != '@')
+                    }
+                    while (*pc != '\0' && *pc != '@') {
                         signature += *pc++;
+                    }
                 }
             } else {
                 if (c == '-' && *(pc + 1) == '>') {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -445,6 +445,9 @@ protected:
         // signature. Using `@^`/`@$` we can force types to be arg/return types while `@!` pops
         // back to the previous state.
         std::stack<bool> is_return_value({false});
+        // The following characters have special meaning in the signature parsing. Literals
+        // containing these are escaped with `!`.
+        std::string special_chars("!@%{}-");
         for (const auto *pc = text; *pc != '\0'; ++pc) {
             const auto c = *pc;
 
@@ -498,9 +501,7 @@ protected:
                 } else {
                     signature += detail::quote_cpp_type_name(detail::clean_type_id(t->name()));
                 }
-            } else if (c == '!'
-                       && (*(pc + 1) == '!' || *(pc + 1) == '@' || *(pc + 1) == '%'
-                           || *(pc + 1) == '{' || *(pc + 1) == '}' || *(pc + 1) == '-')) {
+            } else if (c == '!' && special_chars.find(*(pc + 1)) != std::string::npos) {
                 // typing::Literal escapes special characters with !
                 signature += *++pc;
             } else if (c == '@') {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -336,8 +336,8 @@ protected:
 
         /* Generate a readable signature describing the function's arguments and return
            value types */
-        static constexpr auto signature = const_name("(") + cast_in::arg_names
-                                          + const_name(") -> ") + as_return_type<cast_out>::name;
+        static constexpr auto signature
+            = const_name("(") + cast_in::arg_names + const_name(") -> ") + cast_out::name;
         PYBIND11_DESCR_CONSTEXPR auto types = decltype(signature)::types();
 
         /* Register the function with Python from generic (non-templated) code */

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -444,7 +444,7 @@ protected:
         // `is_return_value.top()` is true if we are currently inside the return type of the
         // signature. Using `@^`/`@$` we can force types to be arg/return types while `@!` pops
         // back to the previous state.
-        std::stack<bool> is_return_value = {false};
+        std::stack<bool> is_return_value({false});
         for (const auto *pc = text; *pc != '\0'; ++pc) {
             const auto c = *pc;
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -440,6 +440,7 @@ protected:
         std::string signature;
         size_t type_index = 0, arg_index = 0;
         bool is_starred = false;
+        bool is_return_value = false;
         for (const auto *pc = text; *pc != '\0'; ++pc) {
             const auto c = *pc;
 
@@ -493,7 +494,29 @@ protected:
                 } else {
                     signature += detail::quote_cpp_type_name(detail::clean_type_id(t->name()));
                 }
+            } else if (c == '@') {
+                // Handle types that differ depending on whether they appear
+                // in an argument or a return value position
+                ++pc;
+                if (!is_return_value) {
+                    while (*pc && *pc != '@')
+                        signature += *pc++;
+                    if (*pc == '@')
+                        ++pc;
+                    while (*pc && *pc != '@')
+                        ++pc;
+                } else {
+                    while (*pc && *pc != '@')
+                        ++pc;
+                    if (*pc == '@')
+                        ++pc;
+                    while (*pc && *pc != '@')
+                        signature += *pc++;
+                }
             } else {
+                if (c == '-' && *(pc + 1) == '>') {
+                    is_return_value = true;
+                }
                 signature += c;
             }
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -505,11 +505,13 @@ protected:
                     is_return_value.emplace(false);
                     ++pc;
                     continue;
-                } else if (*(pc + 1) == '$') {
+                }
+                if (*(pc + 1) == '$') {
                     is_return_value.emplace(true);
                     ++pc;
                     continue;
-                } else if (*(pc + 1) == '!') {
+                }
+                if (*(pc + 1) == '!') {
                     is_return_value.pop();
                     ++pc;
                     continue;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <memory>
 #include <new>
+#include <stack>
 #include <string>
 #include <utility>
 #include <vector>
@@ -444,7 +445,6 @@ protected:
         // signature. Using `@^`/`@$` we can force types to be arg/return types while `@!` pops
         // back to the previous state.
         std::stack<bool> is_return_value = {false};
-        bool use_return_value = false;
         for (const auto *pc = text; *pc != '\0'; ++pc) {
             const auto c = *pc;
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -498,6 +498,11 @@ protected:
                 } else {
                     signature += detail::quote_cpp_type_name(detail::clean_type_id(t->name()));
                 }
+            } else if (c == '!'
+                       && (*(pc + 1) == '!' || *(pc + 1) == '@' || *(pc + 1) == '%'
+                           || *(pc + 1) == '{' || *(pc + 1) == '}')) {
+                // typing::Literal escapes special characters with !
+                signature += *++pc;
             } else if (c == '@') {
                 // `@^ ... @!` and `@$ ... @!` are used to force arg/return value type (see
                 // typing::Callable/detail::arg_descr/detail::return_descr)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -500,7 +500,7 @@ protected:
                 }
             } else if (c == '!'
                        && (*(pc + 1) == '!' || *(pc + 1) == '@' || *(pc + 1) == '%'
-                           || *(pc + 1) == '{' || *(pc + 1) == '}')) {
+                           || *(pc + 1) == '{' || *(pc + 1) == '}' || *(pc + 1) == '-')) {
                 // typing::Literal escapes special characters with !
                 signature += *++pc;
             } else if (c == '@') {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -497,8 +497,10 @@ protected:
             } else if (c == '@') {
                 // Handle types that differ depending on whether they appear
                 // in an argument or a return value position
+                // For named arguments (py::arg()) with noconvert set, use return value type
                 ++pc;
-                if (!is_return_value) {
+                if (!is_return_value
+                    && !(arg_index < rec->args.size() && !rec->args[arg_index].convert)) {
                     while (*pc && *pc != '@')
                         signature += *pc++;
                     if (*pc == '@')

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -106,9 +106,7 @@ public:
         return true;
     }
 
-    PYBIND11_TYPE_CASTER(T, const_name("os.PathLike"));
-    static constexpr auto arg_name = const_name("Union[os.PathLike, str, bytes]");
-    static constexpr auto return_name = const_name("Path");
+    PYBIND11_TYPE_CASTER(T, io_name("Union[os.PathLike, str, bytes]", "Path"));
 };
 
 #endif // PYBIND11_HAS_FILESYSTEM || defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -106,7 +106,7 @@ public:
         return true;
     }
 
-    PYBIND11_TYPE_CASTER(T, io_name("Union[os.PathLike, str, bytes]", "Path"));
+    PYBIND11_TYPE_CASTER(T, io_name("Union[os.PathLike, str, bytes]", "pathlib.Path"));
 };
 
 #endif // PYBIND11_HAS_FILESYSTEM || defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -256,14 +256,14 @@ struct handle_type_name<typing::Never> {
 };
 
 #if defined(PYBIND11_TYPING_H_HAS_STRING_LITERAL)
-template <typing::StringLiteral str>
+template <typing::StringLiteral StrLit>
 consteval auto sanitize_string_literal() {
-    constexpr std::string_view v(str.name);
+    constexpr std::string_view v(StrLit.name);
     char result[v.size() + std::ranges::count(v, '!') + std::ranges::count(v, '@')
                 + std::ranges::count(v, '%') + std::ranges::count(v, '{')
                 + std::ranges::count(v, '}') + 1];
     size_t i = 0;
-    for (auto c : str.name) {
+    for (auto c : StrLit.name) {
         if (c == '!') {
             result[i++] = '!';
             result[i++] = '!';

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -264,24 +264,10 @@ consteval auto sanitize_string_literal() {
                 + std::ranges::count(v, '}') + 1];
     size_t i = 0;
     for (auto c : StrLit.name) {
-        if (c == '!') {
+        if (c == '!' || c == '@' || c == '%' || c == '{' || c == '}') {
             result[i++] = '!';
-            result[i++] = '!';
-        } else if (c == '@') {
-            result[i++] = '!';
-            result[i++] = '@';
-        } else if (c == '%') {
-            result[i++] = '!';
-            result[i++] = '%';
-        } else if (c == '{') {
-            result[i++] = '!';
-            result[i++] = '{';
-        } else if (c == '}') {
-            result[i++] = '!';
-            result[i++] = '}';
-        } else {
-            result[i++] = c;
         }
+        result[i++] = c;
     }
     return typing::StringLiteral(result);
 }

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -143,13 +143,6 @@ struct handle_type_name<typing::Tuple<Types...>> {
     static constexpr auto name = const_name("tuple[")
                                  + ::pybind11::detail::concat(make_caster<Types>::name...)
                                  + const_name("]");
-    static constexpr auto arg_name
-        = const_name("tuple[")
-          + ::pybind11::detail::concat(as_arg_type<make_caster<Types>>::name...) + const_name("]");
-    static constexpr auto return_name
-        = const_name("tuple[")
-          + ::pybind11::detail::concat(as_return_type<make_caster<Types>>::name...)
-          + const_name("]");
 };
 
 template <>
@@ -163,76 +156,48 @@ struct handle_type_name<typing::Tuple<T, ellipsis>> {
     // PEP 484 specifies this syntax for a variable-length tuple
     static constexpr auto name
         = const_name("tuple[") + make_caster<T>::name + const_name(", ...]");
-    static constexpr auto arg_name
-        = const_name("tuple[") + as_arg_type<make_caster<T>>::name + const_name(", ...]");
-    static constexpr auto return_name
-        = const_name("tuple[") + as_return_type<make_caster<T>>::name + const_name(", ...]");
 };
 
 template <typename K, typename V>
 struct handle_type_name<typing::Dict<K, V>> {
     static constexpr auto name = const_name("dict[") + make_caster<K>::name + const_name(", ")
                                  + make_caster<V>::name + const_name("]");
-    static constexpr auto arg_name = const_name("dict[") + as_arg_type<make_caster<K>>::name
-                                     + const_name(", ") + as_arg_type<make_caster<V>>::name
-                                     + const_name("]");
-    static constexpr auto return_name = const_name("dict[") + as_return_type<make_caster<K>>::name
-                                        + const_name(", ") + as_return_type<make_caster<V>>::name
-                                        + const_name("]");
 };
 
 template <typename T>
 struct handle_type_name<typing::List<T>> {
     static constexpr auto name = const_name("list[") + make_caster<T>::name + const_name("]");
-    static constexpr auto arg_name
-        = const_name("list[") + as_arg_type<make_caster<T>>::name + const_name("]");
-    static constexpr auto return_name
-        = const_name("list[") + as_return_type<make_caster<T>>::name + const_name("]");
 };
 
 template <typename T>
 struct handle_type_name<typing::Set<T>> {
     static constexpr auto name = const_name("set[") + make_caster<T>::name + const_name("]");
-    static constexpr auto arg_name
-        = const_name("set[") + as_arg_type<make_caster<T>>::name + const_name("]");
-    static constexpr auto return_name
-        = const_name("set[") + as_return_type<make_caster<T>>::name + const_name("]");
 };
 
 template <typename T>
 struct handle_type_name<typing::Iterable<T>> {
     static constexpr auto name = const_name("Iterable[") + make_caster<T>::name + const_name("]");
-    static constexpr auto arg_name
-        = const_name("Iterable[") + as_arg_type<make_caster<T>>::name + const_name("]");
-    static constexpr auto return_name
-        = const_name("Iterable[") + as_return_type<make_caster<T>>::name + const_name("]");
 };
 
 template <typename T>
 struct handle_type_name<typing::Iterator<T>> {
     static constexpr auto name = const_name("Iterator[") + make_caster<T>::name + const_name("]");
-    static constexpr auto arg_name
-        = const_name("Iterator[") + as_arg_type<make_caster<T>>::name + const_name("]");
-    static constexpr auto return_name
-        = const_name("Iterator[") + as_return_type<make_caster<T>>::name + const_name("]");
 };
 
 template <typename Return, typename... Args>
 struct handle_type_name<typing::Callable<Return(Args...)>> {
     using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
     static constexpr auto name
-        = const_name("Callable[[")
-          + ::pybind11::detail::concat(as_arg_type<make_caster<Args>>::name...) + const_name("], ")
-          + as_return_type<make_caster<retval_type>>::name + const_name("]");
+        = const_name("Callable[[") + ::pybind11::detail::concat(make_caster<Args>::name...)
+          + const_name("], ") + make_caster<retval_type>::name + const_name("]");
 };
 
 template <typename Return>
 struct handle_type_name<typing::Callable<Return(ellipsis)>> {
     // PEP 484 specifies this syntax for defining only return types of callables
     using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
-    static constexpr auto name = const_name("Callable[..., ")
-                                 + as_return_type<make_caster<retval_type>>::name
-                                 + const_name("]");
+    static constexpr auto name
+        = const_name("Callable[..., ") + make_caster<retval_type>::name + const_name("]");
 };
 
 template <typename T>
@@ -245,22 +210,11 @@ struct handle_type_name<typing::Union<Types...>> {
     static constexpr auto name = const_name("Union[")
                                  + ::pybind11::detail::concat(make_caster<Types>::name...)
                                  + const_name("]");
-    static constexpr auto arg_name
-        = const_name("Union[")
-          + ::pybind11::detail::concat(as_arg_type<make_caster<Types>>::name...) + const_name("]");
-    static constexpr auto return_name
-        = const_name("Union[")
-          + ::pybind11::detail::concat(as_return_type<make_caster<Types>>::name...)
-          + const_name("]");
 };
 
 template <typename T>
 struct handle_type_name<typing::Optional<T>> {
     static constexpr auto name = const_name("Optional[") + make_caster<T>::name + const_name("]");
-    static constexpr auto arg_name
-        = const_name("Optional[") + as_arg_type<make_caster<T>>::name + const_name("]");
-    static constexpr auto return_name
-        = const_name("Optional[") + as_return_type<make_caster<T>>::name + const_name("]");
 };
 
 template <typename T>
@@ -273,19 +227,14 @@ struct handle_type_name<typing::ClassVar<T>> {
     static constexpr auto name = const_name("ClassVar[") + make_caster<T>::name + const_name("]");
 };
 
-// TypeGuard and TypeIs use as_return_type to use the return type if available, which is usually
-// the narrower type.
-
 template <typename T>
 struct handle_type_name<typing::TypeGuard<T>> {
-    static constexpr auto name
-        = const_name("TypeGuard[") + as_return_type<make_caster<T>>::name + const_name("]");
+    static constexpr auto name = const_name("TypeGuard[") + make_caster<T>::name + const_name("]");
 };
 
 template <typename T>
 struct handle_type_name<typing::TypeIs<T>> {
-    static constexpr auto name
-        = const_name("TypeIs[") + as_return_type<make_caster<T>>::name + const_name("]");
+    static constexpr auto name = const_name("TypeIs[") + make_caster<T>::name + const_name("]");
 };
 
 template <>

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -188,16 +188,19 @@ template <typename Return, typename... Args>
 struct handle_type_name<typing::Callable<Return(Args...)>> {
     using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
     static constexpr auto name
-        = const_name("Callable[[") + ::pybind11::detail::concat(make_caster<Args>::name...)
-          + const_name("], ") + make_caster<retval_type>::name + const_name("]");
+        = const_name("Callable[[")
+          + ::pybind11::detail::concat(::pybind11::detail::arg_descr(make_caster<Args>::name)...)
+          + const_name("], ") + ::pybind11::detail::return_descr(make_caster<retval_type>::name)
+          + const_name("]");
 };
 
 template <typename Return>
 struct handle_type_name<typing::Callable<Return(ellipsis)>> {
     // PEP 484 specifies this syntax for defining only return types of callables
     using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
-    static constexpr auto name
-        = const_name("Callable[..., ") + make_caster<retval_type>::name + const_name("]");
+    static constexpr auto name = const_name("Callable[..., ")
+                                 + ::pybind11::detail::return_descr(make_caster<retval_type>::name)
+                                 + const_name("]");
 };
 
 template <typename T>

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -262,7 +262,7 @@ consteval auto sanitize_string_literal() {
     constexpr std::string_view v(StrLit.name);
     constexpr std::string_view special_chars("!@%{}-");
     constexpr auto num_special_chars = std::accumulate(
-        special_chars.begin(), special_chars.end(), 0, [&v](auto acc, const char &c) {
+        special_chars.begin(), special_chars.end(), (size_t) 0, [&v](auto acc, const char &c) {
             return std::move(acc) + std::ranges::count(v, c);
         });
     char result[v.size() + num_special_chars + 1];

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -264,7 +264,7 @@ consteval auto sanitize_string_literal() {
                 + std::ranges::count(v, '}') + 1];
     size_t i = 0;
     for (auto c : StrLit.name) {
-        if (c == '!' || c == '@' || c == '%' || c == '{' || c == '}') {
+        if (c == '!' || c == '@' || c == '%' || c == '{' || c == '}' || c == '-') {
             result[i++] = '!';
         }
         result[i++] = c;

--- a/tests/test_docs_advanced_cast_custom.cpp
+++ b/tests/test_docs_advanced_cast_custom.cpp
@@ -20,19 +20,16 @@ namespace detail {
 
 template <>
 struct type_caster<user_space::Point2D> {
-    // This macro inserts a lot of boilerplate code and sets the default type hint to `tuple`
-    PYBIND11_TYPE_CASTER(user_space::Point2D, const_name("tuple"));
-    // `arg_name` and `return_name` may optionally be used to specify type hints separately for
-    // arguments and return values.
+    // This macro inserts a lot of boilerplate code and sets the type hint.
+    // `io_name` is used to specify different type hints for arguments and return values.
     // The signature of our negate function would then look like:
     // `negate(Sequence[float]) -> tuple[float, float]`
-    static constexpr auto arg_name = const_name("Sequence[float]");
-    static constexpr auto return_name = const_name("tuple[float, float]");
+    PYBIND11_TYPE_CASTER(user_space::Point2D, io_name("Sequence[float]", "tuple[float, float]"));
 
     // C++ -> Python: convert `Point2D` to `tuple[float, float]`. The second and third arguments
     // are used to indicate the return value policy and parent object (for
     // return_value_policy::reference_internal) and are often ignored by custom casters.
-    // The return value should reflect the type hint specified by `return_name`.
+    // The return value should reflect the type hint specified by the second argument of `io_name`.
     static handle
     cast(const user_space::Point2D &number, return_value_policy /*policy*/, handle /*parent*/) {
         return py::make_tuple(number.x, number.y).release();
@@ -40,7 +37,8 @@ struct type_caster<user_space::Point2D> {
 
     // Python -> C++: convert a `PyObject` into a `Point2D` and return false upon failure. The
     // second argument indicates whether implicit conversions should be allowed.
-    // The accepted types should reflect the type hint specified by `arg_name`.
+    // The accepted types should reflect the type hint specified by the first argument of
+    // `io_name`.
     bool load(handle src, bool /*convert*/) {
         // Check if handle is a Sequence
         if (!py::isinstance<py::sequence>(src)) {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -142,7 +142,6 @@ typedef py::typing::TypeVar<"V"> TypeVarV;
 // RealNumber:
 // * in arguments -> float | int
 // * in return -> float
-// * fallback -> complex
 // The choice of types is not really useful, but just made different for testing purposes.
 // According to `PEP 484 – Type Hints` annotating with `float` also allows `int`,
 // so using `float | int` could be replaced by just `float`.
@@ -156,9 +155,7 @@ namespace detail {
 
 template <>
 struct type_caster<RealNumber> {
-    PYBIND11_TYPE_CASTER(RealNumber, const_name("complex"));
-    static constexpr auto arg_name = const_name("Union[float, int]");
-    static constexpr auto return_name = const_name("float");
+    PYBIND11_TYPE_CASTER(RealNumber, io_name("Union[float, int]", "float"));
 
     static handle cast(const RealNumber &number, return_value_policy, handle) {
         return py::float_(number.value).release();

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1168,4 +1168,11 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("check_type_is", [](const py::object &x) -> py::typing::TypeIs<RealNumber> {
         return py::isinstance<RealNumber>(x);
     });
+    // Literal with `@`, `%`, `{`, and `}`
+    // m.def("identity_literal_x", [](const py::typing::Literal<"\"x\""> &x) { return x; });
+    // m.def("identity_literal_at", [](const py::typing::Literal<"\"@\""> &x) { return x; });
+    // m.def("identity_literal_percent", [](const py::typing::Literal<"\"%\""> &x) { return x; });
+    // m.def("identity_literal_curly_open", [](const py::typing::Literal<"\"{\""> &x) { return x;
+    // }); m.def("identity_literal_curly_close", [](const py::typing::Literal<"\"}\""> &x) { return
+    // x; });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1145,6 +1145,10 @@ TEST_SUBMODULE(pytypes, m) {
     // Callable<R(...)> identity
     m.def("identity_callable_ellipsis",
           [](const py::typing::Callable<RealNumber(py::ellipsis)> &x) { return x; });
+    // Nested Callable<R(A)> identity
+    m.def("identity_nested_callable",
+          [](const py::typing::Callable<py::typing::Callable<RealNumber(const RealNumber &)>(
+                 py::typing::Callable<RealNumber(const RealNumber &)>)> &x) { return x; });
     // Callable<R(A)>
     m.def("apply_callable",
           [](const RealNumber &x, const py::typing::Callable<RealNumber(const RealNumber &)> &f) {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -977,6 +977,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("identity_literal_percent", [](const py::typing::Literal<"\"%\""> &x) { return x; });
     m.def("identity_literal_curly_open", [](const py::typing::Literal<"\"{\""> &x) { return x; });
     m.def("identity_literal_curly_close", [](const py::typing::Literal<"\"}\""> &x) { return x; });
+    m.def("identity_literal_all_special_chars",
+          [](const py::typing::Literal<"\"!@!!{%}\""> &x) { return x; });
     m.def("annotate_generic_containers",
           [](const py::typing::List<typevar::TypeVarT> &l) -> py::typing::List<typevar::TypeVarV> {
               return l;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -161,7 +161,11 @@ struct type_caster<RealNumber> {
         return py::float_(number.value).release();
     }
 
-    bool load(handle src, bool) {
+    bool load(handle src, bool convert) {
+        // If we're in no-convert mode, only load if given a float
+        if (!convert && !py::isinstance<py::float_>(src)) {
+            return false;
+        }
         if (!py::isinstance<py::float_>(src) && !py::isinstance<py::int_>(src)) {
             return false;
         }
@@ -1067,6 +1071,14 @@ TEST_SUBMODULE(pytypes, m) {
     m.attr("defined___cpp_inline_variables") = false;
 #endif
     m.def("half_of_number", [](const RealNumber &x) { return RealNumber{x.value / 2}; });
+    m.def(
+        "half_of_number_convert",
+        [](const RealNumber &x) { return RealNumber{x.value / 2}; },
+        py::arg("x"));
+    m.def(
+        "half_of_number_noconvert",
+        [](const RealNumber &x) { return RealNumber{x.value / 2}; },
+        py::arg("x").noconvert());
     // std::vector<T>
     m.def("half_of_number_vector", [](const std::vector<RealNumber> &x) {
         std::vector<RealNumber> result;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -977,7 +977,8 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("identity_literal_percent", [](const py::typing::Literal<"\"%\""> &x) { return x; });
     m.def("identity_literal_curly_open", [](const py::typing::Literal<"\"{\""> &x) { return x; });
     m.def("identity_literal_curly_close", [](const py::typing::Literal<"\"}\""> &x) { return x; });
-    m.def("identity_literal_arrow", [](const py::typing::Literal<"\"->\""> &x) { return x; });
+    m.def("identity_literal_arrow_with_io_name",
+          [](const py::typing::Literal<"\"->\""> &x, const RealNumber &y) { return x; });
     m.def("identity_literal_arrow_with_callable",
           [](const py::typing::Callable<RealNumber(const py::typing::Literal<"\"->\""> &,
                                                    const RealNumber &)> &x) { return x; });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -977,8 +977,12 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("identity_literal_percent", [](const py::typing::Literal<"\"%\""> &x) { return x; });
     m.def("identity_literal_curly_open", [](const py::typing::Literal<"\"{\""> &x) { return x; });
     m.def("identity_literal_curly_close", [](const py::typing::Literal<"\"}\""> &x) { return x; });
+    m.def("identity_literal_arrow", [](const py::typing::Literal<"\"->\""> &x) { return x; });
+    m.def("identity_literal_arrow_with_callable",
+          [](const py::typing::Callable<RealNumber(const py::typing::Literal<"\"->\""> &,
+                                                   const RealNumber &)> &x) { return x; });
     m.def("identity_literal_all_special_chars",
-          [](const py::typing::Literal<"\"!@!!{%}\""> &x) { return x; });
+          [](const py::typing::Literal<"\"!@!!->{%}\""> &x) { return x; });
     m.def("annotate_generic_containers",
           [](const py::typing::List<typevar::TypeVarT> &l) -> py::typing::List<typevar::TypeVarV> {
               return l;

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1183,3 +1183,4 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("check_type_is", [](const py::object &x) -> py::typing::TypeIs<RealNumber> {
         return py::isinstance<RealNumber>(x);
     });
+}

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -971,7 +971,7 @@ TEST_SUBMODULE(pytypes, m) {
         .value("BLUE", literals::Color::BLUE);
 
     m.def("annotate_literal", [](literals::LiteralFoo &o) -> py::object { return o; });
-    // Literal with `@`, `%`, `{`, and `}`
+    // Literal with `@`, `%`, `{`, `}`, and `->`
     m.def("identity_literal_exclamation", [](const py::typing::Literal<"\"!\""> &x) { return x; });
     m.def("identity_literal_at", [](const py::typing::Literal<"\"@\""> &x) { return x; });
     m.def("identity_literal_percent", [](const py::typing::Literal<"\"%\""> &x) { return x; });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -978,7 +978,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("identity_literal_curly_open", [](const py::typing::Literal<"\"{\""> &x) { return x; });
     m.def("identity_literal_curly_close", [](const py::typing::Literal<"\"}\""> &x) { return x; });
     m.def("identity_literal_arrow_with_io_name",
-          [](const py::typing::Literal<"\"->\""> &x, const RealNumber &y) { return x; });
+          [](const py::typing::Literal<"\"->\""> &x, const RealNumber &) { return x; });
     m.def("identity_literal_arrow_with_callable",
           [](const py::typing::Callable<RealNumber(const py::typing::Literal<"\"->\""> &,
                                                    const RealNumber &)> &x) { return x; });

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -971,6 +971,11 @@ TEST_SUBMODULE(pytypes, m) {
         .value("BLUE", literals::Color::BLUE);
 
     m.def("annotate_literal", [](literals::LiteralFoo &o) -> py::object { return o; });
+    // Literal with `@`, `%`, `{`, and `}`
+    m.def("identity_literal_at", [](const py::typing::Literal<"\"@\""> &x) { return x; });
+    m.def("identity_literal_percent", [](const py::typing::Literal<"\"%\""> &x) { return x; });
+    m.def("identity_literal_curly_open", [](const py::typing::Literal<"\"{\""> &x) { return x; });
+    m.def("identity_literal_curly_close", [](const py::typing::Literal<"\"}\""> &x) { return x; });
     m.def("annotate_generic_containers",
           [](const py::typing::List<typevar::TypeVarT> &l) -> py::typing::List<typevar::TypeVarV> {
               return l;
@@ -1178,10 +1183,3 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("check_type_is", [](const py::object &x) -> py::typing::TypeIs<RealNumber> {
         return py::isinstance<RealNumber>(x);
     });
-    // Literal with `@`, `%`, `{`, and `}`
-    m.def("identity_literal_x", [](const py::typing::Literal<"\"x\""> &x) { return x; });
-    m.def("identity_literal_at", [](const py::typing::Literal<"\"@\""> &x) { return x; });
-    m.def("identity_literal_percent", [](const py::typing::Literal<"\"%\""> &x) { return x; });
-    m.def("identity_literal_curly_open", [](const py::typing::Literal<"\"{\""> &x) { return x; });
-    m.def("identity_literal_curly_close", [](const py::typing::Literal<"\"}\""> &x) { return x; });
-}

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1179,10 +1179,9 @@ TEST_SUBMODULE(pytypes, m) {
         return py::isinstance<RealNumber>(x);
     });
     // Literal with `@`, `%`, `{`, and `}`
-    // m.def("identity_literal_x", [](const py::typing::Literal<"\"x\""> &x) { return x; });
-    // m.def("identity_literal_at", [](const py::typing::Literal<"\"@\""> &x) { return x; });
-    // m.def("identity_literal_percent", [](const py::typing::Literal<"\"%\""> &x) { return x; });
-    // m.def("identity_literal_curly_open", [](const py::typing::Literal<"\"{\""> &x) { return x;
-    // }); m.def("identity_literal_curly_close", [](const py::typing::Literal<"\"}\""> &x) { return
-    // x; });
+    m.def("identity_literal_x", [](const py::typing::Literal<"\"x\""> &x) { return x; });
+    m.def("identity_literal_at", [](const py::typing::Literal<"\"@\""> &x) { return x; });
+    m.def("identity_literal_percent", [](const py::typing::Literal<"\"%\""> &x) { return x; });
+    m.def("identity_literal_curly_open", [](const py::typing::Literal<"\"{\""> &x) { return x; });
+    m.def("identity_literal_curly_close", [](const py::typing::Literal<"\"}\""> &x) { return x; });
 }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1139,6 +1139,12 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("identity_iterable", [](const py::typing::Iterable<RealNumber> &x) { return x; });
     // Iterator<T>
     m.def("identity_iterator", [](const py::typing::Iterator<RealNumber> &x) { return x; });
+    // Callable<R(A)> identity
+    m.def("identity_callable",
+          [](const py::typing::Callable<RealNumber(const RealNumber &)> &x) { return x; });
+    // Callable<R(...)> identity
+    m.def("identity_callable_ellipsis",
+          [](const py::typing::Callable<RealNumber(py::ellipsis)> &x) { return x; });
     // Callable<R(A)>
     m.def("apply_callable",
           [](const RealNumber &x, const py::typing::Callable<RealNumber(const RealNumber &)> &f) {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -972,6 +972,7 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.def("annotate_literal", [](literals::LiteralFoo &o) -> py::object { return o; });
     // Literal with `@`, `%`, `{`, and `}`
+    m.def("identity_literal_exclamation", [](const py::typing::Literal<"\"!\""> &x) { return x; });
     m.def("identity_literal_at", [](const py::typing::Literal<"\"@\""> &x) { return x; });
     m.def("identity_literal_percent", [](const py::typing::Literal<"\"%\""> &x) { return x; });
     m.def("identity_literal_curly_open", [](const py::typing::Literal<"\"{\""> &x) { return x; });

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1044,6 +1044,23 @@ def test_literal(doc):
         doc(m.annotate_literal)
         == 'annotate_literal(arg0: Literal[26, 0x1A, "hello world", b"hello world", u"hello world", True, Color.RED, None]) -> object'
     )
+    # The characters @, %, and {} are used in the signature parser as special characters, but Literal should escape those for the parser to work.
+    assert (
+        doc(m.identity_literal_at)
+        == 'identity_literal_at(arg0: Literal["@"]) -> Literal["@"]'
+    )
+    assert (
+        doc(m.identity_literal_percent)
+        == 'identity_literal_percent(arg0: Literal["%"]) -> Literal["%"]'
+    )
+    assert (
+        doc(m.identity_literal_curly_open)
+        == 'identity_literal_curly_open(arg0: Literal["{"]) -> Literal["{"]'
+    )
+    assert (
+        doc(m.identity_literal_curly_close)
+        == 'identity_literal_curly_close(arg0: Literal["}"]) -> Literal["}"]'
+    )
 
 
 @pytest.mark.skipif(
@@ -1294,28 +1311,3 @@ def test_arg_return_type_hints(doc):
     )
     # TypeIs<T>
     assert doc(m.check_type_is) == "check_type_is(arg0: object) -> TypeIs[float]"
-    # Literal without special characters
-    assert (
-        doc(m.identity_literal_x)
-        == 'identity_literal_x(arg0: Literal["x"]) -> Literal["x"]'
-    )
-    # Literal with @
-    assert (
-        doc(m.identity_literal_at)
-        == 'identity_literal_at(arg0: Literal["@"]) -> Literal["@"]'
-    )
-    # Literal with %
-    assert (
-        doc(m.identity_literal_percent)
-        == 'identity_literal_percent(arg0: Literal["%"]) -> Literal["%"]'
-    )
-    # Literal with {
-    assert (
-        doc(m.identity_literal_curly_open)
-        == 'identity_literal_curly_open(arg0: Literal["{"]) -> Literal["{"]'
-    )
-    # Literal with }
-    assert (
-        doc(m.identity_literal_curly_close)
-        == 'identity_literal_curly_close(arg0: Literal["}"]) -> Literal["}"]'
-    )

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1044,7 +1044,11 @@ def test_literal(doc):
         doc(m.annotate_literal)
         == 'annotate_literal(arg0: Literal[26, 0x1A, "hello world", b"hello world", u"hello world", True, Color.RED, None]) -> object'
     )
-    # The characters @, %, and {} are used in the signature parser as special characters, but Literal should escape those for the parser to work.
+    # The characters !, @, %, and {} are used in the signature parser as special characters, but Literal should escape those for the parser to work.
+    assert (
+        doc(m.identity_literal_exclamation)
+        == 'identity_literal_exclamation(arg0: Literal["!"]) -> Literal["!"]'
+    )
     assert (
         doc(m.identity_literal_at)
         == 'identity_literal_at(arg0: Literal["@"]) -> Literal["@"]'

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1065,6 +1065,10 @@ def test_literal(doc):
         doc(m.identity_literal_curly_close)
         == 'identity_literal_curly_close(arg0: Literal["}"]) -> Literal["}"]'
     )
+    assert (
+        doc(m.identity_literal_all_special_chars)
+        == 'identity_literal_all_special_chars(arg0: Literal["!@!!{%}"]) -> Literal["!@!!{%}"]'
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1281,3 +1281,29 @@ def test_arg_return_type_hints(doc):
     )
     # TypeIs<T>
     assert doc(m.check_type_is) == "check_type_is(arg0: object) -> TypeIs[float]"
+    # Literal without special characters
+    # assert (
+    # doc(m.identity_literal_x)
+    # == 'identity_literal_x(arg0: Literal["x"]) -> Literal["x"]'
+    # )
+    # The Following tests fail with `ImportError: Internal error while parsing type signature (2)`
+    # Literal with @
+    # assert (
+    # doc(m.identity_literal_at)
+    # == 'identity_literal_at(arg0: Literal["@"]) -> Literal["@"]'
+    # )
+    # Literal with %
+    # assert (
+    # doc(m.identity_literal_percent)
+    # == 'identity_literal_percent(arg0: Literal["%"]) -> Literal["%"]'
+    # )
+    # Literal with {
+    # assert (
+    # doc(m.identity_literal_curly_open)
+    # == 'identity_literal_curly_open(arg0: Literal["{"]) -> Literal["{"]'
+    # )
+    # Literal with }
+    # assert (
+    # doc(m.identity_literal_curly_close)
+    # == 'identity_literal_curly_close(arg0: Literal["}"]) -> Literal["}"]'
+    # )

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1200,10 +1200,10 @@ def test_arg_return_type_hints(doc):
     assert m.half_of_number(0) == 0
     assert isinstance(m.half_of_number(0), float)
     assert not isinstance(m.half_of_number(0), int)
-    # std::vector<T> should use fallback type (complex is not really useful but just used for testing)
+    # std::vector<T>
     assert (
         doc(m.half_of_number_vector)
-        == "half_of_number_vector(arg0: list[complex]) -> list[complex]"
+        == "half_of_number_vector(arg0: list[Union[float, int]]) -> list[float]"
     )
     # Tuple<T, T>
     assert (
@@ -1246,15 +1246,17 @@ def test_arg_return_type_hints(doc):
         == "identity_iterator(arg0: Iterator[Union[float, int]]) -> Iterator[float]"
     )
     # Callable<R(A)>
-    assert (
-        doc(m.apply_callable)
-        == "apply_callable(arg0: Union[float, int], arg1: Callable[[Union[float, int]], float]) -> float"
-    )
+    # TODO: Needs support for arg/return environments
+    # assert (
+    # doc(m.apply_callable)
+    # == "apply_callable(arg0: Union[float, int], arg1: Callable[[Union[float, int]], float]) -> float"
+    # )
     # Callable<R(...)>
-    assert (
-        doc(m.apply_callable_ellipsis)
-        == "apply_callable_ellipsis(arg0: Union[float, int], arg1: Callable[..., float]) -> float"
-    )
+    # TODO: Needs support for arg/return environments
+    # assert (
+    # doc(m.apply_callable_ellipsis)
+    # == "apply_callable_ellipsis(arg0: Union[float, int], arg1: Callable[..., float]) -> float"
+    # )
     # Union<T1, T2>
     assert (
         doc(m.identity_union)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1066,8 +1066,16 @@ def test_literal(doc):
         == 'identity_literal_curly_close(arg0: Literal["}"]) -> Literal["}"]'
     )
     assert (
+        doc(m.identity_literal_arrow)
+        == 'identity_literal_arrow(arg0: Literal["->"]) -> Literal["->"]'
+    )
+    assert (
+        doc(m.identity_literal_arrow_with_callable)
+        == 'identity_literal_arrow_with_callable(arg0: Callable[[Literal["->"], Union[float, int]], float]) -> Callable[[Literal["->"], Union[float, int]], float]'
+    )
+    assert (
         doc(m.identity_literal_all_special_chars)
-        == 'identity_literal_all_special_chars(arg0: Literal["!@!!{%}"]) -> Literal["!@!!{%}"]'
+        == 'identity_literal_all_special_chars(arg0: Literal["!@!!->{%}"]) -> Literal["!@!!->{%}"]'
     )
 
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1044,7 +1044,7 @@ def test_literal(doc):
         doc(m.annotate_literal)
         == 'annotate_literal(arg0: Literal[26, 0x1A, "hello world", b"hello world", u"hello world", True, Color.RED, None]) -> object'
     )
-    # The characters !, @, %, and {} are used in the signature parser as special characters, but Literal should escape those for the parser to work.
+    # The characters !, @, %, {, } and -> are used in the signature parser as special characters, but Literal should escape those for the parser to work.
     assert (
         doc(m.identity_literal_exclamation)
         == 'identity_literal_exclamation(arg0: Literal["!"]) -> Literal["!"]'

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1252,18 +1252,26 @@ def test_arg_return_type_hints(doc):
         doc(m.identity_iterator)
         == "identity_iterator(arg0: Iterator[Union[float, int]]) -> Iterator[float]"
     )
+    # Callable<R(A)> identity
+    assert (
+        doc(m.identity_callable)
+        == "identity_callable(arg0: Callable[[Union[float, int]], float]) -> Callable[[Union[float, int]], float]"
+    )
+    # Callable<R(...)> identity
+    assert (
+        doc(m.identity_callable_ellipsis)
+        == "identity_callable_ellipsis(arg0: Callable[..., float]) -> Callable[..., float]"
+    )
     # Callable<R(A)>
-    # TODO: Needs support for arg/return environments
-    # assert (
-    # doc(m.apply_callable)
-    # == "apply_callable(arg0: Union[float, int], arg1: Callable[[Union[float, int]], float]) -> float"
-    # )
+    assert (
+        doc(m.apply_callable)
+        == "apply_callable(arg0: Union[float, int], arg1: Callable[[Union[float, int]], float]) -> float"
+    )
     # Callable<R(...)>
-    # TODO: Needs support for arg/return environments
-    # assert (
-    # doc(m.apply_callable_ellipsis)
-    # == "apply_callable_ellipsis(arg0: Union[float, int], arg1: Callable[..., float]) -> float"
-    # )
+    assert (
+        doc(m.apply_callable_ellipsis)
+        == "apply_callable_ellipsis(arg0: Union[float, int], arg1: Callable[..., float]) -> float"
+    )
     # Union<T1, T2>
     assert (
         doc(m.identity_union)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1066,8 +1066,8 @@ def test_literal(doc):
         == 'identity_literal_curly_close(arg0: Literal["}"]) -> Literal["}"]'
     )
     assert (
-        doc(m.identity_literal_arrow)
-        == 'identity_literal_arrow(arg0: Literal["->"]) -> Literal["->"]'
+        doc(m.identity_literal_arrow_with_io_name)
+        == 'identity_literal_arrow_with_io_name(arg0: Literal["->"], arg1: Union[float, int]) -> Literal["->"]'
     )
     assert (
         doc(m.identity_literal_arrow_with_callable)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1295,28 +1295,27 @@ def test_arg_return_type_hints(doc):
     # TypeIs<T>
     assert doc(m.check_type_is) == "check_type_is(arg0: object) -> TypeIs[float]"
     # Literal without special characters
-    # assert (
-    # doc(m.identity_literal_x)
-    # == 'identity_literal_x(arg0: Literal["x"]) -> Literal["x"]'
-    # )
-    # The Following tests fail with `ImportError: Internal error while parsing type signature (2)`
+    assert (
+        doc(m.identity_literal_x)
+        == 'identity_literal_x(arg0: Literal["x"]) -> Literal["x"]'
+    )
     # Literal with @
-    # assert (
-    # doc(m.identity_literal_at)
-    # == 'identity_literal_at(arg0: Literal["@"]) -> Literal["@"]'
-    # )
+    assert (
+        doc(m.identity_literal_at)
+        == 'identity_literal_at(arg0: Literal["@"]) -> Literal["@"]'
+    )
     # Literal with %
-    # assert (
-    # doc(m.identity_literal_percent)
-    # == 'identity_literal_percent(arg0: Literal["%"]) -> Literal["%"]'
-    # )
+    assert (
+        doc(m.identity_literal_percent)
+        == 'identity_literal_percent(arg0: Literal["%"]) -> Literal["%"]'
+    )
     # Literal with {
-    # assert (
-    # doc(m.identity_literal_curly_open)
-    # == 'identity_literal_curly_open(arg0: Literal["{"]) -> Literal["{"]'
-    # )
+    assert (
+        doc(m.identity_literal_curly_open)
+        == 'identity_literal_curly_open(arg0: Literal["{"]) -> Literal["{"]'
+    )
     # Literal with }
-    # assert (
-    # doc(m.identity_literal_curly_close)
-    # == 'identity_literal_curly_close(arg0: Literal["}"]) -> Literal["}"]'
-    # )
+    assert (
+        doc(m.identity_literal_curly_close)
+        == 'identity_literal_curly_close(arg0: Literal["}"]) -> Literal["}"]'
+    )

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1195,6 +1195,13 @@ def test_final_annotation() -> None:
 
 def test_arg_return_type_hints(doc):
     assert doc(m.half_of_number) == "half_of_number(arg0: Union[float, int]) -> float"
+    assert (
+        doc(m.half_of_number_convert)
+        == "half_of_number_convert(x: Union[float, int]) -> float"
+    )
+    assert (
+        doc(m.half_of_number_noconvert) == "half_of_number_noconvert(x: float) -> float"
+    )
     assert m.half_of_number(2.0) == 1.0
     assert m.half_of_number(2) == 1.0
     assert m.half_of_number(0) == 0

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1262,6 +1262,11 @@ def test_arg_return_type_hints(doc):
         doc(m.identity_callable_ellipsis)
         == "identity_callable_ellipsis(arg0: Callable[..., float]) -> Callable[..., float]"
     )
+    # Nested Callable<R(A)> identity
+    assert (
+        doc(m.identity_nested_callable)
+        == "identity_nested_callable(arg0: Callable[[Callable[[Union[float, int]], float]], Callable[[Union[float, int]], float]]) -> Callable[[Callable[[Union[float, int]], float]], Callable[[Union[float, int]], float]]"
+    )
     # Callable<R(A)>
     assert (
         doc(m.apply_callable)

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -265,19 +265,19 @@ def test_fs_path(doc):
     assert m.parent_path(PseudoBytesPath()) == Path("foo")
     assert (
         doc(m.parent_path)
-        == "parent_path(arg0: Union[os.PathLike, str, bytes]) -> Path"
+        == "parent_path(arg0: Union[os.PathLike, str, bytes]) -> pathlib.Path"
     )
     # std::vector
     assert m.parent_paths(["foo/bar", "foo/baz"]) == [Path("foo"), Path("foo")]
     assert (
         doc(m.parent_paths)
-        == "parent_paths(arg0: list[Union[os.PathLike, str, bytes]]) -> list[Path]"
+        == "parent_paths(arg0: list[Union[os.PathLike, str, bytes]]) -> list[pathlib.Path]"
     )
     # py::typing::List
     assert m.parent_paths_list(["foo/bar", "foo/baz"]) == [Path("foo"), Path("foo")]
     assert (
         doc(m.parent_paths_list)
-        == "parent_paths_list(arg0: list[Union[os.PathLike, str, bytes]]) -> list[Path]"
+        == "parent_paths_list(arg0: list[Union[os.PathLike, str, bytes]]) -> list[pathlib.Path]"
     )
     # Nested py::typing::List
     assert m.parent_paths_nested_list([["foo/bar"], ["foo/baz", "foo/buzz"]]) == [
@@ -286,13 +286,13 @@ def test_fs_path(doc):
     ]
     assert (
         doc(m.parent_paths_nested_list)
-        == "parent_paths_nested_list(arg0: list[list[Union[os.PathLike, str, bytes]]]) -> list[list[Path]]"
+        == "parent_paths_nested_list(arg0: list[list[Union[os.PathLike, str, bytes]]]) -> list[list[pathlib.Path]]"
     )
     # py::typing::Tuple
     assert m.parent_paths_tuple(("foo/bar", "foo/baz")) == (Path("foo"), Path("foo"))
     assert (
         doc(m.parent_paths_tuple)
-        == "parent_paths_tuple(arg0: tuple[Union[os.PathLike, str, bytes], Union[os.PathLike, str, bytes]]) -> tuple[Path, Path]"
+        == "parent_paths_tuple(arg0: tuple[Union[os.PathLike, str, bytes], Union[os.PathLike, str, bytes]]) -> tuple[pathlib.Path, pathlib.Path]"
     )
     # py::typing::Dict
     assert m.parent_paths_dict(
@@ -308,7 +308,7 @@ def test_fs_path(doc):
     }
     assert (
         doc(m.parent_paths_dict)
-        == "parent_paths_dict(arg0: dict[str, Union[os.PathLike, str, bytes]]) -> dict[str, Path]"
+        == "parent_paths_dict(arg0: dict[str, Union[os.PathLike, str, bytes]]) -> dict[str, pathlib.Path]"
     )
 
 

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -267,11 +267,11 @@ def test_fs_path(doc):
         doc(m.parent_path)
         == "parent_path(arg0: Union[os.PathLike, str, bytes]) -> Path"
     )
-    # std::vector should use name (for arg_name/return_name typing classes must be used)
+    # std::vector
     assert m.parent_paths(["foo/bar", "foo/baz"]) == [Path("foo"), Path("foo")]
     assert (
         doc(m.parent_paths)
-        == "parent_paths(arg0: list[os.PathLike]) -> list[os.PathLike]"
+        == "parent_paths(arg0: list[Union[os.PathLike, str, bytes]]) -> list[Path]"
     )
     # py::typing::List
     assert m.parent_paths_list(["foo/bar", "foo/baz"]) == [Path("foo"), Path("foo")]


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
While working on improving type hints for Eigen/numpy, I found that with the current solution from #5450 it is not possible to have the type hints be influenced by the `py::arg().noconvert()` option.
Certain Eigen types offer to be loaded from anything `np.array()` accepts which would fit to `np.typing.ArrayLike`.
With `.noconvert()` however, only instances of numpy arrays are accepted, which would fit `np.typing.NDArray[<dtype>]`.
It would be nice if `.noconvert()` would force using the return type (which is the more specific type).

Meanwhile, I found that nanobind implements a similar arg/return type hint system using `io_name`.
This system inserts `@arg-type@return-type@` using `@` as a special character, which is evaluated in a later signature parsing stage.
At this stage, the `.noconvert()` info is available, and I was able to implement it similarly.

Additionally, I added `arg_descr` and `return_descr` to force using arg or return type hints.
This is useful for correctly type hinting `typing::Callable`.
The current implementation in this PR does not allow nested Callables (e.g., Callable that has a Callable as argument), but I will add support for that later this week (requires using a stack container to track nested `arg_descr`/`return_descr`).
(See 077d0b6507f310bf9ec0c83c8066ef937e157181)

Finally, I found bugs when using `typing::Literal` with certain special characters:
Currently, `%`, `{`, `}` fail with `ImportError: Internal error while parsing type signature (2)`.
With this PR, the added special character `@` fails as well when used in a Literal.
I will try to find a solution for that later this week as well.
(See 9877aca5352d3875f6b5918c89816750573df611)

This also fixes #5477 by using `pathlib.Path` instead of `Path`.
(See 9d0766c61acee8b1dfc593ae6f1db2cffc8c9e92)

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Rework of arg/return type hints to support .noconvert()
```

<!-- If the upgrade guide needs updating, note that here too -->

## Open issues:
* [x] Nested `arg_descr`/`return_descr` do not work (require tracking using a Stack)
* [x] Special characters in `typing.Literal` fail (`%`, `{`, `}`, `@`)
* [x] Fix usage of auto return type deduction (not supported in C++11)
* [x] Fix clang-tidy issues

## Relevant nanobind code
This PR is based on the following code in nanobind:

https://github.com/wjakob/nanobind/blob/698f449a207e321b364278ff68f0b161127fd3a0/include/nanobind/nb_descr.h#L81-L86

https://github.com/wjakob/nanobind/blob/698f449a207e321b364278ff68f0b161127fd3a0/src/nb_func.cpp#L1018-L1234