### PR TITLE
Added 'bind_set(...)' to stl_binds

### DIFF
--- a/tests/test_stl_binders.cpp
+++ b/tests/test_stl_binders.cpp
@@ -14,6 +14,7 @@
 
 #include <deque>
 #include <map>
+#include <set>
 #include <unordered_map>
 #include <vector>
 
@@ -182,6 +183,9 @@ TEST_SUBMODULE(stl_binders, m) {
     py::class_<El>(m, "El").def(py::init<int>());
     py::bind_vector<std::vector<El>>(m, "VectorEl");
     py::bind_vector<std::vector<std::vector<El>>>(m, "VectorVectorEl");
+
+    // test_set_int
+    py::bind_set<std::set<int>>(m, "SetInt");
 
     // test_map_string_double
     py::bind_map<std::map<std::string, double>>(m, "MapStringDouble");

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -149,6 +149,29 @@ def test_vector_custom():
     assert str(vv_b) == "VectorEl[El{1}, El{2}]"
 
 
+def test_set_int():
+    s_a = m.SetInt()
+    s_b = m.SetInt()
+
+    assert len(s_a) == 0
+    assert s_a == s_b
+
+    s_a.add(1)
+
+    assert 1 in s_a
+    assert str(s_a) == "SetInt{1}"
+    assert s_a != s_b
+
+    for i in range(5):
+        s_a.add(i)
+
+    assert sorted(s_a) == [0, 1, 2, 3, 4]
+
+    s_a.clear()
+    assert len(s_a) == 0
+    assert str(s_a) == "SetInt{}"
+
+
 def test_map_string_double():
     mm = m.MapStringDouble()
     mm["a"] = 1


### PR DESCRIPTION
Added 'bind_set(...)' to stl_binds

## Description

Based off the existing `bind_vector(...)` impl., proposal is to add binding code for sets to `stl_bind.h`. Basic functionality to add/clear/remove from the set, query its size, etc. is added.

## Suggested changelog entry:

```rst
Added 'bind_set(...)' to stl_bind.h
```