### PR TITLE
Fix data race when using shared variables (free threading)

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -312,8 +312,8 @@ inline void traverse_offset_bases(void *valueptr,
     }
 }
 
-static inline void enable_try_inc_ref(PyObject *op) {
 #ifdef Py_GIL_DISABLED
+static inline void enable_try_inc_ref(PyObject *op) {
     // TODO: Replace with PyUnstable_Object_EnableTryIncRef when available.
     // See https://github.com/python/cpython/issues/128844
     if (_Py_IsImmortal(op)) {
@@ -330,11 +330,13 @@ static inline void enable_try_inc_ref(PyObject *op) {
             return;
         }
     }
-#endif
 }
+#endif
 
 inline bool register_instance_impl(void *ptr, instance *self) {
+#ifdef Py_GIL_DISABLED
     enable_try_inc_ref((PyObject *) self);
+#endif
     with_instance_map(ptr, [&](instance_map &instances) { instances.emplace(ptr, self); });
     return true; // unused, but gives the same signature as the deregister func
 }

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -292,7 +292,7 @@ PYBIND11_NOINLINE handle find_registered_python_instance(void *src,
         for (auto it_i = it_instances.first; it_i != it_instances.second; ++it_i) {
             for (auto *instance_type : detail::all_type_info(Py_TYPE(it_i->second))) {
                 if (instance_type && same_type(*instance_type->cpptype, *tinfo->cpptype)) {
-                    PyObject *wrapper = (PyObject *) it_i->second;
+                    auto *wrapper = reinterpret_cast<PyObject *>(it_i->second);
                     if (try_incref(wrapper)) {
                         return handle(wrapper);
                     }

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -241,6 +241,49 @@ PYBIND11_NOINLINE handle get_type_handle(const std::type_info &tp, bool throw_if
     return handle(type_info ? ((PyObject *) type_info->type) : nullptr);
 }
 
+inline bool try_incref(PyObject *obj) {
+    // Tries to increment the reference count of an object if it's not zero.
+    // TODO: Use PyUnstable_TryIncref when available.
+    // See https://github.com/python/cpython/issues/128844
+#ifdef Py_GIL_DISABLED
+    // See https://github.com/python/cpython/blob/d05140f9f77d7dfc753dd1e5ac3a5962aaa03eff/Include/internal/pycore_object.h#L761
+    uint32_t local = _Py_atomic_load_uint32_relaxed(&obj->ob_ref_local);
+    local += 1;
+    if (local == 0) {
+        // immortal
+        return true;
+    }
+    if (_Py_IsOwnedByCurrentThread(obj)) {
+        _Py_atomic_store_uint32_relaxed(&obj->ob_ref_local, local);
+#ifdef Py_REF_DEBUG
+        _Py_INCREF_IncRefTotal();
+#endif
+        return true;
+    }
+    Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&obj->ob_ref_shared);
+    for (;;) {
+        // If the shared refcount is zero and the object is either merged
+        // or may not have weak references, then we cannot incref it.
+        if (shared == 0 || shared == _Py_REF_MERGED) {
+            return false;
+        }
+
+        if (_Py_atomic_compare_exchange_ssize(
+                &obj->ob_ref_shared,
+                &shared,
+                shared + (1 << _Py_REF_SHARED_SHIFT))) {
+#ifdef Py_REF_DEBUG
+            _Py_INCREF_IncRefTotal();
+#endif
+            return true;
+        }
+    }
+#else
+    assert(Py_REFCNT(obj) > 0);
+    Py_INCREF(obj);
+#endif
+}
+
 // Searches the inheritance graph for a registered Python instance, using all_type_info().
 PYBIND11_NOINLINE handle find_registered_python_instance(void *src,
                                                          const detail::type_info *tinfo) {
@@ -249,7 +292,10 @@ PYBIND11_NOINLINE handle find_registered_python_instance(void *src,
         for (auto it_i = it_instances.first; it_i != it_instances.second; ++it_i) {
             for (auto *instance_type : detail::all_type_info(Py_TYPE(it_i->second))) {
                 if (instance_type && same_type(*instance_type->cpptype, *tinfo->cpptype)) {
-                    return handle((PyObject *) it_i->second).inc_ref();
+                    PyObject *wrapper = (PyObject *) it_i->second;
+                    if (try_incref(wrapper)) {
+                        return handle(wrapper);
+                    }
                 }
             }
         }

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -246,7 +246,8 @@ inline bool try_incref(PyObject *obj) {
     // TODO: Use PyUnstable_TryIncref when available.
     // See https://github.com/python/cpython/issues/128844
 #ifdef Py_GIL_DISABLED
-    // See https://github.com/python/cpython/blob/d05140f9f77d7dfc753dd1e5ac3a5962aaa03eff/Include/internal/pycore_object.h#L761
+    // See
+    // https://github.com/python/cpython/blob/d05140f9f77d7dfc753dd1e5ac3a5962aaa03eff/Include/internal/pycore_object.h#L761
     uint32_t local = _Py_atomic_load_uint32_relaxed(&obj->ob_ref_local);
     local += 1;
     if (local == 0) {
@@ -255,9 +256,9 @@ inline bool try_incref(PyObject *obj) {
     }
     if (_Py_IsOwnedByCurrentThread(obj)) {
         _Py_atomic_store_uint32_relaxed(&obj->ob_ref_local, local);
-#ifdef Py_REF_DEBUG
+#    ifdef Py_REF_DEBUG
         _Py_INCREF_IncRefTotal();
-#endif
+#    endif
         return true;
     }
     Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&obj->ob_ref_shared);
@@ -269,12 +270,10 @@ inline bool try_incref(PyObject *obj) {
         }
 
         if (_Py_atomic_compare_exchange_ssize(
-                &obj->ob_ref_shared,
-                &shared,
-                shared + (1 << _Py_REF_SHARED_SHIFT))) {
-#ifdef Py_REF_DEBUG
+                &obj->ob_ref_shared, &shared, shared + (1 << _Py_REF_SHARED_SHIFT))) {
+#    ifdef Py_REF_DEBUG
             _Py_INCREF_IncRefTotal();
-#endif
+#    endif
             return true;
         }
     }

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -280,6 +280,7 @@ inline bool try_incref(PyObject *obj) {
 #else
     assert(Py_REFCNT(obj) > 0);
     Py_INCREF(obj);
+    return true;
 #endif
 }
 

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -29,7 +29,7 @@ struct IntStruct {
 };
 
 struct EmptyStruct {};
-static EmptyStruct SharedInstance;
+EmptyStruct SharedInstance;
 
 } // namespace
 

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -28,6 +28,9 @@ struct IntStruct {
     int value;
 };
 
+struct EmptyStruct {};
+static EmptyStruct SharedInstance;
+
 } // namespace
 
 TEST_SUBMODULE(thread, m) {
@@ -60,6 +63,9 @@ TEST_SUBMODULE(thread, m) {
             }
         },
         py::call_guard<py::gil_scoped_release>());
+
+    py::class_<EmptyStruct>(m, "EmptyStruct")
+        .def_readonly_static("SharedInstance", &SharedInstance);
 
     // NOTE: std::string_view also uses loader_life_support to ensure that
     // the string contents remain alive, but that's a C++ 17 feature.

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -57,9 +57,7 @@ def test_bind_shared_instance():
     def access_shared_instance():
         b.wait()
         for _ in range(1000):
-            # assign to local variable to make ruff happy
-            x = m.EmptyStruct.SharedInstance
-            del x
+            m.EmptyStruct.SharedInstance  # noqa: B018
 
     threads = [
         threading.Thread(target=access_shared_instance) for _ in range(nb_threads)

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -47,3 +47,21 @@ def test_implicit_conversion_no_gil():
         x.start()
     for x in [c, b, a]:
         x.join()
+
+
+@pytest.mark.skipif(sys.platform.startswith("emscripten"), reason="Requires threads")
+def test_bind_shared_instance():
+    nb_threads = 4
+    b = threading.Barrier(nb_threads)
+
+    def access_shared_instance():
+        b.wait()
+        for _ in range(1000):
+            x = m.EmptyStruct.SharedInstance
+            del x
+
+    threads = [threading.Thread(target=access_shared_instance) for _ in range(nb_threads)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -60,7 +60,9 @@ def test_bind_shared_instance():
             x = m.EmptyStruct.SharedInstance
             del x
 
-    threads = [threading.Thread(target=access_shared_instance) for _ in range(nb_threads)]
+    threads = [
+        threading.Thread(target=access_shared_instance) for _ in range(nb_threads)
+    ]
     for thread in threads:
         thread.start()
     for thread in threads:

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -57,7 +57,9 @@ def test_bind_shared_instance():
     def access_shared_instance():
         b.wait()
         for _ in range(1000):
-            m.EmptyStruct.SharedInstance
+            # assign to local variable to make clang-tidy happy
+            x = m.EmptyStruct.SharedInstance
+            del x
 
     threads = [
         threading.Thread(target=access_shared_instance) for _ in range(nb_threads)

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -57,7 +57,7 @@ def test_bind_shared_instance():
     def access_shared_instance():
         b.wait()
         for _ in range(1000):
-            # assign to local variable to make clang-tidy happy
+            # assign to local variable to make ruff happy
             x = m.EmptyStruct.SharedInstance
             del x
 

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -57,8 +57,7 @@ def test_bind_shared_instance():
     def access_shared_instance():
         b.wait()
         for _ in range(1000):
-            x = m.EmptyStruct.SharedInstance
-            del x
+            m.EmptyStruct.SharedInstance
 
     threads = [
         threading.Thread(target=access_shared_instance) for _ in range(nb_threads)


### PR DESCRIPTION
## Description

In the free threading build, there's a race between wrapper re-use and wrapper deallocation. This can happen with a static variable accessed by multiple threads.

Fixing this requires using some private CPython APIs: _Py_TryIncref and _PyObject_SetMaybeWeakref. The implementations of these functions are included until they're made available as public ("unstable") APIs.

Fixes #5489

## Suggested changelog entry:

```rst
Fix data race in free threaded CPython when accessing a shared static variable.
```
