### PR TITLE
chore(cmake): Add an author warning that auto-calculated `PYTHON_MODULE_EXTENSION` may not respect `SETUPTOOLS_EXT_SUFFIX` during cross-compilation

### DIFF
--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -200,6 +200,16 @@ if(PYBIND11_PYTHONLIBS_OVERWRITE OR NOT DEFINED PYTHON_MODULE_DEBUG_POSTFIX)
 endif()
 if(PYBIND11_PYTHONLIBS_OVERWRITE OR NOT DEFINED PYTHON_MODULE_EXTENSION)
   get_filename_component(PYTHON_MODULE_EXTENSION "${_PYTHON_MODULE_EXT_SUFFIX}" EXT)
+  if((NOT "$ENV{SETUPTOOLS_EXT_SUFFIX}" STREQUAL "") AND (NOT "$ENV{SETUPTOOLS_EXT_SUFFIX}"
+                                                          STREQUAL "${PYTHON_MODULE_EXTENSION}"))
+    message(
+      AUTHOR_WARNING,
+      "SETUPTOOLS_EXT_SUFFIX is set to \"$ENV{SETUPTOOLS_EXT_SUFFIX}\", "
+      "but the auto-calculated Python extension suffix is \"${PYTHON_MODULE_EXTENSION}\". "
+      "This may cause problems when importing the Python extensions. "
+      "If you are using cross-compiling Python, you may need to "
+      "set PYTHON_MODULE_EXTENSION manually.")
+  endif()
 endif()
 
 # Make sure the Python has the same pointer-size as the chosen compiler

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -171,6 +171,16 @@ if(NOT _PYBIND11_CROSSCOMPILING)
       set(PYTHON_MODULE_EXTENSION
           "${_PYTHON_MODULE_EXTENSION}"
           CACHE INTERNAL "")
+      if((NOT "$ENV{SETUPTOOLS_EXT_SUFFIX}" STREQUAL "")
+         AND (NOT "$ENV{SETUPTOOLS_EXT_SUFFIX}" STREQUAL "${PYTHON_MODULE_EXTENSION}"))
+        message(
+          AUTHOR_WARNING,
+          "SETUPTOOLS_EXT_SUFFIX is set to \"$ENV{SETUPTOOLS_EXT_SUFFIX}\", "
+          "but the auto-calculated Python extension suffix is \"${PYTHON_MODULE_EXTENSION}\". "
+          "This may cause problems when importing the Python extensions. "
+          "If you are using cross-compiling Python, you may need to "
+          "set PYTHON_MODULE_EXTENSION manually.")
+      endif()
     endif()
   endif()
 else()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

During cross-compilation, the variable `PYTHON_MODULE_EXTENSION` is calculated via the host Python interpreter rather than the target Python. For example, the build host is x64 Python and the target is ARM64, the calculated `PYTHON_MODULE_EXTENSION` will be `.cpXY-win_amd64.pxd` rather than `.cpXY-win_arm64.pxd`. See also:

- https://github.com/metaopt/optree/issues/182#issuecomment-2589853703

This PR adds an author warning to prompt the developer to set `PYTHON_MODULE_EXTENSION` manually during cross-compilation.

Maybe related:

- #3640

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Add an author warning that auto-calculated `PYTHON_MODULE_EXTENSION` may not respect `SETUPTOOLS_EXT_SUFFIX` during cross-compilation
```

<!-- If the upgrade guide needs updating, note that here too -->
