### PR TITLE
PyPy 3.11 does not implement Py_TPFLAGS_MANAGED_DICT

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -574,7 +574,7 @@ extern "C" inline int pybind11_clear(PyObject *self) {
 inline void enable_dynamic_attributes(PyHeapTypeObject *heap_type) {
     auto *type = &heap_type->ht_type;
     type->tp_flags |= Py_TPFLAGS_HAVE_GC;
-#if PY_VERSION_HEX < 0x030B0000
+#if PY_VERSION_HEX < 0x030B0000 || defined(PYPY_VERSION)
     type->tp_dictoffset = type->tp_basicsize;           // place dict at the end
     type->tp_basicsize += (ssize_t) sizeof(PyObject *); // and allocate enough space for it
 #else

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -575,8 +575,8 @@ inline void enable_dynamic_attributes(PyHeapTypeObject *heap_type) {
     auto *type = &heap_type->ht_type;
     type->tp_flags |= Py_TPFLAGS_HAVE_GC;
 #if PY_VERSION_HEX < 0x030B0000 || defined(PYPY_VERSION) // For PyPy see PR #5508
-    type->tp_dictoffset = type->tp_basicsize;           // place dict at the end
-    type->tp_basicsize += (ssize_t) sizeof(PyObject *); // and allocate enough space for it
+    type->tp_dictoffset = type->tp_basicsize;            // place dict at the end
+    type->tp_basicsize += (ssize_t) sizeof(PyObject *);  // and allocate enough space for it
 #else
     type->tp_flags |= Py_TPFLAGS_MANAGED_DICT;
 #endif

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -574,7 +574,7 @@ extern "C" inline int pybind11_clear(PyObject *self) {
 inline void enable_dynamic_attributes(PyHeapTypeObject *heap_type) {
     auto *type = &heap_type->ht_type;
     type->tp_flags |= Py_TPFLAGS_HAVE_GC;
-#if PY_VERSION_HEX < 0x030B0000 || defined(PYPY_VERSION)
+#if PY_VERSION_HEX < 0x030B0000 || defined(PYPY_VERSION) // For PyPy see PR #5508
     type->tp_dictoffset = type->tp_basicsize;           // place dict at the end
     type->tp_basicsize += (ssize_t) sizeof(PyObject *); // and allocate enough space for it
 #else


### PR DESCRIPTION
## Description

PyPy support for Python 3.11 is almost ready for release. The new `Py_TPFLAGS_MANAGED_DICT` is an implementation detail, and PyPy has not yet implemented support for it, see https://github.com/pypy/pypy/issues/5125. I am testing pybind11 via a [weekly cron job](https://github.com/pypy/binary-testing/actions/runs/13094872721) and noticed the failure there. Where would be a good place to add a CI run of PyPy 3.11, which has not been released yet, here?

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Support PyPy3.11
```

<!-- If the upgrade guide needs updating, note that here too -->
