### PR TITLE
Make `PYBIND11_INTERNALS_VERSION 6` the default on all platforms.

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -37,22 +37,14 @@
 /// further ABI-incompatible changes may be made before the ABI is officially
 /// changed to the new version.
 #ifndef PYBIND11_INTERNALS_VERSION
-#    if PY_VERSION_HEX >= 0x030C0000 || defined(_MSC_VER)
-// Version bump for Python 3.12+, before first 3.12 beta release.
-// Version bump for MSVC piggy-backed on PR #4779. See comments there.
-#        ifdef Py_GIL_DISABLED
-#            define PYBIND11_INTERNALS_VERSION 6
-#        else
-#            define PYBIND11_INTERNALS_VERSION 5
-#        endif
-#    else
-#        define PYBIND11_INTERNALS_VERSION 4
-#    endif
+#    define PYBIND11_INTERNALS_VERSION 6
 #endif
 
 // This requirement is mainly to reduce the support burden (see PR #4570).
 static_assert(PY_VERSION_HEX < 0x030C0000 || PYBIND11_INTERNALS_VERSION >= 5,
               "pybind11 ABI version 5 is the minimum for Python 3.12+");
+static_assert(PYBIND11_INTERNALS_VERSION >= 4,
+              "pybind11 ABI version 4 is the minimum for all platforms.");
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Make `PYBIND11_INTERNALS_VERSION 6` the default on all platforms.

Follow-on to `PYBIND11_PLATFORM_ABI_ID` modernizations under PRs #4953 and #5439.

Rationale for this PR:

* The `PYBIND11_PLATFORM_ABI_ID` modernizations under PRs 4953 and 5439 already created an **ABI break** (see below) in most situations. The only exception is when all of  the`PYBIND11_COMPILER_TYPE` `PYBIND11_STDLIB`, and `PYBIND11_BUILD_ABI` macros ([see here](https://github.com/pybind/pybind11/blob/8862cd4e7d44a78d061534223df11e586fc85847/include/pybind11/conduit/pybind11_platform_abi_id.h#L86-L87)) are overriden explicitly. — This is assumed to be rare.

* Standardizing on `PYBIND11_INTERNALS_VERSION 6` for all platforms is therefore assumed to cause few additional ABI breaks, but makes it much easier to reason about the pybind11 behavior, and it sets the stage for eventually purging old code:

* This PR intentionally does not remove the code for supporting `PYBIND11_INTERNALS_VERSION`s `4` and `5`. Therefore users can still override the default if necessary.

* After some transition period the code for supporting `PYBIND11_INTERNALS_VERSION`s `4` and `5` should be purged, especially because it is no longer exercised in the pybind11 GitHub Actions.

* Regarding the choice of version number for the next release: The ABI break is the only kind of break, and the additional features compared to the 2.13 release series are mostly incremental. Therefore @rwgk believes v2.14.0 is better as a version number than v3.0.0.

________

**ABI break**: Extensions built with e.g. pybind11 2.13 will not interoperate with extensions built with pybind11 2.14.

Note for completeness: PR #5296 greatly reduced the impact of changing the `PYBIND11_INTERNALS_VERSION` (see PR description there). The ABI break due to PRs #4953 and #5439 is quite likely the last major pybind11 ABI break.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
``PYBIND11_INTERNALS_VERSION 6`` is now the default on all platforms.
```

<!-- If the upgrade guide needs updating, note that here too -->
