### PR TITLE
Skip transient crash on GraalPy on OS X

### DIFF
--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -108,6 +108,10 @@ def test_nested_acquire():
 
 
 @pytest.mark.skipif(sys.platform.startswith("emscripten"), reason="Requires threads")
+@pytest.mark.skipif(
+    env.GRAALPY and sys.platform == "darwin",
+    reason="Transiently crashes on GraalPy on OS X",
+)
 def test_multi_acquire_release_cross_module():
     for bits in range(16 * 8):
         internals_ids = m.test_multi_acquire_release_cross_module(bits)


### PR DESCRIPTION
I could reproduce the failure even with an old revision of pybind11 and previous minor version of GraalPy, so my guess is that the problem could be due to an OS update. It seems to be isolated to this particular test, so I'd skip it for now.
