### PR TITLE
Add `release_gil_before_calling_cpp_dtor` annotation for `class_`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,6 +115,7 @@ set(PYBIND11_TEST_FILES
     test_callbacks
     test_chrono
     test_class
+    test_class_release_gil_before_calling_cpp_dtor
     test_const_name
     test_constants_and_functions
     test_copy_move

--- a/tests/test_class_release_gil_before_calling_cpp_dtor.cpp
+++ b/tests/test_class_release_gil_before_calling_cpp_dtor.cpp
@@ -10,9 +10,9 @@ namespace class_release_gil_before_calling_cpp_dtor {
 
 using RegistryType = std::unordered_map<std::string, int>;
 
-RegistryType &PyGILState_Check_Results() {
-    static auto *singleton = new RegistryType();
-    return *singleton;
+static RegistryType &PyGILState_Check_Results() {
+    static RegistryType singleton; // Local static variables have thread-safe initialization.
+    return singleton;
 }
 
 template <int> // Using int as a trick to easily generate a series of types.

--- a/tests/test_class_release_gil_before_calling_cpp_dtor.cpp
+++ b/tests/test_class_release_gil_before_calling_cpp_dtor.cpp
@@ -1,0 +1,53 @@
+#include <pybind11/pybind11.h>
+
+#include "pybind11_tests.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace pybind11_tests {
+namespace class_release_gil_before_calling_cpp_dtor {
+
+using RegistryType = std::unordered_map<std::string, int>;
+
+RegistryType &PyGILState_Check_Results() {
+    static auto *singleton = new RegistryType();
+    return *singleton;
+}
+
+template <int> // Using int as a trick to easily generate a series of types.
+struct ProbeType {
+private:
+    std::string unique_key;
+
+public:
+    explicit ProbeType(const std::string &unique_key) : unique_key{unique_key} {}
+
+    ~ProbeType() {
+        RegistryType &reg = PyGILState_Check_Results();
+        assert(reg.count(unique_key) == 0);
+        reg[unique_key] = PyGILState_Check();
+    }
+};
+
+} // namespace class_release_gil_before_calling_cpp_dtor
+} // namespace pybind11_tests
+
+TEST_SUBMODULE(class_release_gil_before_calling_cpp_dtor, m) {
+    using namespace pybind11_tests::class_release_gil_before_calling_cpp_dtor;
+
+    py::class_<ProbeType<0>>(m, "ProbeType0").def(py::init<std::string>());
+
+    py::class_<ProbeType<1>>(m, "ProbeType1", py::release_gil_before_calling_cpp_dtor())
+        .def(py::init<std::string>());
+
+    m.def("PopPyGILState_Check_Result", [](const std::string &unique_key) -> std::string {
+        RegistryType &reg = PyGILState_Check_Results();
+        if (reg.count(unique_key) == 0) {
+            return "MISSING";
+        }
+        int res = reg[unique_key];
+        reg.erase(unique_key);
+        return std::to_string(res);
+    });
+}

--- a/tests/test_class_release_gil_before_calling_cpp_dtor.py
+++ b/tests/test_class_release_gil_before_calling_cpp_dtor.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import gc
+
+import pytest
+
+from pybind11_tests import class_release_gil_before_calling_cpp_dtor as m
+
+
+@pytest.mark.parametrize(
+    ("probe_type", "unique_key", "expected_result"),
+    [
+        (m.ProbeType0, "without_manipulating_gil", "1"),
+        (m.ProbeType1, "release_gil_before_calling_cpp_dtor", "0"),
+    ],
+)
+def test_gil_state_check_results(probe_type, unique_key, expected_result):
+    probe_type(unique_key)
+    gc.collect()
+    result = m.PopPyGILState_Check_Result(unique_key)
+    assert result == expected_result


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Closes #1446.

This PR is a backport of:

* https://github.com/google/pybind11clif/pull/30088 (main PR)
* https://github.com/google/pybind11clif/pull/30092 (minor fixes)

It introduces the `py::release_gil_before_calling_cpp_dtor` option (`py::class_` argument). For background, see the description of google/pybind11clif#30088 and #1446.

* The core change (in pybind11.h `class_::dealloc()`) is to add ReleaseGIL-`try`-`catch`-ReaquireGIL-rethrow logic around the existing code calling the C++ destructor of wrapped objects.

* All the rest is more-or-less boilerplate code to add the `py:: release_gil_before_calling_cpp_dtor` annotation, then use it to enable the new feature if that annotation is provided by the user.
________

Note for completeness:

These are identical to the current versions on the [pybind11clif main branch @ commit 4841661](https://github.com/google/pybind11clif/tree/4841661df5daf26ecdedaace54e64d0782e63f64):

* test_class_release_gil_before_calling_cpp_dtor.cpp
* test_class_release_gil_before_calling_cpp_dtor.py
________

@rainwoodman (original reviewer) for visibility.
________

<!-- Include relevant issues or PRs here, describe what changed and why -->

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
A ``py::release_gil_before_calling_cpp_dtor`` option (for ``py::class_``) was added to resolve the long-standing issue #1446.
```

<!-- If the upgrade guide needs updating, note that here too -->
