### PR TITLE
Fix gcc compiler warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,9 +493,9 @@ jobs:
           - { gcc: 9, std: 20 }
           - { gcc: 10, std: 17 }
           - { gcc: 10, std: 20 }
-          - { gcc: 13, std: 20 }
+          - { gcc: 13, std: 20, cxx_flags: "-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls" }
 
-    name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }}• x64"
+    name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }} • x64${{ matrix.cxx_flags && ' • cxx_flags' || '' }}"
     container: "gcc:${{ matrix.gcc }}"
 
     steps:
@@ -517,6 +517,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+        -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}"
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,9 +330,10 @@ jobs:
             container_suffix: "-bullseye"
           - clang: 18
             std: 20
+            cxx_flags: "-Werror -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls"
             container_suffix: "-bookworm"
 
-    name: "🐍 3 • Clang ${{ matrix.clang }} • C++${{ matrix.std }} • x64"
+    name: "🐍 3 • Clang ${{ matrix.clang }} • C++${{ matrix.std }} • x64${{ matrix.cxx_flags && ' • cxx_flags' || '' }}"
     container: "silkeh/clang:${{ matrix.clang }}${{ matrix.container_suffix }}"
 
     steps:
@@ -348,6 +349,7 @@ jobs:
         -DPYBIND11_WERROR=ON
         -DDOWNLOAD_CATCH=ON
         -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+        -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}"
         -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
 
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       run: |
         uv pip install --python=python --system setuptools
         pytest tests/extra_setuptools
-      if: "!(matrix.runs-on == 'windows-2022')"
+      if: matrix.runs-on != 'windows-2022'
 
   manylinux:
     name: Manylinux on 🐍 3.13t • GIL

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -499,12 +499,12 @@ extern "C" inline void pybind11_object_dealloc(PyObject *self) {
     Py_DECREF(type);
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wredundant-decls"
+PYBIND11_WARNING_PUSH
+PYBIND11_WARNING_DISABLE_GCC("-Wredundant-decls")
 
 std::string error_string();
 
-#pragma GCC diagnostic pop
+PYBIND11_WARNING_POP
 
 /** Create the type which can be used as a common base for all classes.  This is
     needed in order to satisfy Python's requirements for multiple inheritance.

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -499,7 +499,12 @@ extern "C" inline void pybind11_object_dealloc(PyObject *self) {
     Py_DECREF(type);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wredundant-decls"
+
 std::string error_string();
+
+#pragma GCC diagnostic pop
 
 /** Create the type which can be used as a common base for all classes.  This is
     needed in order to satisfy Python's requirements for multiple inheritance.

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -173,9 +173,6 @@ inline int tp_init_impl(PyObject *, PyObject *, PyObject *) {
     // return -1; // Unreachable.
 }
 
-// The implementation needs the definition of `class cpp_function`.
-void tp_dealloc_impl(PyObject *self);
-
 inline void tp_free_impl(void *) {
     pybind11_fail("UNEXPECTED CALL OF function_record_PyTypeObject_methods::tp_free_impl");
 }

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -511,8 +511,13 @@ inline PyThreadState *get_thread_state_unchecked() {
 void keep_alive_impl(handle nurse, handle patient);
 inline PyObject *make_new_instance(PyTypeObject *type);
 
+PYBIND11_WARNING_PUSH
+PYBIND11_WARNING_DISABLE_GCC("-Wredundant-decls")
+
 // PYBIND11:REMINDER: Needs refactoring of existing pybind11 code.
 inline bool deregister_instance(instance *self, void *valptr, const type_info *tinfo);
+
+PYBIND11_WARNING_POP
 
 PYBIND11_NAMESPACE_BEGIN(smart_holder_type_caster_support)
 

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -32,8 +32,13 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wredundant-decls"
+
 // forward declarations
 PyThreadState *get_thread_state_unchecked();
+
+#pragma GCC diagnostic pop
 
 PYBIND11_NAMESPACE_END(detail)
 

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -32,13 +32,13 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wredundant-decls"
+PYBIND11_WARNING_PUSH
+PYBIND11_WARNING_DISABLE_GCC("-Wredundant-decls")
 
 // forward declarations
 PyThreadState *get_thread_state_unchecked();
 
-#pragma GCC diagnostic pop
+PYBIND11_WARNING_POP
 
 PYBIND11_NAMESPACE_END(detail)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -363,7 +363,7 @@ elseif(MSVC)
 else()
   file(
     WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-    "#include <filesystem>\nint main(int argc, char ** argv) {\n  std::filesystem::path p(argv[0]);\n  return p.string().length();\n}"
+    "#include <filesystem>\nint main(int /*argc*/, char ** argv) {\n  std::filesystem::path p(argv[0]);\n  return p.string().length();\n}"
   )
   try_compile(
     STD_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
## Description

Removed redundant declarations causing the following warnings (including `pybind11.h`):
```
In file included from pybind11/include/pybind11/cast.h:15,
                 from pybind11/include/pybind11/attr.h:14,
                 from pybind11/include/pybind11/detail/class.h:12,
                 from pybind11/include/pybind11/pybind11.h:12,
                 from include/py_binding_tools/ros_msg_typecasters.h:39,
                 from src/ros_msg_typecasters.cpp:37:
pybind11/include/pybind11/detail/type_caster_base.h:521:13: warning: redundant redeclaration of ‘bool pybind11::detail::deregister_instance(pybind11::detail::instance*, void*, const pybind11::detail::type_info*)’ in same scope [-Wredundant-decls]
  521 | inline bool deregister_instance(instance *self, void *valptr, const type_info *tinfo);
      |             ^~~~~~~~~~~~~~~~~~~
In file included from pybind11/include/pybind11/detail/type_caster_base.h:14,
                 from pybind11/include/pybind11/cast.h:15,
                 from pybind11/include/pybind11/attr.h:14,
                 from pybind11/include/pybind11/detail/class.h:12,
                 from pybind11/include/pybind11/pybind11.h:12,
                 from include/py_binding_tools/ros_msg_typecasters.h:39,
                 from src/ros_msg_typecasters.cpp:37:
pybind11/include/pybind11/trampoline_self_life_support.h:19:13: note: previous declaration of ‘bool pybind11::detail::deregister_instance(pybind11::detail::instance*, void*, const pybind11::detail::type_info*)’
   19 | inline bool deregister_instance(instance *self, void *valptr, const type_info *tinfo);
      |             ^~~~~~~~~~~~~~~~~~~
In file included from pybind11/include/pybind11/pybind11.h:12,
                 from include/py_binding_tools/ros_msg_typecasters.h:39,
                 from src/ros_msg_typecasters.cpp:37:
pybind11/include/pybind11/detail/class.h:502:13: warning: redundant redeclaration of ‘std::string pybind11::detail::error_string()’ in same scope [-Wredundant-decls]
  502 | std::string error_string();
      |             ^~~~~~~~~~~~
In file included from pybind11/include/pybind11/detail/internals.h:19,
                 from pybind11/include/pybind11/gil.h:17,
                 from pybind11/include/pybind11/detail/type_caster_base.h:12,
                 from pybind11/include/pybind11/cast.h:15,
                 from pybind11/include/pybind11/attr.h:14,
                 from pybind11/include/pybind11/detail/class.h:12,
                 from pybind11/include/pybind11/pybind11.h:12,
                 from include/py_binding_tools/ros_msg_typecasters.h:39,
                 from src/ros_msg_typecasters.cpp:37:
pybind11/include/pybind11/pytypes.h:743:20: note: previous declaration of ‘std::string pybind11::detail::error_string()’
  743 | inline std::string error_string() {
      |                    ^~~~~~~~~~~~
```


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Fix gcc compiler warnings
```

<!-- If the upgrade guide needs updating, note that here too -->
