### PR TITLE
[smart_holder] Disable internals version 4 when including smart_holder.h

### DIFF
--- a/include/pybind11/smart_holder.h
+++ b/include/pybind11/smart_holder.h
@@ -5,8 +5,11 @@
 #pragma once
 
 #include "pybind11.h"
-static_assert(PYBIND11_INTERNALS_VERSION == 106,
+
+#if !defined(PYBIND11_SMART_HOLDER_DISABLE)
+static_assert(PYBIND11_INTERNALS_VERSION >= 106,
               "pybind11 ABI version 106 is required for smart_holder functionality.");
+#endif
 
 // Legacy macros introduced with smart_holder_type_casters implementation in 2021.
 // Deprecated.

--- a/include/pybind11/smart_holder.h
+++ b/include/pybind11/smart_holder.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "pybind11.h"
+static_assert(PYBIND11_INTERNALS_VERSION >= 6,
+              "pybind11 ABI version 6 is required for smart_holder functionality.");
 
 // Legacy macros introduced with smart_holder_type_casters implementation in 2021.
 // Deprecated.

--- a/include/pybind11/smart_holder.h
+++ b/include/pybind11/smart_holder.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "pybind11.h"
-static_assert(PYBIND11_INTERNALS_VERSION >= 6,
-              "pybind11 ABI version 6 is required for smart_holder functionality.");
+static_assert(PYBIND11_INTERNALS_VERSION == 106,
+              "pybind11 ABI version 106 is required for smart_holder functionality.");
 
 // Legacy macros introduced with smart_holder_type_casters implementation in 2021.
 // Deprecated.


### PR DESCRIPTION
Building `smart_holder` branch w/o smart_holder support doesn't make sense and should be flagged early and clearly.