### PR TITLE
Improved reference_internal documentation

### DIFF
--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -81,9 +81,11 @@ The following table provides an overview of available policies:
 |                                                  | it is no longer used. Warning: undefined behavior will ensue when the C++  |
 |                                                  | side deletes an object that is still referenced and used by Python.        |
 +--------------------------------------------------+----------------------------------------------------------------------------+
-| :enum:`return_value_policy::reference_internal`  | Indicates that the lifetime of the return value is tied to the lifetime    |
-|                                                  | of a parent object, namely the implicit ``this``, or ``self`` argument of  |
-|                                                  | the called method or property. Internally, this policy works just like     |
+| :enum:`return_value_policy::reference_internal`  | If the return value is an lvalue reference or a pointer, the parent object |
+|                                                  | (the implicit ``this``, or ``self`` argument of the called method or       |
+|                                                  | property) is kept alive for at least the lifespan of the return value.     |
+|                                                  | Otherwise this policy falls back to the policy                             |
+|                                                  | :enum:`return_value_policy::move`. Internally, this policy works just like |
 |                                                  | :enum:`return_value_policy::reference` but additionally applies a          |
 |                                                  | ``keep_alive<0, 1>`` *call policy* (described in the next section) that    |
 |                                                  | prevents the parent object from being garbage collected as long as the     |

--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -84,8 +84,8 @@ The following table provides an overview of available policies:
 | :enum:`return_value_policy::reference_internal`  | If the return value is an lvalue reference or a pointer, the parent object |
 |                                                  | (the implicit ``this``, or ``self`` argument of the called method or       |
 |                                                  | property) is kept alive for at least the lifespan of the return value.     |
-|                                                  | Otherwise this policy falls back to the policy                             |
-|                                                  | :enum:`return_value_policy::move`. Internally, this policy works just like |
+|                                                  | **Otherwise this policy falls back to :enum:`return_value_policy::move`    |
+|                                                  | (see #5528).** Internally, this policy works just like                     |
 |                                                  | :enum:`return_value_policy::reference` but additionally applies a          |
 |                                                  | ``keep_alive<0, 1>`` *call policy* (described in the next section) that    |
 |                                                  | prevents the parent object from being garbage collected as long as the     |


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

The documentation for the reference_internal return policy implies that `py::keep_alive<0, 1>()` is always applied but this isn't true.

There is quite a bit of confusion about the reference_internal return policy (myself included) stemming from this documentation.

Here are the related issues I have found.
#1764
#2618
#4124
#4236
#5046

These changes:
1) Improve the wording of the reference_internal documentation to make it easier to understand.
2) Add a note about the policy falling back to move if the return value is not an lvalue reference or pointer.

As documented thoroughtly in #4236 and #5046 the `def_property` family does not honor the `keep_alive` argument passed to it and #2618 also mentions it does not honor the `call_guard` argument. I think these issues should be fixed but should it be documented here until it is? The workaround is to use `cpp_function` and add those arguments there.

Fixes #1764
Fixes #2618 
Fixes #4124

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Improved reference_internal documentation
```

<!-- If the upgrade guide needs updating, note that here too -->
