### PR TITLE
Start pybind11v3: Remove all code for `PYBIND11_INTERNALS_VERSION`s `4` and `5`

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -14,13 +14,13 @@
 #    error "PYTHON < 3.8 IS UNSUPPORTED. pybind11 v2.13 was the last to support Python 3.7."
 #endif
 
-#define PYBIND11_VERSION_MAJOR 2
-#define PYBIND11_VERSION_MINOR 14
+#define PYBIND11_VERSION_MAJOR 3
+#define PYBIND11_VERSION_MINOR 0
 #define PYBIND11_VERSION_PATCH 0.dev1
 
 // Similar to Python's convention: https://docs.python.org/3/c-api/apiabiversion.html
 // Additional convention: 0xD = dev
-#define PYBIND11_VERSION_HEX 0x020E00D1
+#define PYBIND11_VERSION_HEX 0x030000D1
 
 // Define some generic pybind11 helper macros for warning management.
 //

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -43,11 +43,7 @@ private:
 
     // Store stack pointer in thread-local storage.
     static PYBIND11_TLS_KEY_REF get_stack_tls_key() {
-#if PYBIND11_INTERNALS_VERSION == 4
-        return get_local_internals().loader_life_support_tls_key;
-#else
         return get_internals().loader_life_support_tls_key;
-#endif
     }
     static loader_life_support *get_stack_top() {
         return static_cast<loader_life_support *>(PYBIND11_TLS_GET_VALUE(get_stack_tls_key()));

--- a/pybind11/_version.py
+++ b/pybind11/_version.py
@@ -8,5 +8,5 @@ def _to_int(s: str) -> int | str:
         return s
 
 
-__version__ = "2.14.0.dev1"
+__version__ = "3.0.0.dev1"
 version_info = tuple(_to_int(s) for s in __version__.split("."))

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -269,12 +269,7 @@ TEST_SUBMODULE(callbacks, m) {
     rec_capsule.set_name(rec_capsule_name);
     m.add_object("custom_function", PyCFunction_New(custom_def, rec_capsule.ptr()));
 
-    // This test requires a new ABI version to pass
-#if PYBIND11_INTERNALS_VERSION > 4 && !defined(GRAALVM_PYTHON)
     // rec_capsule with nullptr name
     py::capsule rec_capsule2(std::malloc(1), [](void *data) { std::free(data); });
     m.add_object("custom_function2", PyCFunction_New(custom_def, rec_capsule2.ptr()));
-#else
-    m.add_object("custom_function2", py::none());
-#endif
 }

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -217,9 +217,6 @@ def test_custom_func():
     assert m.roundtrip(m.custom_function)(4) == 36
 
 
-@pytest.mark.skipif(
-    m.custom_function2 is None, reason="Current PYBIND11_INTERNALS_VERSION too low"
-)
 def test_custom_func2():
     assert m.custom_function2(3) == 27
     assert m.roundtrip(m.custom_function2)(3) == 27

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -217,6 +217,7 @@ def test_custom_func():
     assert m.roundtrip(m.custom_function)(4) == 36
 
 
+@pytest.mark.skipif("env.GRAALPY", reason="TODO debug segfault")
 def test_custom_func2():
     assert m.custom_function2(3) == 27
     assert m.roundtrip(m.custom_function2)(3) == 27

--- a/tests/test_unnamed_namespace_a.cpp
+++ b/tests/test_unnamed_namespace_a.cpp
@@ -10,7 +10,6 @@ TEST_SUBMODULE(unnamed_namespace_a, m) {
     } else {
         m.attr("unnamed_namespace_a_any_struct") = py::none();
     }
-    m.attr("PYBIND11_INTERNALS_VERSION") = PYBIND11_INTERNALS_VERSION;
     m.attr("defined_WIN32_or__WIN32") =
 #if defined(WIN32) || defined(_WIN32)
         true;

--- a/tests/test_unnamed_namespace_a.py
+++ b/tests/test_unnamed_namespace_a.py
@@ -5,13 +5,7 @@ import pytest
 from pybind11_tests import unnamed_namespace_a as m
 from pybind11_tests import unnamed_namespace_b as mb
 
-XFAIL_CONDITION = (
-    "(m.PYBIND11_INTERNALS_VERSION <= 4 and (m.defined___clang__ or not m.defined___GLIBCXX__))"
-    " or "
-    "(m.PYBIND11_INTERNALS_VERSION >= 5 and not m.defined_WIN32_or__WIN32"
-    " and "
-    "(m.defined___clang__ or m.defined__LIBCPP_VERSION))"
-)
+XFAIL_CONDITION = "not m.defined_WIN32_or__WIN32 and (m.defined___clang__ or m.defined__LIBCPP_VERSION)"
 XFAIL_REASON = "Known issues: https://github.com/pybind/pybind11/pull/4319"
 
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Bump pybind11 version to **v3.0.0dev1** and remove all code for `PYBIND11_INTERNALS_VERSION`s `4` and `5`.

This PR is meant to simplify merging the smart_holder branch: A very large number of `#ifdef PYBIND11_INTERNALS_VERSION > 6` (or similar) can be removed.

See also:

* https://github.com/pybind/pybind11/discussions/5524#discussioncomment-12227458
* PR #5529
* PR #5531

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
