### PR TITLE
Remove obsolete `"E501"` line in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ extend-select = [
   "N",           # pep8-naming
   "ARG",         # flake8-unused-arguments
   "C4",          # flake8-comprehensions
-  "E5",          # pycodestyle
   "EM",          # flake8-errmsg
   "ICN",         # flake8-import-conventions
   "PGH",         # pygrep-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ extend-select = [
   "N",           # pep8-naming
   "ARG",         # flake8-unused-arguments
   "C4",          # flake8-comprehensions
+  "E5",          # pycodestyle
   "EM",          # flake8-errmsg
   "ICN",         # flake8-import-conventions
   "PGH",         # pygrep-hooks
@@ -69,7 +70,6 @@ extend-select = [
 ]
 ignore = [
   "PLR",    # Design related pylint
-  "E501",   # Line too long (Black is enough)
   "PT011",  # Too broad with raises in pytest
   "SIM118", # iter(x) is not always the same as iter(x.keys())
 ]


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
With PR #4912 we removed black:

```diff
-# Black, the code formatter, natively supports pre-commit
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: "23.10.1" # Keep in sync with blacken-docs
-  hooks:
-  - id: black
```

So this isn't true anymore:

https://github.com/pybind/pybind11/blob/d8565ac7317b4838a08308170f5b9ba82d091546/pyproject.toml#L72

I tried to remove that line, but it doesn't make a difference, ruff doesn't produce the `E501` error. See dummy test case, which doesn't trigger any ruff errors.

It would be nice to see that error, even if we need to fix manually.

@henryiii: Do you happen to know what suppresses the `E501`? 

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
