### PR TITLE
conduit test failure

### DIFF
--- a/tests/exo_planet_pybind11.cpp
+++ b/tests/exo_planet_pybind11.cpp
@@ -13,6 +13,8 @@ namespace test_cpp_conduit {
 PYBIND11_MODULE(exo_planet_pybind11, m) {
     wrap_traveler(m);
     m.def("wrap_very_lonely_traveler", [m]() { wrap_very_lonely_traveler(m); });
+
+    py::class_<A>(m, "A", "class A").def(py::init<>()).def_readwrite("value", &A::value);
 }
 
 } // namespace test_cpp_conduit

--- a/tests/test_cpp_conduit.cpp
+++ b/tests/test_cpp_conduit.cpp
@@ -16,6 +16,8 @@ TEST_SUBMODULE(cpp_conduit, m) {
 
     wrap_traveler(m);
     wrap_lonely_traveler(m);
+
+    py::class_<B>(m, "B", "class B").def(py::init<>()).def_readonly("a", &B::a);
 }
 
 } // namespace test_cpp_conduit

--- a/tests/test_cpp_conduit.py
+++ b/tests/test_cpp_conduit.py
@@ -164,3 +164,12 @@ def test_exo_planet_pybind11_wrap_very_lonely_traveler():
         '"pybind11_tests::test_cpp_conduit::LonelyTraveler"$',
     ):
         exo_planet_pybind11.wrap_very_lonely_traveler()
+
+
+def test_return_instance_from_exo_planet():
+    b = home_planet.B()
+    a = b.a
+    assert a.value == 0.0
+
+    a.value = 1.0
+    assert a.value == 1.0

--- a/tests/test_cpp_conduit_traveler_types.h
+++ b/tests/test_cpp_conduit_traveler_types.h
@@ -21,5 +21,13 @@ struct PremiumTraveler : Traveler {
 struct LonelyTraveler {};
 struct VeryLonelyTraveler : LonelyTraveler {};
 
+struct A {
+    double value;
+};
+
+struct B {
+    A a{0.0};
+};
+
 } // namespace test_cpp_conduit
 } // namespace pybind11_tests


### PR DESCRIPTION
New unit test illustrating the issue discussed in https://github.com/pybind/pybind11/discussions/5524:
Returning a class instance from an external module fails with `TypeError`.