### PR TITLE
Add pkgconf-pypi entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,10 @@ with remove_output("pybind11/include", "pybind11/share"):
             stderr=sys.stderr,
         )
 
+    # pkgconf-pypi needs pybind11/share/pkgconfig to be importable
+    Path("pybind11/share/__init__.py").touch()
+    Path("pybind11/share/pkgconfig/__init__.py").touch()
+
     txt = get_and_replace(setup_py, version=version, extra_cmd=extra_cmd)
     code = compile(txt, setup_py, "exec")
     exec(code, {"SDist": SDist})

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -106,6 +106,8 @@ py_files = {
     "commands.py",
     "py.typed",
     "setup_helpers.py",
+    "share/__init__.py",
+    "share/pkgconfig/__init__.py",
 }
 
 headers = main_headers | conduit_headers | detail_headers | eigen_headers | stl_headers

--- a/tools/setup_main.py.in
+++ b/tools/setup_main.py.in
@@ -18,6 +18,7 @@ setup(
         "pybind11.include.pybind11.detail",
         "pybind11.include.pybind11.eigen",
         "pybind11.include.pybind11.stl",
+        "pybind11.share",
         "pybind11.share.cmake.pybind11",
         "pybind11.share.pkgconfig",
     ],
@@ -40,7 +41,10 @@ setup(
         ],
         "pipx.run": [
              "pybind11 = pybind11.__main__:main",
-        ]
+        ],
+        "pkg_config": [
+             "pybind11 = pybind11.share.pkgconfig",
+        ],
     },
     cmdclass=cmdclass
 )


### PR DESCRIPTION
- This allows `pkgconf --cflags pybind11` and similar commands to work as expected if pkgconf is installed from pypi

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

pkgconf is used by build tools such as meson to find pkg-config files. In a virtualenv, the system pkgconf cannot find pybind11 installed in the virtualenv (though meson has other ways to do this). 

https://github.com/pypackaging-native/pkgconf-pypi packages pkgconf into a wheel, and uses entrypoints to extend the PKG_CONFIG_PATH so that .pc files can be found in the virtualenv ([docs](https://pkgconf-pypi.readthedocs.io/en/latest/)).

pybind11 already distributes a .pc file in the wheel. This PR adds an entrypoint so that it's usable with pkgconf-pypi.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Added support for finding pybind11 using pkgconf distributed on pypi
```

<!-- If the upgrade guide needs updating, note that here too -->
