### PR TITLE
feat: FindPython by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,17 +52,17 @@ jobs:
           - runs-on: ubuntu-20.04
             python: '3.8'
             args: >
-              -DPYBIND11_FINDPYTHON=ON
+              -DPYBIND11_FINDPYTHON=OFF
               -DCMAKE_CXX_FLAGS="-D_=1"
             exercise_D_: 1
           - runs-on: ubuntu-20.04
             python: 'pypy-3.8'
             args: >
-              -DPYBIND11_FINDPYTHON=ON
+              -DPYBIND11_FINDPYTHON=OFF
           - runs-on: windows-2019
             python: '3.8'
             args: >
-              -DPYBIND11_FINDPYTHON=ON
+              -DPYBIND11_FINDPYTHON=OFF
           # Inject a couple Windows 2019 runs
           - runs-on: windows-2019
             python: '3.9'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 else()
   set(PYBIND11_MASTER_PROJECT OFF)
   set(pybind11_system SYSTEM)
-  set(_pybind11_findpython_default OFF)
+  set(_pybind11_findpython_default COMPAT)
 endif()
 
 # Options
@@ -114,7 +114,9 @@ cmake_dependent_option(
   "Install pybind11 headers in Python include directory instead of default installation prefix"
   OFF "PYBIND11_INSTALL" OFF)
 
-option(PYBIND11_FINDPYTHON "Force new FindPython" ${_pybind11_findpython_default})
+set(PYBIND11_FINDPYTHON
+    ${_pybind11_findpython_default}
+    CACHE STRING "Force new FindPython - NEW, OLD, COMPAT")
 
 # Allow PYTHON_EXECUTABLE if in FINDPYTHON mode and building pybind11's tests
 # (makes transition easier while we support both modes).

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -192,7 +192,25 @@ elseif(
       ))
 
   # New mode
-  include("${CMAKE_CURRENT_LIST_DIR}/pybind11NewTools.cmake")
+  if(Python_FOUND OR Python3_FOUND)
+    include("${CMAKE_CURRENT_LIST_DIR}/pybind11NewTools.cmake")
+  else()
+    include("${CMAKE_CURRENT_LIST_DIR}/pybind11NewTools.cmake")
+
+    message(
+      "Using compatibility mode for Python, set PYBIND11_FINDPYTHON to NEW/OLD to silence this message"
+    )
+    set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
+    set(PYTHON_INCLUDE_DIR "${Python_INCLUDE_DIR}")
+    set(Python_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
+    set(PYTHON_LIBRARY "${Python_LIRARY}")
+    set(PYTHON_LIBRARIES "${Python_LIRARIES}")
+    set(PYTHON_VERSION "${Python_VERSION}")
+    set(PYTHON_VERSION_STRING "${Python_VERSION_STRING}")
+    set(PYTHON_VERSION_MAJOR "${Python_VERSION_MAJOR}")
+    set(PYTHON_VERSION_MINOR "${Python_VERSION_MINOR}")
+    set(PYTHON_VERSION_PATCH "${Python_VERSION_PATCH}")
+  endif()
 
 else()
 

--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -72,7 +72,7 @@ compatible names (`PYTHON_*` vs. the new `Python_* names). Set the mode
 explicitly to avoid the compatibility defines. You can specify this mode
 explicitly by setting `PYBIND11_FINDPYTHON` to `COMPAT`, but if you are changing
 your CMakeLists anyway, please just use the `ON` mode. A future release may
-default on `ON`.
+default to `ON`.
 
 New FindPython mode
 ^^^^^^^^^^^^^^^^^^^

--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -67,6 +67,13 @@ from 3.12+ forward (3.15+ _highly_ recommended). If you set the minimum or
 maximum version of CMake to 3.27+, then FindPython is the default (since
 FindPythonInterp/FindPythonLibs has been removed via policy `CMP0148`).
 
+Starting in pybind11 3.0, the new mode is the default, but we provide backward
+compatible names (`PYTHON_*` vs. the new `Python_* names). Set the mode
+explicitly to avoid the compatibility defines. You can specify this mode
+explicitly by setting `PYBIND11_FINDPYTHON` to `COMPAT`, but if you are changing
+your CMakeLists anyway, please just use the `ON` mode. A future release may
+default on `ON`.
+
 New FindPython mode
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

This makes FindPython the default, and introduces a COMPAT mode that sets common variables to reduce breakage. FindPythonInterp/Libs was removed in CMake 3.27, and has a lot of downsides like not supporting cross compilation (like for Pyodide) properly.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Enable FindPython mode by default, with a COMPAT mode that sets some of the old variables to ease transition.
```

<!-- If the upgrade guide needs updating, note that here too -->
