### PR TITLE
Updated py::capsule type hint to use new types.CapsuleType

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -303,7 +303,7 @@ public:
     template <typename T>
     using cast_op_type = void *&;
     explicit operator void *&() { return value; }
-    static constexpr auto name = const_name("capsule");
+    static constexpr auto name = const_name("types.CapsuleType");
 
 private:
     void *value = nullptr;
@@ -1000,7 +1000,7 @@ struct handle_type_name<type> {
 };
 template <>
 struct handle_type_name<capsule> {
-    static constexpr auto name = const_name("capsule");
+    static constexpr auto name = const_name("types.CapsuleType");
 };
 template <>
 struct handle_type_name<ellipsis> {

--- a/tests/test_opaque_types.py
+++ b/tests/test_opaque_types.py
@@ -41,7 +41,7 @@ def test_pointers(msg):
         msg(excinfo.value)
         == """
         get_void_ptr_value(): incompatible function arguments. The following argument types are supported:
-            1. (arg0: capsule) -> int
+            1. (arg0: types.CapsuleType) -> int
 
         Invoked with: [1, 2, 3]
     """


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Python 3.13 adds [types.CapsuleType](https://docs.python.org/3/library/types.html#types.CapsuleType).
This PR changes the type hint for `py::capsule` to the new type.

One open question:
Should I only enable `types.CapsuleType` for Python Version>=3.13 or for all versions?
Since this only changes type hints/signature it is only in strings and no import is required, so tests still work.
`typing.Annotated` is already in use without version guard and requires Python Version >= 3.9.
Nanobind falls back to `typing_extensions.CapsuleType` in previous versions.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Updated type hint for py::capsule to type.CapsuleType
```

<!-- If the upgrade guide needs updating, note that here too -->
