### PR TITLE
chore: bump catch download to 2.13.10

### DIFF
--- a/tests/pure_cpp/CMakeLists.txt
+++ b/tests/pure_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Catch 2.13.2)
+find_package(Catch 2.13.10)
 
 if(CATCH_FOUND)
   message(STATUS "Building pure C++ tests (not depending on Python) using Catch v${CATCH_VERSION}")

--- a/tests/test_embed/CMakeLists.txt
+++ b/tests/test_embed/CMakeLists.txt
@@ -16,7 +16,7 @@ if(TARGET Python::Module AND NOT TARGET Python::Python)
   return()
 endif()
 
-find_package(Catch 2.13.9)
+find_package(Catch 2.13.10)
 
 if(CATCH_FOUND)
   message(STATUS "Building interpreter tests using Catch v${CATCH_VERSION}")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

I'm not sure if this is related to https://github.com/pypy/binary-testing/issues/54, but I noticed we are loading two different versions of catch2, and it's a bit out of date, let's use the last 2.x release everywhere. (3.x require C++14+).


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Download the final Catch2 2.x release if Catch download is requested
```

<!-- If the upgrade guide needs updating, note that here too -->
