### PR TITLE
docs: fix incorrect name (PYBIND11_NEWPYTHON)

### DIFF
--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -159,7 +159,7 @@ default is ``MODULE``. There are several options:
   Use thin LTO instead of regular if there's a choice (pybind11's selection
   is disabled if ``CMAKE_INTERPROCEDURAL_OPTIMIZATIONS`` is set).
 ``WITHOUT_SOABI``
-  Disable the SOABI component (``PYBIND11_NEWPYTHON`` mode only).
+  Disable the SOABI component (``PYBIND11_FINDPYTHON`` mode only).
 ``NO_EXTRAS``
   Disable all extras, exit immediately after making the module.
 


### PR DESCRIPTION
Found in https://github.com/mlc-ai/xgrammar/pull/249. We ended up on the FINDPYTHON name, but NEWPYTHON seems to have snuck in somewhere.

