### PR TITLE
Update NDArray[object] to be NDArray[numpy.object_]

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1521,7 +1521,7 @@ struct npy_format_descriptor<
     enable_if_t<is_same_ignoring_cvref<T, PyObject *>::value
                 || ((std::is_same<T, handle>::value || std::is_same<T, object>::value)
                     && sizeof(T) == sizeof(PyObject *))>> {
-    static constexpr auto name = const_name("object");
+    static constexpr auto name = const_name("numpy.object_");
 
     static constexpr int value = npy_api::NPY_OBJECT_;
 

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -301,9 +301,12 @@ def test_constructors():
     assert results["array_t<int32>"].dtype == np.int32
     assert results["array_t<double>"].dtype == np.float64
 
+
 def test_array_object_type(doc):
-    assert doc(m.pass_array_object_return_as_list) == \
-        "pass_array_object_return_as_list(arg0: typing.Annotated[numpy.typing.ArrayLike, numpy.object_]) -> list"
+    assert (
+        doc(m.pass_array_object_return_as_list)
+        == "pass_array_object_return_as_list(arg0: typing.Annotated[numpy.typing.ArrayLike, numpy.object_]) -> list"
+    )
 
 
 def test_overload_resolution(msg):

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -301,6 +301,10 @@ def test_constructors():
     assert results["array_t<int32>"].dtype == np.int32
     assert results["array_t<double>"].dtype == np.float64
 
+def test_array_object_type(doc):
+    assert doc(m.pass_array_object_return_as_list) == \
+        "pass_array_object_return_as_list(arg0: typing.Annotated[numpy.typing.ArrayLike, numpy.object_]) -> list"
+
 
 def test_overload_resolution(msg):
     # Exact overload matches:


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Use proper `numpy.object_` type instead of default `object` type.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Use `numpy.object_` instead of `object`
```

<!-- If the upgrade guide needs updating, note that here too -->
