### PR TITLE
Change PYBIND11_MODULE to use multi-phase init (PEP 489)

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -447,16 +447,16 @@ PYBIND11_WARNING_PUSH
 PYBIND11_WARNING_DISABLE_CLANG("-Wgnu-zero-variadic-macro-arguments")
 #define PYBIND11_MODULE(name, variable, ...)                                                      \
     static ::pybind11::module_::module_def PYBIND11_CONCAT(pybind11_module_def_, name);           \
-    static std::vector<PyModuleDef_Slot> PYBIND11_CONCAT(pybind11_module_slots_, name);           \
+    static ::pybind11::module_::slots_array PYBIND11_CONCAT(pybind11_module_slots_, name);        \
     static int PYBIND11_CONCAT(pybind11_exec_, name)(PyObject *);                                 \
     static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);                     \
     PYBIND11_PLUGIN_IMPL(name) {                                                                  \
         PYBIND11_CHECK_PYTHON_VERSION                                                             \
         PYBIND11_ENSURE_INTERNALS_READY                                                           \
         auto &slots = PYBIND11_CONCAT(pybind11_module_slots_, name);                              \
-        slots.clear();                                                                            \
-        slots.emplace_back(PyModuleDef_Slot{                                                      \
-            Py_mod_exec, reinterpret_cast<void *>(&PYBIND11_CONCAT(pybind11_exec_, name))});      \
+        slots[0]                                                                                  \
+            = {Py_mod_exec, reinterpret_cast<void *>(&PYBIND11_CONCAT(pybind11_exec_, name))};    \
+        slots[1] = {0, nullptr};                                                                  \
         auto m = ::pybind11::module_::initialize_multiphase_module_def(                           \
             PYBIND11_TOSTRING(name),                                                              \
             nullptr,                                                                              \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -372,11 +372,9 @@
 #define PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
     catch (pybind11::error_already_set & e) {                                                     \
         pybind11::raise_from(e, PyExc_ImportError, "initialization failed");                      \
-        return nullptr;                                                                           \
     }                                                                                             \
     catch (const std::exception &e) {                                                             \
         ::pybind11::set_error(PyExc_ImportError, e.what());                                       \
-        return nullptr;                                                                           \
     }
 
 /** \rst
@@ -404,6 +402,7 @@
             return pybind11_init();                                                               \
         }                                                                                         \
         PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
+        return nullptr;                                                                           \
     }                                                                                             \
     PyObject *pybind11_init()
 
@@ -447,23 +446,33 @@
 PYBIND11_WARNING_PUSH
 PYBIND11_WARNING_DISABLE_CLANG("-Wgnu-zero-variadic-macro-arguments")
 #define PYBIND11_MODULE(name, variable, ...)                                                      \
-    static ::pybind11::module_::module_def PYBIND11_CONCAT(pybind11_module_def_, name)            \
-        PYBIND11_MAYBE_UNUSED;                                                                    \
-    PYBIND11_MAYBE_UNUSED                                                                         \
+    static ::pybind11::module_::module_def PYBIND11_CONCAT(pybind11_module_def_, name);           \
+    static std::vector<PyModuleDef_Slot> PYBIND11_CONCAT(pybind11_module_slots_, name);           \
+    static int PYBIND11_CONCAT(pybind11_exec_, name)(PyObject *);                                 \
     static void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ &);                     \
     PYBIND11_PLUGIN_IMPL(name) {                                                                  \
         PYBIND11_CHECK_PYTHON_VERSION                                                             \
         PYBIND11_ENSURE_INTERNALS_READY                                                           \
-        auto m = ::pybind11::module_::create_extension_module(                                    \
+        auto &slots = PYBIND11_CONCAT(pybind11_module_slots_, name);                              \
+        slots.clear();                                                                            \
+        slots.emplace_back(PyModuleDef_Slot{                                                      \
+            Py_mod_exec, reinterpret_cast<void *>(&PYBIND11_CONCAT(pybind11_exec_, name))});      \
+        auto m = ::pybind11::module_::initialize_multiphase_module_def(                           \
             PYBIND11_TOSTRING(name),                                                              \
             nullptr,                                                                              \
             &PYBIND11_CONCAT(pybind11_module_def_, name),                                         \
+            slots,                                                                                \
             ##__VA_ARGS__);                                                                       \
+        return m.ptr();                                                                           \
+    }                                                                                             \
+    int PYBIND11_CONCAT(pybind11_exec_, name)(PyObject * pm) {                                    \
         try {                                                                                     \
+            auto m = pybind11::reinterpret_borrow<::pybind11::module_>(pm);                       \
             PYBIND11_CONCAT(pybind11_init_, name)(m);                                             \
-            return m.ptr();                                                                       \
+            return 0;                                                                             \
         }                                                                                         \
         PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
+        return -1;                                                                                \
     }                                                                                             \
     void PYBIND11_CONCAT(pybind11_init_, name)(::pybind11::module_ & (variable))
 PYBIND11_WARNING_POP

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -49,6 +49,7 @@
             return m.ptr();                                                                       \
         }                                                                                         \
         PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \
+        return nullptr;                                                                           \
     }                                                                                             \
     PYBIND11_EMBEDDED_MODULE_IMPL(name)                                                           \
     ::pybind11::detail::embedded_module PYBIND11_CONCAT(pybind11_module_, name)(                  \

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1437,7 +1437,7 @@ public:
             if (next_slot >= term_slot) {
                 pybind11_fail("initialize_multiphase_module_def: not enough space in slots");
             }
-            slots[next_slot++] = {Py_mod_gil, Py_MOD_GIL_NOT_USED});
+            slots[next_slot++] = {Py_mod_gil, Py_MOD_GIL_NOT_USED};
 #endif
         }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1378,7 +1378,7 @@ public:
                                            = mod_gil_not_used(false)) {
         // module_def is PyModuleDef
         // Placement new (not an allocation).
-        def = new (def)
+        new (def)
             PyModuleDef{/* m_base */ PyModuleDef_HEAD_INIT,
                         /* m_name */ name,
                         /* m_doc */ options::show_user_defined_docstrings() ? doc : nullptr,
@@ -1408,7 +1408,7 @@ public:
 
     /// Must be a POD type, and must hold enough entries for all of the possible slots PLUS ONE for
     /// the sentinel (0) end slot.
-    using slots_array = std::array<PyModuleDef_Slot, 4>;
+    using slots_array = std::array<PyModuleDef_Slot, 3>;
 
     /** \rst
         Initialized a module def for use with multi-phase module initialization.
@@ -1449,7 +1449,7 @@ public:
 
         // module_def is PyModuleDef
         // Placement new (not an allocation).
-        def = new (def)
+        new (def)
             PyModuleDef{/* m_base */ PyModuleDef_HEAD_INIT,
                         /* m_name */ name,
                         /* m_doc */ options::show_user_defined_docstrings() ? doc : nullptr,

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1378,16 +1378,15 @@ public:
                                            = mod_gil_not_used(false)) {
         // module_def is PyModuleDef
         // Placement new (not an allocation).
-        new (def)
-            PyModuleDef{/* m_base */ PyModuleDef_HEAD_INIT,
-                        /* m_name */ name,
-                        /* m_doc */ options::show_user_defined_docstrings() ? doc : nullptr,
-                        /* m_size */ -1,
-                        /* m_methods */ nullptr,
-                        /* m_slots */ nullptr,
-                        /* m_traverse */ nullptr,
-                        /* m_clear */ nullptr,
-                        /* m_free */ nullptr};
+        new (def) PyModuleDef{/* m_base */ PyModuleDef_HEAD_INIT,
+                              /* m_name */ name,
+                              /* m_doc */ options::show_user_defined_docstrings() ? doc : nullptr,
+                              /* m_size */ -1,
+                              /* m_methods */ nullptr,
+                              /* m_slots */ nullptr,
+                              /* m_traverse */ nullptr,
+                              /* m_clear */ nullptr,
+                              /* m_free */ nullptr};
         auto *m = PyModule_Create(def);
         if (m == nullptr) {
             if (PyErr_Occurred()) {
@@ -1449,16 +1448,15 @@ public:
 
         // module_def is PyModuleDef
         // Placement new (not an allocation).
-        new (def)
-            PyModuleDef{/* m_base */ PyModuleDef_HEAD_INIT,
-                        /* m_name */ name,
-                        /* m_doc */ options::show_user_defined_docstrings() ? doc : nullptr,
-                        /* m_size */ 0,
-                        /* m_methods */ nullptr,
-                        /* m_slots */ &slots[0],
-                        /* m_traverse */ nullptr,
-                        /* m_clear */ nullptr,
-                        /* m_free */ nullptr};
+        new (def) PyModuleDef{/* m_base */ PyModuleDef_HEAD_INIT,
+                              /* m_name */ name,
+                              /* m_doc */ options::show_user_defined_docstrings() ? doc : nullptr,
+                              /* m_size */ 0,
+                              /* m_methods */ nullptr,
+                              /* m_slots */ &slots[0],
+                              /* m_traverse */ nullptr,
+                              /* m_clear */ nullptr,
+                              /* m_free */ nullptr};
         auto *m = PyModuleDef_Init(def);
         if (m == nullptr) {
             if (PyErr_Occurred()) {


### PR DESCRIPTION
## Description

Changed PYBIND11_MODULE to use multi-phase init.  Multi-phase init (slots) is required for sub-interpreter support in (see #5564).  This splits the init portion from that PR out into this smaller PR as requested by @rwgk . 

This PR Adds a new function `init_module_def` to `module_`, similar to the existing (unchanged) `create_extension_module`.  `init_module_def` takes a variadic final argument to allow for future initialization tags (no tags are added in this PR, the `py::mod_gil_not_used` tag works with this new function). 

This also has the minor side benefit of not needing to use the unstable API (`PyUnstable_Module_SetGIL`) for the `Py_MOD_GIL_NOT_USED` option. However, the `module_::create_extension_module` function has not been changed and so it still uses the unstable API.

No tests are changed, the arguments to the macro are unchanged, and all behavior is expected to be the same.  Multi-phase init has been supported since Python 3.5, so no compatibility issues are expected either.

## Suggested changelog entry:

Not sure if this one is worth a mention...

```rst
* Changed ``PYBIND11_MODULE`` macro implementation to perform multi-phase module initialization (PEP 489) behind the scenes.
```
