### PR TITLE
Fix null pointer dereference in `attr_with_type_hint`

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1639,7 +1639,7 @@ str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
 
     static constexpr auto type_name = make_caster<T>::name;
     PYBIND11_DESCR_CONSTEXPR auto types = decltype(type_name)::types();
-    
+
     const char *text = type_name.text;
 
     size_t type_index = 0;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1606,7 +1606,6 @@ inline void object::cast() && {
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-
 // forward declaration (definition in pybind11.h)
 template <typename T>
 std::string generate_type_signature();
@@ -1631,7 +1630,7 @@ str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
     if (ann.contains(key)) {
         throw std::runtime_error("__annotations__[\"" + std::string(key) + "\"] was set already.");
     }
-   
+
     ann[key] = generate_type_signature<T>();
     return {derived(), key};
 }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1642,7 +1642,7 @@ str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
 
     const char *text = caster_name_field.text;
 
-    auto func_rec = detail::function_record();
+    auto func_rec = function_record();
     size_t type_index = 0;
     size_t arg_index = 0;
     ann[key]
@@ -1873,8 +1873,6 @@ using is_kw_only = std::is_same<intrinsic_t<T>, kw_only>;
 template <typename T>
 using is_pos_only = std::is_same<intrinsic_t<T>, pos_only>;
 
-// forward declaration (definition in attr.h)
-struct function_record;
 
 /// Internal data associated with a single function call
 struct function_call {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1645,7 +1645,8 @@ str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
     auto func_rec = detail::function_record();
     size_t type_index = 0;
     size_t arg_index = 0;
-    ann[key] = generate_function_signature(text, &func_rec, descr_types.data(), type_index, arg_index);
+    ann[key]
+        = generate_function_signature(text, &func_rec, descr_types.data(), type_index, arg_index);
     return {derived(), key};
 }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1607,7 +1607,7 @@ inline void object::cast() && {
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 // forward declaration (definition in attr.h)
-struct function_record;
+typedef struct function_record function_record;
 
 // forward declaration (definition in pybind11.h)
 std::string generate_function_signature(const char *type_caster_name_field,

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1873,7 +1873,6 @@ using is_kw_only = std::is_same<intrinsic_t<T>, kw_only>;
 template <typename T>
 using is_pos_only = std::is_same<intrinsic_t<T>, pos_only>;
 
-
 /// Internal data associated with a single function call
 struct function_call {
     function_call(const function_record &f, handle p); // Implementation in attr.h

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1610,11 +1610,11 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 struct function_record;
 
 // forward declaration (definition in pybind11.h)
-inline std::string generate_function_signature(const char *type_caster_name_field,
-                                               function_record *func_rec,
-                                               const std::type_info *const *types,
-                                               size_t &type_index,
-                                               size_t &arg_index);
+std::string generate_function_signature(const char *type_caster_name_field,
+                                        function_record *func_rec,
+                                        const std::type_info *const *types,
+                                        size_t &type_index,
+                                        size_t &arg_index);
 
 // Declared in pytypes.h:
 template <typename T, enable_if_t<!is_pyobject<T>::value, int>>
@@ -1637,15 +1637,15 @@ str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
         throw std::runtime_error("__annotations__[\"" + std::string(key) + "\"] was set already.");
     }
 
-    static constexpr auto type_name = make_caster<T>::name;
-    PYBIND11_DESCR_CONSTEXPR auto types = decltype(type_name)::types();
+    static constexpr auto caster_name_field = make_caster<T>::name;
+    PYBIND11_DESCR_CONSTEXPR auto descr_types = decltype(caster_name_field)::types();
 
-    const char *text = type_name.text;
+    const char *text = caster_name_field.text;
 
+    auto func_rec = detail::function_record();
     size_t type_index = 0;
-    size_t unused = 0;
-
-    ann[key] = generate_function_signature(text, nullptr, types.data(), type_index, unused);
+    size_t arg_index = 0;
+    ann[key] = generate_function_signature(text, &func_rec, descr_types.data(), type_index, arg_index);
     return {derived(), key};
 }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1606,15 +1606,10 @@ inline void object::cast() && {
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-// forward declaration (definition in attr.h)
-typedef struct function_record function_record;
 
 // forward declaration (definition in pybind11.h)
-std::string generate_function_signature(const char *type_caster_name_field,
-                                        function_record *func_rec,
-                                        const std::type_info *const *types,
-                                        size_t &type_index,
-                                        size_t &arg_index);
+template <typename T>
+std::string generate_type_signature();
 
 // Declared in pytypes.h:
 template <typename T, enable_if_t<!is_pyobject<T>::value, int>>
@@ -1636,17 +1631,8 @@ str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
     if (ann.contains(key)) {
         throw std::runtime_error("__annotations__[\"" + std::string(key) + "\"] was set already.");
     }
-
-    static constexpr auto caster_name_field = make_caster<T>::name;
-    PYBIND11_DESCR_CONSTEXPR auto descr_types = decltype(caster_name_field)::types();
-
-    const char *text = caster_name_field.text;
-
-    auto func_rec = function_record();
-    size_t type_index = 0;
-    size_t arg_index = 0;
-    ann[key]
-        = generate_function_signature(text, &func_rec, descr_types.data(), type_index, arg_index);
+   
+    ann[key] = generate_type_signature<T>();
     return {derived(), key};
 }
 
@@ -1872,6 +1858,9 @@ template <typename T>
 using is_kw_only = std::is_same<intrinsic_t<T>, kw_only>;
 template <typename T>
 using is_pos_only = std::is_same<intrinsic_t<T>, pos_only>;
+
+// forward declaration (definition in attr.h)
+struct function_record;
 
 /// Internal data associated with a single function call
 struct function_call {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1610,11 +1610,11 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 struct function_record;
 
 // forward declaration (definition in pybind11.h)
-std::string generate_function_signature(const char *type_caster_name_field,
-                                        function_record *func_rec,
-                                        const std::type_info *const *types,
-                                        size_t &type_index,
-                                        size_t &arg_index);
+inline std::string generate_function_signature(const char *type_caster_name_field,
+                                               function_record *func_rec,
+                                               const std::type_info *const *types,
+                                               size_t &type_index,
+                                               size_t &arg_index);
 
 // Declared in pytypes.h:
 template <typename T, enable_if_t<!is_pyobject<T>::value, int>>
@@ -1637,10 +1637,15 @@ str_attr_accessor object_api<D>::attr_with_type_hint(const char *key) const {
         throw std::runtime_error("__annotations__[\"" + std::string(key) + "\"] was set already.");
     }
 
-    const char *text = make_caster<T>::name.text;
+    static constexpr auto type_name = make_caster<T>::name;
+    PYBIND11_DESCR_CONSTEXPR auto types = decltype(type_name)::types();
+    
+    const char *text = type_name.text;
 
+    size_t type_index = 0;
     size_t unused = 0;
-    ann[key] = generate_function_signature(text, nullptr, nullptr, unused, unused);
+
+    ann[key] = generate_function_signature(text, nullptr, types.data(), type_index, unused);
     return {derived(), key};
 }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -230,7 +230,7 @@ inline std::string generate_function_signature(const char *type_caster_name_fiel
 }
 
 template <typename T>
-inline std::string generate_type_signature(){
+inline std::string generate_type_signature() {
     static constexpr auto caster_name_field = make_caster<T>::name;
     PYBIND11_DESCR_CONSTEXPR auto descr_types = decltype(caster_name_field)::types();
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -233,11 +233,13 @@ template <typename T>
 inline std::string generate_type_signature() {
     static constexpr auto caster_name_field = make_caster<T>::name;
     PYBIND11_DESCR_CONSTEXPR auto descr_types = decltype(caster_name_field)::types();
-    // Create a default function_record to ensure the function signature has the proper configuration e.j. no_convert.
+    // Create a default function_record to ensure the function signature has the proper
+    // configuration e.j. no_convert.
     auto func_rec = function_record();
     size_t type_index = 0;
     size_t arg_index = 0;
-    return generate_function_signature(caster_name_field.text, &func_rec, descr_types.data(), type_index, arg_index);
+    return generate_function_signature(
+        caster_name_field.text, &func_rec, descr_types.data(), type_index, arg_index);
 }
 
 #if defined(_MSC_VER)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -234,7 +234,7 @@ inline std::string generate_type_signature() {
     static constexpr auto caster_name_field = make_caster<T>::name;
     PYBIND11_DESCR_CONSTEXPR auto descr_types = decltype(caster_name_field)::types();
     // Create a default function_record to ensure the function signature has the proper
-    // configuration e.j. no_convert.
+    // configuration e.g. no_convert.
     auto func_rec = function_record();
     size_t type_index = 0;
     size_t arg_index = 0;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -112,7 +112,6 @@ inline std::string generate_function_signature(const char *type_caster_name_fiel
                                                size_t &arg_index) {
     std::string signature;
     bool is_starred = false;
-    bool is_annotation = func_rec == nullptr;
     // `is_return_value.top()` is true if we are currently inside the return type of the
     // signature. Using `@^`/`@$` we can force types to be arg/return types while `@!` pops
     // back to the previous state.
@@ -199,8 +198,7 @@ inline std::string generate_function_signature(const char *type_caster_name_fiel
             // For named arguments (py::arg()) with noconvert set, return value type is used.
             ++pc;
             if (!is_return_value.top()
-                && (is_annotation
-                    || !(arg_index < func_rec->args.size()
+                && (!(arg_index < func_rec->args.size()
                          && !func_rec->args[arg_index].convert))) {
                 while (*pc != '\0' && *pc != '@') {
                     signature += *pc++;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -229,6 +229,19 @@ inline std::string generate_function_signature(const char *type_caster_name_fiel
     return signature;
 }
 
+template <typename T>
+inline std::string generate_type_signature(){
+    static constexpr auto caster_name_field = make_caster<T>::name;
+    PYBIND11_DESCR_CONSTEXPR auto descr_types = decltype(caster_name_field)::types();
+
+    const char *text = caster_name_field.text;
+
+    auto func_rec = function_record();
+    size_t type_index = 0;
+    size_t arg_index = 0;
+    return generate_function_signature(text, &func_rec, descr_types.data(), type_index, arg_index);
+}
+
 #if defined(_MSC_VER)
 #    define PYBIND11_COMPAT_STRDUP _strdup
 #else

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -198,8 +198,7 @@ inline std::string generate_function_signature(const char *type_caster_name_fiel
             // For named arguments (py::arg()) with noconvert set, return value type is used.
             ++pc;
             if (!is_return_value.top()
-                && (!(arg_index < func_rec->args.size()
-                         && !func_rec->args[arg_index].convert))) {
+                && (!(arg_index < func_rec->args.size() && !func_rec->args[arg_index].convert))) {
                 while (*pc != '\0' && *pc != '@') {
                     signature += *pc++;
                 }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -233,13 +233,11 @@ template <typename T>
 inline std::string generate_type_signature() {
     static constexpr auto caster_name_field = make_caster<T>::name;
     PYBIND11_DESCR_CONSTEXPR auto descr_types = decltype(caster_name_field)::types();
-
-    const char *text = caster_name_field.text;
-
+    // Create a default function_record to ensure the function signature has the proper configuration e.j. no_convert.
     auto func_rec = function_record();
     size_t type_index = 0;
     size_t arg_index = 0;
-    return generate_function_signature(text, &func_rec, descr_types.data(), type_index, arg_index);
+    return generate_function_signature(caster_name_field.text, &func_rec, descr_types.data(), type_index, arg_index);
 }
 
 #if defined(_MSC_VER)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1058,15 +1058,14 @@ TEST_SUBMODULE(pytypes, m) {
     // Exercises py::handle overload:
     m.attr_with_type_hint<py::typing::Set<py::str>>(py::str("set_str")) = py::set();
 
-    struct foo_t{};
-    struct foo2{};
-    struct foo3{};
+    struct foo_t {};
+    struct foo2 {};
+    struct foo3 {};
 
     pybind11::class_<foo_t>(m, "foo");
     pybind11::class_<foo2>(m, "foo2");
     pybind11::class_<foo3>(m, "foo3");
     m.attr_with_type_hint<foo_t>("foo") = foo_t{};
-
 
     m.attr_with_type_hint<py::typing::Union<foo_t, foo2, foo3>>("foo_union") = foo_t{};
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1058,6 +1058,18 @@ TEST_SUBMODULE(pytypes, m) {
     // Exercises py::handle overload:
     m.attr_with_type_hint<py::typing::Set<py::str>>(py::str("set_str")) = py::set();
 
+    struct foo_t{};
+    struct foo2{};
+    struct foo3{};
+
+    pybind11::class_<foo_t>(m, "foo");
+    pybind11::class_<foo2>(m, "foo2");
+    pybind11::class_<foo3>(m, "foo3");
+    m.attr_with_type_hint<foo_t>("foo") = foo_t{};
+
+
+    m.attr_with_type_hint<py::typing::Union<foo_t, foo2, foo3>>("foo_union") = foo_t{};
+
     struct Empty {};
     py::class_<Empty>(m, "EmptyAnnotationClass");
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1069,6 +1069,10 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.attr_with_type_hint<py::typing::Union<foo_t, foo2, foo3>>("foo_union") = foo_t{};
 
+
+    struct foo4 {};
+    m.attr_with_type_hint<foo4>("foo4") = 3;
+
     struct Empty {};
     py::class_<Empty>(m, "EmptyAnnotationClass");
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1069,7 +1069,6 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.attr_with_type_hint<py::typing::Union<foo_t, foo2, foo3>>("foo_union") = foo_t{};
 
-
     struct foo4 {};
     m.attr_with_type_hint<foo4>("foo4") = 3;
 

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -1069,6 +1069,7 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.attr_with_type_hint<py::typing::Union<foo_t, foo2, foo3>>("foo_union") = foo_t{};
 
+    // Include to ensure this does not crash
     struct foo4 {};
     m.attr_with_type_hint<foo4>("foo4") = 3;
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1157,6 +1157,8 @@ def test_module_attribute_types() -> None:
 
     assert module_annotations["list_int"] == "list[typing.SupportsInt]"
     assert module_annotations["set_str"] == "set[str]"
+    assert module_annotations["foo"] == "pybind11_tests.pytypes.foo"
+    assert module_annotations["foo_union"] == "Union[pybind11_tests.pytypes.foo, pybind11_tests.pytypes.foo2, pybind11_tests.pytypes.foo3]"
 
 
 @pytest.mark.skipif(

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1163,6 +1163,8 @@ def test_module_attribute_types() -> None:
         == "Union[pybind11_tests.pytypes.foo, pybind11_tests.pytypes.foo2, pybind11_tests.pytypes.foo3]"
     )
 
+    assert module_annotations["foo4"] == "test_submodule_pytypes(module_&)::foo4"
+
 
 @pytest.mark.skipif(
     not m.defined___cpp_inline_variables,

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1158,7 +1158,10 @@ def test_module_attribute_types() -> None:
     assert module_annotations["list_int"] == "list[typing.SupportsInt]"
     assert module_annotations["set_str"] == "set[str]"
     assert module_annotations["foo"] == "pybind11_tests.pytypes.foo"
-    assert module_annotations["foo_union"] == "Union[pybind11_tests.pytypes.foo, pybind11_tests.pytypes.foo2, pybind11_tests.pytypes.foo3]"
+    assert (
+        module_annotations["foo_union"]
+        == "Union[pybind11_tests.pytypes.foo, pybind11_tests.pytypes.foo2, pybind11_tests.pytypes.foo3]"
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1163,8 +1163,6 @@ def test_module_attribute_types() -> None:
         == "Union[pybind11_tests.pytypes.foo, pybind11_tests.pytypes.foo2, pybind11_tests.pytypes.foo3]"
     )
 
-    assert module_annotations["foo4"] == "test_submodule_pytypes(module_&)::foo4"
-
 
 @pytest.mark.skipif(
     not m.defined___cpp_inline_variables,


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Fixes regression caught in #5575 

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
    Fix bug in `attr_with_type_hint` to allow objects to be in `attr_with_type_hint`
```

<!-- If the upgrade guide needs updating, note that here too -->
