### PR TITLE
Remove PyPy 3.8 and 3.9 testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
         - '3.9'
         - '3.12'
         - '3.13'
-        - 'pypy-3.8'
-        - 'pypy-3.9'
         - 'pypy-3.10'
         - 'pypy-3.11'
         - 'graalpy-24.1'
@@ -55,10 +53,6 @@ jobs:
               -DPYBIND11_FINDPYTHON=OFF
               -DCMAKE_CXX_FLAGS="-D_=1"
             exercise_D_: 1
-          - runs-on: ubuntu-20.04
-            python: 'pypy-3.8'
-            args: >
-              -DPYBIND11_FINDPYTHON=OFF
           - runs-on: windows-2019
             python: '3.8'
             args: >

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -561,12 +561,6 @@ struct error_fetch_and_normalize {
                           + " failed to obtain the name "
                             "of the normalized active exception type.");
         }
-#    if defined(PYPY_VERSION_NUM) && PYPY_VERSION_NUM < 0x07030a00
-        // This behavior runs the risk of masking errors in the error handling, but avoids a
-        // conflict with PyPy, which relies on the normalization here to change OSError to
-        // FileNotFoundError (https://github.com/pybind/pybind11/issues/4075).
-        m_lazy_error_string = exc_type_name_norm;
-#    else
         if (exc_type_name_norm != m_lazy_error_string) {
             std::string msg = std::string(called)
                               + ": MISMATCH of original and normalized "
@@ -578,7 +572,6 @@ struct error_fetch_and_normalize {
             msg += ": " + format_value_and_trace();
             pybind11_fail(msg);
         }
-#    endif
 #endif
     }
 

--- a/tests/test_local_bindings.py
+++ b/tests/test_local_bindings.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-import env  # noqa: F401
 from pybind11_tests import local_bindings as m
 
 
@@ -181,7 +180,6 @@ def test_internal_locals_differ():
     assert m.local_cpp_types_addr() != cm.local_cpp_types_addr()
 
 
-@pytest.mark.xfail("env.PYPY and sys.pypy_version_info < (7, 3, 2)")
 def test_stl_caster_vs_stl_bind(msg):
     """One module uses a generic vector caster from `<pybind11/stl.h>` while the other
     exports `std::vector<int>` via `py:bind_vector` and `py::module_local`"""

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -263,7 +263,6 @@ def test_mi_static_properties():
         assert d.static_value == 0
 
 
-# Requires PyPy 6+
 def test_mi_dynamic_attributes():
     """Mixing bases with and without dynamic attribute support"""
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -198,7 +198,6 @@ class CustomContains:
         (CustomContains(), m.obj_contains),
     ],
 )
-@pytest.mark.xfail("env.PYPY and sys.pypy_version_info < (7, 3, 10)", strict=False)
 def test_unhashable_exceptions(arg, func):
     class Unhashable:
         __hash__ = None


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Also make a pass through the entire repo to remove obviously obsolete workarounds for PyPy < 3.10.

This PR removes 6 GitHub Actions jobs, saving a total of 149 runner minutes per invocation of ci.yml:
* CI / 🐍 pypy-3.8 • macos-13 • x64 (pull_request)Successful in 23m
* CI / 🐍 pypy-3.8 • ubuntu-20.04 • x64 -DPYBIND11_FINDPYTHON=OFF (pull_request)Successful in 22m
* CI / 🐍 pypy-3.8 • windows-2022 • x64 (pull_request)Successful in 30m
* CI / 🐍 pypy-3.9 • macos-13 • x64 (pull_request)Successful in 24m
* CI / 🐍 pypy-3.9 • ubuntu-20.04 • x64 (pull_request)Successful in 22m
* CI / 🐍 pypy-3.9 • windows-2022 • x64 (pull_request)Successful in 28m

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Support for PyPy 3.8 and 3.9 was dropped.
```

<!-- If the upgrade guide needs updating, note that here too -->
