### PR TITLE
Make wrapped C++ functions pickleable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ set(PYBIND11_HEADERS
     include/pybind11/detail/cpp_conduit.h
     include/pybind11/detail/descr.h
     include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h
+    include/pybind11/detail/function_record_pyobject.h
     include/pybind11/detail/init.h
     include/pybind11/detail/internals.h
     include/pybind11/detail/native_enum_data.h

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -192,6 +192,7 @@ struct argument_record {
 
 /// Internal data structure which holds metadata about a bound function (signature, overloads,
 /// etc.)
+#define PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID "v1" // PLEASE UPDATE if the struct is changed.
 struct function_record {
     function_record()
         : is_constructor(false), is_new_style_constructor(false), is_stateless(false),

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -1,0 +1,207 @@
+// Copyright (c) 2024-2025 The Pybind Development Team.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// For background see the description of PR google/pybind11clif#30099.
+
+#pragma once
+
+#include <pybind11/attr.h>
+#include <pybind11/conduit/pybind11_platform_abi_id.h>
+#include <pybind11/pytypes.h>
+
+#include "common.h"
+
+#include <cstring>
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+struct function_record_PyObject {
+    PyObject_HEAD
+    function_record *cpp_func_rec;
+};
+
+PYBIND11_NAMESPACE_BEGIN(function_record_PyTypeObject_methods)
+
+PyObject *tp_new_impl(PyTypeObject *type, PyObject *args, PyObject *kwds);
+PyObject *tp_alloc_impl(PyTypeObject *type, Py_ssize_t nitems);
+int tp_init_impl(PyObject *self, PyObject *args, PyObject *kwds);
+void tp_dealloc_impl(PyObject *self);
+void tp_free_impl(void *self);
+
+static PyObject *reduce_ex_impl(PyObject *self, PyObject *, PyObject *);
+
+PYBIND11_WARNING_PUSH
+#if defined(__GNUC__) && __GNUC__ >= 8
+PYBIND11_WARNING_DISABLE_GCC("-Wcast-function-type")
+#endif
+static PyMethodDef tp_methods_impl[]
+    = {{"__reduce_ex__", (PyCFunction) reduce_ex_impl, METH_VARARGS | METH_KEYWORDS, nullptr},
+       {nullptr, nullptr, 0, nullptr}};
+PYBIND11_WARNING_POP
+
+// Note that this name is versioned.
+constexpr char tp_name_impl[]
+    = "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
+      "_" PYBIND11_PLATFORM_ABI_ID;
+
+PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)
+
+// Designated initializers are a C++20 feature:
+// https://en.cppreference.com/w/cpp/language/aggregate_initialization#Designated_initializers
+// MSVC rejects them unless /std:c++20 is used (error code C7555).
+PYBIND11_WARNING_PUSH
+PYBIND11_WARNING_DISABLE_CLANG("-Wmissing-field-initializers")
+#if defined(__GNUC__) && __GNUC__ >= 8
+PYBIND11_WARNING_DISABLE_GCC("-Wmissing-field-initializers")
+#endif
+static PyTypeObject function_record_PyTypeObject = {
+    PyVarObject_HEAD_INIT(nullptr, 0)
+    /* const char *tp_name */ function_record_PyTypeObject_methods::tp_name_impl,
+    /* Py_ssize_t tp_basicsize */ sizeof(function_record_PyObject),
+    /* Py_ssize_t tp_itemsize */ 0,
+    /* destructor tp_dealloc */ function_record_PyTypeObject_methods::tp_dealloc_impl,
+    /* Py_ssize_t tp_vectorcall_offset */ 0,
+    /* getattrfunc tp_getattr */ nullptr,
+    /* setattrfunc tp_setattr */ nullptr,
+    /* PyAsyncMethods *tp_as_async */ nullptr,
+    /* reprfunc tp_repr */ nullptr,
+    /* PyNumberMethods *tp_as_number */ nullptr,
+    /* PySequenceMethods *tp_as_sequence */ nullptr,
+    /* PyMappingMethods *tp_as_mapping */ nullptr,
+    /* hashfunc tp_hash */ nullptr,
+    /* ternaryfunc tp_call */ nullptr,
+    /* reprfunc tp_str */ nullptr,
+    /* getattrofunc tp_getattro */ nullptr,
+    /* setattrofunc tp_setattro */ nullptr,
+    /* PyBufferProcs *tp_as_buffer */ nullptr,
+    /* unsigned long tp_flags */ Py_TPFLAGS_DEFAULT,
+    /* const char *tp_doc */ nullptr,
+    /* traverseproc tp_traverse */ nullptr,
+    /* inquiry tp_clear */ nullptr,
+    /* richcmpfunc tp_richcompare */ nullptr,
+    /* Py_ssize_t tp_weaklistoffset */ 0,
+    /* getiterfunc tp_iter */ nullptr,
+    /* iternextfunc tp_iternext */ nullptr,
+    /* struct PyMethodDef *tp_methods */ function_record_PyTypeObject_methods::tp_methods_impl,
+    /* struct PyMemberDef *tp_members */ nullptr,
+    /* struct PyGetSetDef *tp_getset */ nullptr,
+    /* struct _typeobject *tp_base */ nullptr,
+    /* PyObject *tp_dict */ nullptr,
+    /* descrgetfunc tp_descr_get */ nullptr,
+    /* descrsetfunc tp_descr_set */ nullptr,
+    /* Py_ssize_t tp_dictoffset */ 0,
+    /* initproc tp_init */ function_record_PyTypeObject_methods::tp_init_impl,
+    /* allocfunc tp_alloc */ function_record_PyTypeObject_methods::tp_alloc_impl,
+    /* newfunc tp_new */ function_record_PyTypeObject_methods::tp_new_impl,
+    /* freefunc tp_free */ function_record_PyTypeObject_methods::tp_free_impl,
+    /* inquiry tp_is_gc */ nullptr,
+    /* PyObject *tp_bases */ nullptr,
+    /* PyObject *tp_mro */ nullptr,
+    /* PyObject *tp_cache */ nullptr,
+    /* PyObject *tp_subclasses */ nullptr,
+    /* PyObject *tp_weaklist */ nullptr,
+    /* destructor tp_del */ nullptr,
+    /* unsigned int tp_version_tag */ 0,
+    /* destructor tp_finalize */ nullptr,
+#if PY_VERSION_HEX >= 0x03080000
+    /* vectorcallfunc tp_vectorcall */ nullptr,
+#endif
+};
+PYBIND11_WARNING_POP
+
+static bool function_record_PyTypeObject_PyType_Ready_first_call = true;
+
+inline void function_record_PyTypeObject_PyType_Ready() {
+    if (function_record_PyTypeObject_PyType_Ready_first_call) {
+        if (PyType_Ready(&function_record_PyTypeObject) < 0) {
+            throw error_already_set();
+        }
+        function_record_PyTypeObject_PyType_Ready_first_call = false;
+    }
+}
+
+inline bool is_function_record_PyObject(PyObject *obj) {
+    if (PyType_Check(obj) != 0) {
+        return false;
+    }
+    PyTypeObject *obj_type = Py_TYPE(obj);
+    // Fast path (pointer comparison).
+    if (obj_type == &function_record_PyTypeObject) {
+        return true;
+    }
+    // This works across extension modules. Note that tp_name is versioned.
+    if (strcmp(obj_type->tp_name, function_record_PyTypeObject.tp_name) == 0) {
+        return true;
+    }
+    return false;
+}
+
+inline function_record *function_record_ptr_from_PyObject(PyObject *obj) {
+    if (is_function_record_PyObject(obj)) {
+        return ((detail::function_record_PyObject *) obj)->cpp_func_rec;
+    }
+    return nullptr;
+}
+
+inline object function_record_PyObject_New() {
+    auto *py_func_rec = PyObject_New(function_record_PyObject, &function_record_PyTypeObject);
+    if (py_func_rec == nullptr) {
+        throw error_already_set();
+    }
+    py_func_rec->cpp_func_rec = nullptr; // For clarity/purity. Redundant in practice.
+    return reinterpret_steal<object>((PyObject *) py_func_rec);
+}
+
+PYBIND11_NAMESPACE_BEGIN(function_record_PyTypeObject_methods)
+
+// Guard against accidents & oversights, in particular when porting to future Python versions.
+inline PyObject *tp_new_impl(PyTypeObject *, PyObject *, PyObject *) {
+    pybind11_fail("UNEXPECTED CALL OF function_record_PyTypeObject_methods::tp_new_impl");
+    // return nullptr; // Unreachable.
+}
+
+inline PyObject *tp_alloc_impl(PyTypeObject *, Py_ssize_t) {
+    pybind11_fail("UNEXPECTED CALL OF function_record_PyTypeObject_methods::tp_alloc_impl");
+    // return nullptr; // Unreachable.
+}
+
+inline int tp_init_impl(PyObject *, PyObject *, PyObject *) {
+    pybind11_fail("UNEXPECTED CALL OF function_record_PyTypeObject_methods::tp_init_impl");
+    // return -1; // Unreachable.
+}
+
+// The implementation needs the definition of `class cpp_function`.
+void tp_dealloc_impl(PyObject *self);
+
+inline void tp_free_impl(void *) {
+    pybind11_fail("UNEXPECTED CALL OF function_record_PyTypeObject_methods::tp_free_impl");
+}
+
+inline PyObject *reduce_ex_impl(PyObject *self, PyObject *, PyObject *) {
+    // Deliberately ignoring the arguments for simplicity (expected is `protocol: int`).
+    const function_record *rec = function_record_ptr_from_PyObject(self);
+    if (rec == nullptr) {
+        pybind11_fail(
+            "FATAL: function_record_PyTypeObject reduce_ex_impl(): cannot obtain cpp_func_rec.");
+    }
+    if (rec->name != nullptr && rec->name[0] != '\0' && rec->scope
+        && PyModule_Check(rec->scope.ptr()) != 0) {
+        object scope_module = get_scope_module(rec->scope);
+        if (scope_module) {
+            return make_tuple(reinterpret_borrow<object>(PyEval_GetBuiltins())["eval"],
+                              make_tuple(str("__import__('importlib').import_module('")
+                                         + scope_module + str("')")))
+                .release()
+                .ptr();
+        }
+    }
+    set_error(PyExc_RuntimeError, repr(self) + str(" is not pickleable."));
+    return nullptr;
+}
+
+PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)
+
+PYBIND11_NAMESPACE_END(detail)
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -36,6 +36,9 @@ PYBIND11_WARNING_PUSH
 #if defined(__GNUC__) && __GNUC__ >= 8
 PYBIND11_WARNING_DISABLE_GCC("-Wcast-function-type")
 #endif
+#if defined(__clang__) && !defined(__apple_build_version__) && __clang_major__ >= 19
+PYBIND11_WARNING_DISABLE_CLANG("-Wcast-function-type-mismatch")
+#endif
 static PyMethodDef tp_methods_impl[]
     = {{"__reduce_ex__", (PyCFunction) reduce_ex_impl, METH_VARARGS | METH_KEYWORDS, nullptr},
        {nullptr, nullptr, 0, nullptr}};

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -108,9 +108,7 @@ static PyTypeObject function_record_PyTypeObject = {
     /* destructor tp_del */ nullptr,
     /* unsigned int tp_version_tag */ 0,
     /* destructor tp_finalize */ nullptr,
-#if PY_VERSION_HEX >= 0x03080000
     /* vectorcallfunc tp_vectorcall */ nullptr,
-#endif
 };
 PYBIND11_WARNING_POP
 

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -93,15 +93,8 @@ public:
             auto *cfunc_self = PyCFunction_GET_SELF(cfunc.ptr());
             if (cfunc_self == nullptr) {
                 PyErr_Clear();
-            } else if (isinstance<capsule>(cfunc_self)) {
-                auto c = reinterpret_borrow<capsule>(cfunc_self);
-
-                function_record *rec = nullptr;
-                // Check that we can safely reinterpret the capsule into a function_record
-                if (detail::is_function_record_capsule(c)) {
-                    rec = c.get_pointer<function_record>();
-                }
-
+            } else {
+                function_record *rec = function_record_ptr_from_PyObject(cfunc_self);
                 while (rec != nullptr) {
                     if (rec->is_stateless
                         && same_type(typeid(function_type),

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -12,6 +12,7 @@
 #include "detail/class.h"
 #include "detail/dynamic_raw_ptr_cast_if_possible.h"
 #include "detail/exception_translation.h"
+#include "detail/function_record_pyobject.h"
 #include "detail/init.h"
 #include "detail/native_enum_data.h"
 #include "detail/using_smart_holder.h"
@@ -21,6 +22,7 @@
 #include "options.h"
 #include "typing.h"
 
+#include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
@@ -598,20 +600,11 @@ protected:
         if (rec->sibling) {
             if (PyCFunction_Check(rec->sibling.ptr())) {
                 auto *self = PyCFunction_GET_SELF(rec->sibling.ptr());
-                if (!isinstance<capsule>(self)) {
+                chain = detail::function_record_ptr_from_PyObject(self);
+                if (chain && !chain->scope.is(rec->scope)) {
+                    /* Never append a method to an overload chain of a parent class;
+                       instead, hide the parent's overloads in this case */
                     chain = nullptr;
-                } else {
-                    auto rec_capsule = reinterpret_borrow<capsule>(self);
-                    if (detail::is_function_record_capsule(rec_capsule)) {
-                        chain = rec_capsule.get_pointer<detail::function_record>();
-                        /* Never append a method to an overload chain of a parent class;
-                           instead, hide the parent's overloads in this case */
-                        if (!chain->scope.is(rec->scope)) {
-                            chain = nullptr;
-                        }
-                    } else {
-                        chain = nullptr;
-                    }
                 }
             }
             // Don't trigger for things like the default __init__, which are wrapper_descriptors
@@ -631,21 +624,14 @@ protected:
                 = reinterpret_cast<PyCFunction>(reinterpret_cast<void (*)()>(dispatcher));
             rec->def->ml_flags = METH_VARARGS | METH_KEYWORDS;
 
-            capsule rec_capsule(unique_rec.release(),
-                                detail::get_function_record_capsule_name(),
-                                [](void *ptr) { destruct((detail::function_record *) ptr); });
+            detail::function_record_PyTypeObject_PyType_Ready(); // Call-once initialization.
+            object py_func_rec = detail::function_record_PyObject_New();
+            ((detail::function_record_PyObject *) py_func_rec.ptr())->cpp_func_rec
+                = unique_rec.release();
             guarded_strdup.release();
 
-            object scope_module;
-            if (rec->scope) {
-                if (hasattr(rec->scope, "__module__")) {
-                    scope_module = rec->scope.attr("__module__");
-                } else if (hasattr(rec->scope, "__name__")) {
-                    scope_module = rec->scope.attr("__name__");
-                }
-            }
-
-            m_ptr = PyCFunction_NewEx(rec->def, rec_capsule.ptr(), scope_module.ptr());
+            object scope_module = detail::get_scope_module(rec->scope);
+            m_ptr = PyCFunction_NewEx(rec->def, py_func_rec.ptr(), scope_module.ptr());
             if (!m_ptr) {
                 pybind11_fail("cpp_function::cpp_function(): Could not allocate function object");
             }
@@ -674,8 +660,9 @@ protected:
                 // chain.
                 chain_start = rec;
                 rec->next = chain;
-                auto rec_capsule = reinterpret_borrow<capsule>(PyCFunction_GET_SELF(m_ptr));
-                rec_capsule.set_pointer(unique_rec.release());
+                auto *py_func_rec
+                    = (detail::function_record_PyObject *) PyCFunction_GET_SELF(m_ptr);
+                py_func_rec->cpp_func_rec = unique_rec.release();
                 guarded_strdup.release();
             } else {
                 // Or end of chain (normal behavior)
@@ -750,6 +737,8 @@ protected:
         }
     }
 
+    friend void detail::function_record_PyTypeObject_methods::tp_dealloc_impl(PyObject *);
+
     /// When a cpp_function is GCed, release any memory allocated by pybind11
     static void destruct(detail::function_record *rec, bool free_strings = true) {
 // If on Python 3.9, check the interpreter "MICRO" (patch) version.
@@ -799,13 +788,11 @@ protected:
     /// Main dispatch logic for calls to functions bound using pybind11
     static PyObject *dispatcher(PyObject *self, PyObject *args_in, PyObject *kwargs_in) {
         using namespace detail;
-        assert(isinstance<capsule>(self));
+        const function_record *overloads = function_record_ptr_from_PyObject(self);
+        assert(overloads != nullptr);
 
         /* Iterator over the list of potentially admissible overloads */
-        const function_record *overloads = reinterpret_cast<function_record *>(
-                                  PyCapsule_GetPointer(self, get_function_record_capsule_name())),
-                              *current_overload = overloads;
-        assert(overloads != nullptr);
+        const function_record *current_overload = overloads;
 
         /* Need to know how many arguments + keyword arguments there are to pick the right
            overload */
@@ -1248,6 +1235,17 @@ protected:
 };
 
 PYBIND11_NAMESPACE_BEGIN(detail)
+
+PYBIND11_NAMESPACE_BEGIN(function_record_PyTypeObject_methods)
+
+// This implementation needs the definition of `class cpp_function`.
+inline void tp_dealloc_impl(PyObject *self) {
+    auto *py_func_rec = (function_record_PyObject *) self;
+    cpp_function::destruct(py_func_rec->cpp_func_rec);
+    py_func_rec->cpp_func_rec = nullptr;
+}
+
+PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)
 
 template <>
 struct handle_type_name<cpp_function> {
@@ -2465,14 +2463,7 @@ private:
         if (!func_self) {
             throw error_already_set();
         }
-        if (!isinstance<capsule>(func_self)) {
-            return nullptr;
-        }
-        auto cap = reinterpret_borrow<capsule>(func_self);
-        if (!detail::is_function_record_capsule(cap)) {
-            return nullptr;
-        }
-        return cap.get_pointer<detail::function_record>();
+        return detail::function_record_ptr_from_PyObject(func_self.ptr());
     }
 };
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1398,6 +1398,18 @@ class simple_collector;
 template <return_value_policy policy = return_value_policy::automatic_reference>
 class unpacking_collector;
 
+inline object get_scope_module(handle scope) {
+    if (scope) {
+        if (hasattr(scope, "__module__")) {
+            return scope.attr("__module__");
+        }
+        if (hasattr(scope, "__name__")) {
+            return scope.attr("__name__");
+        }
+    }
+    return object();
+}
+
 PYBIND11_NAMESPACE_END(detail)
 
 // TODO: After the deprecated constructors are removed, this macro can be simplified by

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -65,6 +65,7 @@ detail_headers = {
     "include/pybind11/detail/cpp_conduit.h",
     "include/pybind11/detail/descr.h",
     "include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h",
+    "include/pybind11/detail/function_record_pyobject.h",
     "include/pybind11/detail/init.h",
     "include/pybind11/detail/internals.h",
     "include/pybind11/detail/native_enum_data.h",


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
**This PR requires a `PYBIND11_INTERNALS_VERSION` bump (from `8` to `9`).**
________
Closes #1261

[Full ChatGPT assessment](https://chatgpt.com/share/67d09e7a-d1b0-8008-995d-79860b77169d)

**ChatGPT summary** (with a couple edits)

**Motivation and Importance**

Before this PR, pybind11-bound functions are not pickleable, which creates significant friction for Python users who rely on `pickle` and related serialization mechanisms for common tasks such as:

1. **Parallel and Concurrent Processing**

    Python's `multiprocessing` module depends on pickling to distribute tasks across worker processes. Since pybind11 functions cannot be pickled, users are forced to implement fragile and inefficient workarounds (e.g., passing function names as strings or relying on global state). This limits the usability of pybind11 bindings in parallel and distributed computing frameworks such as `multiprocessing`, `concurrent.futures`, and `joblib`.

2. **Caching and Memoization**

    Libraries like `joblib`, `functools.lru_cache`, and `diskcache` rely on pickle to store function results and enable fast recomputation. The inability to pickle pybind11-bound functions makes it difficult to integrate C++ extensions with these widely used caching mechanisms.

3. **Distributed Computing and Cloud Environments**

    Modern data processing frameworks such as Dask and Ray depend on pickling to serialize tasks and distribute them across clusters. The current pybind11 limitation prevents users from leveraging C++-based functions in these environments without cumbersome workarounds.

4. **Testing and Mocking**

    Serialization of test artifacts and fixtures is a common practice in Python testing frameworks like `pytest`. Non-pickleable pybind11 functions make it difficult to persist test state and mock functions consistently.

5. **General Python Compatibility**

    Python developers expect functions and objects to be pickleable as a baseline feature. The fact that pybind11-bound functions break this expectation creates unnecessary obstacles.

This PR introduces a solution to enable pickling of pybind11-bound functions in a way that is efficient, reliable, and consistent with Python's native serialization semantics. The solution has been tested extensively in large-scale production environments and is designed to maintain backward compatibility and minimal performance overhead. By addressing this long-standing limitation, this PR will significantly improve the usability of pybind11 for parallel processing, distributed systems, caching, and testing — making it easier for developers to integrate C++ extensions into modern Python workflows.
________
________
________
 
**Notes:**

* The `repr()` for pybind11 functions is made much more informative and truthful:

Before this PR:
```
<built-in method simple_callable of PyCapsule object at 0x...>
```

(`PyCapsule` objects do not have methods.)

With this PR:
```
<built-in method simple_callable of pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1 object at 0x...>
```

* The increase in generated machine code size is very small (using `-DCMAKE_BUILD_TYPE=MinSizeRel`):

Before this PR:
```
------ pybind11_tests.cpython-312-x86_64-linux-gnu.so file size: 5252640
```

With this PR:
```
------ pybind11_tests.cpython-312-x86_64-linux-gnu.so file size: 5257248
```

Factor: 5257248 / 5252640 = 1.0008772731426483

**Comparison with stock Python and other systems for Python-C++ bindings:**

* [Python functions (built-in & native) are pickleable.](https://github.com/google/pywrapcc/pull/30099#issuecomment-1947027004)

* [SWIG functions are pickleable.](https://github.com/google/pywrapcc/pull/30099#issuecomment-1946921946)

* [PyCLIF-C-API functions are pickleable.](https://github.com/google/clif/) (Because they are implemented exactly like stock Python build-in functions.)

* [Boost.Python functions are not pickleable.](https://github.com/rwgk/stuff/blob/master/test_with_boost_python/test_pickle_simple_callable_build_and_test.txt)

* [nanobind functions are not pickleable.](https://github.com/google/pywrapcc/pull/30099#issuecomment-1946877566)

________
________
________

**Everything below are very technical details:**

Why is

```c++
m.def("simple_callable", []() { return 0; });
```

not pickleable before this PR?

The reason is that the `simple_callable` is implemented as shown by `repr(simple_callable)`:

```
<built-in method simple_callable of PyCapsule object at 0x...>
```

To Python it appears to be a bound function of the type `PyCapsule`. (The reasons for this choice of implementation are deep and omitted here.)

`pickle.dumps(simple_callable)` is capable of pickling built-in methods. It does that in two steps:

```
simple_callable.__reduce_ex__(0)
```

produces this tuple (see [`__reduce_ex__` documentation](https://docs.python.org/3/library/pickle.html#object.__reduce_ex__)):

```
(<built-in function getattr>, (<capsule object NULL at 0x...>, 'simple_callable'))
```

pickle then recurses, attempting to serialize `<built-in function getattr>` (no problem), `<capsule object NULL at 0x...>` (**problem**), and `'simple_callable'` (no problem).

The attempt to serialize `<capsule object NULL at 0x...>` fails with this exception (copy-pasted from pytest output):

```
>       pickle.dumps(m.simple_callable)
E       TypeError: cannot pickle 'PyCapsule' object
```

While this is not the desired behavior when pickling `simple_callable`, there are very good reasons in general that `PyCapsule` objects are not pickleable. See, for example, here:

* https://github.com/uqfoundation/dill/pull/477/files#diff-bdd40cc870892c410adce8c1b155daf5e6c5b5e7192e751f171e6dae6a578dc1R1220

```python
warnings.warn('Creating a new PyCapsule %s for a C data structure that may not be present in memory. Segmentation faults or other memory errors are possible.' % (name,), UnpicklingWarning)
```

The solution implemented in this PR is to

1. replace the `PyCapsule` with a custom built-in type, wrapping the [`pybind11::detail::function_record` C++ type](https://github.com/pybind/pybind11/blob/8b48ff878c168b51fe5ef7b8c728815b9e1a9857/include/pybind11/attr.h#L189-L269) the good-old way, with manually written bindings (implemented in include/pybind11/detail/function_record_pyobject.h),

5. which then makes it possible to provide a `__reduce_ex__` implementation to achieve the desired behavior.

The new `repr(simple_callable)` is:

```
<built-in method simple_callable of pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1 object at 0x...>
```

Side note: The Python type name is versioned to ensure ABI compatibility, but to maximize compatibility it is independent of `PYBIND11_INTERNALS_VERSION`.

`simple_callable.__reduce_ex__(0)` now produces:

```
(<built-in function getattr>, (<pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1 object at 0x...>, 'simple_callable'))
```

When pickle recurses to call `__reduce_ex__` of the wrapped `function_record` object, the result is:

```
(<built-in function eval>, ("__import__('importlib').import_module('pybind11_tests.pickling')",))
```

Very simple! — Your author has to admit though that it took quite a while to figure this out. See the development history of google/pybind11clif#30099 for the many dead ends explored before this solution was discovered.

To explain how this works in the `pickle.load()` step:

1. `eval("__import__('importlib').import_module('pybind11_tests.pickling')")` produces a reference to the imported `pybind11_tests.pickling` module.

2. `getattr(imported_module, 'simple_callable')` simply accesses what was just imported.

Note that `__import__('pybind11_tests.pickling')` only produces the top-level module (`pybind11_tests` in this case), as explained in the [`importlib.import_module()` documentation](https://docs.python.org/3/library/importlib.html#importlib.import_module).
________
________
________
This PR is a backport of google/pybind11clif#30099

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
pybind11-bound functions are now pickleable.
```

<!-- If the upgrade guide needs updating, note that here too -->
