### PR TITLE
Add test for `boost::histogram::func_transform` situation.

### DIFF
--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#define PYBIND11_HAS_TYPE_CASTER_STD_FUNCTION_FUNC_IS_STATELESS_WITH_EXACT_TYPE
 #define PYBIND11_HAS_TYPE_CASTER_STD_FUNCTION_SPECIALIZATIONS
 
 #include "pybind11.h"
@@ -66,15 +65,8 @@ struct type_caster<std::function<Return(Args...)>> {
     using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
     using function_type = Return (*)(Args...);
 
-private:
-    bool func_is_stateless_with_exact_type_ = false;
-
 public:
-    bool func_is_stateless_with_exact_type() const { return func_is_stateless_with_exact_type_; }
-
     bool load(handle src, bool convert) {
-        func_is_stateless_with_exact_type_ = false;
-
         if (src.is_none()) {
             // Defer accepting None to other overloads (if we aren't in convert mode):
             if (!convert) {
@@ -118,7 +110,6 @@ public:
                             function_type f;
                         };
                         value = ((capture *) &rec->data)->f;
-                        func_is_stateless_with_exact_type_ = true;
                         return true;
                     }
                     rec = rec->next;

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#define PYBIND11_HAS_TYPE_CASTER_STD_FUNCTION_FUNC_IS_STATELESS_WITH_EXACT_TYPE
 #define PYBIND11_HAS_TYPE_CASTER_STD_FUNCTION_SPECIALIZATIONS
 
 #include "pybind11.h"
@@ -65,8 +66,15 @@ struct type_caster<std::function<Return(Args...)>> {
     using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
     using function_type = Return (*)(Args...);
 
+private:
+    bool func_is_stateless_with_exact_type_ = false;
+
 public:
+    bool func_is_stateless_with_exact_type() const { return func_is_stateless_with_exact_type_; }
+
     bool load(handle src, bool convert) {
+        func_is_stateless_with_exact_type_ = false;
+
         if (src.is_none()) {
             // Defer accepting None to other overloads (if we aren't in convert mode):
             if (!convert) {
@@ -110,6 +118,7 @@ public:
                             function_type f;
                         };
                         value = ((capture *) &rec->data)->f;
+                        func_is_stateless_with_exact_type_ = true;
                         return true;
                     }
                     rec = rec->next;

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -30,8 +30,8 @@ double apply_custom_transform(const py::object &src, double value) {
         return -100;
     }
     auto func = static_cast<std::function<raw_t> &>(func_caster);
-    auto cfunc = func.target<raw_t*>();
-    if(cfunc == nullptr) {
+    auto cfunc = func.target<raw_t *>();
+    if (cfunc == nullptr) {
         return -200;
     }
     return (*cfunc)(value);

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -29,10 +29,12 @@ double apply_custom_transform(const py::object &src, double value) {
     if (!func_caster.load(src, /*convert*/ false)) {
         return -100;
     }
-    if (!func_caster.func_is_stateless_with_exact_type()) {
+    auto func = static_cast<std::function<raw_t> &>(func_caster);
+    auto cfunc = func.target<raw_t*>();
+    if(cfunc == nullptr) {
         return -200;
     }
-    return static_cast<std::function<raw_t> &>(func_caster)(value);
+    return (*cfunc)(value);
 }
 
 } // namespace boost_histogram

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -29,6 +29,9 @@ double apply_custom_transform(const py::object &src, double value) {
     if (!func_caster.load(src, /*convert*/ false)) {
         return -100;
     }
+    if (!func_caster.func_is_stateless_with_exact_type()) {
+        return -200;
+    }
     return static_cast<std::function<raw_t> &>(func_caster)(value);
 }
 

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -30,7 +30,7 @@ double apply_custom_transform(const py::object &src, double value) {
         return -100;
     }
     auto func = static_cast<std::function<raw_t> &>(func_caster);
-    auto cfunc = func.target<raw_t *>();
+    auto *cfunc = func.target<raw_t *>();
     if (cfunc == nullptr) {
         return -200;
     }

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -30,7 +30,7 @@ double apply_custom_transform(const py::object &src, double value) {
     if (auto cfunc = func.cpp_function()) {
         auto c = py::reinterpret_borrow<py::capsule>(PyCFunction_GET_SELF(cfunc.ptr()));
 
-        auto rec = c.get_pointer<py::detail::function_record>();
+        auto *rec = c.get_pointer<py::detail::function_record>();
 
         if (rec && rec->is_stateless
             && py::detail::same_type(typeid(raw_t *),
@@ -38,7 +38,7 @@ double apply_custom_transform(const py::object &src, double value) {
             struct capture {
                 raw_t *f;
             };
-            auto cap = reinterpret_cast<capture *>(&rec->data);
+            auto *cap = reinterpret_cast<capture *>(&rec->data);
             return (*cap->f)(value);
         }
         return -200;

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -241,8 +241,9 @@ def test_boost_histogram_apply_custom_transform():
     cti = m.boost_histogram_custom_transform_int
     apply = m.boost_histogram_apply_custom_transform
     assert apply(ctd, 5) == 15
-    assert apply(cti, 0) == -200
+    with pytest.raises(TypeError):
+        assert apply(cti, 0)
     assert apply(None, 0) == -100
-    assert apply(lambda value: value, 0) == -100
+    assert apply(lambda value: value * 10, 4) == 40
     assert apply({}, 0) == -100
     assert apply("", 0) == -100

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -234,3 +234,15 @@ def test_callback_docstring():
         m.test_tuple_unpacking.__doc__.strip()
         == "test_tuple_unpacking(arg0: Callable) -> object"
     )
+
+
+def test_boost_histogram_apply_custom_transform():
+    ctd = m.boost_histogram_custom_transform_double
+    cti = m.boost_histogram_custom_transform_int
+    apply = m.boost_histogram_apply_custom_transform
+    assert apply(ctd, 5) == 15
+    assert apply(cti, 0) == -200
+    assert apply(None, 0) == -100
+    assert apply(lambda value: value, 0) == -100
+    assert apply({}, 0) == -100
+    assert apply("", 0) == -100

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -241,9 +241,8 @@ def test_boost_histogram_apply_custom_transform():
     cti = m.boost_histogram_custom_transform_int
     apply = m.boost_histogram_apply_custom_transform
     assert apply(ctd, 5) == 15
-    with pytest.raises(TypeError):
-        assert apply(cti, 0)
+    assert apply(cti, 0) == -200
     assert apply(None, 0) == -100
-    assert apply(lambda value: value * 10, 4) == 40
+    assert apply(lambda value: value, 9) == -200
     assert apply({}, 0) == -100
     assert apply("", 0) == -100


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The added test reflects this change in boost-histogram:

* https://github.com/scikit-hep/boost-histogram/pull/994

The APIs used in the added test code here are considered public.

See also: Discussions under PR #5580

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
