### PR TITLE
fix: set __file__ on submodules

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1337,10 +1337,18 @@ public:
             result.attr("__doc__") = pybind11::str(doc);
         }
 
+#ifdef GRAALVM_PYTHON
         // GraalPy doesn't support PyModule_GetFilenameObject,
         // so getting by attribute
         handle this_module = m_ptr;
         result.attr("__file__") = this_module.attr("__file__");
+#else
+        handle this_file = PyModule_GetFilenameObject(m_ptr);
+        if (!this_file) {
+            throw error_already_set();
+        }
+        result.attr("__file__") = this_file;
+#endif
         attr(name) = result;
         return result;
     }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1337,9 +1337,9 @@ public:
             result.attr("__doc__") = pybind11::str(doc);
         }
 
-#ifdef GRAALVM_PYTHON
+#if defined(GRAALVM_PYTHON) && GRAALPY_VERSION_NUM < 0x190000
         // GraalPy doesn't support PyModule_GetFilenameObject,
-        // so getting by attribute
+        // so getting by attribute (see PR #5584)
         handle this_module = m_ptr;
         result.attr("__file__") = this_module.attr("__file__");
 #else

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1336,6 +1336,11 @@ public:
         if (doc && options::show_user_defined_docstrings()) {
             result.attr("__doc__") = pybind11::str(doc);
         }
+        handle this_file = PyModule_GetFilenameObject(m_ptr);
+        if (!this_file) {
+            throw error_already_set();
+        }
+        result.attr("__file__") = this_file;
         attr(name) = result;
         return result;
     }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1336,11 +1336,11 @@ public:
         if (doc && options::show_user_defined_docstrings()) {
             result.attr("__doc__") = pybind11::str(doc);
         }
-        handle this_file = PyModule_GetFilenameObject(m_ptr);
-        if (!this_file) {
-            throw error_already_set();
-        }
-        result.attr("__file__") = this_file;
+
+        // GraalPy doesn't support PyModule_GetFilenameObject,
+        // so getting by attribute
+        handle this_module = m_ptr;
+        result.attr("__file__") = this_module.attr("__file__");
         attr(name) = result;
         return result;
     }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1337,7 +1337,7 @@ public:
             result.attr("__doc__") = pybind11::str(doc);
         }
 
-#if defined(GRAALVM_PYTHON) && GRAALPY_VERSION_NUM < 0x190000
+#if defined(GRAALVM_PYTHON) && (!defined(GRAALPY_VERSION_NUM) || GRAALPY_VERSION_NUM < 0x190000)
         // GraalPy doesn't support PyModule_GetFilenameObject,
         // so getting by attribute (see PR #5584)
         handle this_module = m_ptr;

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -21,6 +21,7 @@ def test_nested_modules():
     )
     assert m.__name__ == "pybind11_tests.modules"
     assert ms.__name__ == "pybind11_tests.modules.subsubmodule"
+    assert m.__file__ == ms.__file__
 
     assert ms.submodule_func() == "submodule_func()"
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

The docs state ['The caller is responsible for setting a `__file__` attribute'](https://docs.python.org/3/c-api/module.html), but we
were not doing that, which interferes with pickling objects in submodules using cloudpickle. Users previously had to set the `__file__` attributes manually,
such as in https://github.com/scikit-hep/boost-histogram/blob/1fbbe1632e1665863b9c84b10edf6aa659a14bf1/src/boost_histogram/histogram.py#L83-L90.


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Set `__file__` on submodules.
```

<!-- If the upgrade guide needs updating, note that here too -->
