### PR TITLE
ci: update to GraalPy 24.2 and mention in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         - '3.13'
         - 'pypy-3.10'
         - 'pypy-3.11'
-        - 'graalpy-24.1'
+        - 'graalpy-24.2'
 
         # Items in here will either be added to the build matrix (if not
         # present), or add new keys to an existing matrix element if all the
@@ -95,9 +95,12 @@ jobs:
             python: '3.12'
             args: >
               -DCMAKE_CXX_FLAGS="/DPYBIND11_RUN_TESTING_WITH_SMART_HOLDER_AS_DEFAULT_BUT_NEVER_USE_IN_PRODUCTION_PLEASE /GR /EHsc"
+          - python: 'graalpy-24.1'
+            runs-on: 'ubuntu-latest'
         exclude:
           # The setup-python action currently doesn't have graalpy for windows
-          - python: 'graalpy-24.1'
+          # See https://github.com/actions/setup-python/pull/880
+          - python: 'graalpy-24.2'
             runs-on: 'windows-2022'
 
 

--- a/README.rst
+++ b/README.rst
@@ -34,12 +34,12 @@ dependency.
 Think of this library as a tiny self-contained version of Boost.Python
 with everything stripped away that isn't relevant for binding
 generation. Without comments, the core header files only require ~4K
-lines of code and depend on Python (3.8+, or PyPy) and the C++
-standard library. This compact implementation was possible thanks to
-some C++11 language features (specifically: tuples, lambda functions and
-variadic templates). Since its creation, this library has grown beyond
-Boost.Python in many ways, leading to dramatically simpler binding code in many
-common situations.
+lines of code and depend on Python (CPython 3.8+, PyPy, or GraalPy) and the C++
+standard library. This compact implementation was possible thanks to some C++11
+language features (specifically: tuples, lambda functions and variadic
+templates). Since its creation, this library has grown beyond Boost.Python in
+many ways, leading to dramatically simpler binding code in many common
+situations.
 
 Tutorial and reference documentation is provided at
 `pybind11.readthedocs.io <https://pybind11.readthedocs.io/en/latest>`_.
@@ -79,8 +79,9 @@ Goodies
 In addition to the core functionality, pybind11 provides some extra
 goodies:
 
-- Python 3.8+, and PyPy3 7.3 are supported with an implementation-agnostic
-  interface (pybind11 2.9 was the last version to support Python 2 and 3.5).
+- Python 3.8+, PyPy3 7.3, and GraalPy 24.1+ are supported with an
+  implementation-agnostic interface (pybind11 2.9 was the last version to
+  support Python 2 and 3.5).
 
 - It is possible to bind C++11 lambda functions with captured
   variables. The lambda capture data is stored inside the resulting


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

This keeps one 24.1 build, and adds a mention to the README alongside PyPy. I thought about adding Pyodide here too, but since that's
basically CPython, it seems odd to call it out here. Maybe somewhere else.

