### PR TITLE
`function_record` code health enhancements (`std::launder`, `std::is_standard_layout`)

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -272,6 +272,12 @@ struct function_record {
     /// Pointer to next overload
     function_record *next = nullptr;
 };
+// The main purpose of this macro is to make it easy to pin-point the critically related code
+// sections.
+#define PYBIND11_ENSURE_PRECONDITION_FOR_FUNCTIONAL_H_PERFORMANCE_OPTIMIZATIONS(...)              \
+    static_assert(                                                                                \
+        __VA_ARGS__,                                                                              \
+        "Violation of precondition for pybind11/functional.h performance optimizations!")
 
 /// Special data structure which (temporarily) holds metadata about a bound class
 struct type_record {

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -123,6 +123,14 @@
 #    endif
 #endif
 
+#if defined(__cpp_lib_launder) && !(defined(_MSC_VER) && (_MSC_VER < 1914))
+#    define PYBIND11_STD_LAUNDER std::launder
+#    define PYBIND11_HAS_STD_LAUNDER 1
+#else
+#    define PYBIND11_STD_LAUNDER
+#    define PYBIND11_HAS_STD_LAUNDER 0
+#endif
+
 #if defined(PYBIND11_CPP20)
 #    define PYBIND11_CONSTINIT constinit
 #    define PYBIND11_DTOR_CONSTEXPR constexpr

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -101,8 +101,14 @@ public:
                                      *reinterpret_cast<const std::type_info *>(rec->data[1]))) {
                         struct capture {
                             function_type f;
+
+                            static capture *from_data(void **data) {
+                                return PYBIND11_STD_LAUNDER(reinterpret_cast<capture *>(data));
+                            }
                         };
-                        value = ((capture *) &rec->data)->f;
+                        PYBIND11_ENSURE_PRECONDITION_FOR_FUNCTIONAL_H_PERFORMANCE_OPTIMIZATIONS(
+                            std::is_standard_layout<capture>::value);
+                        value = capture::from_data(rec->data)->f;
                         return true;
                     }
                     rec = rec->next;


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This PR refines and extends the use of `std::launder` for callable captures stored in `function_record::data`. It generalizes the approach first introduced in PR #2816 by applying it more consistently and defensively.

Key Improvements:

- 🔁 **Consistent use of `std::launder`**  
  All reinterpretations of the `data` field into the internal `capture` type now go through a centralized `capture::from_data(void**)` helper, which applies `std::launder` where supported. This eliminates ad hoc casting and ensures correct behavior under the C++ object model.

- 🛡️ **Precondition enforcement**  
  Adds a `static_assert` on `std::is_standard_layout<capture>` at critical optimization points. This ensures that reinterpret_casts and in-place storage remain well-defined.

- 🧼 **Macro centralization**  
  Moves the `PYBIND11_STD_LAUNDER` and `PYBIND11_HAS_STD_LAUNDER` macro definitions to `common.h`, enabling their reuse across headers (e.g., `functional.h` in addition to `pybind11.h`).

- 📉 **Reduced reliance on compiler-specific warnings**  
  The change removes special-case `#pragma` use around `-Wstrict-aliasing` by ensuring that laundering is properly applied across the board.

Motivation:

The original `std::launder` usage in PR #2816 was narrow in scope and only applied during destruction of non-trivially destructible callables. This patch addresses potential undefined behavior more broadly and makes the low-level implementation safer and easier to reason about, while maintaining performance characteristics.

ABI Note:

No changes to the ABI are introduced. The layout of `function_record` and the capture storage remains unchanged.

Changelog: Not needed.

Upgrade guide: Not needed.
________

This PR is a by-product of work under PR #5585 (which we will not merge, most likely).

________

[Browse function_record_std_launder/manuscript tree](https://github.com/rwgk/pybind11/tree/57b9a0af815d19b236b74be06a172bc5c9956618)

[Browse function_record_std_launder/manuscript commits](https://github.com/rwgk/pybind11/commits/57b9a0af815d19b236b74be06a172bc5c9956618/)
