### PR TITLE
feat: drop PYBIND11_NUMPY_1_ONLY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,6 @@ option(PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION
        "To enforce that a handle_type_name<> specialization exists" OFF)
 option(PYBIND11_SIMPLE_GIL_MANAGEMENT
        "Use simpler GIL management logic that does not support disassociation" OFF)
-option(PYBIND11_NUMPY_1_ONLY
-       "Disable NumPy 2 support to avoid changes to previous pybind11 versions." OFF)
 set(PYBIND11_INTERNALS_VERSION
     ""
     CACHE STRING "Override the ABI version, may be used to enable the unstable ABI.")
@@ -104,9 +102,6 @@ if(PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION)
 endif()
 if(PYBIND11_SIMPLE_GIL_MANAGEMENT)
   add_compile_definitions(PYBIND11_SIMPLE_GIL_MANAGEMENT)
-endif()
-if(PYBIND11_NUMPY_1_ONLY)
-  add_compile_definitions(PYBIND11_NUMPY_1_ONLY)
 endif()
 
 cmake_dependent_option(

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -251,10 +251,6 @@
 #    endif
 #endif
 
-#if defined(PYBIND11_NUMPY_1_ONLY)
-#    define PYBIND11_INTERNAL_NUMPY_1_ONLY_DETECTED
-#endif
-
 #if (defined(PYPY_VERSION) || defined(GRAALVM_PYTHON)) && !defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
 #    define PYBIND11_SIMPLE_GIL_MANAGEMENT
 #endif

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -29,6 +29,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(PYBIND11_NUMPY_1_ONLY)
+#    error "PYBIND11_NUMPY_1_ONLY is no longer supported (see PR #5595)."
+#endif
+
 /* This will be true on all flat address space platforms and allows us to reduce the
    whole npy_intp / ssize_t / Py_intptr_t business down to just ssize_t for all size
    and dimension types (e.g. shape, strides, indexing), instead of inflicting this

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -29,10 +29,6 @@
 #include <utility>
 #include <vector>
 
-#if defined(PYBIND11_NUMPY_1_ONLY) && !defined(PYBIND11_INTERNAL_NUMPY_1_ONLY_DETECTED)
-#    error PYBIND11_NUMPY_1_ONLY must be defined before any pybind11 header is included.
-#endif
-
 /* This will be true on all flat address space platforms and allows us to reduce the
    whole npy_intp / ssize_t / Py_intptr_t business down to just ssize_t for all size
    and dimension types (e.g. shape, strides, indexing), instead of inflicting this
@@ -80,7 +76,6 @@ struct PyArrayDescr1_Proxy {
     PyObject *names;
 };
 
-#ifndef PYBIND11_NUMPY_1_ONLY
 struct PyArrayDescr_Proxy {
     PyObject_HEAD
     PyObject *typeobj;
@@ -91,10 +86,6 @@ struct PyArrayDescr_Proxy {
     int type_num;
     /* Additional fields are NumPy version specific. */
 };
-#else
-/* NumPy 1.x only, we can expose all fields */
-using PyArrayDescr_Proxy = PyArrayDescr1_Proxy;
-#endif
 
 /* NumPy 2 proxy, including legacy fields */
 struct PyArrayDescr2_Proxy {
@@ -179,14 +170,6 @@ PYBIND11_NOINLINE module_ import_numpy_core_submodule(const char *submodule_name
     object numpy_version = numpy_lib.attr("NumpyVersion")(version_string);
     int major_version = numpy_version.attr("major").cast<int>();
 
-#ifdef PYBIND11_NUMPY_1_ONLY
-    if (major_version >= 2) {
-        throw std::runtime_error(
-            "This extension was built with PYBIND11_NUMPY_1_ONLY defined, "
-            "but NumPy 2 is used in this process. For NumPy2 compatibility, "
-            "this extension needs to be rebuilt without the PYBIND11_NUMPY_1_ONLY define.");
-    }
-#endif
     /* `numpy.core` was renamed to `numpy._core` in NumPy 2.0 as it officially
         became a private module. */
     std::string numpy_core_path = major_version >= 2 ? "numpy._core" : "numpy.core";
@@ -300,16 +283,6 @@ struct npy_api {
     PyObject *(*PyArray_FromAny_)(PyObject *, PyObject *, int, int, int, PyObject *);
     int (*PyArray_DescrConverter_)(PyObject *, PyObject **);
     bool (*PyArray_EquivTypes_)(PyObject *, PyObject *);
-#ifdef PYBIND11_NUMPY_1_ONLY
-    int (*PyArray_GetArrayParamsFromObject_)(PyObject *,
-                                             PyObject *,
-                                             unsigned char,
-                                             PyObject **,
-                                             int *,
-                                             Py_intptr_t *,
-                                             PyObject **,
-                                             PyObject *);
-#endif
     PyObject *(*PyArray_Squeeze_)(PyObject *);
     // Unused. Not removed because that affects ABI of the class.
     int (*PyArray_SetBaseObject_)(PyObject *, PyObject *);
@@ -337,9 +310,6 @@ private:
         API_PyArray_View = 137,
         API_PyArray_DescrConverter = 174,
         API_PyArray_EquivTypes = 182,
-#ifdef PYBIND11_NUMPY_1_ONLY
-        API_PyArray_GetArrayParamsFromObject = 278,
-#endif
         API_PyArray_SetBaseObject = 282
     };
 
@@ -374,9 +344,6 @@ private:
         DECL_NPY_API(PyArray_View);
         DECL_NPY_API(PyArray_DescrConverter);
         DECL_NPY_API(PyArray_EquivTypes);
-#ifdef PYBIND11_NUMPY_1_ONLY
-        DECL_NPY_API(PyArray_GetArrayParamsFromObject);
-#endif
         DECL_NPY_API(PyArray_SetBaseObject);
 
 #undef DECL_NPY_API
@@ -760,21 +727,14 @@ public:
     }
 
     /// Size of the data type in bytes.
-#ifdef PYBIND11_NUMPY_1_ONLY
-    ssize_t itemsize() const { return detail::array_descriptor_proxy(m_ptr)->elsize; }
-#else
     ssize_t itemsize() const {
         if (detail::npy_api::get().PyArray_RUNTIME_VERSION_ < 0x12) {
             return detail::array_descriptor1_proxy(m_ptr)->elsize;
         }
         return detail::array_descriptor2_proxy(m_ptr)->elsize;
     }
-#endif
 
     /// Returns true for structured data types.
-#ifdef PYBIND11_NUMPY_1_ONLY
-    bool has_fields() const { return detail::array_descriptor_proxy(m_ptr)->names != nullptr; }
-#else
     bool has_fields() const {
         if (detail::npy_api::get().PyArray_RUNTIME_VERSION_ < 0x12) {
             return detail::array_descriptor1_proxy(m_ptr)->names != nullptr;
@@ -785,7 +745,6 @@ public:
         }
         return proxy->names != nullptr;
     }
-#endif
 
     /// Single-character code for dtype's kind.
     /// For example, floating point types are 'f' and integral types are 'i'.
@@ -824,29 +783,21 @@ public:
     /// Single character for byteorder
     char byteorder() const { return detail::array_descriptor_proxy(m_ptr)->byteorder; }
 
-/// Alignment of the data type
-#ifdef PYBIND11_NUMPY_1_ONLY
-    int alignment() const { return detail::array_descriptor_proxy(m_ptr)->alignment; }
-#else
+    /// Alignment of the data type
     ssize_t alignment() const {
         if (detail::npy_api::get().PyArray_RUNTIME_VERSION_ < 0x12) {
             return detail::array_descriptor1_proxy(m_ptr)->alignment;
         }
         return detail::array_descriptor2_proxy(m_ptr)->alignment;
     }
-#endif
 
-/// Flags for the array descriptor
-#ifdef PYBIND11_NUMPY_1_ONLY
-    char flags() const { return detail::array_descriptor_proxy(m_ptr)->flags; }
-#else
+    /// Flags for the array descriptor
     std::uint64_t flags() const {
         if (detail::npy_api::get().PyArray_RUNTIME_VERSION_ < 0x12) {
             return (unsigned char) detail::array_descriptor1_proxy(m_ptr)->flags;
         }
         return detail::array_descriptor2_proxy(m_ptr)->flags;
     }
-#endif
 
 private:
     static object &_dtype_from_pep3118() {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,6 @@ def pytest_report_header():
         f"{pybind11_tests.cpp_std}",
         f"{pybind11_tests.PYBIND11_INTERNALS_ID}",
         f"PYBIND11_SIMPLE_GIL_MANAGEMENT={pybind11_tests.PYBIND11_SIMPLE_GIL_MANAGEMENT}",
-        f"PYBIND11_NUMPY_1_ONLY={pybind11_tests.PYBIND11_NUMPY_1_ONLY}",
     ]
     if "__graalpython__" in sys.modules:
         cpp_info.append(

--- a/tests/pybind11_tests.cpp
+++ b/tests/pybind11_tests.cpp
@@ -97,12 +97,6 @@ PYBIND11_MODULE(pybind11_tests, m, py::mod_gil_not_used()) {
 #else
         false;
 #endif
-    m.attr("PYBIND11_NUMPY_1_ONLY") =
-#if defined(PYBIND11_NUMPY_1_ONLY)
-        true;
-#else
-        false;
-#endif
 
     bind_ConstructorStats(m);
 

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -5,7 +5,6 @@ import re
 import pytest
 
 import env  # noqa: F401
-from pybind11_tests import PYBIND11_NUMPY_1_ONLY
 from pybind11_tests import numpy_dtypes as m
 
 np = pytest.importorskip("numpy")
@@ -181,12 +180,7 @@ def test_dtype(simple_dtype):
     assert m.test_dtype_num() == [np.dtype(ch).num for ch in expected_chars]
     assert m.test_dtype_byteorder() == [np.dtype(ch).byteorder for ch in expected_chars]
     assert m.test_dtype_alignment() == [np.dtype(ch).alignment for ch in expected_chars]
-    if not PYBIND11_NUMPY_1_ONLY:
-        assert m.test_dtype_flags() == [np.dtype(ch).flags for ch in expected_chars]
-    else:
-        assert m.test_dtype_flags() == [
-            chr(np.dtype(ch).flags) for ch in expected_chars
-        ]
+    assert m.test_dtype_flags() == [np.dtype(ch).flags for ch in expected_chars]
 
     for a, b in m.test_dtype_num_of():
         assert a == b


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

I can find no usages at all of this define on GitHub. Most packages support
NumPy 2, and the few that don't yet still don't need this define, which was
added in an abundance of caution, I believe. Let's remove it and simplify our
testing.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Legacy-mode option `PYBIND11_NUMPY_1_ONLY` has been removed.
```

<!-- If the upgrade guide needs updating, note that here too -->
