### PR TITLE
fix: fully deprecate get_type_of (deprecated in 2.6 but no warning)

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2520,7 +2520,7 @@ detail::initimpl::pickle_factory<GetState, SetState> pickle(GetState &&g, SetSta
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 inline str enum_name(handle arg) {
-    dict entries = arg.get_type().attr("__entries");
+    dict entries = type::handle_of(arg).attr("__entries");
     for (auto kv : entries) {
         if (handle(kv.second[int_(0)]).equal(arg)) {
             return pybind11::str(kv.first);

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -210,8 +210,7 @@ public:
 #endif
     }
 
-    // TODO PYBIND11_DEPRECATED(
-    //     "Call py::type::handle_of(h) or py::type::of(h) instead of h.get_type()")
+    PYBIND11_DEPRECATED("Call py::type::handle_of(h) or py::type::of(h) instead of h.get_type()")
     handle get_type() const;
 
 private:

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -219,7 +219,7 @@ TEST_SUBMODULE(class_, m) {
 
     m.def("get_type_of", [](py::object ob) { return py::type::of(std::move(ob)); });
 
-    m.def("get_type_classic", [](py::handle h) { return h.get_type(); });
+    m.def("get_type_classic", [](py::handle h) { return py::type::handle_of(h); });
 
     m.def("as_type", [](const py::object &ob) { return py::type(ob); });
 


### PR DESCRIPTION
Signed-off-by: Henry Schreiner <henryschreineriii@gmail.com>

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

This was deprecated in pybind11 2.6 (2020), but never produced the normal warning. Adding the warning now.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Add a deprecation warning to ``.get_type`` (deprecated in pybind11 2.6 in 2020)
```

<!-- If the upgrade guide needs updating, note that here too -->
