### PR TITLE
ci: speed up ci a bit by thinning out matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,24 +202,6 @@ jobs:
     - name: C++ tests
       run: cmake --build build2 --target cpptest
 
-    # Third build - C++17 mode with unstable ABI
-    - name: Configure (unstable ABI)
-      run: >
-        cmake -S . -B build3
-        -DPYBIND11_WERROR=ON
-        -DPYBIND11_PYTEST_ARGS=-v
-        -DDOWNLOAD_CATCH=ON
-        -DDOWNLOAD_EIGEN=ON
-        -DCMAKE_CXX_STANDARD=17
-        -DPYBIND11_INTERNALS_VERSION=10000000
-        ${{ matrix.args }}
-
-    - name: Build (unstable ABI)
-      run: cmake --build build3 -j 2
-
-    - name: Python tests (unstable ABI)
-      run: cmake --build build3 --target pytest
-
     - name: Interface test
       run: cmake --build build2 --target test_cmake_build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,14 @@ jobs:
         # We support an optional key: args, for cmake args
         include:
           # Just add a key
-          - runs-on: ubuntu-20.04
+          - runs-on: ubuntu-22.04
             python: '3.8'
             args: >
               -DPYBIND11_FINDPYTHON=OFF
               -DCMAKE_CXX_FLAGS="-D_=1"
               -DPYBIND11_NUMPY_1_ONLY=ON
             exercise_D_: 1
-          - runs-on: windows-2019
+          - runs-on: windows-2022
             python: '3.8'
             args: >
               -DPYBIND11_FINDPYTHON=OFF
@@ -82,8 +82,6 @@ jobs:
           - runs-on: ubuntu-latest
             python: '3.9'
           - runs-on: ubuntu-latest
-            python: '3.10'
-          - runs-on: ubuntu-latest
             python: '3.11'
           # Run tests with py::smart_holder as the default holder
           # with recent (or ideally latest) released Python version.
@@ -99,8 +97,8 @@ jobs:
             python: '3.12'
             args: >
               -DCMAKE_CXX_FLAGS="/DPYBIND11_RUN_TESTING_WITH_SMART_HOLDER_AS_DEFAULT_BUT_NEVER_USE_IN_PRODUCTION_PLEASE /GR /EHsc"
-          - python: 'graalpy-24.1'
-            runs-on: 'ubuntu-latest'
+          - runs-on: 'ubuntu-latest'
+            python: 'graalpy-24.1'
         exclude:
           # The setup-python action currently doesn't have graalpy for windows
           # See https://github.com/actions/setup-python/pull/880

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-20.04, windows-2022, macos-13]
+        runs-on: [ubuntu-22.04, windows-2022, macos-13]
         python:
         - '3.8'
-        - '3.9'
-        - '3.12'
         - '3.13'
         - 'pypy-3.10'
         - 'pypy-3.11'
@@ -80,7 +78,11 @@ jobs:
             python: '3.12'
             args: >
               -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebugDLL
-          # Extra ubuntu latest job
+          # Extra ubuntu latest jobs
+          - runs-on: ubuntu-latest
+            python: '3.9'
+          - runs-on: ubuntu-latest
+            python: '3.10'
           - runs-on: ubuntu-latest
             python: '3.11'
           # Run tests with py::smart_holder as the default holder
@@ -273,7 +275,7 @@ jobs:
           python-debug: false
 
     name: "🐍 ${{ matrix.python-version }}${{ matrix.python-debug && '-dbg' || '' }} (deadsnakes)${{ matrix.valgrind && ' • Valgrind' || '' }} • x64"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -353,21 +355,11 @@ jobs:
             std: 14
           - clang: 11
             std: 20
-          - clang: 12
-            std: 20
-          - clang: 13
-            std: 20
           - clang: 14
             std: 20
-          - clang: 15
-            std: 20
-            container_suffix: "-bullseye"
           - clang: 16
             std: 20
             container_suffix: "-bullseye"
-          - clang: 17
-            std: 20
-            container_suffix: "-bookworm"
           - clang: 18
             std: 20
             container_suffix: "-bookworm"
@@ -531,8 +523,6 @@ jobs:
           - { gcc: 9, std: 20 }
           - { gcc: 10, std: 17 }
           - { gcc: 10, std: 20 }
-          - { gcc: 11, std: 20 }
-          - { gcc: 12, std: 20 }
           - { gcc: 13, std: 20 }
 
     name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }}• x64"
@@ -831,10 +821,7 @@ jobs:
       matrix:
         python:
         - '3.8'
-        - '3.9'
-        - '3.10'
-        - '3.11'
-        - '3.12'
+        - '3.13'
 
         include:
           - python: '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,17 +56,17 @@ jobs:
             python: '3.8'
             args: >
               -DPYBIND11_FINDPYTHON=OFF
-          # Inject a couple Windows 2019 runs
+          # Inject a Windows 2019 run
           - runs-on: windows-2019
             python: '3.9'
           # Inject a few runs with different runtime libraries
           - runs-on: windows-2022
-            python: '3.9'
+            python: '3.8'
             args: >
               -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
               -DPYBIND11_NUMPY_1_ONLY=ON
           - runs-on: windows-2022
-            python: '3.10'
+            python: '3.9'
             args: >
               -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL
           # This needs a python built with MTd
@@ -75,14 +75,9 @@ jobs:
           #   args: >
           #     -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug
           - runs-on: windows-2022
-            python: '3.12'
+            python: '3.13'
             args: >
               -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebugDLL
-          # Extra ubuntu latest jobs
-          - runs-on: ubuntu-latest
-            python: '3.9'
-          - runs-on: ubuntu-latest
-            python: '3.11'
           # Run tests with py::smart_holder as the default holder
           # with recent (or ideally latest) released Python version.
           - runs-on: ubuntu-latest
@@ -90,11 +85,11 @@ jobs:
             args: >
               -DCMAKE_CXX_FLAGS="-DPYBIND11_RUN_TESTING_WITH_SMART_HOLDER_AS_DEFAULT_BUT_NEVER_USE_IN_PRODUCTION_PLEASE"
           - runs-on: macos-13
-            python: '3.12'
+            python: '3.11'
             args: >
               -DCMAKE_CXX_FLAGS="-DPYBIND11_RUN_TESTING_WITH_SMART_HOLDER_AS_DEFAULT_BUT_NEVER_USE_IN_PRODUCTION_PLEASE"
           - runs-on: windows-2022
-            python: '3.12'
+            python: '3.10'
             args: >
               -DCMAKE_CXX_FLAGS="/DPYBIND11_RUN_TESTING_WITH_SMART_HOLDER_AS_DEFAULT_BUT_NEVER_USE_IN_PRODUCTION_PLEASE /GR /EHsc"
           - runs-on: 'ubuntu-latest'
@@ -328,8 +323,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container_suffix:
-          - ""
         include:
           - clang: 5
             std: 14
@@ -801,16 +794,11 @@ jobs:
       matrix:
         python:
         - '3.8'
+        - '3.10'
         - '3.13'
 
         include:
-          - python: '3.12'
-            args: -DCMAKE_CXX_STANDARD=20
-          - python: '3.11'
-            args: -DCMAKE_CXX_STANDARD=20
           - python: '3.10'
-            args: -DCMAKE_CXX_STANDARD=20
-          - python: '3.9'
             args: -DCMAKE_CXX_STANDARD=20
           - python: '3.8'
             args: -DCMAKE_CXX_STANDARD=17
@@ -859,10 +847,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python:
-        - 3.8
-        - 3.9
-
         include:
           - python: 3.9
             args: -DCMAKE_CXX_STANDARD=20

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -24,30 +24,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-22.04, macos-13, windows-latest]
-        arch: [x64]
-        cmake: ["3.26"]
-
         include:
         - runs-on: ubuntu-22.04
-          arch: x64
           cmake: "3.15"
 
         - runs-on: ubuntu-22.04
-          arch: x64
+          cmake: "3.26"
+
+        - runs-on: ubuntu-22.04
           cmake: "3.29"
 
         - runs-on: macos-13
-          arch: x64
           cmake: "3.15"
 
         - runs-on: macos-14
-          arch: arm64
           cmake: "4.0"
 
         - runs-on: windows-2019
-          arch: x64 # x86 compilers seem to be missing on 2019 image
           cmake: "3.18"
+
+        - runs-on: windows-latest
+          cmake: "4.0"
 
     name: 🐍 3.11 • CMake ${{ matrix.cmake }} • ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
@@ -59,7 +56,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
-        architecture: ${{ matrix.arch }}
 
     - name: Prepare env
       run: python -m pip install -r tests/requirements.txt

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -42,7 +42,7 @@ jobs:
           cmake: "3.15"
 
         - runs-on: macos-14
-          arch: x64
+          arch: arm64
           cmake: "4.0"
 
         - runs-on: windows-2019

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -41,6 +41,10 @@ jobs:
           arch: x64
           cmake: "3.15"
 
+        - runs-on: macos-14
+          arch: x64
+          cmake: "4.0"
+
         - runs-on: windows-2019
           arch: x64 # x86 compilers seem to be missing on 2019 image
           cmake: "3.18"

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -49,16 +49,16 @@ jobs:
           arch: x64 # x86 compilers seem to be missing on 2019 image
           cmake: "3.18"
 
-    name: 🐍 3.8 • CMake ${{ matrix.cmake }} • ${{ matrix.runs-on }}
+    name: 🐍 3.9 • CMake ${{ matrix.cmake }} • ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Python 3.8
+    - name: Setup Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
         architecture: ${{ matrix.arch }}
 
     - name: Prepare env

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -49,16 +49,16 @@ jobs:
           arch: x64 # x86 compilers seem to be missing on 2019 image
           cmake: "3.18"
 
-    name: 🐍 3.9 • CMake ${{ matrix.cmake }} • ${{ matrix.runs-on }}
+    name: 🐍 3.11 • CMake ${{ matrix.cmake }} • ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Python 3.9
+    - name: Setup Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
         architecture: ${{ matrix.arch }}
 
     - name: Prepare env


### PR DESCRIPTION
Also modernizing slightly. We should probably get off of ubuntu-20.04 as it's probably not going to be a runner for much longer.
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
