### PR TITLE
Change `PyCFunction` cast in function_record_pyobject.h to sidestep unhelpful compiler warnings.

### DIFF
--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -38,6 +38,7 @@ static PyMethodDef tp_methods_impl[]
         // requires a PyCFunction. The cast through void* is safe and
         // idiomatic with METH_KEYWORDS, and it successfully sidesteps
         // unhelpful compiler warnings.
+        // NOLINTNEXTLINE(bugprone-casting-through-void)
         reinterpret_cast<PyCFunction>(reinterpret_cast<void *>(reduce_ex_impl)),
         METH_VARARGS | METH_KEYWORDS,
         nullptr},

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -32,17 +32,16 @@ void tp_free_impl(void *self);
 
 static PyObject *reduce_ex_impl(PyObject *self, PyObject *, PyObject *);
 
-PYBIND11_WARNING_PUSH
-#if defined(__GNUC__) && __GNUC__ >= 8
-PYBIND11_WARNING_DISABLE_GCC("-Wcast-function-type")
-#endif
-#if defined(__clang__) && !defined(__apple_build_version__) && __clang_major__ >= 19
-PYBIND11_WARNING_DISABLE_CLANG("-Wcast-function-type-mismatch")
-#endif
 static PyMethodDef tp_methods_impl[]
-    = {{"__reduce_ex__", (PyCFunction) reduce_ex_impl, METH_VARARGS | METH_KEYWORDS, nullptr},
+    = {{"__reduce_ex__",
+        // reduce_ex_impl is a PyCFunctionWithKeywords, but PyMethodDef
+        // requires a PyCFunction. The cast through void* is safe and
+        // idiomatic with METH_KEYWORDS, and it successfully sidesteps
+        // unhelpful compiler warnings.
+        reinterpret_cast<PyCFunction>(reinterpret_cast<void *>(reduce_ex_impl)),
+        METH_VARARGS | METH_KEYWORDS,
+        nullptr},
        {nullptr, nullptr, 0, nullptr}};
-PYBIND11_WARNING_POP
 
 // Note that this name is versioned.
 constexpr char tp_name_impl[]


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
With a little help from ChatGPT: https://chatgpt.com/share/67f60e22-8964-8008-aca6-1e13d24e019e

Although rwgk wants/needs to take full responsibility for the `void *` cast trick/hack:

Casting to `void *` before casting to `PyCFunction` is a more portable and easier way to silence compiler warnings.

Using C++-style casts is mostly a matter of style. Probably, C-style casts would work, too.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
