### PR TITLE
Fix GraalPy version parsing on dev builds

### DIFF
--- a/tests/env.py
+++ b/tests/env.py
@@ -16,7 +16,7 @@ GRAALPY = sys.implementation.name == "graalpy"
 _graalpy_version = (
     sys.modules["__graalpython__"].get_graalvm_version() if GRAALPY else "0.0.0"
 )
-GRAALPY_VERSION = tuple(int(t) for t in _graalpy_version.split(".")[:3])
+GRAALPY_VERSION = tuple(int(t) for t in _graalpy_version.split("-")[0].split(".")[:3])
 PY_GIL_DISABLED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -223,7 +223,6 @@ def test_custom_func():
     assert m.roundtrip(m.custom_function)(4) == 36
 
 
-@pytest.mark.skipif("env.GRAALPY", reason="TODO debug segfault")
 def test_custom_func2():
     assert m.custom_function2(3) == 27
     assert m.roundtrip(m.custom_function2)(3) == 27


### PR DESCRIPTION
I want to run pybind11 tests in our CI and dev builds have `-dev` suffix in the version.
I also unskipped a test that was previously broken due to the capsule name comparisons, but pybind11 has since moved away from doing those comparisons altogether.