### PR TITLE
fix(cmake): warning about missing file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
     # More-or-less randomly adding -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF here.
     - name: Configure C++17
       run: >
-        cmake -S . -B build2
+        cmake -S . -B build2 -Werror=dev
         -DPYBIND11_WERROR=ON
         -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF
         -DPYBIND11_PYTEST_ARGS=-v

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ pybind11Targets.cmake
 /docs/_build/*
 .ipynb_checkpoints/
 tests/main.cpp
+CMakeUserPresents.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,16 +129,17 @@ set(PYBIND11_HEADERS
     include/pybind11/detail/cpp_conduit.h
     include/pybind11/detail/descr.h
     include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h
+    include/pybind11/detail/exception_translation.h
     include/pybind11/detail/function_record_pyobject.h
     include/pybind11/detail/init.h
     include/pybind11/detail/internals.h
     include/pybind11/detail/native_enum_data.h
+    include/pybind11/detail/pybind11_namespace_macros.h
     include/pybind11/detail/struct_smart_holder.h
     include/pybind11/detail/type_caster_base.h
     include/pybind11/detail/typeid.h
     include/pybind11/detail/using_smart_holder.h
     include/pybind11/detail/value_and_holder.h
-    include/pybind11/detail/exception_translation.h
     include/pybind11/attr.h
     include/pybind11/buffer_info.h
     include/pybind11/cast.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -412,22 +412,26 @@ function(pybind11_enable_warnings target_name)
   endif()
 
   if(PYBIND11_WERROR)
-    if(MSVC)
-      target_compile_options(${target_name} PRIVATE /WX)
-    elseif(PYBIND11_CUDA_TESTS)
-      target_compile_options(${target_name} PRIVATE "SHELL:-Werror all-warnings")
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang|IntelLLVM)")
-      target_compile_options(${target_name} PRIVATE -Werror)
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
       if(CMAKE_CXX_STANDARD EQUAL 17) # See PR #3570
         target_compile_options(${target_name} PRIVATE -Wno-conversion)
       endif()
-      target_compile_options(
-        ${target_name}
-        PRIVATE
-          -Werror-all
-          # "Inlining inhibited by limit max-size", "Inlining inhibited by limit max-total-size"
-          -diag-disable 11074,11076)
+      # "Inlining inhibited by limit max-size", "Inlining inhibited by limit max-total-size"
+      target_compile_options(${target_name} PRIVATE -diag-disable 11074,11076)
+    endif()
+
+    if(CMAKE_VERSION VERSION_LESS "3.24")
+      if(MSVC)
+        target_compile_options(${target_name} PRIVATE /WX)
+      elseif(PYBIND11_CUDA_TESTS)
+        target_compile_options(${target_name} PRIVATE "SHELL:-Werror all-warnings")
+      elseif(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang|IntelLLVM)")
+        target_compile_options(${target_name} PRIVATE -Werror)
+      elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+        target_compile_options(${target_name} PRIVATE -Werror-all)
+      endif()
+    else()
+      set_target_properties(${target_name} PROPERTIES COMPILE_WARNING_AS_ERROR ON)
     endif()
   endif()
 endfunction()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

`include/pybind11/detail/pybind11_namespace_macros.h` is producing a warning. Adding it and updating the CMake a bit:

* Error CI on CMake warnings
* Use CMake 3.24+'s warnings as errors if available

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Use cmake's warnings as errors if available (CMake 3.24+)
```

<!-- If the upgrade guide needs updating, note that here too -->
