### PR TITLE
Factor out pybind11/gil_simple.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ set(PYBIND11_HEADERS
     include/pybind11/eval.h
     include/pybind11/gil.h
     include/pybind11/gil_safe_call_once.h
+    include/pybind11/gil_simple.h
     include/pybind11/iostream.h
     include/pybind11/functional.h
     include/pybind11/native_enum.h

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -9,13 +9,24 @@
 
 #pragma once
 
-#include "detail/common.h"
+#if defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
 
-#include <cassert>
+#    include "detail/common.h"
+#    include "gil_simple.h"
 
-#if !defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+
+using gil_scoped_acquire = gil_scoped_acquire_simple;
+using gil_scoped_release = gil_scoped_release_simple;
+
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
+
+#else
+
+#    include "detail/common.h"
 #    include "detail/internals.h"
-#endif
+
+#    include <cassert>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
@@ -25,8 +36,6 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 PyThreadState *get_thread_state_unchecked();
 
 PYBIND11_NAMESPACE_END(detail)
-
-#if !defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
 
 /* The functions below essentially reproduce the PyGILState_* API using a RAII
  * pattern, but there are a few important differences:
@@ -182,34 +191,6 @@ private:
     bool active = true;
 };
 
-#else // PYBIND11_SIMPLE_GIL_MANAGEMENT
-
-class gil_scoped_acquire {
-    PyGILState_STATE state;
-
-public:
-    gil_scoped_acquire() : state{PyGILState_Ensure()} {}
-    gil_scoped_acquire(const gil_scoped_acquire &) = delete;
-    gil_scoped_acquire &operator=(const gil_scoped_acquire &) = delete;
-    ~gil_scoped_acquire() { PyGILState_Release(state); }
-    void disarm() {}
-};
-
-class gil_scoped_release {
-    PyThreadState *state;
-
-public:
-    // PRECONDITION: The GIL must be held when this constructor is called.
-    gil_scoped_release() {
-        assert(PyGILState_Check());
-        state = PyEval_SaveThread();
-    }
-    gil_scoped_release(const gil_scoped_release &) = delete;
-    gil_scoped_release &operator=(const gil_scoped_release &) = delete;
-    ~gil_scoped_release() { PyEval_RestoreThread(state); }
-    void disarm() {}
-};
-
-#endif // PYBIND11_SIMPLE_GIL_MANAGEMENT
-
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
+
+#endif // !PYBIND11_SIMPLE_GIL_MANAGEMENT

--- a/include/pybind11/gil_simple.h
+++ b/include/pybind11/gil_simple.h
@@ -18,7 +18,6 @@ public:
     gil_scoped_acquire_simple(const gil_scoped_acquire_simple &) = delete;
     gil_scoped_acquire_simple &operator=(const gil_scoped_acquire_simple &) = delete;
     ~gil_scoped_acquire_simple() { PyGILState_Release(state); }
-    void disarm() {}
 };
 
 class gil_scoped_release_simple {
@@ -33,7 +32,6 @@ public:
     gil_scoped_release_simple(const gil_scoped_release_simple &) = delete;
     gil_scoped_release_simple &operator=(const gil_scoped_release_simple &) = delete;
     ~gil_scoped_release_simple() { PyEval_RestoreThread(state); }
-    void disarm() {}
 };
 
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/gil_simple.h
+++ b/include/pybind11/gil_simple.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2025 The Pybind Development Team.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#pragma once
+
+#include "detail/common.h"
+
+#include <cassert>
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+
+class gil_scoped_acquire_simple {
+    PyGILState_STATE state;
+
+public:
+    gil_scoped_acquire_simple() : state{PyGILState_Ensure()} {}
+    gil_scoped_acquire_simple(const gil_scoped_acquire_simple &) = delete;
+    gil_scoped_acquire_simple &operator=(const gil_scoped_acquire_simple &) = delete;
+    ~gil_scoped_acquire_simple() { PyGILState_Release(state); }
+    void disarm() {}
+};
+
+class gil_scoped_release_simple {
+    PyThreadState *state;
+
+public:
+    // PRECONDITION: The GIL must be held when this constructor is called.
+    gil_scoped_release_simple() {
+        assert(PyGILState_Check());
+        state = PyEval_SaveThread();
+    }
+    gil_scoped_release_simple(const gil_scoped_release_simple &) = delete;
+    gil_scoped_release_simple &operator=(const gil_scoped_release_simple &) = delete;
+    ~gil_scoped_release_simple() { PyEval_RestoreThread(state); }
+    void disarm() {}
+};
+
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -37,6 +37,7 @@ main_headers = {
     "include/pybind11/functional.h",
     "include/pybind11/gil.h",
     "include/pybind11/gil_safe_call_once.h",
+    "include/pybind11/gil_simple.h",
     "include/pybind11/iostream.h",
     "include/pybind11/native_enum.h",
     "include/pybind11/numpy.h",


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Long overdue, straightforward refactoring, eliminating code duplication in pybind11/detail/internals.h

Current motivation: Simplify PR #5564

Subtle API change (does NOT require any production code changes):

* The `disarm()` member functions are removed from `gil_scoped_acquire_simple` and `gil_scoped_release_simple`.

This means, `PYBIND11_SIMPLE_GIL_MANAGEMENT` is no longer compatible with uses of `disarm()`. However, this is strictly an improvement, because the removed member functions were no-ops. — Note also that the `disarm()` functions are used only in very rare cases.
________

See also ChatGPT's take on `using` vs inheritance: https://chatgpt.com/share/67fc24a7-c4bc-8008-aa9b-b82c4909e0b4

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
pybind11/gil_simple.h was factored out from pybind11/gil.h, so that it can easily be reused.
```

<!-- If the upgrade guide needs updating, note that here too -->
