### PR TITLE
fix: provide useful behavior of default `py::slice`

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1942,13 +1942,14 @@ private:
 
 class slice : public object {
 public:
-    PYBIND11_OBJECT_DEFAULT(slice, object, PySlice_Check)
+    PYBIND11_OBJECT(slice, object, PySlice_Check)
     slice(handle start, handle stop, handle step)
         : object(PySlice_New(start.ptr(), stop.ptr(), step.ptr()), stolen_t{}) {
         if (!m_ptr) {
             pybind11_fail("Could not allocate slice object!");
         }
     }
+    slice() : slice(none(), none(), none()) {}
 
 #ifdef PYBIND11_HAS_OPTIONAL
     slice(std::optional<ssize_t> start, std::optional<ssize_t> stop, std::optional<ssize_t> step)

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -671,6 +671,8 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.def("test_list_slicing", [](const py::list &a) { return a[py::slice(0, -1, 2)]; });
 
+    m.def("test_list_slicing_default", [](py::list a) { return a[py::slice()]; });
+
     // See #2361
     m.def("issue2361_str_implicit_copy_none", []() {
         py::str is_this_none = py::none();

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -671,7 +671,7 @@ TEST_SUBMODULE(pytypes, m) {
 
     m.def("test_list_slicing", [](const py::list &a) { return a[py::slice(0, -1, 2)]; });
 
-    m.def("test_list_slicing_default", [](py::list a) { return a[py::slice()]; });
+    m.def("test_list_slicing_default", [](const py::list &a) { return a[py::slice()]; });
 
     // See #2361
     m.def("issue2361_str_implicit_copy_none", []() {

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -604,6 +604,7 @@ def test_number_protocol():
 def test_list_slicing():
     li = list(range(100))
     assert li[::2] == m.test_list_slicing(li)
+    assert li[::] == m.test_list_slicing_default(li)
 
 
 def test_issue2361():

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -603,7 +603,7 @@ def test_number_protocol():
 
 def test_list_slicing():
     li = list(range(100))
-    assert li[::2] == m.test_list_slicing(li)
+    assert li[0:-1:2] == m.test_list_slicing(li)
     assert li[::] == m.test_list_slicing_default(li)
 
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Change the behavior of the default constructor of `py::slice` to be equivalent to `vals[::]`. I converted a large code base from boost::python to pybind11, and one of the stumbling blocks was this issue (see #5579).

Without this change, calling `a[py::slice()]` leads to an error, e.g. like this:

```sh
______________________________________________________________________________________ test_list_slicing _______________________________________________________________________________________

    def test_list_slicing():
        li = list(range(100))
        assert li[::2] == m.test_list_slicing(li)
>       assert li[::] == m.test_list_slicing_default(li)
E       SystemError: null argument to internal routine

li         = [0, 1, 2, 3, 4, 5, ...]

../../tests/test_pytypes.py:607: SystemError
```

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Change the behavior of the default constructor of `py::slice` to be equivalent to `::` in Python.
```

<!-- If the upgrade guide needs updating, note that here too -->
