### PR TITLE
Failing test for `std::weak_ptr` used with derived Python class and `py::smart_holder`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,6 +130,7 @@ set(PYBIND11_TEST_FILES
     test_class_sh_trampoline_shared_from_this
     test_class_sh_trampoline_shared_ptr_cpp_arg
     test_class_sh_trampoline_unique_ptr
+    test_class_sh_trampoline_weak_ptr
     test_class_sh_unique_ptr_custom_deleter
     test_class_sh_unique_ptr_member
     test_class_sh_virtual_py_cpp_mix

--- a/tests/test_class_sh_trampoline_weak_ptr.cpp
+++ b/tests/test_class_sh_trampoline_weak_ptr.cpp
@@ -35,9 +35,6 @@ struct WpBaseTester {
     void set_object(std::shared_ptr<WpBase> obj) { m_obj = obj; }
     bool is_expired() { return m_obj.expired(); }
     bool is_base_used() { return m_obj.lock()->is_base_used(); }
-    //    bool has_instance() { return (bool) m_obj.lock(); }
-    //    bool has_python_instance() { return m_obj.lock() && m_obj.lock()->has_python_instance();
-    //    } void set_nonpython_instance() { m_obj = std::make_shared<WpBase>(); }
     std::weak_ptr<WpBase> m_obj;
 };
 
@@ -61,8 +58,4 @@ TEST_SUBMODULE(class_sh_trampoline_weak_ptr, m) {
         .def("set_object", &WpBaseTester::set_object)
         .def("is_expired", &WpBaseTester::is_expired)
         .def("is_base_used", &WpBaseTester::is_base_used);
-    //        .def("has_instance", &WpBaseTester::has_instance)
-    //        .def("has_python_instance", &WpBaseTester::has_python_instance)
-    //        .def("set_nonpython_instance", &WpBaseTester::set_nonpython_instance)
-    //        .def_readwrite("obj", &WpBaseTester::m_obj);
 }

--- a/tests/test_class_sh_trampoline_weak_ptr.cpp
+++ b/tests/test_class_sh_trampoline_weak_ptr.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 The Pybind Development Team.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "pybind11_tests.h"
+
+#include <utility>
+
+namespace pybind11_tests {
+namespace class_sh_trampoline_weak_ptr {
+
+// // For testing whether a python subclass of a C++ object can be accessed from a C++ weak_ptr
+struct WpBase {
+    // returns true if the base virtual function is called
+    virtual bool is_base_used() { return true; }
+
+    // returns true if there's an associated python instance
+    bool has_python_instance() {
+        auto *tinfo = py::detail::get_type_info(typeid(WpBase));
+        return (bool) py::detail::get_object_handle(this, tinfo);
+    }
+
+    WpBase() = default;
+    WpBase(const WpBase &) = delete;
+    virtual ~WpBase() = default;
+};
+
+struct PyWpBase : WpBase {
+    using WpBase::WpBase;
+    bool is_base_used() override { PYBIND11_OVERRIDE(bool, WpBase, is_base_used); }
+};
+
+struct WpBaseTester {
+    std::shared_ptr<WpBase> get_object() const { return m_obj.lock(); }
+    void set_object(std::shared_ptr<WpBase> obj) { m_obj = obj; }
+    bool is_expired() { return m_obj.expired(); }
+    bool is_base_used() { return m_obj.lock()->is_base_used(); }
+    //    bool has_instance() { return (bool) m_obj.lock(); }
+    //    bool has_python_instance() { return m_obj.lock() && m_obj.lock()->has_python_instance();
+    //    } void set_nonpython_instance() { m_obj = std::make_shared<WpBase>(); }
+    std::weak_ptr<WpBase> m_obj;
+};
+
+} // namespace class_sh_trampoline_weak_ptr
+} // namespace pybind11_tests
+
+using namespace pybind11_tests::class_sh_trampoline_weak_ptr;
+
+TEST_SUBMODULE(class_sh_trampoline_weak_ptr, m) {
+    // For testing whether a python subclass of a C++ object can be accessed from a C++ weak_ptr
+
+    py::classh<WpBase, PyWpBase>(m, "WpBase")
+        .def(py::init<>())
+        .def(py::init([](int) { return std::make_shared<PyWpBase>(); }))
+        .def("is_base_used", &WpBase::is_base_used)
+        .def("has_python_instance", &WpBase::has_python_instance);
+
+    py::classh<WpBaseTester>(m, "WpBaseTester")
+        .def(py::init<>())
+        .def("get_object", &WpBaseTester::get_object)
+        .def("set_object", &WpBaseTester::set_object)
+        .def("is_expired", &WpBaseTester::is_expired)
+        .def("is_base_used", &WpBaseTester::is_base_used);
+    //        .def("has_instance", &WpBaseTester::has_instance)
+    //        .def("has_python_instance", &WpBaseTester::has_python_instance)
+    //        .def("set_nonpython_instance", &WpBaseTester::set_nonpython_instance)
+    //        .def_readwrite("obj", &WpBaseTester::m_obj);
+}

--- a/tests/test_class_sh_trampoline_weak_ptr.py
+++ b/tests/test_class_sh_trampoline_weak_ptr.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+import env  # noqa: F401
+import pybind11_tests.class_sh_trampoline_weak_ptr as m
+
+
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
+def test_weak_ptr_base():
+    tester = m.WpBaseTester()
+
+    obj = m.WpBase()
+
+    tester.set_object(obj)
+
+    assert tester.is_expired() is False
+    assert tester.is_base_used() is True
+    assert tester.get_object().is_base_used() is True
+
+
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
+def test_weak_ptr_child():
+    class PyChild(m.WpBase):
+        def is_base_used(self):
+            return False
+
+    tester = m.WpBaseTester()
+
+    obj = PyChild()
+
+    tester.set_object(obj)
+
+    assert tester.is_expired() is False
+    assert tester.is_base_used() is False
+    assert tester.get_object().is_base_used() is False


### PR DESCRIPTION
## Description

PR is in support of issue #5623.  

The added test shows that if you hold a reference to a derived Python object with a C++ `std::weak_ptr`, and the relevant classes use `py::smart_holder`, the `weak_ptr` will expire even if the Python object still exists.

