### PR TITLE
demo issue occuring in pybind11-stubgen

### DIFF
--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -60,6 +60,10 @@ class Args : public py::args {};
 
 } // namespace test_class
 
+namespace {
+class Foo {};
+} // namespace
+
 static_assert(py::detail::is_same_or_base_of<py::args, py::args>::value, "");
 static_assert(
     py::detail::is_same_or_base_of<py::args,
@@ -577,6 +581,9 @@ TEST_SUBMODULE(class_, m) {
     });
 
     test_class::pr4220_tripped_over_this::bind_empty0(m);
+
+    // test register different classes with same name (in anonymous namespace)
+    py::class_<Foo>(m, "Foo");
 }
 
 template <int N>

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -177,6 +177,10 @@ struct type_caster<RealNumber> {
 } // namespace detail
 } // namespace pybind11
 
+namespace {
+class Foo {};
+} // namespace
+
 TEST_SUBMODULE(pytypes, m) {
     m.def("obj_class_name", [](py::handle obj) { return py::detail::obj_class_name(obj.ptr()); });
 
@@ -1206,4 +1210,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("check_type_is", [](const py::object &x) -> py::typing::TypeIs<RealNumber> {
         return py::isinstance<RealNumber>(x);
     });
+
+    // test register different classes with same name (in anonymous namespace)
+    py::class_<Foo>(m, "Foo");
 }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Illustrates #5627

Distinct classes with the same name but in separate anonymous namespaces trigger 
>> ImportError: generic_type: type "Foo" is already registered!

This seems to be a new behavior in the current master branch and did not happen in 2.13.6.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
