### PR TITLE
fix: define `_DEBUG` macro to `1` on redefinition

### DIFF
--- a/include/pybind11/conduit/wrap_include_python_h.h
+++ b/include/pybind11/conduit/wrap_include_python_h.h
@@ -50,7 +50,7 @@
 #endif
 
 #if defined(PYBIND11_DEBUG_MARKER)
-#    define _DEBUG
+#    define _DEBUG 1
 #    undef PYBIND11_DEBUG_MARKER
 #endif
 


### PR DESCRIPTION
## Description

The `_DEBUG` macro is currently defined without value on redefinition. According to the [msvc documentation](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros), the macro should be defined to `1`.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Properly define ``_DEBUG`` macro to ``1`` instead of defining it without value
```
