### PR TITLE
docs: Add a note about calling Python C APIs on `py::native_enum`

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -583,6 +583,13 @@ The older ``py::enum_`` is not PEP 435 compatible
 but remains supported indefinitely for backward compatibility.
 New bindings should prefer ``py::native_enum``.
 
+.. important::
+
+    The enum types created by ``py::native_enum`` are native Python types, while
+    the enum types created by the older ``py::enum_`` are C++ pybind11 types.
+    Developers **SHOULD NOT** call ``PyType_*`` Python C APIs on the enum types
+    created by ``py:native_enum``.
+
 .. note::
 
     The deprecated ``py::enum_`` is :ref:`documented here <deprecated_enum>`.


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Add a note about calling Python C APIs on `py::native_enum` in the documentation.
Developers should never call ``PyType_*`` Python C APIs on the enum types created by ``py:native_enum``, which can cause unexpected issues.

See also:

- metaopt/optree#214
- https://github.com/metaopt/optree/pull/214/files#diff-b552e0451de79baea976f15c4ee5458fa7b6faa75bebb8b3780a90ec3d40a427R472-R486

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Add a note about calling Python C APIs on `py::native_enum` in the documentation.
```

<!-- If the upgrade guide needs updating, note that here too -->
