### PR TITLE
Collect all `#define PYBIND11_HAS_...` macros in pybind11/detail/common.h

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -50,6 +50,21 @@
 #    endif
 #endif
 
+// These PYBIND11_HAS_... macros are consolidated in pybind11/detail/common.h
+// to simplify backward compatibility handling for users (e.g., via #ifdef checks):
+#define PYBIND11_HAS_TYPE_CASTER_STD_FUNCTION_SPECIALIZATIONS 1
+#define PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT 1
+#define PYBIND11_HAS_CPP_CONDUIT 1
+#define PYBIND11_HAS_NATIVE_ENUM 1
+
+#if defined(PYBIND11_CPP17) && defined(__has_include)
+#    if __has_include(<filesystem>)
+#        define PYBIND11_HAS_FILESYSTEM 1
+#    elif __has_include(<experimental/filesystem>)
+#        define PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM 1
+#    endif
+#endif
+
 #if defined(__cpp_lib_launder) && !(defined(_MSC_VER) && (_MSC_VER < 1914))
 #    define PYBIND11_STD_LAUNDER std::launder
 #    define PYBIND11_HAS_STD_LAUNDER 1
@@ -168,14 +183,9 @@
 #    define PYBIND11_HAS_VARIANT 1
 #endif
 
-#if defined(PYBIND11_CPP17)
-#    if defined(__has_include)
-#        if __has_include(<string_view>)
-#            define PYBIND11_HAS_STRING_VIEW
-#        endif
-#    elif defined(_MSC_VER)
-#        define PYBIND11_HAS_STRING_VIEW
-#    endif
+#if defined(PYBIND11_CPP17)                                                                       \
+    && ((defined(__has_include) && __has_include(<string_view>)) || defined(_MSC_VER))
+#    define PYBIND11_HAS_STRING_VIEW 1
 #endif
 
 #if (defined(PYPY_VERSION) || defined(GRAALVM_PYTHON)) && !defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)
@@ -213,7 +223,7 @@
 
 // Must be after including <version> or one of the other headers specified by the standard
 #if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
-#    define PYBIND11_HAS_U8STRING
+#    define PYBIND11_HAS_U8STRING 1
 #endif
 
 // See description of PR #4246:

--- a/include/pybind11/detail/cpp_conduit.h
+++ b/include/pybind11/detail/cpp_conduit.h
@@ -71,7 +71,5 @@ inline void *try_raw_pointer_ephemeral_from_cpp_conduit(handle src,
     return nullptr;
 }
 
-#define PYBIND11_HAS_CPP_CONDUIT 1
-
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -206,9 +206,6 @@ struct internals {
     }
 };
 
-// For backwards compatibility (i.e. #ifdef guards):
-#define PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT
-
 enum class holder_enum_t : uint8_t {
     undefined,
     std_unique_ptr, // Default, lacking interop with std::shared_ptr.

--- a/include/pybind11/detail/native_enum_data.h
+++ b/include/pybind11/detail/native_enum_data.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#define PYBIND11_HAS_NATIVE_ENUM
-
 #include "../pytypes.h"
 #include "common.h"
 #include "internals.h"

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -9,8 +9,6 @@
 
 #pragma once
 
-#define PYBIND11_HAS_TYPE_CASTER_STD_FUNCTION_SPECIALIZATIONS
-
 #include "pybind11.h"
 
 #include <functional>

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -12,22 +12,12 @@
 
 #include <string>
 
-#ifdef __has_include
-#    if defined(PYBIND11_CPP17)
-#        if __has_include(<filesystem>)
-#            include <filesystem>
-#            define PYBIND11_HAS_FILESYSTEM 1
-#        elif __has_include(<experimental/filesystem>)
-#            include <experimental/filesystem>
-#            define PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM 1
-#        endif
-#    endif
-#endif
-
-#if !defined(PYBIND11_HAS_FILESYSTEM) && !defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)           \
-    && !defined(PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL)
-#    error                                                                                        \
-        "Neither #include <filesystem> nor #include <experimental/filesystem is available. (Use -DPYBIND11_HAS_FILESYSTEM_IS_OPTIONAL to ignore.)"
+#if defined(PYBIND11_HAS_FILESYSTEM)
+#    include <filesystem>
+#elif defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)
+#    include <experimental/filesystem>
+#else
+#    error "Neither #include <filesystem> nor #include <experimental/filesystem is available."
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -12,10 +12,10 @@
 #include "constructor_stats.h"
 #include "pybind11_tests.h"
 
-#ifndef PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL
-#    define PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL
+#if defined(PYBIND11_HAS_FILESYSTEM) || defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)
+#    include <pybind11/stl/filesystem.h>
 #endif
-#include <pybind11/stl/filesystem.h>
+
 #include <pybind11/typing.h>
 
 #include <string>


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The trigger for working on this PR was [seeing complicated code like this](https://github.com/metaopt/optree/pull/214#discussion_r2078063999).

With the help of my best friend Chat Geepeetee:

This PR consolidates all `PYBIND11_HAS_...` feature macros into `pybind11/detail/common.h`.

**Benefits:**

* Simplifies user-side compatibility checks:

  * Users can reliably use `#ifdef` guards on `PYBIND11_HAS_...` macros without needing to worry about which pybind11 headers have been included.

* Enables safer header inclusion patterns:
  * Users can conditionally include newer pybind11 headers based on feature availability, regardless of current include state.

* Improves internal maintainability:
  * Simplifies refactoring within pybind11 itself by eliminating the need to manage include order just to ensure a given `PYBIND11_HAS_...` macro is visible.

This change promotes cleaner and more robust code, both for users and within pybind11's internals.
________

Minor details:
* All `PYBIND11_HAS_...` macros are now consistently defined as `1`.
* The awkward `PYBIND11_HAS_FILESYSTEM_IS_OPTIONAL` macro is no longer needed (see changes in `include/pybind11/stl/filesystem.h` and `tests/test_stl.cpp`).
________

Before this PR:

```
$ git switch master
Switched to branch 'master'
Your branch is up to date with 'upstream/master'.

$ git grep '^# *define  *PYBIND11_HAS_' | grep -v '^include/pybind11/detail/common.h:' | cutniq
include/pybind11/detail/cpp_conduit.h
include/pybind11/detail/internals.h
include/pybind11/detail/native_enum_data.h
include/pybind11/functional.h
include/pybind11/stl/filesystem.h
tests/test_stl.cpp
```

With this PR:

```
$ git switch collect_define_pybind11_has
Switched to branch 'collect_define_pybind11_has'

$ git grep '^# *define  *PYBIND11_HAS_' | grep -v '^include/pybind11/detail/common.h:' | cutniq
```
(no output)

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
Consolidated all ``PYBIND11_HAS_...`` feature macros into ``pybind11/detail/common.h`` to streamline backward compatibility checks and simplify internal refactoring. This change ensures consistent macro availability regardless of header inclusion order.
```

<!-- If the upgrade guide needs updating, note that here too -->
