### PR TITLE
fix(cmake): avoid message if FINDPYTHON NEW

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -200,19 +200,21 @@ elseif(
   else()
     include("${CMAKE_CURRENT_LIST_DIR}/pybind11NewTools.cmake")
 
-    message(
-      "Using compatibility mode for Python, set PYBIND11_FINDPYTHON to NEW/OLD to silence this message"
-    )
-    set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
-    set(PYTHON_INCLUDE_DIR "${Python_INCLUDE_DIR}")
-    set(Python_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
-    set(PYTHON_LIBRARY "${Python_LIBRARY}")
-    set(PYTHON_LIBRARIES "${Python_LIBRARIES}")
-    set(PYTHON_VERSION "${Python_VERSION}")
-    set(PYTHON_VERSION_STRING "${Python_VERSION_STRING}")
-    set(PYTHON_VERSION_MAJOR "${Python_VERSION_MAJOR}")
-    set(PYTHON_VERSION_MINOR "${Python_VERSION_MINOR}")
-    set(PYTHON_VERSION_PATCH "${Python_VERSION_PATCH}")
+    if(PYBIND11_FINDPYTHON STREQUAL "COMPAT")
+      message(
+        "Using compatibility mode for Python, set PYBIND11_FINDPYTHON to NEW/OLD to silence this message"
+      )
+      set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
+      set(PYTHON_INCLUDE_DIR "${Python_INCLUDE_DIR}")
+      set(Python_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
+      set(PYTHON_LIBRARY "${Python_LIBRARY}")
+      set(PYTHON_LIBRARIES "${Python_LIBRARIES}")
+      set(PYTHON_VERSION "${Python_VERSION}")
+      set(PYTHON_VERSION_STRING "${Python_VERSION_STRING}")
+      set(PYTHON_VERSION_MAJOR "${Python_VERSION_MAJOR}")
+      set(PYTHON_VERSION_MINOR "${Python_VERSION_MINOR}")
+      set(PYTHON_VERSION_PATCH "${Python_VERSION_PATCH}")
+    endif()
   endif()
 
 else()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

This message wasn't supposed to be showing up if NEW was selected. It was also doing all the compat values no matter what.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Fix issue with NEW/OLD message showing up
```

<!-- If the upgrade guide needs updating, note that here too -->
