### PR TITLE
fix: use original dict

### DIFF
--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -451,7 +451,10 @@ void setstate(value_and_holder &v_h, std::pair<T, O> &&result, bool need_alias) 
         // See PR #2972 for details.
         return;
     }
-    setattr((PyObject *) v_h.inst, "__dict__", d);
+    auto dict = getattr((PyObject *) v_h.inst, "__dict__");
+    if (PyDict_Update(dict.ptr(), d.ptr()) < 0) {
+        throw error_already_set();
+    }
 }
 
 /// Implementation for py::pickle(GetState, SetState)

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -451,9 +451,15 @@ void setstate(value_and_holder &v_h, std::pair<T, O> &&result, bool need_alias) 
         // See PR #2972 for details.
         return;
     }
-    auto dict = getattr((PyObject *) v_h.inst, "__dict__");
-    if (PyDict_Update(dict.ptr(), d.ptr()) < 0) {
-        throw error_already_set();
+    // Our tests never run into an unset dict, but being careful here for now (see #5658)
+    auto dict = getattr((PyObject *) v_h.inst, "__dict__", none());
+    if (dict.is_none()) {
+        setattr((PyObject *) v_h.inst, "__dict__", d);
+    } else {
+        // Keep the original object dict and just update it
+        if (PyDict_Update(dict.ptr(), d.ptr()) < 0) {
+            throw error_already_set();
+        }
     }
 }
 

--- a/tests/test_pickling.cpp
+++ b/tests/test_pickling.cpp
@@ -35,10 +35,7 @@ void wrap(py::module m) {
         .def_readwrite("num", &SimpleBase::num)
         .def(py::pickle(
             [](const py::object &self) {
-                py::dict d;
-                if (py::hasattr(self, "__dict__")) {
-                    d = self.attr("__dict__");
-                }
+                py::dict d = py::getattr(self, "__dict__", py::dict());
                 return py::make_tuple(self.attr("num"), d);
             },
             [](const py::tuple &t) {


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


Pulled from #5646, I think this might make sense in general. By replacing `__dict__`, we throw away the original specialized dict that can do key sharing. We do need to update instead, but I think this makes sense. ChatGPT also liked it. https://chatgpt.com/share/6822d35a-c8b4-8012-8b97-6b387013ea09

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
* Update the dict when restoring pickles, instead of assigning a replacement dict.
```

<!-- If the upgrade guide needs updating, note that here too -->
