### PR TITLE
Add documentation for mod_gil_not_used and multiple_interpreters

### DIFF
--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -218,7 +218,7 @@ legacy-only behavior by using the :func:`multiple_interpreters::shared_gil()` ta
 ``PYBIND11_MODULE``.
 
 You can explicitly disable sub-interpreter support in your module by using the
-:func:`multiple_interpreter::not_supported()` tag. This is the default behavior if you do not
+:func:`multiple_interpreters::not_supported()` tag. This is the default behavior if you do not
 specify a multiple_interpreters tag.
 
 Concurrency and Parallelism in Python with pybind11

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -189,7 +189,7 @@ For example:
 .. code-block:: cpp
     :emphasize-lines: 1
 
-    PYBIND11_MODULE(example, m, py::multiple_interpreters_per_interpreter_gil()) {
+    PYBIND11_MODULE(example, m, py::multiple_interpreters::per_interpreter_gil()) {
         py::class_<Animal> animal(m, "Animal");
         // etc
     }

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -221,8 +221,8 @@ You can explicitly disable sub-interpreter support in your module by using the
 :func:`multiple_interpreter::not_supported()` tag. This is the default behavior if you do not
 specify a multiple_interpreters tag.
 
-Parallel Python exposition
-==========================
+Concurrency and Parallelism in Python with pybind11
+===================================================
 
 Sub-interpreter support does not imply free-threading support or vice versa.  Free-threading safe
 modules can still have global/static state (as long as access to them is thread-safe), but

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -170,9 +170,9 @@ For example:
     }
 
 Note, of course, enabling your module to be used in free threading is also your promise that
-your code is thread safe. To actually enable the feature your module must also be compiled
-with the Python free-threading source tree. Adding this tag does not break compatibility with
-non-free-threaded Python.
+your code is thread safe. Modules must still be built against the Python free-threading branch to enable 
+free-threading, even if they specify this tag.  Adding this tag does not break compatibility with non-free-threaded 
+Python. 
 
 Sub-interpreter support
 ==================================================================
@@ -191,26 +191,21 @@ For example:
         // etc
     }
 
-To make your module sub-interpreter safe, global/static state is strongly discouraged.  Instead,
-any state that your module keeps outside of Python objects must be carefully to the current
-sub-interpreter (where, of course, there can now be more than one).  Python objects (except
-immortal objects) may not be shared between different sub-interpreters, modules must take care not
-to accidentally share Python objects across sub-interpreters.
-
 Sub-interpreter Tips:
 
-- Your initialization function will run for each interpreter that imports your module
+- Your initialization function will run for each interpreter that imports your module.
 
-- Never share python objects across interpreter boundaries.
+- Never share python objects across different sub-interpreters.
 
-- Keep state it in the interpreter's state dict if necessary. No global/static state!
+- Keep state it in the interpreter's state dict if necessary. Avoid global/static state 
+  whenever possible.
 
 - Avoid trying to "cache" python objects in C++ variables across function calls (this is an easy
-  way to accidentally introduce bugs).
+  way to accidentally introduce sub-interpreter bugs).
 
-- While the interpreters each have their own GIL, isolated/independent
-  sub-interpreters each have their own lock, so concurrent calls into a module from two different
-  sub-interpreters are still possible.
+- While sub-interpreters each have their own GIL, there can now be multiple independent GILs in one
+  program so concurrent calls into a module from two different sub-interpreters are still possible.
+  Therefore, your module still needs to consider thread safety.
 
 pybind11 also supports "legacy" sub-interpreters which shared a single global GIL.  You can enable
 legacy behavior by using the :func:`multiple_interpreters::shared_gil()` tag in

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -193,8 +193,8 @@ For example:
 
 To make your module sub-interpreter safe, global/static state is strongly discouraged.  Instead,
 any state that your module keeps outside of Python objects must be carefully to the current
-sub-interpreter (where, of course, there can now be more than one).  Python objects (except 
-immortal objects) may not be shared between different sub-interpreters, modules must take care not 
+sub-interpreter (where, of course, there can now be more than one).  Python objects (except
+immortal objects) may not be shared between different sub-interpreters, modules must take care not
 to accidentally share Python objects across sub-interpreters.
 
 Sub-interpreter Tips:
@@ -220,8 +220,8 @@ You can explicitly disable multiple interpreter support in your module by using 
 :func:`multiple_interpreter::not_supported()` tag. This is the default behavior if you do not
 specify a multiple_interpreters tag.
 
-Note: Sub-interpreter support does not imply free-threading support or vice-versa. 
-Free-threaded modules can still have global/static state, but multiple interpreter modules cannot. 
+Note: Sub-interpreter support does not imply free-threading support or vice-versa.
+Free-threaded modules can still have global/static state, but multiple interpreter modules cannot.
 Likewise, sub-interpreter modules can still use the GIL, but free-threaded modules cannot.
 
 Binding sequence data types, iterators, the slicing protocol, etc.

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -153,6 +153,73 @@ following checklist.
   within pybind11 that will throw exceptions on certain GIL handling errors
   (reference counting operations).
 
+Free-threading support
+==================================================================
+
+pybind11 supports the experimental free-threaded Python build.  pybind11's internal data
+structures are thread safe. To enable your modules to be used with free-threading, pass the
+:class:`mod_gil_not_used` tag as the third argument to ``PYBIND11_MODULE``.
+
+For example:
+
+.. code-block:: cpp
+    :emphasize-lines: 1
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
+        py::class_<Animal> animal(m, "Animal");
+        // etc
+    }
+
+Note, of course, enabling your module to be used in free threading is also your promise that
+your code is thread safe. To actually enable the feature your module must also be compiled
+with the Python free-threading source tree. Adding this tag does not break compatibility with
+non-free-threaded Python.
+
+Sub-interpreter support
+==================================================================
+
+pybind11 supports isolated sub-interpreters.  Pybind11's internal data structures are
+sub-interpreter safe. To enable your modules to be imported in isolated sub-interpreters, pass the
+:func:`multiple_interpreters::per_interpreter_gil()` tag as the third or later argument to
+``PYBIND11_MODULE``.
+
+For example:
+
+.. code-block:: cpp
+    :emphasize-lines: 1
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used(), py::multiple_interpreters_per_interpreter_gil()) {
+        py::class_<Animal> animal(m, "Animal");
+        // etc
+    }
+
+To make your module sub-interpreter safe, global/static state is strongly discouraged.  Instead,
+any state that your module keeps outside of Python objects must be carefully to the current
+interpreter (where, of course, there can now be more than one).  Python objects (except immortal
+objects) may not be shared between different interpreters, modules must take care not to
+accidentally share Python objects across sub-interpreters.
+
+Sub-interpreter Tips:
+
+- Your initialization function will run for each interpreter that imports your module
+
+- Never share python objects across interpreter boundaries.
+
+- Keep state it in the interpreter's state dict if necessary. No global/static state!
+
+- Avoid trying to "cache" python objects in C++ variables across function calls (this is an easy
+  way to accidentally introduce bugs).
+
+- While the interpreters each have their own global interpreter lock, isolated/independent
+  sub-interpreters each have their own lock, so concurrent calls into a module from two different
+  sub-interpreters are still possible.
+
+pybind11 also supports "legacy" sub-interpreters which shared a single global GIL.  You can enable
+legacy behavior by using the :func:`multiple_interpreters::shared_gil()` tag in
+```PYBIND11_MODULE``.
+
+You can explicitly disable multiple interpreter support in your module by using the
+:func:`multiple_interpreter::not_supported()` tag. This is the default behavior if you do not
+specify a multiple_interpreters tag.
+
 Binding sequence data types, iterators, the slicing protocol, etc.
 ==================================================================
 

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -179,7 +179,7 @@ compatibility with non-free-threaded Python.
 Sub-interpreter support
 ==================================================================
 
-pybind11 supports isolated sub-interpreters, which are stable in Python 3.12+.  Pybind11's
+pybind11 supports isolated sub-interpreters, which are stable in Python 3.12+.  pybind11's
 internal data structures are sub-interpreter safe. To enable your modules to be imported in
 isolated sub-interpreters, pass the :func:`multiple_interpreters::per_interpreter_gil()`
 tag as the third or later argument to ``PYBIND11_MODULE``.

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -170,9 +170,9 @@ For example:
     }
 
 Note, of course, enabling your module to be used in free threading is also your promise that
-your code is thread safe. Modules must still be built against the Python free-threading branch to enable 
-free-threading, even if they specify this tag.  Adding this tag does not break compatibility with non-free-threaded 
-Python. 
+your code is thread safe. Modules must still be built against the Python free-threading branch to enable
+free-threading, even if they specify this tag.  Adding this tag does not break compatibility with non-free-threaded
+Python.
 
 Sub-interpreter support
 ==================================================================
@@ -197,7 +197,7 @@ Sub-interpreter Tips:
 
 - Never share python objects across different sub-interpreters.
 
-- Keep state it in the interpreter's state dict if necessary. Avoid global/static state 
+- Keep state it in the interpreter's state dict if necessary. Avoid global/static state
   whenever possible.
 
 - Avoid trying to "cache" python objects in C++ variables across function calls (this is an easy

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -296,7 +296,7 @@ calculation is not synchronized. We can synchronize it using a Python critical s
     :emphasize-lines: 1,5,10
 
     PYBIND11_MODULE(example, m, py::multiple_interpreters::per_interpreter_gil(), py::mod_gil_not_used()) {
-        m.def("get_last", [](py::object key, py::object next) {
+        m.def("calc_next", []() {
             size_t old;
             py::dict g = py::globals();
             Py_BEGIN_CRITICAL_SECTION(g);

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -193,9 +193,9 @@ For example:
 
 To make your module sub-interpreter safe, global/static state is strongly discouraged.  Instead,
 any state that your module keeps outside of Python objects must be carefully to the current
-interpreter (where, of course, there can now be more than one).  Python objects (except immortal
-objects) may not be shared between different interpreters, modules must take care not to
-accidentally share Python objects across sub-interpreters.
+sub-interpreter (where, of course, there can now be more than one).  Python objects (except 
+immortal objects) may not be shared between different sub-interpreters, modules must take care not 
+to accidentally share Python objects across sub-interpreters.
 
 Sub-interpreter Tips:
 
@@ -208,7 +208,7 @@ Sub-interpreter Tips:
 - Avoid trying to "cache" python objects in C++ variables across function calls (this is an easy
   way to accidentally introduce bugs).
 
-- While the interpreters each have their own global interpreter lock, isolated/independent
+- While the interpreters each have their own GIL, isolated/independent
   sub-interpreters each have their own lock, so concurrent calls into a module from two different
   sub-interpreters are still possible.
 
@@ -219,6 +219,10 @@ legacy behavior by using the :func:`multiple_interpreters::shared_gil()` tag in
 You can explicitly disable multiple interpreter support in your module by using the
 :func:`multiple_interpreter::not_supported()` tag. This is the default behavior if you do not
 specify a multiple_interpreters tag.
+
+Note: Sub-interpreter support does not imply free-threading support or vice-versa. 
+Free-threaded modules can still have global/static state, but multiple interpreter modules cannot. 
+Likewise, sub-interpreter modules can still use the GIL, but free-threaded modules cannot.
 
 Binding sequence data types, iterators, the slicing protocol, etc.
 ==================================================================


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Adding documentation for #5564 the multiple_interpreters tags (sub-interpreter support), and also `py::mod_gil_not_used()` with usage examples and best-practice guidance.

- Introduce “Free-threading support” section describing how to use py::mod_gil_not_used()
- Introduce “Sub-interpreter support” section covering py::multiple_interpreters::per_interpreter_gil(), shared_gil(), and disabling with not_supported()
- Provide end-to-end examples showing how to combine free-threading and sub-interpreter safety
