### PR TITLE
Fix Buffer type hint

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1387,7 +1387,7 @@ struct handle_type_name<bytes> {
 };
 template <>
 struct handle_type_name<buffer> {
-    static constexpr auto name = const_name("collections.abc.Buffer");
+    static constexpr auto name = const_name(PYBIND11_BUFFER_TYPE_HINT);
 };
 template <>
 struct handle_type_name<int_> {

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -243,7 +243,7 @@
 #if 0x030C0000 <= PY_VERSION_HEX
     #define PYBIND11_BUFFER_TYPE_HINT "collections.abc.Buffer"
 #else
-	#define PYBIND11_BUFFER_TYPE_HINT "typing_extensions.Buffer"
+    #define PYBIND11_BUFFER_TYPE_HINT "typing_extensions.Buffer"
 #endif
 
 // #define PYBIND11_STR_LEGACY_PERMISSIVE

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -239,7 +239,7 @@
 #    define PYBIND11_SUBINTERPRETER_SUPPORT
 #endif
 
-// 3.13
+// 3.12 Compatibility
 #if 0x030C0000 <= PY_VERSION_HEX
     #define PYBIND11_BUFFER_TYPE_HINT "collections.abc.Buffer"
 #else

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -232,6 +232,12 @@
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif
 
+// 3.13
+#if 0x030C0000 <= PY_VERSION_HEX
+    #define PYBIND11_BUFFER_TYPE_HINT "collections.abc.Buffer"
+#else
+	#define PYBIND11_BUFFER_TYPE_HINT "typing_extensions.Buffer"
+#endif
 // #define PYBIND11_STR_LEGACY_PERMISSIVE
 // If DEFINED, pybind11::str can hold PyUnicodeObject or PyBytesObject
 //             (probably surprising and never documented, but this was the

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -241,9 +241,9 @@
 
 // 3.12 Compatibility
 #if 0x030C0000 <= PY_VERSION_HEX
-    #define PYBIND11_BUFFER_TYPE_HINT "collections.abc.Buffer"
+#    define PYBIND11_BUFFER_TYPE_HINT "collections.abc.Buffer"
 #else
-    #define PYBIND11_BUFFER_TYPE_HINT "typing_extensions.Buffer"
+#    define PYBIND11_BUFFER_TYPE_HINT "typing_extensions.Buffer"
 #endif
 
 // #define PYBIND11_STR_LEGACY_PERMISSIVE

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -228,10 +228,11 @@ def test_ctypes_from_buffer():
 
 
 def test_buffer_docstring():
-    assert (
-        m.get_buffer_info.__doc__.strip()
-        == "get_buffer_info(arg0: collections.abc.Buffer) -> pybind11_tests.buffers.buffer_info"
-    )
+    if (3, 12) <= sys.version_info:
+        docstring = "get_buffer_info(arg0: collections.abc.Buffer) -> pybind11_tests.buffers.buffer_info"
+    else:
+        docstring = "get_buffer_info(arg0: typing_extensions.Buffer) -> pybind11_tests.buffers.buffer_info"
+    assert (m.get_buffer_info.__doc__.strip() == docstring)
 
 
 def test_buffer_exception():

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -229,11 +229,11 @@ def test_ctypes_from_buffer():
 
 
 def test_buffer_docstring():
-    if (3, 12) <= sys.version_info:
+    if sys.version_info >= (3, 12):
         docstring = "get_buffer_info(arg0: collections.abc.Buffer) -> pybind11_tests.buffers.buffer_info"
     else:
         docstring = "get_buffer_info(arg0: typing_extensions.Buffer) -> pybind11_tests.buffers.buffer_info"
-    assert (m.get_buffer_info.__doc__.strip() == docstring)
+    assert m.get_buffer_info.__doc__.strip() == docstring
 
 
 def test_buffer_exception():

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ctypes
 import io
 import struct
+import sys
 
 import pytest
 


### PR DESCRIPTION
## Description

Fix a type hint regression introduced in #5566.
`collections.abc.Buffer` was added in Python 3.12.
If the Python version being compiled against is less than this it uses `typing_extensions.Buffer`.

Fixes #5660 

## Suggested changelog entry:

```rst
Fix Buffer type hint
```
