### PR TITLE
Remove `inline` from declarations

### DIFF
--- a/include/pybind11/detail/cpp_conduit.h
+++ b/include/pybind11/detail/cpp_conduit.h
@@ -13,7 +13,7 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 // Forward declaration needed here: Refactoring opportunity.
-extern "C" inline PyObject *pybind11_object_new(PyTypeObject *type, PyObject *, PyObject *);
+extern "C" PyObject *pybind11_object_new(PyTypeObject *type, PyObject *, PyObject *);
 
 inline bool type_is_managed_by_our_internals(PyTypeObject *type_obj) {
 #if defined(PYPY_VERSION)

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -51,10 +51,10 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 constexpr const char *internals_function_record_capsule_name = "pybind11_function_record_capsule";
 
 // Forward declarations
-inline PyTypeObject *make_static_property_type();
-inline PyTypeObject *make_default_metaclass();
-inline PyObject *make_object_base_type(PyTypeObject *metaclass);
-inline void translate_exception(std::exception_ptr p);
+PyTypeObject *make_static_property_type();
+PyTypeObject *make_default_metaclass();
+PyObject *make_object_base_type(PyTypeObject *metaclass);
+void translate_exception(std::exception_ptr p);
 
 // The old Python Thread Local Storage (TLS) API is deprecated in Python 3.7 in favor of the new
 // Thread Specific Storage (TSS) API.

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -94,7 +94,7 @@ public:
 // Gets the cache entry for the given type, creating it if necessary.  The return value is the pair
 // returned by emplace, i.e. an iterator for the entry and a bool set to `true` if the entry was
 // just created.
-inline std::pair<decltype(internals::registered_types_py)::iterator, bool>
+std::pair<decltype(internals::registered_types_py)::iterator, bool>
 all_type_info_get_cache(PyTypeObject *type);
 
 // Band-aid workaround to fix a subtle but serious bug in a minimalistic fashion. See PR #4762.

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -499,7 +499,7 @@ PYBIND11_NOINLINE handle get_object_handle(const void *ptr, const detail::type_i
 
 // Forward declarations
 void keep_alive_impl(handle nurse, handle patient);
-inline PyObject *make_new_instance(PyTypeObject *type);
+PyObject *make_new_instance(PyTypeObject *type);
 
 PYBIND11_WARNING_PUSH
 PYBIND11_WARNING_DISABLE_GCC("-Wredundant-decls")


### PR DESCRIPTION
## Description

Function declarations that are not definitions should not be declared `inline`.
Otherwise, they could trigger `undefined-inline` warning, which [should actually be an error](https://github.com/llvm/llvm-project/blob/440e510b896be2ef4a4f0730b8201378beee55b3/clang/include/clang/Basic/DiagnosticSemaKinds.td#L6162-L6175).