### PR TITLE
feat: Embeded sub-interpreters

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -55,3 +55,6 @@ jobs:
 
     - name: Build
       run: cmake --build build -j 2 -- --keep-going
+
+    - name: Embedded
+      run: cmake --build build -t cpptest -j 2 -- --keep-going

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ set(PYBIND11_HEADERS
     include/pybind11/operators.h
     include/pybind11/pybind11.h
     include/pybind11/pytypes.h
+    include/pybind11/subinterpreter.h
     include/pybind11/stl.h
     include/pybind11/stl_bind.h
     include/pybind11/stl/filesystem.h

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -247,8 +247,8 @@ global data. All the details can be found in the CPython documentation.
 
 .. _subinterp:
 
-Sub-interpreter support
-=======================
+Embedding Sub-interpreters
+==========================
 
 A sub-interpreter is a separate interpreter instance which provides a
 separate, isolated interpreter environment within the same process as the main
@@ -256,13 +256,13 @@ interpreter.  Sub-interpreters are created and managed with a separate API from
 the main interpreter. Beginning in Python 3.12, sub-interpreters each have
 their own Global Interpreter Lock (GIL), which means that running a
 sub-interpreter in a separate thread from the main interpreter can achieve true
-concurrency. 
+concurrency.
 
 pybind11's sub-interpreter API can be found in ``pybind11/subinterpreter.h``.
 
-pybind11 :class:`subinterpreter` instances can be safely moved and shared between 
-threads as needed. However, managing multiple threads and the lifetimes of multiple 
-interpreters and their GILs can be challenging. 
+pybind11 :class:`subinterpreter` instances can be safely moved and shared between
+threads as needed. However, managing multiple threads and the lifetimes of multiple
+interpreters and their GILs can be challenging.
 Proceed with caution (and lots of testing)!
 
 The main interpreter must be initialized before creating a sub-interpreter, and
@@ -307,7 +307,7 @@ sub-interpreters.
 :class:`gil_scoped_release` and :class:`gil_scoped_acquire` can be used to
 manage the GIL of a sub-interpreter just as they do for the main interpreter.
 They both manage the GIL of the currently active interpreter, without the
-programmer having to do anything special or different. There is one important 
+programmer having to do anything special or different. There is one important
 caveat:
 
 .. note::
@@ -319,7 +319,7 @@ caveat:
 
 Each sub-interpreter will import a separate copy of each ``PYBIND11_EMBEDDED_MODULE``
 when those modules specify a ``multiple_interpreters`` tag. If a module does not
-specify a ``multiple_interpreters`` tag, then Python will report an ``ImportError`` 
+specify a ``multiple_interpreters`` tag, then Python will report an ``ImportError``
 if it is imported in a sub-interpreter.
 
 Here is an example showing how to create and activate sub-interpreters:
@@ -393,8 +393,8 @@ it when it goes out of scope.
 
 Best Practices for sub-interpreter safety:
 
-- Avoid moving or disarming RAII objects managing GIL and sub-interpreter lifetimes. Doing so can 
-  lead to confusion about lifetimes.  (For example, accidentally extending a 
+- Avoid moving or disarming RAII objects managing GIL and sub-interpreter lifetimes. Doing so can
+  lead to confusion about lifetimes.  (For example, accidentally extending a
   :class:`subinterpreter_scoped_activate` past the lifetime of it's :class:`subinterpreter`.)
 
 - Never share Python objects across different interpreters.
@@ -410,9 +410,11 @@ Best Practices for sub-interpreter safety:
   resulting Python object when the wrong interpreter was active.
 
 - While sub-interpreters each have their own GIL, there can now be multiple independent GILs in one
-  program you need to consider the possibility of deadlocks caused by multiple GILs and/or the 
+  program you need to consider the possibility of deadlocks caused by multiple GILs and/or the
   interactions of the GIL(s) and your C++ code's own locking.
 
 - When using multiple threads to run independent sub-interpreters, the independent GILs allow
-  concurrent calls from different interpreters into the same C++ code from different threads. 
+  concurrent calls from different interpreters into the same C++ code from different threads.
   So you must still consider the thread safety of your C++ code.
+
+- Familiarize yourself with :ref:`misc_concurrency`.

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -301,7 +301,7 @@ Activating a Sub-interpreter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once a sub-interpreter is created, you can "activate" it on a thread (and
-acquire it's GIL) by creating a :class:`subinterpreter_scoped_activate`
+acquire its GIL) by creating a :class:`subinterpreter_scoped_activate`
 instance and passing it the sub-intepreter to be activated.  The function
 will acquire the sub-interpreter's GIL and make the sub-interpreter the
 current active interpreter on the current thread for the lifetime of the

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -448,6 +448,14 @@ Expected output:
     After Main, still within sub; Current Interpreter is 1
     At end; Current Interpreter is 0
 
+.. warning::
+
+    In Python 3.12 sub-interpreters must be destroyed in the same OS thread
+    that created them.  Failure to follow this rule may result in deadlocks
+    or crashes when destroying the sub-interpreter on the wrong thread.
+
+    This constraint is not present in Python 3.13+.
+
 
 Best Practices for sub-interpreter safety
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -458,7 +466,8 @@ Best Practices for sub-interpreter safety
   and :func:`error_already_set::what()` acquires the GIL. So Python exceptions must
   **never** be allowed to propagate past the enclosing
   :class:`subinterpreter_scoped_activate` instance!
-  (So your try/catch should be *just inside* the scope covered by the :class:`subinterpreter_scoped_activate`.)
+  (So your try/catch should be *just inside* the scope covered by the
+  :class:`subinterpreter_scoped_activate`.)
 
 - Avoid global/static state whenever possible. Instead, keep state within each interpreter,
   such as within the interpreter state dict, which can be accessed via
@@ -480,6 +489,7 @@ Best Practices for sub-interpreter safety
 
 - When using multiple threads to run independent sub-interpreters, the independent GILs allow
   concurrent calls from different interpreters into the same C++ code from different threads.
-  So you must still consider the thread safety of your C++ code.
+  So you must still consider the thread safety of your C++ code.  Remember, in Python 3.12
+  sub-interpreters must be destroyed on the same thread that they were created on.
 
 - Familiarize yourself with :ref:`misc_concurrency`.

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -436,6 +436,12 @@ Best Practices for sub-interpreter safety
 
 - Never share Python objects across different interpreters.
 
+- :class:`error_already_set` objects contain a reference to the Python exception type, 
+  and :func:`error_already_set::what()` acquires the GIL. So Python exceptions must 
+  **never** be allowed to propoagate past the enclosing 
+  :class:`subinterpreter_scoped_activate` instance!
+  (So your try/catch should be *just inside* the scope covered by the :class:`subinterpreter_scoped_activate`.)
+
 - Avoid global/static state whenever possible. Instead, keep state within each interpreter,
   such as within the interpreter state dict, which can be accessed via
   ``subinterpreter::current().state_dict()``, or within instance members and tied to

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -436,9 +436,9 @@ Best Practices for sub-interpreter safety
 
 - Never share Python objects across different interpreters.
 
-- :class:`error_already_set` objects contain a reference to the Python exception type, 
-  and :func:`error_already_set::what()` acquires the GIL. So Python exceptions must 
-  **never** be allowed to propoagate past the enclosing 
+- :class:`error_already_set` objects contain a reference to the Python exception type,
+  and :func:`error_already_set::what()` acquires the GIL. So Python exceptions must
+  **never** be allowed to propoagate past the enclosing
   :class:`subinterpreter_scoped_activate` instance!
   (So your try/catch should be *just inside* the scope covered by the :class:`subinterpreter_scoped_activate`.)
 

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -341,7 +341,7 @@ Here is an example showing how to create and activate sub-interpreters:
     }
 
     int main() {
-        py::scoped_interpreter main_int{};
+        py::scoped_interpreter main_interp;
 
         py::module_::import("printer").attr("which")("First init");
 
@@ -351,7 +351,7 @@ Here is an example showing how to create and activate sub-interpreters:
             py::module_::import("printer").attr("which")("Created sub");
 
             {
-                py::subinterpreter_scoped_activate ssa(sub);
+                py::subinterpreter_scoped_activate guard(sub);
                 py::module_::import("printer").attr("which")("Activated sub");
             }
 
@@ -360,9 +360,9 @@ Here is an example showing how to create and activate sub-interpreters:
             {
                 py::gil_scoped_release nogil;
                 {
-                    py::subinterpreter_scoped_activate ssa(sub);
+                    py::subinterpreter_scoped_activate guard(sub);
                     {
-                        auto main_sa = py::subinterpreter::main_scoped_activate();
+                        py::subinterpreter_scoped_activate main_guard(py::subinterpreter::main());
                         py::module_::import("printer").attr("which")("Main within sub");
                     }
                     py::module_::import("printer").attr("which")("After Main, still within sub");

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -335,7 +335,7 @@ Here is an example showing how to create and activate sub-interpreters:
     PYBIND11_EMBEDDED_MODULE(printer, m, py::multiple_interpreters::per_interpreter_gil()) {
         m.def("which", [](const std::string& when) {
             std::cout << when << "; Current Interpreter is "
-                    << PyInterpreterState_GetID(PyInterpreterState_Get())
+                    << py::subinterpreter::current().id()
                     << std::endl;
         });
     }

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -228,6 +228,8 @@ You can explicitly disable sub-interpreter support in your module by using the
 :func:`multiple_interpreters::not_supported()` tag. This is the default behavior if you do not
 specify a multiple_interpreters tag.
 
+.. _misc_concurrency:
+
 Concurrency and Parallelism in Python with pybind11
 ===================================================
 

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -155,6 +155,8 @@ following checklist.
   within pybind11 that will throw exceptions on certain GIL handling errors
   (reference counting operations).
 
+.. _misc_free_threading:
+
 Free-threading support
 ==================================================================
 
@@ -177,6 +179,8 @@ Importantly, enabling your module to be used with free-threading is also your pr
 your code is thread safe.  Modules must still be built against the Python free-threading branch to
 enable free-threading, even if they specify this tag.  Adding this tag does not break
 compatibility with non-free-threaded Python.
+
+.. _misc_subinterp:
 
 Sub-interpreter support
 ==================================================================

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -155,8 +155,6 @@ following checklist.
   within pybind11 that will throw exceptions on certain GIL handling errors
   (reference counting operations).
 
-.. _misc_free_threading:
-
 Free-threading support
 ==================================================================
 
@@ -179,8 +177,6 @@ Importantly, enabling your module to be used with free-threading is also your pr
 your code is thread safe.  Modules must still be built against the Python free-threading branch to
 enable free-threading, even if they specify this tag.  Adding this tag does not break
 compatibility with non-free-threaded Python.
-
-.. _misc_subinterp:
 
 Sub-interpreter support
 ==================================================================

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -130,7 +130,7 @@ public:
     }
 
     /// This method will disable the PyThreadState_DeleteCurrent call and the
-    /// GIL won't be acquired. This method should be used if the interpreter
+    /// GIL won't be released. This method should be used if the interpreter
     /// could be shutting down when this is called, as thread deletion is not
     /// allowed during shutdown. Check _Py_IsFinalizing() on Python 3.7+, and
     /// protect subsequent code.

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -1,0 +1,205 @@
+#pragma once
+
+#include "detail/common.h"
+#include "detail/internals.h"
+#include "gil.h"
+
+#include <stdexcept>
+
+#if !defined(PYBIND11_SUBINTERPRETER_SUPPORT)
+#    error "This platform does not support subinterpreters, do not include this file."
+#endif
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+
+class subinterpreter;
+
+/// Activate the subinterpreter and acquire it's GIL, while also releasing any GIL and interpreter
+/// currently held. Upon exiting the scope, the previous subinterpreter (if any) and it's
+/// associated GIL are restored to their state as they were before the scope was entered.
+class subinterpreter_scoped_activate {
+public:
+    explicit subinterpreter_scoped_activate(subinterpreter const &si);
+    ~subinterpreter_scoped_activate();
+
+private:
+    PyThreadState *old_tstate_ = nullptr;
+    PyThreadState *free_tstate_ = nullptr;
+    PyGILState_STATE gil_state_;
+    bool simple_gil_ = false;
+};
+
+class subinterpreter {
+public:
+    subinterpreter() = default;
+    subinterpreter(subinterpreter const &copy) = delete;
+    subinterpreter &operator=(subinterpreter const &copy) = delete;
+
+    subinterpreter(subinterpreter &&old) : tstate_(old.tstate_), istate_(old.istate_) {
+        old.tstate_ = nullptr;
+        old.istate_ = nullptr;
+    }
+
+    subinterpreter &operator=(subinterpreter &&old) {
+        std::swap(old.tstate_, tstate_);
+        std::swap(old.istate_, istate_);
+        return *this;
+    }
+
+    ~subinterpreter() {
+        if (tstate_) {
+            if (PyThread_get_thread_ident() != tstate_->native_thread_id) {
+                // Throwing from destructors is bad :(
+                // But if we don't throw, we either leak the interpreter or the code hangs because
+                // internal Python TSS values are wrong/missing
+                throw std::runtime_error(
+                    "wrong thread called subinterpreter destruct. subinterpreters can only "
+                    "destruct on the thread that created them!");
+            }
+
+            // has to be the active interpreter in order to call End on it
+            // switch into the expiring interpreter
+            auto old_tstate = PyThreadState_Swap(tstate_);
+
+            // make sure we have the GIL
+            (void) PyGILState_Ensure();
+
+            // End it
+            Py_EndInterpreter(tstate_);
+
+            // switch back to the old tstate and old GIL (if there was one)
+            if (old_tstate != tstate_)
+                PyThreadState_Swap(old_tstate);
+
+            // do NOT decrease detail::get_num_interpreters_seen, because it can never decrease
+            // while other threads are running...
+        }
+    }
+
+    /// abandon cleanup of this subinterpreter.  might be needed during finalization
+    void disarm() { tstate_ = nullptr; }
+
+    /// Get a handle to the main interpreter that can be used with subinterpreter_scoped_activate
+    /// Note that destructing the handle is a noop, the main interpreter can only be ended by
+    /// py::finalize_interpreter()
+    static subinterpreter_scoped_activate main_scoped_activate() {
+        subinterpreter m;
+        m.istate_ = PyInterpreterState_Main();
+        m.disarm(); // make destruct a noop
+        return subinterpreter_scoped_activate(m);
+    }
+
+    /// Create a new subinterpreter with the specified configuration
+    /// Note Well:
+    static inline subinterpreter create(PyInterpreterConfig const &cfg) {
+        error_scope err_scope;
+        auto main_guard = main_scoped_activate();
+        subinterpreter result;
+        {
+            // we must hold the main GIL in order to create a subinterpreter
+            gil_scoped_acquire gil;
+
+            auto prev_tstate = PyThreadState_Get();
+
+            auto status = Py_NewInterpreterFromConfig(&result.tstate_, &cfg);
+
+            // this doesn't raise a normal Python exception, it provides an exit() status code.
+            if (PyStatus_Exception(status)) {
+                pybind11_fail("failed to create new sub-interpreter");
+            }
+
+            // upon success, the new interpreter is activated in this thread
+            result.istate_ = result.tstate_->interp;
+            detail::get_num_interpreters_seen() += 1; // there are now many interpreters
+            detail::get_internals(); // initialize internals.tstate, amongst other things...
+
+            // we have to switch back to main, and then the scopes will handle cleanup
+            PyThreadState_Swap(prev_tstate);
+        }
+        return result;
+    }
+
+    /// Call create() with a default configuration of an isolated interpreter that disallows fork,
+    /// exec, and Python threads.
+    static inline subinterpreter create() {
+        // same as the default config in the python docs
+        PyInterpreterConfig cfg;
+        memset(&cfg, 0, sizeof(cfg));
+        cfg.check_multi_interp_extensions = 1;
+        cfg.gil = PyInterpreterConfig_OWN_GIL;
+        return create(cfg);
+    }
+
+private:
+    friend class subinterpreter_scoped_activate;
+    PyThreadState *tstate_ = nullptr;
+    PyInterpreterState *istate_ = nullptr;
+};
+
+subinterpreter_scoped_activate::subinterpreter_scoped_activate(subinterpreter const &si) {
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
+    if (!si.istate_ || !si.tstate_) {
+        pybind11_fail("null subinterpreter");
+    }
+#endif
+
+    auto cur_tstate = detail::get_thread_state_unchecked();
+    if (cur_tstate && cur_tstate->interp == si.istate_) {
+        // we are already on this interpreter, make sure we hold the GIL
+        simple_gil_ = true;
+        gil_state_ = PyGILState_Ensure();
+        return;
+    }
+
+    PyThreadState *desired_tstate = nullptr;
+
+    // get the state dict for the interpreter we want
+    dict idict = reinterpret_borrow<dict>(PyInterpreterState_GetDict(si.istate_));
+    // and get the internals from it
+    auto *internals_pp = detail::get_internals_pp_from_capsule_in_state_dict<detail::internals>(
+        idict, PYBIND11_INTERNALS_ID);
+    if (internals_pp && *internals_pp) {
+        // see if there is already a tstate for this thread
+        desired_tstate = (PyThreadState *) PYBIND11_TLS_GET_VALUE((*internals_pp)->tstate);
+        if (!desired_tstate) {
+            // nope, we have to create one.
+            desired_tstate = PyThreadState_New(si.istate_);
+            free_tstate_ = desired_tstate;
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
+            if (!desired_tstate) {
+                pybind11_fail("subinterpreter_scoped_activate: could not create thread state!");
+            }
+#endif
+            PYBIND11_TLS_REPLACE_VALUE((*internals_pp)->tstate, desired_tstate);
+        }
+    } else {
+        desired_tstate = PyThreadState_New(si.istate_);
+        free_tstate_ = desired_tstate;
+    }
+
+    // make the interpreter active and acquire the GIL
+    old_tstate_ = PyThreadState_Swap(desired_tstate);
+}
+
+subinterpreter_scoped_activate::~subinterpreter_scoped_activate() {
+    if (simple_gil_) {
+        // We were on this interpreter already, so just make sure the GIL goes back as it was
+        PyGILState_Release(gil_state_);
+    } else {
+        if (free_tstate_) {
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
+            if (detail::get_thread_state_unchecked() != free_tstate_) {
+                pybind11_fail("~subinterpreter_scoped_activate: thread state must be current!");
+            }
+#endif
+            PYBIND11_TLS_DELETE_VALUE(detail::get_internals().tstate);
+            PyThreadState_Clear(free_tstate_);
+            PyThreadState_DeleteCurrent();
+        }
+
+        // Go back the previous interpreter (if any) and acquire THAT gil
+        PyThreadState_Swap(old_tstate_);
+    }
+}
+
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -28,7 +28,7 @@ PyInterpreterState *get_interpreter_state_unchecked() {
     else
         return nullptr;
 }
-PYBIND11_NAMESPACE_END()
+PYBIND11_NAMESPACE_END(detail)
 
 class subinterpreter;
 
@@ -77,7 +77,7 @@ public:
     /// interpreter and its GIL are not required to be held prior to calling this function.
     static inline subinterpreter create(PyInterpreterConfig const &cfg) {
         error_scope err_scope;
-        auto main_guard = main_scoped_activate();
+        subinterpreter_scoped_activate main_guard(main());
         subinterpreter result;
         {
             // we must hold the main GIL in order to create a subinterpreter
@@ -179,11 +179,11 @@ public:
     /// Get a handle to the main interpreter that can be used with subinterpreter_scoped_activate
     /// Note that destructing the handle is a noop, the main interpreter can only be ended by
     /// py::finalize_interpreter()
-    static subinterpreter_scoped_activate main_scoped_activate() {
+    static subinterpreter main() {
         subinterpreter m;
         m.istate_ = PyInterpreterState_Main();
         m.disarm(); // make destruct a noop
-        return subinterpreter_scoped_activate(m);
+        return m;
     }
 
     /// Get a non-owning wrapper of the currently active interpreter (if any)

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -1,5 +1,5 @@
 /*
-    pybind11/subinterpreters.h: Support for creating and using subinterpreters
+    pybind11/subinterpreter.h: Support for creating and using subinterpreters
 
     Copyright (c) 2025 The Pybind Development Team.
 
@@ -195,7 +195,12 @@ public:
     }
 
     /// Get the numerical identifier for the sub-interpreter
-    int64_t id() const { return PyInterpreterState_GetID(istate_); }
+    int64_t id() const { 
+        if (istate_ != nullptr)
+            return PyInterpreterState_GetID(istate_);
+        else
+            return -1; // CPython uses one-up numbers from 0, so negative should be safe to return here.
+    }
 
     /// Get the interpreter's state dict.  This interpreter's GIL must be held before calling!
     dict state_dict() { return reinterpret_borrow<dict>(PyInterpreterState_GetDict(istate_)); }

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -116,7 +116,7 @@ public:
     static inline subinterpreter create() {
         // same as the default config in the python docs
         PyInterpreterConfig cfg;
-        memset(&cfg, 0, sizeof(cfg));
+        std::memset(&cfg, 0, sizeof(cfg));
         cfg.check_multi_interp_extensions = 1;
         cfg.gil = PyInterpreterConfig_OWN_GIL;
         return create(cfg);

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -131,13 +131,14 @@ public:
         PyThreadState *destroy_tstate;
         PyThreadState *old_tstate;
 
-        // Python 3.12 requires us to keep the original PyThreadState alive until we are ready to destroy the interpreter.  We prefer to use that to destroy the interpreter.
+        // Python 3.12 requires us to keep the original PyThreadState alive until we are ready to
+        // destroy the interpreter.  We prefer to use that to destroy the interpreter.
 #if PY_VERSION_HEX < 0x030D0000
         // The tstate passed to Py_EndInterpreter MUST have been created on the current OS thread.
         bool same_thread = false;
-        #ifdef PY_HAVE_THREAD_NATIVE_ID
+#    ifdef PY_HAVE_THREAD_NATIVE_ID
         same_thread = PyThread_get_thread_native_id() == creation_tstate_->native_thread_id;
-        #endif
+#    endif
         if (same_thread) {
             // OK it is safe to use the creation state here
             destroy_tstate = creation_tstate_;
@@ -155,7 +156,7 @@ public:
         destroy_state = PyThreadState_New(istate_);
         old_tstate = PyThreadState_Swap(destroy_state);
 #endif
-        
+
         bool switch_back = old_tstate && old_tstate->interp != istate_;
 
         // Get the internals pointer (without creating it if it doesn't exist).  It's possible

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -195,11 +195,12 @@ public:
     }
 
     /// Get the numerical identifier for the sub-interpreter
-    int64_t id() const { 
+    int64_t id() const {
         if (istate_ != nullptr)
             return PyInterpreterState_GetID(istate_);
         else
-            return -1; // CPython uses one-up numbers from 0, so negative should be safe to return here.
+            return -1; // CPython uses one-up numbers from 0, so negative should be safe to return
+                       // here.
     }
 
     /// Get the interpreter's state dict.  This interpreter's GIL must be held before calling!

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -148,13 +148,13 @@ public:
             destroy_tstate = PyThreadState_New(istate_);
             old_tstate = PyThreadState_Swap(destroy_tstate);
 
-            // We can use temp, the one we just created, and delete the creation state.
+            // We can use the one we just created, so we must delete the creation state.
             PyThreadState_Clear(creation_tstate_);
             PyThreadState_Delete(creation_tstate_);
         }
 #else
-        destroy_state = PyThreadState_New(istate_);
-        old_tstate = PyThreadState_Swap(destroy_state);
+        destroy_tstate = PyThreadState_New(istate_);
+        old_tstate = PyThreadState_Swap(destroy_tstate);
 #endif
 
         bool switch_back = old_tstate && old_tstate->interp != istate_;

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -274,7 +274,7 @@ inline subinterpreter_scoped_activate::~subinterpreter_scoped_activate() {
         if (has_active_exception) {
             try {
                 std::rethrow_exception(std::current_exception());
-            } catch (error_already_set &e) {
+            } catch (error_already_set &) {
                 // Because error_already_set holds python objects and what() acquires the GIL, it
                 // is basically never OK to let these exceptions propagate outside the current
                 // active interpreter.

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -61,13 +61,13 @@ public:
     subinterpreter(subinterpreter const &copy) = delete;
     subinterpreter &operator=(subinterpreter const &copy) = delete;
 
-    subinterpreter(subinterpreter &&old)
+    subinterpreter(subinterpreter &&old) noexcept
         : istate_(old.istate_), creation_tstate_(old.creation_tstate_) {
         old.istate_ = nullptr;
         old.creation_tstate_ = nullptr;
     }
 
-    subinterpreter &operator=(subinterpreter &&old) {
+    subinterpreter &operator=(subinterpreter &&old) noexcept {
         std::swap(old.istate_, istate_);
         std::swap(old.creation_tstate_, creation_tstate_);
         return *this;

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -32,8 +32,8 @@ PYBIND11_NAMESPACE_END(detail)
 
 class subinterpreter;
 
-/// Activate the subinterpreter and acquire it's GIL, while also releasing any GIL and interpreter
-/// currently held. Upon exiting the scope, the previous subinterpreter (if any) and it's
+/// Activate the subinterpreter and acquire its GIL, while also releasing any GIL and interpreter
+/// currently held. Upon exiting the scope, the previous subinterpreter (if any) and its
 /// associated GIL are restored to their state as they were before the scope was entered.
 class subinterpreter_scoped_activate {
 public:
@@ -263,8 +263,8 @@ inline subinterpreter_scoped_activate::subinterpreter_scoped_activate(subinterpr
         return;
     }
 
-    // we can't really innteract with the interpreter at all until we switch to it
-    // not even to, for example, look in it's state dict or touch its internals
+    // we can't really interact with the interpreter at all until we switch to it
+    // not even to, for example, look in its state dict or touch its internals
     tstate_ = PyThreadState_New(si.istate_);
 
     // make the interpreter active and acquire the GIL

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -46,8 +46,9 @@ private:
 /// Holds a Python subinterpreter instance
 class subinterpreter {
 public:
-    subinterpreter() = default; /// empty/unusable, but move-assignable.  use create() to create a subinterpreter.
-    
+    /// empty/unusable, but move-assignable.  use create() to create a subinterpreter.
+    subinterpreter() = default;
+
     subinterpreter(subinterpreter const &copy) = delete;
     subinterpreter &operator=(subinterpreter const &copy) = delete;
 
@@ -56,14 +57,15 @@ public:
         old.istate_ = nullptr;
     }
 
-    subinterpreter &operator = (subinterpreter &&old) {
+    subinterpreter &operator=(subinterpreter &&old) {
         std::swap(old.tstate_, tstate_);
         std::swap(old.istate_, istate_);
         return *this;
     }
 
     /// Create a new subinterpreter with the specified configuration
-    /// Note Well:
+    /// @note This function acquires (and then releases) the main interpreter GIL, but the main
+    /// interpreter and its GIL are not required to be held prior to calling this function.
     static inline subinterpreter create(PyInterpreterConfig const &cfg) {
         error_scope err_scope;
         auto main_guard = main_scoped_activate();
@@ -92,7 +94,7 @@ public:
         return result;
     }
 
-    /// Call create() with a default configuration of an isolated interpreter that disallows fork,
+    /// Calls create() with a default configuration of an isolated interpreter that disallows fork,
     /// exec, and Python threads.
     static inline subinterpreter create() {
         // same as the default config in the python docs

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -58,6 +58,7 @@ main_headers = {
     "include/pybind11/options.h",
     "include/pybind11/pybind11.h",
     "include/pybind11/pytypes.h",
+    "include/pybind11/subinterpreter.h",
     "include/pybind11/stl.h",
     "include/pybind11/stl_bind.h",
     "include/pybind11/trampoline_self_life_support.h",

--- a/tests/test_embed/CMakeLists.txt
+++ b/tests/test_embed/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 find_package(Threads REQUIRED)
 
-add_executable(test_embed catch.cpp test_interpreter.cpp)
+add_executable(test_embed catch.cpp test_interpreter.cpp test_subinterpreter.cpp)
 pybind11_enable_warnings(test_embed)
 
 target_link_libraries(test_embed PRIVATE pybind11::embed Catch2::Catch2 Threads::Threads)

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/embed.h>
+#include <pybind11/subinterpreter.h>
 
 // Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to
 // catch 2.0.1; this should be fixed in the next catch release after 2.0.1).
@@ -17,6 +18,21 @@ using namespace py::literals;
 size_t get_sys_path_size() {
     auto sys_path = py::module::import("sys").attr("path");
     return py::len(sys_path);
+}
+
+bool has_state_dict_internals_obj() {
+    py::dict state = py::detail::get_python_state_dict();
+    return state.contains(PYBIND11_INTERNALS_ID);
+}
+
+bool has_pybind11_internals_static() {
+    auto *&ipp = py::detail::get_internals_pp<py::detail::internals>();
+    return (ipp != nullptr) && *ipp;
+}
+
+uintptr_t get_details_as_uintptr() {
+    return reinterpret_cast<uintptr_t>(
+        py::detail::get_internals_pp<py::detail::internals>()->get());
 }
 
 class Widget {
@@ -258,21 +274,6 @@ TEST_CASE("Add program dir to path using PyConfig") {
 }
 #endif
 
-bool has_state_dict_internals_obj() {
-    py::dict state = py::detail::get_python_state_dict();
-    return state.contains(PYBIND11_INTERNALS_ID);
-}
-
-bool has_pybind11_internals_static() {
-    auto *&ipp = py::detail::get_internals_pp<py::detail::internals>();
-    return (ipp != nullptr) && *ipp;
-}
-
-uintptr_t get_details_as_uintptr() {
-    return reinterpret_cast<uintptr_t>(
-        py::detail::get_internals_pp<py::detail::internals>()->get());
-}
-
 TEST_CASE("Restart the interpreter") {
     // Verify pre-restart state.
     REQUIRE(py::module_::import("widget_module").attr("add")(1, 2).cast<int>() == 3);
@@ -335,279 +336,6 @@ TEST_CASE("Restart the interpreter") {
     auto py_widget = py_module.attr("DerivedWidget")("Hello after restart");
     REQUIRE(py_widget.attr("the_message").cast<std::string>() == "Hello after restart");
 }
-
-#if defined(PYBIND11_SUBINTERPRETER_SUPPORT)
-TEST_CASE("Subinterpreter") {
-    py::module_::import("external_module"); // in the main interpreter
-
-    // Add tags to the modules in the main interpreter and test the basics.
-    py::module_::import("__main__").attr("main_tag") = "main interpreter";
-    {
-        auto m = py::module_::import("widget_module");
-        m.attr("extension_module_tag") = "added to module in main interpreter";
-
-        REQUIRE(m.attr("add")(1, 2).cast<int>() == 3);
-    }
-
-    auto main_int
-        = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
-
-    REQUIRE(has_state_dict_internals_obj());
-    REQUIRE(has_pybind11_internals_static());
-
-    /// Create and switch to a subinterpreter.
-    auto *main_tstate = PyThreadState_Get();
-    auto *sub_tstate = Py_NewInterpreter();
-
-    py::detail::get_num_interpreters_seen()++;
-
-    // Subinterpreters get their own copy of builtins.
-    REQUIRE_FALSE(has_state_dict_internals_obj());
-
-    // internals hasn't been populated yet, but will be different for the subinterpreter
-    REQUIRE_FALSE(has_pybind11_internals_static());
-
-    py::list(py::module_::import("sys").attr("path")).append(py::str("."));
-
-    auto ext_int = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
-    py::detail::get_internals();
-    REQUIRE(has_pybind11_internals_static());
-    REQUIRE(get_details_as_uintptr() == ext_int);
-    REQUIRE(main_int != ext_int);
-
-    // Modules tags should be gone.
-    REQUIRE_FALSE(py::hasattr(py::module_::import("__main__"), "tag"));
-    {
-        REQUIRE_NOTHROW(py::module_::import("widget_module"));
-        auto m = py::module_::import("widget_module");
-        REQUIRE_FALSE(py::hasattr(m, "extension_module_tag"));
-
-        // Function bindings should still work.
-        REQUIRE(m.attr("add")(1, 2).cast<int>() == 3);
-    }
-
-    // The subinterpreter now has internals populated since we imported a pybind11 module
-    REQUIRE(has_pybind11_internals_static());
-
-    // Restore main interpreter.
-    Py_EndInterpreter(sub_tstate);
-    py::detail::get_num_interpreters_seen() = 1;
-    PyThreadState_Swap(main_tstate);
-
-    REQUIRE(py::hasattr(py::module_::import("__main__"), "main_tag"));
-    REQUIRE(py::hasattr(py::module_::import("widget_module"), "extension_module_tag"));
-    REQUIRE(has_state_dict_internals_obj());
-}
-
-TEST_CASE("Multiple Subinterpreters") {
-    // Make sure the module is in the main interpreter and save its pointer
-    auto *main_ext = py::module_::import("external_module").ptr();
-    auto main_int
-        = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
-    py::module_::import("external_module").attr("multi_interp") = "1";
-
-    auto *main_tstate = PyThreadState_Get();
-
-    /// Create and switch to a subinterpreter.
-    auto *sub1_tstate = Py_NewInterpreter();
-    py::detail::get_num_interpreters_seen()++;
-
-    py::list(py::module_::import("sys").attr("path")).append(py::str("."));
-
-    // The subinterpreter has its own copy of this module which is completely separate from main
-    auto *sub1_ext = py::module_::import("external_module").ptr();
-    REQUIRE(sub1_ext != main_ext);
-    REQUIRE_FALSE(py::hasattr(py::module_::import("external_module"), "multi_interp"));
-    py::module_::import("external_module").attr("multi_interp") = "2";
-    // The subinterpreter also has its own internals
-    auto sub1_int
-        = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
-    REQUIRE(sub1_int != main_int);
-
-    // Create another interpreter
-    auto *sub2_tstate = Py_NewInterpreter();
-    py::detail::get_num_interpreters_seen()++;
-
-    py::list(py::module_::import("sys").attr("path")).append(py::str("."));
-
-    // The second subinterpreter is separate from both main and the other subinterpreter
-    auto *sub2_ext = py::module_::import("external_module").ptr();
-    REQUIRE(sub2_ext != main_ext);
-    REQUIRE(sub2_ext != sub1_ext);
-    REQUIRE_FALSE(py::hasattr(py::module_::import("external_module"), "multi_interp"));
-    py::module_::import("external_module").attr("multi_interp") = "3";
-    // The subinterpreter also has its own internals
-    auto sub2_int
-        = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
-    REQUIRE(sub2_int != main_int);
-    REQUIRE(sub2_int != sub1_int);
-
-    PyThreadState_Swap(sub1_tstate); // go back to sub1
-
-    REQUIRE(py::cast<std::string>(py::module_::import("external_module").attr("multi_interp"))
-            == "2");
-
-    PyThreadState_Swap(main_tstate); // go back to main
-
-    auto post_int
-        = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
-    // Make sure internals went back the way it was before
-    REQUIRE(main_int == post_int);
-
-    REQUIRE(py::cast<std::string>(py::module_::import("external_module").attr("multi_interp"))
-            == "1");
-
-    PyThreadState_Swap(sub1_tstate);
-    Py_EndInterpreter(sub1_tstate);
-    PyThreadState_Swap(sub2_tstate);
-    Py_EndInterpreter(sub2_tstate);
-
-    py::detail::get_num_interpreters_seen() = 1;
-    PyThreadState_Swap(main_tstate);
-}
-#endif
-
-#if defined(Py_MOD_PER_INTERPRETER_GIL_SUPPORTED) && defined(PYBIND11_SUBINTERPRETER_SUPPORT)
-TEST_CASE("Per-Subinterpreter GIL") {
-    auto main_int
-        = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
-
-    std::atomic<int> started, sync, failure;
-    started = 0;
-    sync = 0;
-    failure = 0;
-
-// REQUIRE throws on failure, so we can't use it within the thread
-#    define T_REQUIRE(status)                                                                     \
-        do {                                                                                      \
-            assert(status);                                                                       \
-            if (!(status))                                                                        \
-                ++failure;                                                                        \
-        } while (0)
-
-    auto &&thread_main = [&](int num) {
-        while (started == 0)
-            std::this_thread::sleep_for(std::chrono::microseconds(1));
-        ++started;
-
-        py::gil_scoped_acquire gil;
-        auto main_tstate = PyThreadState_Get();
-
-        // we have the GIL, we can access the main interpreter
-        auto t_int
-            = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
-        T_REQUIRE(t_int == main_int);
-        py::module_::import("external_module").attr("multi_interp") = "1";
-
-        PyThreadState *sub = nullptr;
-        PyInterpreterConfig cfg;
-        memset(&cfg, 0, sizeof(cfg));
-        cfg.check_multi_interp_extensions = 1;
-        cfg.gil = PyInterpreterConfig_OWN_GIL;
-        auto status = Py_NewInterpreterFromConfig(&sub, &cfg);
-        T_REQUIRE(!PyStatus_IsError(status));
-
-        py::detail::get_num_interpreters_seen()++;
-
-        py::list(py::module_::import("sys").attr("path")).append(py::str("."));
-
-        // we have switched to the new interpreter and released the main gil
-
-        // trampoline_module did not provide the per_interpreter_gil tag, so it cannot be
-        // imported
-        bool caught = false;
-        try {
-            py::module_::import("trampoline_module");
-        } catch (pybind11::error_already_set &pe) {
-            T_REQUIRE(pe.matches(PyExc_ImportError));
-            std::string msg(pe.what());
-            T_REQUIRE(msg.find("does not support loading in subinterpreters")
-                      != std::string::npos);
-            caught = true;
-        }
-        T_REQUIRE(caught);
-
-        // widget_module did provide the per_interpreter_gil tag, so it this does not throw
-        py::module_::import("widget_module");
-
-        T_REQUIRE(!py::hasattr(py::module_::import("external_module"), "multi_interp"));
-        py::module_::import("external_module").attr("multi_interp") = std::to_string(num);
-
-        // wait for something to set sync to our thread number
-        // we are holding our subinterpreter's GIL
-        while (sync != num)
-            std::this_thread::sleep_for(std::chrono::microseconds(1));
-
-        // now change it so the next thread can mvoe on
-        ++sync;
-
-        // but keep holding the GIL until after the next thread moves on as well
-        while (sync == num + 1)
-            std::this_thread::sleep_for(std::chrono::microseconds(1));
-
-        // one last check before quitting the thread, the internals should be different
-        auto sub_int
-            = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
-        T_REQUIRE(sub_int != main_int);
-
-        Py_EndInterpreter(sub);
-
-        // switch back so the scoped_acquire can release the GIL properly
-        PyThreadState_Swap(main_tstate);
-    };
-
-    std::thread t1(thread_main, 1);
-    std::thread t2(thread_main, 2);
-
-    // we spawned two threads, at this point they are both waiting for started to increase
-    ++started;
-
-    // ok now wait for the threads to start
-    while (started != 3)
-        std::this_thread::sleep_for(std::chrono::microseconds(1));
-
-    // we still hold the main GIL, at this point both threads are waiting on the main GIL
-    // IN THE CASE of free threading, the threads are waiting on sync (because there is no GIL)
-
-    // IF the below code hangs in one of the wait loops, then the child thread GIL behavior did not
-    // function as expected.
-    {
-        // release the GIL and allow the threads to run
-        py::gil_scoped_release nogil;
-
-        // the threads are now waiting on the sync
-        REQUIRE(sync == 0);
-
-        // this will trigger thread 1 and then advance and trigger 2 and then advance
-        sync = 1;
-
-        // wait for thread 2 to advance
-        while (sync != 3)
-            std::this_thread::sleep_for(std::chrono::microseconds(1));
-
-        // we know now that thread 1 has run and may be finishing
-        // and thread 2 is waiting for permission to advance
-
-        // so we move sync so that thread 2 can finish executing
-        ++sync;
-
-        // now wait for both threads to complete
-        t1.join();
-        t2.join();
-    }
-
-    // now we have the gil again, sanity check
-    REQUIRE(py::cast<std::string>(py::module_::import("external_module").attr("multi_interp"))
-            == "1");
-
-    // the threads are stopped. we can now lower this for the rest of the test
-    py::detail::get_num_interpreters_seen() = 1;
-
-    // make sure nothing unexpected happened inside the threads, now that they are completed
-    REQUIRE(failure == 0);
-#    undef T_REQUIRE
-}
-#endif
 
 TEST_CASE("Execution frame") {
     // When the interpreter is embedded, there is no execution frame, but `py::exec`

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/embed.h>
-#include <pybind11/subinterpreter.h>
 
 // Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to
 // catch 2.0.1; this should be fixed in the next catch release after 2.0.1).

--- a/tests/test_embed/test_subinterpreter.cpp
+++ b/tests/test_embed/test_subinterpreter.cpp
@@ -80,7 +80,6 @@ TEST_CASE("Single Subinterpreter") {
     unsafe_reset_internals_for_single_interpreter();
 }
 
-
 TEST_CASE("Move Subinterpreter") {
 
     auto ssi = std::make_unique<py::subinterpreter>(py::subinterpreter::create());
@@ -95,8 +94,7 @@ TEST_CASE("Move Subinterpreter") {
         py::module_::import("external_module");
     }
 
-    std::thread temp([ssi=std::move(ssi)]() mutable {
-
+    std::thread temp([ssi = std::move(ssi)]() mutable {
         // Use it again
         {
             py::subinterpreter_scoped_activate activate(*ssi);
@@ -235,7 +233,8 @@ TEST_CASE("Per-Subinterpreter GIL") {
 
             // we have switched to the new interpreter and released the main gil
 
-            // trampoline_module did not provide the per_interpreter_gil tag, so it cannot be imported
+            // trampoline_module did not provide the per_interpreter_gil tag, so it cannot be
+            // imported
             bool caught = false;
             try {
                 py::module_::import("trampoline_module");

--- a/tests/test_embed/test_subinterpreter.cpp
+++ b/tests/test_embed/test_subinterpreter.cpp
@@ -81,7 +81,7 @@ TEST_CASE("Single Subinterpreter") {
     unsafe_reset_internals_for_single_interpreter();
 }
 
-#if PY_VERSION_HEX >= 0x030D0000
+#    if PY_VERSION_HEX >= 0x030D0000
 TEST_CASE("Move Subinterpreter") {
     std::unique_ptr<py::subinterpreter> sub(new py::subinterpreter(py::subinterpreter::create()));
 
@@ -108,7 +108,7 @@ TEST_CASE("Move Subinterpreter") {
 
     unsafe_reset_internals_for_single_interpreter();
 }
-#endif
+#    endif
 
 TEST_CASE("GIL Subinterpreter") {
 

--- a/tests/test_embed/test_subinterpreter.cpp
+++ b/tests/test_embed/test_subinterpreter.cpp
@@ -132,7 +132,7 @@ TEST_CASE("GIL Subinterpreter") {
             py::module_::import("external_module");
 
             {
-                auto main_activate = py::subinterpreter::main_scoped_activate();
+                py::subinterpreter_scoped_activate main(py::subinterpreter::main());
                 REQUIRE(PyInterpreterState_Get() == main_interp);
 
                 {

--- a/tests/test_embed/test_subinterpreter.cpp
+++ b/tests/test_embed/test_subinterpreter.cpp
@@ -342,7 +342,13 @@ TEST_CASE("Per-Subinterpreter GIL") {
             T_REQUIRE(caught);
 
             // widget_module did provide the per_interpreter_gil tag, so it this does not throw
-            py::module_::import("widget_module");
+            try {
+                py::module_::import("widget_module");
+                caught = false;
+            } catch (pybind11::error_already_set &) {
+                caught = true;
+            }
+            T_REQUIRE(!caught);
 
             // widget_module did provide the per_interpreter_gil tag, so it this does not throw
             py::module_::import("widget_module");

--- a/tests/test_embed/test_subinterpreter.cpp
+++ b/tests/test_embed/test_subinterpreter.cpp
@@ -81,8 +81,8 @@ TEST_CASE("Single Subinterpreter") {
     unsafe_reset_internals_for_single_interpreter();
 }
 
+#if PY_VERSION_HEX >= 0x030D0000
 TEST_CASE("Move Subinterpreter") {
-
     std::unique_ptr<py::subinterpreter> sub(new py::subinterpreter(py::subinterpreter::create()));
 
     // on this thread, use the subinterpreter and import some non-trivial junk
@@ -108,6 +108,7 @@ TEST_CASE("Move Subinterpreter") {
 
     unsafe_reset_internals_for_single_interpreter();
 }
+#endif
 
 TEST_CASE("GIL Subinterpreter") {
 

--- a/tests/test_embed/test_subinterpreter.cpp
+++ b/tests/test_embed/test_subinterpreter.cpp
@@ -44,7 +44,8 @@ TEST_CASE("Single Subinterpreter") {
     REQUIRE(has_state_dict_internals_obj());
     REQUIRE(has_pybind11_internals_static());
 
-    auto main_int = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+    auto main_int
+        = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
 
     /// Create and switch to a subinterpreter.
     {

--- a/tests/test_embed/test_subinterpreter.cpp
+++ b/tests/test_embed/test_subinterpreter.cpp
@@ -1,0 +1,288 @@
+#include <pybind11/embed.h>
+#ifdef PYBIND11_SUBINTERPRETER_SUPPORT
+#include <pybind11/subinterpreter.h>
+
+// Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to
+// catch 2.0.1; this should be fixed in the next catch release after 2.0.1).
+PYBIND11_WARNING_DISABLE_MSVC(4996)
+
+#include <catch.hpp>
+#include <cstdlib>
+#include <fstream>
+#include <functional>
+#include <thread>
+#include <utility>
+
+namespace py = pybind11;
+using namespace py::literals;
+
+bool has_state_dict_internals_obj();
+bool has_pybind11_internals_static();
+uintptr_t get_details_as_uintptr();
+
+void unsafe_reset_internals_for_single_interpreter() {
+    // unsafe normally, but for subsequent tests, put this back.. we know there are no threads running and only 1 interpreter
+    py::detail::get_num_interpreters_seen() = 1;
+    py::detail::get_internals_pp<py::detail::internals>() = nullptr;
+    py::detail::get_internals();
+    py::detail::get_internals_pp<py::detail::local_internals>() = nullptr;
+    py::detail::get_local_internals();
+}
+
+TEST_CASE("Single Subinterpreter") {
+    py::module_::import("external_module"); // in the main interpreter
+
+    // Add tags to the modules in the main interpreter and test the basics.
+    py::module_::import("__main__").attr("main_tag") = "main interpreter";
+    {
+        auto m = py::module_::import("widget_module");
+        m.attr("extension_module_tag") = "added to module in main interpreter";
+
+        REQUIRE(m.attr("add")(1, 2).cast<int>() == 3);
+    }
+    REQUIRE(has_state_dict_internals_obj());
+    REQUIRE(has_pybind11_internals_static());
+
+    auto main_int = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+
+    /// Create and switch to a subinterpreter.
+    {
+        py::scoped_subinterpreter ssi;
+
+        // The subinterpreter has internals populated 
+        REQUIRE(has_pybind11_internals_static());
+
+        py::list(py::module_::import("sys").attr("path")).append(py::str("."));
+
+        auto ext_int = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+        py::detail::get_internals();
+        REQUIRE(has_pybind11_internals_static());
+        REQUIRE(get_details_as_uintptr() == ext_int);
+        REQUIRE(ext_int != main_int);
+
+        // Modules tags should be gone.
+        REQUIRE_FALSE(py::hasattr(py::module_::import("__main__"), "tag"));
+        {
+            auto m = py::module_::import("widget_module");
+            REQUIRE_FALSE(py::hasattr(m, "extension_module_tag"));
+
+            // Function bindings should still work.
+            REQUIRE(m.attr("add")(1, 2).cast<int>() == 3);
+        }
+    }
+
+    REQUIRE(py::hasattr(py::module_::import("__main__"), "main_tag"));
+    REQUIRE(py::hasattr(py::module_::import("widget_module"), "extension_module_tag"));
+    REQUIRE(has_state_dict_internals_obj());
+
+    unsafe_reset_internals_for_single_interpreter();
+}
+
+TEST_CASE("Multiple Subinterpreters") {
+    // Make sure the module is in the main interpreter and save its pointer
+    auto *main_ext = py::module_::import("external_module").ptr();
+    auto main_int
+        = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+    py::module_::import("external_module").attr("multi_interp") = "1";
+
+    {
+        py::subinterpreter si1 = py::subinterpreter::create();
+        std::unique_ptr<py::subinterpreter> psi2;
+
+        PyObject *sub1_ext = nullptr;
+        PyObject *sub2_ext = nullptr;
+        uintptr_t sub1_int = 0;
+        uintptr_t sub2_int = 0;
+
+        {
+            py::subinterpreter_scoped_activate scoped(si1);
+            py::list(py::module_::import("sys").attr("path")).append(py::str("."));
+
+            // The subinterpreter has its own copy of this module which is completely separate from main
+            sub1_ext = py::module_::import("external_module").ptr();
+            REQUIRE(sub1_ext != main_ext);
+            REQUIRE_FALSE(py::hasattr(py::module_::import("external_module"), "multi_interp"));
+            py::module_::import("external_module").attr("multi_interp") = "2";
+            // The subinterpreter also has its own internals
+            sub1_int
+                = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+            REQUIRE(sub1_int != main_int);
+
+            // while the old one is active, create a new one
+            psi2 = std::make_unique<py::subinterpreter>(py::subinterpreter::create());
+        }
+        
+        {
+            py::subinterpreter_scoped_activate scoped(*psi2);
+            py::list(py::module_::import("sys").attr("path")).append(py::str("."));
+
+            // The second subinterpreter is separate from both main and the other subinterpreter
+            sub2_ext = py::module_::import("external_module").ptr();
+            REQUIRE(sub2_ext != main_ext);
+            REQUIRE(sub2_ext != sub1_ext);
+            REQUIRE_FALSE(py::hasattr(py::module_::import("external_module"), "multi_interp"));
+            py::module_::import("external_module").attr("multi_interp") = "3";
+            // The subinterpreter also has its own internals
+            sub2_int
+                = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+            REQUIRE(sub2_int != main_int);
+            REQUIRE(sub2_int != sub1_int);
+        }
+    
+        {
+            py::subinterpreter_scoped_activate scoped(si1);
+            REQUIRE(py::cast<std::string>(py::module_::import("external_module").attr("multi_interp"))
+                    == "2");
+        }
+
+        // out here we should be in the main interpreter, with the GIL, with the other 2 still alive
+    
+        auto post_int
+            = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+        // Make sure internals went back the way it was before
+        REQUIRE(main_int == post_int);
+
+        REQUIRE(py::cast<std::string>(py::module_::import("external_module").attr("multi_interp"))
+                == "1");
+    }
+
+    // now back to just main
+
+    auto post_int = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+    // Make sure internals went back the way it was before
+    REQUIRE(main_int == post_int);
+
+    REQUIRE(py::cast<std::string>(py::module_::import("external_module").attr("multi_interp"))
+        == "1");
+    
+    unsafe_reset_internals_for_single_interpreter();
+}
+
+#ifdef Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
+TEST_CASE("Per-Subinterpreter GIL") {
+    auto main_int
+        = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+
+    std::atomic<int> started, sync, failure;
+    started = 0;
+    sync = 0;
+    failure = 0;
+
+// REQUIRE throws on failure, so we can't use it within the thread
+#    define T_REQUIRE(status)                                                                     \
+        do {                                                                                      \
+            assert(status);                                                                       \
+            if (!(status))                                                                        \
+                ++failure;                                                                        \
+        } while (0)
+
+    auto &&thread_main = [&](int num) {
+        while (started == 0)
+            std::this_thread::sleep_for(std::chrono::microseconds(1));
+        ++started;
+
+        py::gil_scoped_acquire gil;
+
+        // we have the GIL, we can access the main interpreter
+        auto t_int
+            = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+        T_REQUIRE(t_int == main_int);
+        py::module_::import("external_module").attr("multi_interp") = "1";
+
+        auto sub = py::subinterpreter::create();
+
+        {
+            py::subinterpreter_scoped_activate sguard{sub};
+
+            py::list(py::module_::import("sys").attr("path")).append(py::str("."));
+
+            // we have switched to the new interpreter and released the main gil
+
+            // trampoline_module did not provide the mod_per_interpreter_gil tag, so it cannot be
+            // imported
+            bool caught = false;
+            try {
+                py::module_::import("trampoline_module");
+            } catch (pybind11::error_already_set &pe) {
+                caught = true;
+            }
+            T_REQUIRE(!caught);
+
+            // widget_module did provide the per_interpreter_gil tag, so it this does not throw
+            py::module_::import("widget_module");
+
+            T_REQUIRE(!py::hasattr(py::module_::import("external_module"), "multi_interp"));
+            py::module_::import("external_module").attr("multi_interp") = std::to_string(num);
+
+            // wait for something to set sync to our thread number
+            // we are holding our subinterpreter's GIL
+            while (sync != num)
+                std::this_thread::sleep_for(std::chrono::microseconds(1));
+
+            // now change it so the next thread can move on
+            ++sync;
+
+            // but keep holding the GIL until after the next thread moves on as well
+            while (sync == num + 1)
+                std::this_thread::sleep_for(std::chrono::microseconds(1));
+
+            // one last check before quitting the thread, the internals should be different
+            auto sub_int
+                = py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>();
+            T_REQUIRE(sub_int != main_int);
+        }
+    };
+#    undef T_REQUIRE
+
+    std::thread t1(thread_main, 1);
+    std::thread t2(thread_main, 2);
+
+    // we spawned two threads, at this point they are both waiting for started to increase
+    ++started;
+
+    // ok now wait for the threads to start
+    while (started != 3)
+        std::this_thread::sleep_for(std::chrono::microseconds(1));
+
+    // we still hold the main GIL, at this point both threads are waiting on the main GIL
+    // IN THE CASE of free threading, the threads are waiting on sync (because there is no GIL)
+
+    // IF the below code hangs in one of the wait loops, then the child thread GIL behavior did not
+    // function as expected.
+    {
+        // release the GIL and allow the threads to run
+        py::gil_scoped_release nogil;
+
+        // the threads are now waiting on the sync
+        REQUIRE(sync == 0);
+
+        // this will trigger thread 1 and then advance and trigger 2 and then advance
+        sync = 1;
+
+        // wait for thread 2 to advance
+        while (sync != 3)
+            std::this_thread::sleep_for(std::chrono::microseconds(1));
+
+        // we know now that thread 1 has run and may be finishing
+        // and thread 2 is waiting for permission to advance
+
+        // so we move sync so that thread 2 can finish executing
+        ++sync;
+
+        // now wait for both threads to complete
+        t1.join();
+        t2.join();
+    }
+
+    // now we have the gil again, sanity check
+    REQUIRE(py::cast<std::string>(py::module_::import("external_module").attr("multi_interp"))
+            == "1");
+
+    unsafe_reset_internals_for_single_interpreter();
+
+    // make sure nothing unexpected happened inside the threads, now that they are completed
+    REQUIRE(failure == 0);
+}
+#endif//Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
+
+#endif// PYBIND11_SUBINTERPRETER_SUPPORT


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
This PR adds a header file, `subinterpreter.h` which provides utility classes for embedded Python to create, use, and destroy sub-interpreters.  The PR includes documentation rewrite of the "Embedded Sub-interpreter support" section.  The PR also splits out the multiple interpreter tests from `test_embed/test_interpreter.cpp` into their own file in that directory, updates them to use the new API, and adds new tests to cover the API and some interesting aspects of subinterpreters.

### API

Everything is in `subinterpreter.h` because this feature requires `PYBIND11_SUBINTERPRETER_SUPPORT`, which is 3.12+ (and some other caveats).  Including this file in non-supported versions produces a `#error`. There are no notable API outside of this new file, except for a change to embedded modules which was split out into its own PR: #5665 .  This PR currently includes the `embed.h` changes from that PR because this PR would not compile without them, and so this PR depends on that one being merged first (and when it is, I will fix this one with a rebase).

Class `subinterpreter` manages the lifetime of a sub-interpreter. Default constructing a `subinterpreter` does not create a `subinterpreter` it creates an empty wrapper, this is done to make the objects easier to move around and to prevent accidentally creating them (as creating them has to acquire and release the GIL).

To create a sub-interpreter, one does: `py::subinterpreter si = subinterpreter::create()`, similar to `py::initialize_interpreter()` for the main interpreter.  I didn't provide a `py::subinterpreter::destroy(...)` since that doesn't seem to make a lot of sense (you instead destruct the `subinterpreter` object returned by `create`) but if we want one to mirror `py::finalize_interpreter()` then I could add one easily.

`subinterpreter` also includes some useful utilities: `current()` to get a non-owning `subinterpreter` for the currently active interpreter (even the main one), `main()`  to get a non-owning `subinterpreter` for the main interpreter (even if it is not the current one), `id()` to get the ID number, and `state_dict()` to get the interpreter state dict.

Class `subinterpreter_scoped_activate` is the RAII wrapper, similar to `gil_scoped_acquire` which acquires the sub-interpreter's GIL and makes it the active interpreter.  The similarity to what the gil RAII classes do is also why it is named that.

Class `scoped_subinterpreter` is also provided in order to mirror the main interpreter's `scoped_interpreter`.

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

* Added API in `pybind11/subinterpreter.h` for embedding sub-intepreters (requires Python 3.12+).


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5666.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->