### PR TITLE
tests: expect free-threaded import warnings

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -20,4 +20,3 @@ filterwarnings =
     # bogus numpy ABI warning (see numpy/#432)
     ignore:.*numpy.dtype size changed.*:RuntimeWarning
     ignore:.*numpy.ufunc size changed.*:RuntimeWarning
-    default:The global interpreter lock:RuntimeWarning

--- a/tests/test_cpp_conduit.py
+++ b/tests/test_cpp_conduit.py
@@ -2,13 +2,34 @@
 
 from __future__ import annotations
 
-import exo_planet_c_api
-import exo_planet_pybind11
-import home_planet_very_lonely_traveler
+import importlib
+import sys
+
 import pytest
 
 import env
 from pybind11_tests import cpp_conduit as home_planet
+
+
+def import_warns_freethreaded(name):
+    if (
+        name not in sys.modules
+        and hasattr(sys, "_is_gil_enabled")
+        and not sys._is_gil_enabled()
+    ):
+        with pytest.warns(
+            RuntimeWarning, match=f"has been enabled to load module '{name}'"
+        ):
+            return importlib.import_module(name)
+
+    return importlib.import_module(name)
+
+
+exo_planet_c_api = import_warns_freethreaded("exo_planet_c_api")
+exo_planet_pybind11 = import_warns_freethreaded("exo_planet_pybind11")
+home_planet_very_lonely_traveler = import_warns_freethreaded(
+    "home_planet_very_lonely_traveler"
+)
 
 
 def test_traveler_getattr_actually_exists():

--- a/tests/test_cpp_conduit.py
+++ b/tests/test_cpp_conduit.py
@@ -12,7 +12,7 @@ from pybind11_tests import cpp_conduit as home_planet
 
 
 def import_warns_freethreaded(name):
-    if name not in sys.modules and not getattr(sys, "_is_gil_enabled", lambda: False)():
+    if name not in sys.modules and not getattr(sys, "_is_gil_enabled", lambda: True)():
         with pytest.warns(
             RuntimeWarning, match=f"has been enabled to load module '{name}'"
         ):

--- a/tests/test_cpp_conduit.py
+++ b/tests/test_cpp_conduit.py
@@ -12,11 +12,7 @@ from pybind11_tests import cpp_conduit as home_planet
 
 
 def import_warns_freethreaded(name):
-    if (
-        name not in sys.modules
-        and hasattr(sys, "_is_gil_enabled")
-        and not sys._is_gil_enabled()
-    ):
+    if name not in sys.modules and not getattr(sys, "_is_gil_enabled", lambda: False)():
         with pytest.warns(
             RuntimeWarning, match=f"has been enabled to load module '{name}'"
         ):


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Gets rid of a warning we expect/want to see. You can see the warnings, for example, in #5674.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Expect free-threaded warning when loading a non-free-threaded module.
