### PR TITLE
chore: rename macro `PYBIND11_SUBINTERPRETER_SUPPORT` -> `PYBIND11_HAS_SUBINTERPRETER_SUPPORT` to meet naming convention

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -232,11 +232,11 @@
 #    define PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF
 #endif
 
-// Slightly faster code paths are available when PYBIND11_SUBINTERPRETER_SUPPORT is *not* defined,
-// so avoid defining it for implementations that do not support subinterpreters.
-// However, defining it unnecessarily is not expected to break anything.
+// Slightly faster code paths are available when PYBIND11_HAS_SUBINTERPRETER_SUPPORT is *not*
+// defined, so avoid defining it for implementations that do not support subinterpreters. However,
+// defining it unnecessarily is not expected to break anything.
 #if PY_VERSION_HEX >= 0x030C0000 && !defined(PYPY_VERSION) && !defined(GRAALVM_PYTHON)
-#    define PYBIND11_SUBINTERPRETER_SUPPORT
+#    define PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 #endif
 
 // 3.12 Compatibility

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -324,7 +324,7 @@ inline std::atomic<int> &get_num_interpreters_seen() {
 
 template <typename InternalsType>
 inline std::unique_ptr<InternalsType> *&get_internals_pp() {
-#ifdef PYBIND11_SUBINTERPRETER_SUPPORT
+#ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
     if (get_num_interpreters_seen() > 1) {
         // Internals is one per interpreter. When multiple interpreters are alive in different
         // threads we have to allow them to have different internals, so we need a thread_local.

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -15,7 +15,7 @@
 
 #include <stdexcept>
 
-#if !defined(PYBIND11_SUBINTERPRETER_SUPPORT)
+#if !defined(PYBIND11_HAS_SUBINTERPRETER_SUPPORT)
 #    error "This platform does not support subinterpreters, do not include this file."
 #endif
 

--- a/tests/test_embed/test_subinterpreter.cpp
+++ b/tests/test_embed/test_subinterpreter.cpp
@@ -1,5 +1,5 @@
 #include <pybind11/embed.h>
-#ifdef PYBIND11_SUBINTERPRETER_SUPPORT
+#ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 #    include <pybind11/subinterpreter.h>
 
 // Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to
@@ -428,4 +428,4 @@ TEST_CASE("Per-Subinterpreter GIL") {
 }
 #    endif // Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
 
-#endif // PYBIND11_SUBINTERPRETER_SUPPORT
+#endif // PYBIND11_HAS_SUBINTERPRETER_SUPPORT


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Rename macro `PYBIND11_SUBINTERPRETER_SUPPORT` -> `PYBIND11_HAS_SUBINTERPRETER_SUPPORT` to meet naming convention.