### PR TITLE
refactor: use CPython macros to construct `PYBIND11_VERSION_HEX`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -28,7 +28,7 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
 - Update the version number
 
   - Update ``PYBIND11_VERSION_MAJOR`` etc. in
-    ``include/pybind11/detail/common.h``. PATCH should be a simple integer.
+    ``include/pybind11/detail/common.h``. MICRO should be a simple integer.
 
   - Run ``nox -s tests_packaging`` to ensure this was done correctly.
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -10,11 +10,13 @@ For example:
 
     #define PYBIND11_VERSION_MAJOR X
     #define PYBIND11_VERSION_MINOR Y
+    #define PYBIND11_VERSION_MICRO Z
+    #define PYBIND11_VERSION_RELEASE_LEVEL PY_RELEASE_LEVEL_ALPHA
+    #define PYBIND11_VERSION_RELEASE_SERIAL 0
     #define PYBIND11_VERSION_PATCH Za0
 
 For beta, ``PYBIND11_VERSION_PATCH`` should be ``Zb1``. RC's can be ``Zrc1``.
-For a final release, this must be a simple integer. There is also
-``PYBIND11_VERSION_HEX`` just below that needs to be updated.
+For a final release, this must be a simple integer.
 
 
 To release a new version of pybind11:
@@ -27,8 +29,6 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
 
   - Update ``PYBIND11_VERSION_MAJOR`` etc. in
     ``include/pybind11/detail/common.h``. PATCH should be a simple integer.
-
-  - Update ``PYBIND11_VERSION_HEX`` just below as well.
 
   - Run ``nox -s tests_packaging`` to ensure this was done correctly.
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -14,13 +14,30 @@
 #    error "PYTHON < 3.8 IS UNSUPPORTED. pybind11 v2.13 was the last to support Python 3.7."
 #endif
 
+// Similar to Python's convention: https://docs.python.org/3/c-api/apiabiversion.html
+// See also: https://github.com/python/cpython/blob/HEAD/Include/patchlevel.h
 #define PYBIND11_VERSION_MAJOR 3
 #define PYBIND11_VERSION_MINOR 0
+#define PYBIND11_VERSION_MICRO 0
+// The release level is set to "alpha" for development versions.
+// Use 0xA0 (LEVEL=0xA, SERIAL=0) for development versions.
+// ALPHA = 0xA, BETA = 0xB, GAMMA = 0xC (release candidate), FINAL = 0xF (stable release)
+#define PYBIND11_VERSION_RELEASE_LEVEL PY_RELEASE_LEVEL_GAMMA
+#define PYBIND11_VERSION_RELEASE_SERIAL 1
 #define PYBIND11_VERSION_PATCH 0rc1
 
-// Similar to Python's convention: https://docs.python.org/3/c-api/apiabiversion.html
-// Use 0xA0 for dev
-#define PYBIND11_VERSION_HEX 0x030000C1
+#if !defined(Py_PACK_FULL_VERSION)
+// Stable API since Python 3.14.0a4
+#    define Py_PACK_FULL_VERSION(X, Y, Z, LEVEL, SERIAL)                                          \
+        ((((X) & 0xff) << 24) | (((Y) & 0xff) << 16) | (((Z) & 0xff) << 8)                        \
+         | (((LEVEL) & 0xf) << 4) | (((SERIAL) & 0xf) << 0))
+#endif
+#define PYBIND11_VERSION_HEX                                                                      \
+    Py_PACK_FULL_VERSION(PYBIND11_VERSION_MAJOR,                                                  \
+                         PYBIND11_VERSION_MINOR,                                                  \
+                         PYBIND11_VERSION_MICRO,                                                  \
+                         PYBIND11_VERSION_RELEASE_LEVEL,                                          \
+                         PYBIND11_VERSION_RELEASE_SERIAL)
 
 #include "pybind11_namespace_macros.h"
 

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -16,15 +16,19 @@
 
 // Similar to Python's convention: https://docs.python.org/3/c-api/apiabiversion.html
 // See also: https://github.com/python/cpython/blob/HEAD/Include/patchlevel.h
+/* -- start version constants -- */
 #define PYBIND11_VERSION_MAJOR 3
 #define PYBIND11_VERSION_MINOR 0
 #define PYBIND11_VERSION_MICRO 0
-// The release level is set to "alpha" for development versions.
-// Use 0xA0 (LEVEL=0xA, SERIAL=0) for development versions.
 // ALPHA = 0xA, BETA = 0xB, GAMMA = 0xC (release candidate), FINAL = 0xF (stable release)
+// - The release level is set to "alpha" for development versions.
+//   Use 0xA0 (LEVEL=0xA, SERIAL=0) for development versions.
+// - For stable releases, set the serial to 0.
 #define PYBIND11_VERSION_RELEASE_LEVEL PY_RELEASE_LEVEL_GAMMA
 #define PYBIND11_VERSION_RELEASE_SERIAL 1
+// String version of (micro, release level, release serial), e.g.: 0a0, 0b1, 0rc1, 0
 #define PYBIND11_VERSION_PATCH 0rc1
+/* -- end version constants -- */
 
 #if !defined(Py_PACK_FULL_VERSION)
 // Stable API since Python 3.14.0a4
@@ -32,6 +36,7 @@
         ((((X) & 0xff) << 24) | (((Y) & 0xff) << 16) | (((Z) & 0xff) << 8)                        \
          | (((LEVEL) & 0xf) << 4) | (((SERIAL) & 0xf) << 0))
 #endif
+// Version as a single 4-byte hex number, e.g. 0x030C04B5 == 3.12.4b5.
 #define PYBIND11_VERSION_HEX                                                                      \
     Py_PACK_FULL_VERSION(PYBIND11_VERSION_MAJOR,                                                  \
                          PYBIND11_VERSION_MINOR,                                                  \

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -354,7 +354,7 @@ def test_version_matches():
     text = header.read_text()
 
     # Extract the relevant macro values
-    regex_prefix = r"^\s*#\s*define\s+PYBIND11_VERSION_"
+    regex_prefix = r"#\s*define\s+PYBIND11_VERSION_"
     micro = re.search(rf"{regex_prefix}MICRO\s+(\d+)\b", text).group(1)
     release_level = re.search(rf"{regex_prefix}RELEASE_LEVEL\s+(\w+)\b", text).group(1)
     release_serial = re.search(

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -354,10 +354,14 @@ def test_version_matches():
     text = header.read_text()
 
     # Extract the relevant macro values
-    micro = re.search(r'#define\s+PYBIND11_VERSION_MICRO\s+(\d+)', text).group(1)
-    release_level = re.search(r'#define\s+PYBIND11_VERSION_RELEASE_LEVEL\s+([A-Za-z0-9_]+)', text).group(1)
-    release_serial = re.search(r'#define\s+PYBIND11_VERSION_RELEASE_SERIAL\s+(\d+)', text).group(1)
-    patch = re.search(r'#define\s+PYBIND11_VERSION_PATCH\s+([^\s]+)', text).group(1)
+    micro = re.search(r"#define\s+PYBIND11_VERSION_MICRO\s+(\d+)", text).group(1)
+    release_level = re.search(
+        r"#define\s+PYBIND11_VERSION_RELEASE_LEVEL\s+([A-Za-z0-9_]+)", text
+    ).group(1)
+    release_serial = re.search(
+        r"#define\s+PYBIND11_VERSION_RELEASE_SERIAL\s+(\d+)", text
+    ).group(1)
+    patch = re.search(r"#define\s+PYBIND11_VERSION_PATCH\s+([^\s]+)", text).group(1)
 
     # Map release level macro to string
     level_map = {

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -354,19 +354,25 @@ def test_version_matches():
     text = header.read_text()
 
     # Extract the relevant macro values
-    prefix = r"^\s*#\s*define\s+PYBIND11_VERSION_"
-    micro = re.search(rf"{prefix}MICRO\s+(\d+)", text).group(1)
-    release_level = re.search(
-        rf"{prefix}RELEASE_LEVEL\s+PY_RELEASE_LEVEL_(\w+)", text
+    regex_prefix = r"^\s*#\s*define\s+PYBIND11_VERSION_"
+    micro = re.search(rf"{regex_prefix}MICRO\s+(\d+)\b", text).group(1)
+    release_level = re.search(rf"{regex_prefix}RELEASE_LEVEL\s+(\w+)\b", text).group(1)
+    release_serial = re.search(
+        rf"{regex_prefix}RELEASE_SERIAL\s+(\d+)\b",
+        text,
     ).group(1)
-    release_serial = re.search(rf"{prefix}RELEASE_SERIAL\s+(\d+)", text).group(1)
-    patch = re.search(rf"{prefix}PATCH\s+([^\s]+)", text).group(1)
+    patch = re.search(rf"{regex_prefix}PATCH\s+([\w.-]+)\b", text).group(1)
 
     # Map release level macro to string
-    level_map = {"ALPHA": "a", "BETA": "b", "GAMMA": "rc", "FINAL": ""}
+    level_map = {
+        "PY_RELEASE_LEVEL_ALPHA": "a",
+        "PY_RELEASE_LEVEL_BETA": "b",
+        "PY_RELEASE_LEVEL_GAMMA": "rc",
+        "PY_RELEASE_LEVEL_FINAL": "",
+    }
     level_str = level_map[release_level]
 
-    if release_level == "FINAL":
+    if release_level == "PY_RELEASE_LEVEL_FINAL":
         assert level_str == ""
         assert release_serial == "0"
         expected_patch = micro

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -347,3 +347,27 @@ def tests_build_global_wheel(monkeypatch, tmpdir):
 
     pkgconfig_expected = PKGCONFIG.format(VERSION=simple_version)
     assert pkgconfig_expected == pkgconfig
+
+
+def test_version_matches():
+    header = MAIN_DIR / "include/pybind11/detail/common.h"
+    text = header.read_text()
+
+    # Extract the relevant macro values
+    micro = re.search(r'#define\s+PYBIND11_VERSION_MICRO\s+(\d+)', text).group(1)
+    release_level = re.search(r'#define\s+PYBIND11_VERSION_RELEASE_LEVEL\s+([A-Za-z0-9_]+)', text).group(1)
+    release_serial = re.search(r'#define\s+PYBIND11_VERSION_RELEASE_SERIAL\s+(\d+)', text).group(1)
+    patch = re.search(r'#define\s+PYBIND11_VERSION_PATCH\s+([^\s]+)', text).group(1)
+
+    # Map release level macro to string
+    level_map = {
+        "PY_RELEASE_LEVEL_ALPHA": "a",
+        "PY_RELEASE_LEVEL_BETA": "b",
+        "PY_RELEASE_LEVEL_GAMMA": "rc",
+        "PY_RELEASE_LEVEL_FINAL": "",
+    }
+    level_str = level_map.get(release_level, release_level.lower())
+
+    expected_patch = f"{micro}{level_str}{release_serial}"
+
+    assert patch == expected_patch


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

As per title, use CPython macros to construct `PYBIND11_VERSION_HEX`. See also: https://github.com/python/cpython/blob/HEAD/Include/patchlevel.h

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Use CPython macros to construct `PYBIND11_VERSION_HEX`


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5683.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->