### PR TITLE
chore(cmake): add compile commands to preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,10 +12,12 @@
       },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "PYBIND11_FINDPYTHON": "NEW",
-        "PYBIND11_WERROR": true,
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "DOWNLOAD_CATCH": true,
-        "DOWNLOAD_EIGEN": true
+        "DOWNLOAD_EIGEN": true,
+        "PYBIND11_FINDPYTHON": "NEW",
+        "PYBIND11_WERROR": true
+
       }
     },
     {
@@ -24,12 +26,13 @@
       "inherits": "default",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "PYBIND11_CREATE_WITH_UV": "python3",
-        "Python_ROOT_DIR": ".venv",
-        "PYBIND11_WERROR": true,
-        "PYBIND11_FINDPYTHON": "NEW",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "DOWNLOAD_CATCH": true,
-        "DOWNLOAD_EIGEN": true
+        "DOWNLOAD_EIGEN": true,
+        "PYBIND11_CREATE_WITH_UV": "python3",
+        "PYBIND11_FINDPYTHON": "NEW",
+        "PYBIND11_WERROR": true,
+        "Python_ROOT_DIR": ".venv"
       }
     }
   ],


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

I thought I added this before, but it's not there. This will generate an
IDE-friendly file in `build/compile_commands.json` if supported.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Presets now generate `compile_commands.json`.
