### PR TITLE
Immortalize modules on init

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -311,8 +311,10 @@
 
 #ifdef _Py_IMMORTAL_REFCNT
 #    define PYBIND11_IMMORTALIZE(o) Py_SET_REFCNT(o.ptr(), _Py_IMMORTAL_REFCNT)
+#elif defined(Py_SET_REFCNT)
+#    define PYBIND11_IMMORTALIZE(o) Py_SET_REFCNT(o.ptr(), (UINT_MAX>>2))
 #else
-#    define PYBIND11_IMMORTALIZE(o)
+#    define PYBIND11_IMMORTALIZE(o) Py_INCREF(o.ptr())
 #endif
 
 #define PYBIND11_CHECK_PYTHON_VERSION                                                             \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -309,6 +309,12 @@
         } while (0)
 #endif
 
+#ifdef _Py_IMMORTAL_REFCNT
+#    define PYBIND11_IMMORTALIZE(o) Py_SET_REFCNT(o.ptr(), _Py_IMMORTAL_REFCNT)
+#else
+#    define PYBIND11_IMMORTALIZE(o)
+#endif
+
 #define PYBIND11_CHECK_PYTHON_VERSION                                                             \
     {                                                                                             \
         const char *compiled_ver                                                                  \
@@ -379,12 +385,14 @@ PYBIND11_WARNING_DISABLE_CLANG("-Wgnu-zero-variadic-macro-arguments")
             slots[0] = {Py_mod_exec,                                                              \
                         reinterpret_cast<void *>(&PYBIND11_CONCAT(pybind11_exec_, name))};        \
             slots[1] = {0, nullptr};                                                              \
-            return ::pybind11::module_::initialize_multiphase_module_def(                         \
+            auto o = ::pybind11::module_::initialize_multiphase_module_def(                       \
                 PYBIND11_TOSTRING(name),                                                          \
                 nullptr,                                                                          \
                 &PYBIND11_CONCAT(pybind11_module_def_, name),                                     \
                 slots,                                                                            \
                 ##__VA_ARGS__);                                                                   \
+            PYBIND11_IMMORTALIZE(o);                                                              \
+            return o;                                                                             \
         }();                                                                                      \
         return result.ptr();                                                                      \
     }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Likely fix for #5687.

The module objects created by MODULE_INIT macros are stored in static `pybind11::object`, which will try to DECREF them when the program exits, which is likely to crash because the interpreter has probably shut down by then.

The solution is that these objects should be marked immortal.  Deleting them is not possible, and they normally outlive the interpreter.


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
