### PR TITLE
fix: prepare for 3.14 beta 2

### DIFF
--- a/tests/test_methods_and_attributes.py
+++ b/tests/test_methods_and_attributes.py
@@ -306,8 +306,9 @@ def test_property_rvalue_policy():
 # https://foss.heptapod.net/pypy/pypy/-/issues/2447
 @pytest.mark.xfail("env.PYPY")
 @pytest.mark.xfail(
-    sys.version_info == (3, 14, 0, "beta", 1),
-    reason="3.14.0b1 bug: https://github.com/python/cpython/issues/133912",
+    sys.version_info == (3, 14, 0, "beta", 1)
+    or sys.version_info == (3, 14, 0, "beta", 2),
+    reason="3.14.0b1/2 bug: https://github.com/python/cpython/issues/133912",
     strict=True,
 )
 def test_dynamic_attributes():

--- a/tests/test_multiple_interpreters.py
+++ b/tests/test_multiple_interpreters.py
@@ -15,7 +15,7 @@ def test_independent_subinterpreters():
 
     sys.path.append(".")
 
-    # This is supposed to be added to PyPI sometime in 3.14's lifespan
+    # This is supposed to be added in 3.14.0b3
     if sys.version_info >= (3, 15):
         import interpreters
     elif sys.version_info >= (3, 13):

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -69,8 +69,9 @@ def test_roundtrip(cls_name):
         pytest.param(
             "PickleableWithDict",
             marks=pytest.mark.xfail(
-                sys.version_info == (3, 14, 0, "beta", 1),
-                reason="3.14.0b1 bug: https://github.com/python/cpython/issues/133912",
+                sys.version_info == (3, 14, 0, "beta", 1)
+                or sys.version_info == (3, 14, 0, "beta", 2),
+                reason="3.14.0b1/2 bug: https://github.com/python/cpython/issues/133912",
                 strict=True,
             ),
         ),


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

https://github.com/python/cpython/issues/133912 isn't blocking the 3.14b2 release (already tagged), so we have to extend our test skip.

The fix is in https://github.com/python/cpython/pull/134725 (haven't tested it yet, but the added test looks correct).


