### PR TITLE
tests: always disable on the nogil build

### DIFF
--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -11,6 +11,9 @@ import pytest
 import env
 from pybind11_tests import gil_scoped as m
 
+# Test collection seems to hold the gil
+# These tests have rare flakes in nogil; since they
+# are testing the gil, they are skipped at the moment.
 skipif_not_free_threaded = pytest.mark.skipif(
     sysconfig.get_config_var("Py_GIL_DISABLED"),
     reason="Flaky without the GIL",

--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -11,7 +11,6 @@ import pytest
 import env
 from pybind11_tests import gil_scoped as m
 
-
 skipif_not_free_threaded = pytest.mark.skipif(
     sysconfig.get_config_var("Py_GIL_DISABLED"),
     reason="Flaky without the GIL",

--- a/tests/test_gil_scoped.py
+++ b/tests/test_gil_scoped.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import multiprocessing
 import sys
+import sysconfig
 import threading
 import time
 
@@ -10,8 +11,9 @@ import pytest
 import env
 from pybind11_tests import gil_scoped as m
 
+
 skipif_not_free_threaded = pytest.mark.skipif(
-    not getattr(sys, "_is_gil_enabled", lambda: True)(),
+    sysconfig.get_config_var("Py_GIL_DISABLED"),
     reason="Flaky without the GIL",
 )
 

--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -94,7 +94,7 @@ you can either use the basic targets, or use the FindPython tools:
   target_link_libraries(MyModule2 PUBLIC pybind11::headers)
   set_target_properties(MyModule2 PROPERTIES
                                   INTERPROCEDURAL_OPTIMIZATION ON
-                                  CXX_VISIBILITY_PRESET ON
+                                  CXX_VISIBILITY_PRESET hidden
                                   VISIBILITY_INLINES_HIDDEN ON)
 
 If you build targets yourself, you may be interested in stripping the output


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

- **docs: fix docs on visibility preset hidden**
- **tests: always disable on the nogil build**

<!-- Include relevant issues or PRs here, describe what changed and why -->

See #5700, this isn't actually skipping. Let's just always disable it on the free-threaded build.

Also a small docs fix mentioned in #5696.
