### PR TITLE
fix: allow subinterpreters to be manually disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-  push:
-    branches:
-      - master
-      - stable
-      - v*
 
 permissions: read-all
 
@@ -175,22 +170,22 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-latest
-            python: '3.9'
+            python-version: '3.9'
           - runs-on: macos-latest
-            python: '3.12'
+            python-version: '3.12'
           - runs-on: windows-latest
-            python: '3.11'
+            python-version: '3.11'
 
-    name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 inplace C++14"
+    name: "🐍 ${{ matrix.python-version }} • ${{ matrix.runs-on }} • x64 inplace C++14"
     runs-on: ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Python ${{ matrix.python }}
+    - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python }}
+        python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
     - name: Install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
             cmake-args: -DCMAKE_CXX_STANDARD=20 -DPYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION=ON
           - runs-on: ubuntu-latest
             python-version: '3.14'
-            cmake-args: -DCMAKE_CXX_STANDARD=14
+            cmake-args: -DCMAKE_CXX_STANDARD=14 -DCMAKE_CXX_FLAGS="-DPYBIND11_HAS_SUBINTERPRETER_SUPPORT=0"
           - runs-on: ubuntu-latest
             python-version: 'pypy-3.10'
             cmake-args: -DCMAKE_CXX_STANDARD=14

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -256,9 +256,13 @@
 
 // Slightly faster code paths are available when PYBIND11_HAS_SUBINTERPRETER_SUPPORT is *not*
 // defined, so avoid defining it for implementations that do not support subinterpreters. However,
-// defining it unnecessarily is not expected to break anything.
-#if PY_VERSION_HEX >= 0x030C0000 && !defined(PYPY_VERSION) && !defined(GRAALVM_PYTHON)
-#    define PYBIND11_HAS_SUBINTERPRETER_SUPPORT
+// defining it unnecessarily is not expected to break anything (other than old iOS targets).
+#ifndef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
+#    if PY_VERSION_HEX >= 0x030C0000 && !defined(PYPY_VERSION) && !defined(GRAALVM_PYTHON)
+#        define PYBIND11_HAS_SUBINTERPRETER_SUPPORT 1
+#    else
+#        define PYBIND11_HAS_SUBINTERPRETER_SUPPORT 0
+#    endif
 #endif
 
 // 3.12 Compatibility

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -324,7 +324,7 @@ inline std::atomic<int> &get_num_interpreters_seen() {
 
 template <typename InternalsType>
 inline std::unique_ptr<InternalsType> *&get_internals_pp() {
-#ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
+#if PYBIND11_HAS_SUBINTERPRETER_SUPPORT
     if (get_num_interpreters_seen() > 1) {
         // Internals is one per interpreter. When multiple interpreters are alive in different
         // threads we have to allow them to have different internals, so we need a thread_local.

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -15,7 +15,7 @@
 
 #include <stdexcept>
 
-#if !defined(PYBIND11_HAS_SUBINTERPRETER_SUPPORT)
+#if !PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 #    error "This platform does not support subinterpreters, do not include this file."
 #endif
 

--- a/tests/mod_per_interpreter_gil.cpp
+++ b/tests/mod_per_interpreter_gil.cpp
@@ -12,4 +12,5 @@ PYBIND11_MODULE(mod_per_interpreter_gil,
                 py::multiple_interpreters::per_interpreter_gil()) {
     m.def("internals_at",
           []() { return reinterpret_cast<uintptr_t>(&py::detail::get_internals()); });
+    m.attr("PYBIND11_HAS_SUBINTERPRETER_SUPPORT") = PYBIND11_HAS_SUBINTERPRETER_SUPPORT;
 }

--- a/tests/mod_shared_interpreter_gil.cpp
+++ b/tests/mod_shared_interpreter_gil.cpp
@@ -9,4 +9,5 @@ namespace py = pybind11;
 PYBIND11_MODULE(mod_shared_interpreter_gil, m, py::multiple_interpreters::shared_gil()) {
     m.def("internals_at",
           []() { return reinterpret_cast<uintptr_t>(&py::detail::get_internals()); });
+    m.attr("PYBIND11_HAS_SUBINTERPRETER_SUPPORT") = PYBIND11_HAS_SUBINTERPRETER_SUPPORT;
 }

--- a/tests/test_embed/test_subinterpreter.cpp
+++ b/tests/test_embed/test_subinterpreter.cpp
@@ -1,5 +1,5 @@
 #include <pybind11/embed.h>
-#ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
+#if PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 #    include <pybind11/subinterpreter.h>
 
 // Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to

--- a/tests/test_multiple_interpreters.py
+++ b/tests/test_multiple_interpreters.py
@@ -23,9 +23,12 @@ def test_independent_subinterpreters():
     elif sys.version_info >= (3, 12):
         import _xxsubinterpreters as interpreters
     else:
-        pytest.skip("Test requires a the interpreters stdlib module")
+        pytest.skip("Test requires the interpreters stdlib module")
 
-    import mod_per_interpreter_gil as m
+    m = pytest.importorskip("mod_per_interpreter_gil")
+
+    if not m.PYBIND11_HAS_SUBINTERPRETER_SUPPORT:
+        pytest.skip("Does not have subinterpreter support compiled in")
 
     code = """
 import mod_per_interpreter_gil as m
@@ -94,9 +97,12 @@ def test_dependent_subinterpreters():
     elif sys.version_info >= (3, 12):
         import _xxsubinterpreters as interpreters
     else:
-        pytest.skip("Test requires a the interpreters stdlib module")
+        pytest.skip("Test requires the interpreters stdlib module")
 
-    import mod_shared_interpreter_gil as m
+    m = pytest.importorskip("mod_shared_interpreter_gil")
+
+    if not m.PYBIND11_HAS_SUBINTERPRETER_SUPPORT:
+        pytest.skip("Does not have subinterpreter support compiled in")
 
     code = """
 import mod_shared_interpreter_gil as m


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

- **fix: allow subinterp support to be disabled**
- **ci: drop main tests on main**
<!-- Include relevant issues or PRs here, describe what changed and why -->

Pulled out of #5705.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Allow subinterpreter support to be disabled if defined to 0. This is mostly an emergency workaround, and is not exposed in CMake.
