### PR TITLE
Modify the internals pointer-to-pointer implementation to not use `thread_local`

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -345,7 +345,11 @@
 #define PYBIND11_STRINGIFY(x) #x
 #define PYBIND11_TOSTRING(x) PYBIND11_STRINGIFY(x)
 #define PYBIND11_CONCAT(first, second) first##second
-#define PYBIND11_ENSURE_INTERNALS_READY pybind11::detail::get_internals();
+#define PYBIND11_ENSURE_INTERNALS_READY                                                           \
+    {                                                                                             \
+        pybind11::detail::get_internals_pp_manager().unref();                                     \
+        pybind11::detail::get_internals();                                                        \
+    }
 
 #if !defined(GRAALVM_PYTHON)
 #    define PYBIND11_PYCFUNCTION_GET_DOC(func) ((func)->m_ml->ml_doc)

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -256,7 +256,7 @@
 
 // Slightly faster code paths are available when PYBIND11_HAS_SUBINTERPRETER_SUPPORT is *not*
 // defined, so avoid defining it for implementations that do not support subinterpreters. However,
-// defining it unnecessarily is not expected to break anything (other than old iOS targets).
+// defining it unnecessarily is not expected to break anything.
 // This can be overridden by the user with -DPYBIND11_HAS_SUBINTERPRETER_SUPPORT=1 or 0
 #ifndef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 #    if PY_VERSION_HEX >= 0x030C0000 && !defined(PYPY_VERSION) && !defined(GRAALVM_PYTHON)

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -545,7 +545,7 @@ public:
 #if PYBIND11_HAS_SUBINTERPRETER_SUPPORT
         if (get_num_interpreters_seen() > 1) {
             auto *tstate = get_thread_state_unchecked();
-            // this could be called without an active interpreter, that's OK, just use what we
+            // this could be called without an active interpreter, just use what was cached
             if (!tstate || tstate->interp == last_istate_.get()) {
                 auto tpp = internals_tls_p_.get();
                 if (tpp) {
@@ -556,11 +556,7 @@ public:
             return;
         }
 #endif
-        // we can never delete the main interpreter PP because other modules may hold a copy of it
-        if (internals_singleton_pp_) {
-            // but we CAN and DO delete the internals inside.
-            internals_singleton_pp_->reset();
-        }
+        delete internals_singleton_pp_;
         unref();
     }
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -35,11 +35,11 @@
 /// further ABI-incompatible changes may be made before the ABI is officially
 /// changed to the new version.
 #ifndef PYBIND11_INTERNALS_VERSION
-#    define PYBIND11_INTERNALS_VERSION 9
+#    define PYBIND11_INTERNALS_VERSION 10
 #endif
 
-#if PYBIND11_INTERNALS_VERSION < 9
-#    error "PYBIND11_INTERNALS_VERSION 9 is the minimum for all platforms for pybind11v3."
+#if PYBIND11_INTERNALS_VERSION < 10
+#    error "PYBIND11_INTERNALS_VERSION 10 is the minimum for all platforms for pybind11v3."
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -74,6 +74,8 @@ using ExceptionTranslator = void (*)(std::exception_ptr);
 #define PYBIND11_TLS_DELETE_VALUE(key) PyThread_tss_set(&(key), nullptr)
 #define PYBIND11_TLS_FREE(key) PyThread_tss_delete(&(key))
 
+/// A smart-pointer-like wrapper around a thread-specific value. get/set of the pointer applies to
+/// the current thread only.
 template <typename T>
 class thread_specific_storage {
 public:
@@ -598,7 +600,6 @@ private:
     std::unique_ptr<InternalsType> *internals_singleton_pp_;
 };
 
-#if !defined(__GLIBCXX__)
 // If We loaded the internals through `state_dict`, our `error_already_set`
 // and `builtin_exception` may be different local classes than the ones set up in the
 // initial exception translator, below, so add another for our local exception classes.
@@ -606,6 +607,7 @@ private:
 // libstdc++ doesn't require this (types there are identified only by name)
 // libc++ with CPython doesn't require this (types are explicitly exported)
 // libc++ with PyPy still need it, awaiting further investigation
+#if !defined(__GLIBCXX__)
 inline void check_internals_local_exception_translator(internals *internals_ptr) {
     if (internals_ptr) {
         for (auto et : internals_ptr->registered_exception_translators) {

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -513,7 +513,7 @@ public:
     /// Get the current pointer-to-pointer, allocating it if it does not already exist.  May
     /// acquire the GIL. Will never return nullptr.
     std::unique_ptr<InternalsType> *get_pp() {
-#if PYBIND11_HAS_SUBINTERPRETER_SUPPORT
+#ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
         if (get_num_interpreters_seen() > 1) {
             // Whenever the interpreter changes on the current thread we need to invalidate the
             // internals_pp so that it can be pulled from the interpreter's state dict.  That is
@@ -539,7 +539,7 @@ public:
 
     /// Drop all the references we're currently holding.
     void unref() {
-#if PYBIND11_HAS_SUBINTERPRETER_SUPPORT
+#ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
         last_istate_.reset();
         internals_tls_p_.reset();
 #endif
@@ -547,7 +547,7 @@ public:
     }
 
     void destroy() {
-#if PYBIND11_HAS_SUBINTERPRETER_SUPPORT
+#ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
         if (get_num_interpreters_seen() > 1) {
             auto *tstate = get_thread_state_unchecked();
             // this could be called without an active interpreter, just use what was cached
@@ -593,7 +593,7 @@ private:
 
     char const *holder_id_ = nullptr;
     on_fetch_function *on_fetch_ = nullptr;
-#if PYBIND11_HAS_SUBINTERPRETER_SUPPORT
+#ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
     thread_specific_storage<PyInterpreterState> last_istate_;
     thread_specific_storage<std::unique_ptr<InternalsType>> internals_tls_p_;
 #endif

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -45,27 +45,21 @@ private:
     loader_life_support *parent = nullptr;
     std::unordered_set<PyObject *> keep_alive;
 
-    // Store stack pointer in thread-local storage.
-    static PYBIND11_TLS_KEY_REF get_stack_tls_key() {
-        return get_internals().loader_life_support_tls_key;
-    }
-    static loader_life_support *get_stack_top() {
-        return static_cast<loader_life_support *>(PYBIND11_TLS_GET_VALUE(get_stack_tls_key()));
-    }
-    static void set_stack_top(loader_life_support *value) {
-        PYBIND11_TLS_REPLACE_VALUE(get_stack_tls_key(), value);
-    }
-
 public:
     /// A new patient frame is created when a function is entered
-    loader_life_support() : parent{get_stack_top()} { set_stack_top(this); }
+    loader_life_support() {
+        auto &stack_top = get_internals().loader_life_support_tls;
+        parent = stack_top;
+        stack_top = this;
+    }
 
     /// ... and destroyed after it returns
     ~loader_life_support() {
-        if (get_stack_top() != this) {
+        auto &stack_top = get_internals().loader_life_support_tls;
+        if (stack_top.get() != this) {
             pybind11_fail("loader_life_support: internal error");
         }
-        set_stack_top(parent);
+        stack_top = parent;
         for (auto *item : keep_alive) {
             Py_DECREF(item);
         }
@@ -74,7 +68,7 @@ public:
     /// This can only be used inside a pybind11-bound function, either by `argument_loader`
     /// at argument preparation time or by `py::cast()` at execution time.
     PYBIND11_NOINLINE static void add_patient(handle h) {
-        loader_life_support *frame = get_stack_top();
+        loader_life_support *frame = get_internals().loader_life_support_tls;
         if (!frame) {
             // NOTE: It would be nice to include the stack frames here, as this indicates
             // use of pybind11::cast<> outside the normal call framework, finding such

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -49,7 +49,7 @@ public:
     /// A new patient frame is created when a function is entered
     loader_life_support() {
         auto &stack_top = get_internals().loader_life_support_tls;
-        parent = stack_top;
+        parent = stack_top.get();
         stack_top = this;
     }
 
@@ -68,7 +68,7 @@ public:
     /// This can only be used inside a pybind11-bound function, either by `argument_loader`
     /// at argument preparation time or by `py::cast()` at execution time.
     PYBIND11_NOINLINE static void add_patient(handle h) {
-        loader_life_support *frame = get_internals().loader_life_support_tls;
+        loader_life_support *frame = get_internals().loader_life_support_tls.get();
         if (!frame) {
             // NOTE: It would be nice to include the stack frames here, as this indicates
             // use of pybind11::cast<> outside the normal call framework, finding such

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -33,4 +33,4 @@ pyodide.test-groups = ["numpy", "scipy"]
 ios.test-groups = ["numpy"]
 ios.xbuild-tools = ["cmake", "ninja"]
 ios.environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/beeware/simple"
-ios.config-settings."cmake.define.CMAKE_CXX_FLAGS" = "-DPYBIND11_HAS_SUBINTERPRETER_SUPPORT=0"
+

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -33,4 +33,3 @@ pyodide.test-groups = ["numpy", "scipy"]
 ios.test-groups = ["numpy"]
 ios.xbuild-tools = ["cmake", "ninja"]
 ios.environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/beeware/simple"
-

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -272,12 +272,11 @@ TEST_CASE("Restart the interpreter") {
     // Verify pre-restart state.
     REQUIRE(py::module_::import("widget_module").attr("add")(1, 2).cast<int>() == 3);
     REQUIRE(has_state_dict_internals_obj());
-    auto internals_addr = get_details_as_uintptr();
     REQUIRE(py::module_::import("external_module").attr("A")(123).attr("value").cast<int>()
             == 123);
 
     // local and foreign module internals should point to the same internals:
-    REQUIRE(internals_addr
+    REQUIRE(get_details_as_uintptr()
             == py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>());
 
     // Restart the interpreter.
@@ -289,11 +288,11 @@ TEST_CASE("Restart the interpreter") {
 
     // Internals are deleted after a restart.
     REQUIRE_FALSE(has_state_dict_internals_obj());
+    REQUIRE(get_details_as_uintptr() == 0);
     pybind11::detail::get_internals();
     REQUIRE(has_state_dict_internals_obj());
-    REQUIRE(internals_addr != get_details_as_uintptr());
-    internals_addr = get_details_as_uintptr();
-    REQUIRE(internals_addr
+    REQUIRE(get_details_as_uintptr() != 0);
+    REQUIRE(get_details_as_uintptr()
             == py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>());
 
     // Make sure that an interpreter with no get_internals() created until finalize still gets the
@@ -313,7 +312,7 @@ TEST_CASE("Restart the interpreter") {
     REQUIRE(ran);
     py::initialize_interpreter();
     REQUIRE_FALSE(has_state_dict_internals_obj());
-    REQUIRE(internals_addr != get_details_as_uintptr());
+    REQUIRE(get_details_as_uintptr() == 0);
 
     // C++ modules can be reloaded.
     auto cpp_module = py::module_::import("widget_module");

--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -25,14 +25,8 @@ bool has_state_dict_internals_obj() {
     return state.contains(PYBIND11_INTERNALS_ID);
 }
 
-bool has_pybind11_internals_static() {
-    auto *&ipp = py::detail::get_internals_pp<py::detail::internals>();
-    return (ipp != nullptr) && *ipp;
-}
-
 uintptr_t get_details_as_uintptr() {
-    return reinterpret_cast<uintptr_t>(
-        py::detail::get_internals_pp<py::detail::internals>()->get());
+    return reinterpret_cast<uintptr_t>(py::detail::get_internals_pp_manager().get_pp()->get());
 }
 
 class Widget {
@@ -278,12 +272,12 @@ TEST_CASE("Restart the interpreter") {
     // Verify pre-restart state.
     REQUIRE(py::module_::import("widget_module").attr("add")(1, 2).cast<int>() == 3);
     REQUIRE(has_state_dict_internals_obj());
-    REQUIRE(has_pybind11_internals_static());
+    auto internals_addr = get_details_as_uintptr();
     REQUIRE(py::module_::import("external_module").attr("A")(123).attr("value").cast<int>()
             == 123);
 
     // local and foreign module internals should point to the same internals:
-    REQUIRE(get_details_as_uintptr()
+    REQUIRE(internals_addr
             == py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>());
 
     // Restart the interpreter.
@@ -295,11 +289,11 @@ TEST_CASE("Restart the interpreter") {
 
     // Internals are deleted after a restart.
     REQUIRE_FALSE(has_state_dict_internals_obj());
-    REQUIRE_FALSE(has_pybind11_internals_static());
     pybind11::detail::get_internals();
     REQUIRE(has_state_dict_internals_obj());
-    REQUIRE(has_pybind11_internals_static());
-    REQUIRE(get_details_as_uintptr()
+    REQUIRE(internals_addr != get_details_as_uintptr());
+    internals_addr = get_details_as_uintptr();
+    REQUIRE(internals_addr
             == py::module_::import("external_module").attr("internals_at")().cast<uintptr_t>());
 
     // Make sure that an interpreter with no get_internals() created until finalize still gets the
@@ -311,18 +305,15 @@ TEST_CASE("Restart the interpreter") {
         = py::capsule(&ran, [](void *ran) {
               py::detail::get_internals();
               REQUIRE(has_state_dict_internals_obj());
-              REQUIRE(has_pybind11_internals_static());
               *static_cast<bool *>(ran) = true;
           });
     REQUIRE_FALSE(has_state_dict_internals_obj());
-    REQUIRE_FALSE(has_pybind11_internals_static());
     REQUIRE_FALSE(ran);
     py::finalize_interpreter();
     REQUIRE(ran);
-    REQUIRE_FALSE(has_pybind11_internals_static());
     py::initialize_interpreter();
     REQUIRE_FALSE(has_state_dict_internals_obj());
-    REQUIRE_FALSE(has_pybind11_internals_static());
+    REQUIRE(internals_addr != get_details_as_uintptr());
 
     // C++ modules can be reloaded.
     auto cpp_module = py::module_::import("widget_module");
@@ -348,7 +339,6 @@ TEST_CASE("Threads") {
     // Restart interpreter to ensure threads are not initialized
     py::finalize_interpreter();
     py::initialize_interpreter();
-    REQUIRE_FALSE(has_pybind11_internals_static());
 
     constexpr auto num_threads = 10;
     auto locals = py::dict("count"_a = 0);


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

As mentioned in #5705, there are a couple platforms that don't support C++11's `thread_local` keyword but they do still support Python's thread-specific-storage.

So this implementation restructures the part of sub-interpreter support that was using thread_local to instead use CPython's TSS.  

To make this a little easier I added a wrapper class around the PYBIND11_TLS_* macros.  This makes accessing them feel a lot more like accessing a pointer, and puts their allocation and release into RAII.

I also changed the `internals` use of PYBIND11_TLS (`tstate` and `loader_life_support_tls_key` members) to use the new wrapper.  This was not strictly required to address the goal of the PR, but it makes sense to do this since there is a wrapper for it now.  

**NOTE:** This should probably increment the internals ABI number, but since that was already changed for RC1, I didn't change it in this PR.  Should it be changed?

