### PR TITLE
feat: numpy scalars

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -261,7 +261,7 @@ them mapping to respective C++ counterparts.
 
 .. note::
 
-    This is a strict type, it will only allows to specify NumPy type as input
+    This is a strict type, it will only allow to specify NumPy type as input
     arguments, and does not allow other types of input parameters (e.g.,
     ``py::numpy_scalar<int64_t>`` will not accept Python's builtin ``int`` ).
 

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -261,9 +261,9 @@ them mapping to respective C++ counterparts.
 
 .. note::
 
-    This is a strict type, it will only allow to specify NumPy type as input
-    arguments, and does not allow other types of input parameters (e.g.,
-    ``py::numpy_scalar<int64_t>`` will not accept Python's builtin ``int`` ).
+    ``py::numpy_scalar<T>`` strictly matches NumPy scalar types. For example,
+    ``py::numpy_scalar<int64_t>`` will accept ``np.int64(123)``,
+    but **not** a regular Python ``int`` like ``123``.
 
 .. note::
 

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -232,6 +232,46 @@ prevent many types of unsupported structures, it is still the user's
 responsibility to use only "plain" structures that can be safely manipulated as
 raw memory without violating invariants.
 
+Scalar types
+============
+
+In some cases we may want to accept or return NumPy scalar values such as
+``np.float32`` or ``np.float64``. We hope to be able to handle single-precision
+and double-precision on the C-side. However, both are bound to Python's
+double-precision builtin float by default, so they cannot be processed separately.
+We used the ``py::buffer`` trick to implement the previous approach, which
+will cause the readability of the code to drop significantly.
+
+Luckily, there's a helper type for this occasion - ``py::numpy_scalar``:
+
+.. code-block:: cpp
+
+    m.def("add", [](py::numpy_scalar<float> a, py::numpy_scalar<float> b) {
+        return py::make_scalar(a + b);
+    });
+    m.def("add", [](py::numpy_scalar<double> a, py::numpy_scalar<double> b) {
+        return py::make_scalar(a + b);
+    });
+
+This type is trivially convertible to and from the type it wraps; currently
+supported scalar types are NumPy arithmetic types: ``bool_``, ``int8``,
+``int16``, ``int32``, ``int64``, ``uint8``, ``uint16``, ``uint32``,
+``uint64``, ``float32``, ``float64``, ``complex64``, ``complex128``, all of
+them mapping to respective C++ counterparts.
+
+.. note::
+
+    This is a strict type, it will only allows to specify NumPy type as input
+    arguments, and does not allow other types of input parameters (e.g.,
+    ``py::numpy_scalar<int64_t>`` will not accept Python's builtin ``int`` ).
+
+.. note::
+
+    Native C types are mapped to NumPy types in a platform specific way: for
+    instance, ``char`` may be mapped to either ``np.int8`` or ``np.uint8``
+    and ``long`` may use 4 or 8 bytes depending on the platform. Unless you
+    clearly understand the difference and your needs, please use ``<cstdint>``.
+
 Vectorizing functions
 =====================
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -422,7 +422,7 @@ struct npy_format_descriptor_name<T, enable_if_t<is_complex<T>::value>> {
 template <typename T>
 struct numpy_scalar_info {};
 
-#define DECL_NPY_SCALAR(ctype_, typenum_)                                                         \
+#define PYBIND11_NUMPY_SCALAR_IMPL(ctype_, typenum_)                                              \
     template <>                                                                                   \
     struct numpy_scalar_info<ctype_> {                                                            \
         static constexpr auto name = npy_format_descriptor_name<ctype_>::name;                    \
@@ -430,34 +430,34 @@ struct numpy_scalar_info {};
     }
 
 // boolean type
-DECL_NPY_SCALAR(bool, NPY_BOOL);
+PYBIND11_NUMPY_SCALAR_IMPL(bool, NPY_BOOL);
 
 // character types
-DECL_NPY_SCALAR(char, NPY_CHAR);
-DECL_NPY_SCALAR(signed char, NPY_BYTE);
-DECL_NPY_SCALAR(unsigned char, NPY_UBYTE);
+PYBIND11_NUMPY_SCALAR_IMPL(char, NPY_CHAR);
+PYBIND11_NUMPY_SCALAR_IMPL(signed char, NPY_BYTE);
+PYBIND11_NUMPY_SCALAR_IMPL(unsigned char, NPY_UBYTE);
 
 // signed integer types
-DECL_NPY_SCALAR(std::int16_t, NPY_INT16);
-DECL_NPY_SCALAR(std::int32_t, NPY_INT32);
-DECL_NPY_SCALAR(std::int64_t, NPY_INT64);
+PYBIND11_NUMPY_SCALAR_IMPL(std::int16_t, NPY_INT16);
+PYBIND11_NUMPY_SCALAR_IMPL(std::int32_t, NPY_INT32);
+PYBIND11_NUMPY_SCALAR_IMPL(std::int64_t, NPY_INT64);
 
 // unsigned integer types
-DECL_NPY_SCALAR(std::uint16_t, NPY_UINT16);
-DECL_NPY_SCALAR(std::uint32_t, NPY_UINT32);
-DECL_NPY_SCALAR(std::uint64_t, NPY_UINT64);
+PYBIND11_NUMPY_SCALAR_IMPL(std::uint16_t, NPY_UINT16);
+PYBIND11_NUMPY_SCALAR_IMPL(std::uint32_t, NPY_UINT32);
+PYBIND11_NUMPY_SCALAR_IMPL(std::uint64_t, NPY_UINT64);
 
 // floating point types
-DECL_NPY_SCALAR(float, NPY_FLOAT);
-DECL_NPY_SCALAR(double, NPY_DOUBLE);
-DECL_NPY_SCALAR(long double, NPY_LONGDOUBLE);
+PYBIND11_NUMPY_SCALAR_IMPL(float, NPY_FLOAT);
+PYBIND11_NUMPY_SCALAR_IMPL(double, NPY_DOUBLE);
+PYBIND11_NUMPY_SCALAR_IMPL(long double, NPY_LONGDOUBLE);
 
 // complex types
-DECL_NPY_SCALAR(std::complex<float>, NPY_CFLOAT);
-DECL_NPY_SCALAR(std::complex<double>, NPY_CDOUBLE);
-DECL_NPY_SCALAR(std::complex<long double>, NPY_CLONGDOUBLE);
+PYBIND11_NUMPY_SCALAR_IMPL(std::complex<float>, NPY_CFLOAT);
+PYBIND11_NUMPY_SCALAR_IMPL(std::complex<double>, NPY_CDOUBLE);
+PYBIND11_NUMPY_SCALAR_IMPL(std::complex<long double>, NPY_CLONGDOUBLE);
 
-#undef DECL_NPY_SCALAR
+#undef PYBIND11_NUMPY_SCALAR_IMPL
 
 // This table normalizes typenums by mapping NPY_INT_, NPY_LONG, ... to NPY_INT32_, NPY_INT64, ...
 // This is needed to correctly handle situations where multiple typenums map to the same type,

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -811,7 +811,7 @@ struct numpy_scalar {
     numpy_scalar() = default;
     explicit numpy_scalar(value_type value) : value(value) {}
 
-    explicit operator value_type() { return value; }
+    explicit operator value_type() const { return value; }
     numpy_scalar &operator=(value_type value) {
         this->value = value;
         return *this;

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -393,25 +393,30 @@ struct npy_format_descriptor_name;
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_integral<T>::value>> {
     static constexpr auto name = const_name<std::is_same<T, bool>::value>(
-        const_name("bool"),
-        const_name<std::is_signed<T>::value>("int", "uint") + const_name<sizeof(T) * 8>());
+        const_name("numpy.bool"),
+        const_name<std::is_signed<T>::value>("numpy.int", "numpy.uint")
+            + const_name<sizeof(T) * 8>());
 };
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<std::is_floating_point<T>::value>> {
-    static constexpr auto name
-        = const_name < std::is_same<T, float>::value
-          || std::is_same<T, double>::value
-                 > (const_name("float") + const_name<sizeof(T) * 8>(), const_name("longdouble"));
+    static constexpr auto name = const_name < std::is_same<T, float>::value
+                                 || std::is_same<T, const float>::value
+                                 || std::is_same<T, double>::value
+                                 || std::is_same<T, const double>::value
+                                        > (const_name("numpy.float") + const_name<sizeof(T) * 8>(),
+                                           const_name("numpy.longdouble"));
 };
 
 template <typename T>
 struct npy_format_descriptor_name<T, enable_if_t<is_complex<T>::value>> {
-    static constexpr auto name
-        = const_name < std::is_same<typename T::value_type, float>::value
-          || std::is_same<typename T::value_type, double>::value
-                 > (const_name("complex") + const_name<sizeof(typename T::value_type) * 16>(),
-                    const_name("longcomplex"));
+    static constexpr auto name = const_name < std::is_same<typename T::value_type, float>::value
+                                 || std::is_same<typename T::value_type, const float>::value
+                                 || std::is_same<typename T::value_type, double>::value
+                                 || std::is_same<typename T::value_type, const double>::value
+                                        > (const_name("numpy.complex")
+                                               + const_name<sizeof(typename T::value_type) * 16>(),
+                                           const_name("numpy.longcomplex"));
 };
 
 template <typename T>

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -438,24 +438,14 @@ DECL_NPY_SCALAR(signed char, NPY_BYTE);
 DECL_NPY_SCALAR(unsigned char, NPY_UBYTE);
 
 // signed integer types
-DECL_NPY_SCALAR(std::int16_t, NPY_SHORT);
-DECL_NPY_SCALAR(std::int32_t, NPY_INT);
-DECL_NPY_SCALAR(std::int64_t, NPY_LONG);
-#if defined(__linux__)
-DECL_NPY_SCALAR(long long, NPY_LONG);
-#else
-DECL_NPY_SCALAR(long, NPY_LONG);
-#endif
+DECL_NPY_SCALAR(std::int16_t, NPY_INT16);
+DECL_NPY_SCALAR(std::int32_t, NPY_INT32);
+DECL_NPY_SCALAR(std::int64_t, NPY_INT64);
 
 // unsigned integer types
-DECL_NPY_SCALAR(std::uint16_t, NPY_USHORT);
-DECL_NPY_SCALAR(std::uint32_t, NPY_UINT);
-DECL_NPY_SCALAR(std::uint64_t, NPY_ULONG);
-#if defined(__linux__)
-DECL_NPY_SCALAR(unsigned long long, NPY_ULONG);
-#else
-DECL_NPY_SCALAR(unsigned long, NPY_ULONG);
-#endif
+DECL_NPY_SCALAR(std::uint16_t, NPY_UINT16);
+DECL_NPY_SCALAR(std::uint32_t, NPY_UINT32);
+DECL_NPY_SCALAR(std::uint64_t, NPY_UINT64);
 
 // floating point types
 DECL_NPY_SCALAR(float, NPY_FLOAT);
@@ -819,9 +809,9 @@ struct numpy_scalar {
     value_type value;
 
     numpy_scalar() = default;
-    numpy_scalar(value_type value) : value(value) {}
+    explicit numpy_scalar(value_type value) : value(value) {}
 
-    operator value_type() { return value; }
+    explicit operator value_type() { return value; }
     numpy_scalar &operator=(value_type value) {
         this->value = value;
         return *this;

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -816,6 +816,12 @@ struct numpy_scalar {
         this->value = value;
         return *this;
     }
+
+    friend bool operator==(const numpy_scalar &a, const numpy_scalar &b) {
+        return a.value == b.value;
+    }
+
+    friend bool operator!=(const numpy_scalar &a, const numpy_scalar &b) { return !(a == b); }
 };
 
 template <typename T>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -159,6 +159,7 @@ set(PYBIND11_TEST_FILES
     test_native_enum
     test_numpy_array
     test_numpy_dtypes
+    test_numpy_scalars
     test_numpy_vectorize
     test_opaque_types
     test_operator_overloading

--- a/tests/test_numpy_scalars.cpp
+++ b/tests/test_numpy_scalars.cpp
@@ -49,4 +49,7 @@ TEST_SUBMODULE(numpy_scalars, m) {
     register_test<double>(m, "float64", add<double>(0.25f));
     register_test<cfloat>(m, "complex64", add<cfloat>({0, -0.125f}));
     register_test<cdouble>(m, "complex128", add<cdouble>({0, -0.25f}));
+
+    m.def("test_eq", [](py::numpy_scalar<int> a, py::numpy_scalar<int> b) { return a == b; });
+    m.def("test_ne", [](py::numpy_scalar<int> a, py::numpy_scalar<int> b) { return a != b; });
 }

--- a/tests/test_numpy_scalars.cpp
+++ b/tests/test_numpy_scalars.cpp
@@ -1,0 +1,52 @@
+/*
+  tests/test_numpy_scalars.cpp -- strict NumPy scalars
+
+  Copyright (c) 2021 Steve R. Sun
+
+  All rights reserved. Use of this source code is governed by a
+  BSD-style license that can be found in the LICENSE file.
+*/
+
+#include <pybind11/numpy.h>
+
+#include "pybind11_tests.h"
+
+#include <complex>
+#include <cstdint>
+
+namespace py = pybind11;
+
+template <typename T>
+struct add {
+    T x;
+    add(T x) : x(x) {}
+    T operator()(T y) const { return static_cast<T>(x + y); }
+};
+
+template <typename T, typename F>
+void register_test(py::module &m, const char *name, F &&func) {
+    m.def((std::string("test_") + name).c_str(),
+          [=](py::numpy_scalar<T> v) {
+              return std::make_tuple(name, py::make_scalar(static_cast<T>(func(v.value))));
+          },
+          py::arg("x"));
+}
+
+TEST_SUBMODULE(numpy_scalars, m) {
+    using cfloat = std::complex<float>;
+    using cdouble = std::complex<double>;
+
+    register_test<bool>(m, "bool", [](bool x) { return !x; });
+    register_test<int8_t>(m, "int8", add<int8_t>(-8));
+    register_test<int16_t>(m, "int16", add<int16_t>(-16));
+    register_test<int32_t>(m, "int32", add<int32_t>(-32));
+    register_test<int64_t>(m, "int64", add<int64_t>(-64));
+    register_test<uint8_t>(m, "uint8", add<uint8_t>(8));
+    register_test<uint16_t>(m, "uint16", add<uint16_t>(16));
+    register_test<uint32_t>(m, "uint32", add<uint32_t>(32));
+    register_test<uint64_t>(m, "uint64", add<uint64_t>(64));
+    register_test<float>(m, "float32", add<float>(0.125f));
+    register_test<double>(m, "float64", add<double>(0.25f));
+    register_test<cfloat>(m, "complex64", add<cfloat>({0, -0.125f}));
+    register_test<cdouble>(m, "complex128", add<cdouble>({0, -0.25f}));
+}

--- a/tests/test_numpy_scalars.cpp
+++ b/tests/test_numpy_scalars.cpp
@@ -19,7 +19,7 @@ namespace py = pybind11;
 template <typename T>
 struct add {
     T x;
-    add(T x) : x(x) {}
+    explicit add(T x) : x(x) {}
     T operator()(T y) const { return static_cast<T>(x + y); }
 };
 

--- a/tests/test_numpy_scalars.cpp
+++ b/tests/test_numpy_scalars.cpp
@@ -16,6 +16,8 @@
 
 namespace py = pybind11;
 
+namespace pybind11_test_numpy_scalars {
+
 template <typename T>
 struct add {
     T x;
@@ -31,6 +33,10 @@ void register_test(py::module &m, const char *name, F &&func) {
           },
           py::arg("x"));
 }
+
+} // namespace pybind11_test_numpy_scalars
+
+using namespace pybind11_test_numpy_scalars;
 
 TEST_SUBMODULE(numpy_scalars, m) {
     using cfloat = std::complex<float>;

--- a/tests/test_numpy_scalars.cpp
+++ b/tests/test_numpy_scalars.cpp
@@ -56,6 +56,8 @@ TEST_SUBMODULE(numpy_scalars, m) {
     register_test<cfloat>(m, "complex64", add<cfloat>({0, -0.125f}));
     register_test<cdouble>(m, "complex128", add<cdouble>({0, -0.25f}));
 
-    m.def("test_eq", [](py::numpy_scalar<int> a, py::numpy_scalar<int> b) { return a == b; });
-    m.def("test_ne", [](py::numpy_scalar<int> a, py::numpy_scalar<int> b) { return a != b; });
+    m.def("test_eq",
+          [](py::numpy_scalar<int32_t> a, py::numpy_scalar<int32_t> b) { return a == b; });
+    m.def("test_ne",
+          [](py::numpy_scalar<int32_t> a, py::numpy_scalar<int32_t> b) { return a != b; });
 }

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -45,3 +45,10 @@ def test_numpy_scalars(npy_scalar_type, expected_value):
         else:
             with pytest.raises(TypeError):
                 test_tpnm(value)
+
+
+def test_eq_ne():
+    assert m.test_eq(np.int32(3), np.int32(3))
+    assert not m.test_eq(np.int32(3), np.int32(5))
+    assert not m.test_ne(np.int32(3), np.int32(3))
+    assert m.test_ne(np.int32(3), np.int32(5))

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -42,7 +42,7 @@ def scalar_type(request):
 def expected_signature(tp):
     s = "str" if sys.version_info[0] >= 3 else "unicode"
     t = type_name(tp)
-    return f"test_{t}(x: {t}) -> tuple[{s}, {t}]\n"
+    return f"test_{t}(x: numpy.{t}) -> tuple[{s}, numpy.{t}]\n"
 
 
 def test_numpy_scalars(scalar_type):

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from pybind11_tests import numpy_scalars as m
+
+np = pytest.importorskip("numpy")
+
+SCALAR_TYPES = {
+    np.bool_: False,
+    np.int8: -7,
+    np.int16: -15,
+    np.int32: -31,
+    np.int64: -63,
+    np.uint8: 9,
+    np.uint16: 17,
+    np.uint32: 33,
+    np.uint64: 65,
+    np.single: 1.125,
+    np.double: 1.25,
+    np.complex64: 1 - 0.125j,
+    np.complex128: 1 - 0.25j,
+}
+ALL_TYPES = [int, bool, float, bytes, str] + list(SCALAR_TYPES)
+
+
+def type_name(tp):
+    try:
+        return tp.__name__.rstrip("_")
+    except BaseException:
+        # no numpy
+        return str(tp)
+
+
+@pytest.fixture(scope="module", params=list(SCALAR_TYPES), ids=type_name)
+def scalar_type(request):
+    return request.param
+
+
+def expected_signature(tp):
+    s = "str" if sys.version_info[0] >= 3 else "unicode"
+    t = type_name(tp)
+    return f"test_{t}(x: {t}) -> tuple[{s}, {t}]\n"
+
+
+def test_numpy_scalars(scalar_type):
+    expected = SCALAR_TYPES[scalar_type]
+    name = type_name(scalar_type)
+    func = getattr(m, "test_" + name)
+    assert func.__doc__ == expected_signature(scalar_type)
+    for tp in ALL_TYPES:
+        value = tp(1)
+        if tp is scalar_type:
+            result = func(value)
+            assert result[0] == name
+            assert isinstance(result[1], tp)
+            assert result[1] == tp(expected)
+        else:
+            with pytest.raises(TypeError):
+                func(value)


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Reworked (close #3544) by @sun1638650145. Which is a reworked (close #2060) from @aldanor. Adds wrappers for the scalar values part of the NumPy API. This is a bit more minimal than those, following the current coding style more closely (quite a bit of the diff is just moving stuff around so it's defined before it's used with the new usage), and it supports 32-bit systems (Windows and wasm32).

This PR includes a minor consistency fix:

The string returned by `npy_format_descriptor_name<bool>` was changed from `"bool"` to `"numpy.bool"` to match the naming convention used for other scalar types (e.g., `"numpy.int64"`, `"numpy.float32"`). This ensures consistent formatting for documentation and diagnostics.

## Suggested changelog entry:

* Support `py::numpy_scalar<>` / `py::make_scalar()` for NumPy types.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5726.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->