### PR TITLE
Eliminate cross-DSO RTTI reliance in `smart_holder` functionality (for platforms like macOS).

### DIFF
--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -12,6 +12,7 @@
 
 #include "detail/common.h"
 #include "cast.h"
+#include "trampoline_self_life_support.h"
 
 #include <functional>
 
@@ -311,6 +312,10 @@ struct type_record {
 
     /// Function pointer to class_<..>::dealloc
     void (*dealloc)(detail::value_and_holder &) = nullptr;
+
+    /// Function pointer for casting alias class (aka trampoline) pointer to
+    /// trampoline_self_life_support pointer.
+    get_trampoline_self_life_support_fn get_trampoline_self_life_support = nullptr;
 
     /// List of base classes of the newly created type
     list bases;

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -314,8 +314,8 @@ struct type_record {
     void (*dealloc)(detail::value_and_holder &) = nullptr;
 
     /// Function pointer for casting alias class (aka trampoline) pointer to
-    /// trampoline_self_life_support pointer. Sidesteps dynamic_cast RTTI issues
-    /// on platforms like macOS.
+    /// trampoline_self_life_support pointer. Sidesteps cross-DSO RTTI issues
+    /// on platforms like macOS (see PR #5728 for details).
     get_trampoline_self_life_support_fn get_trampoline_self_life_support
         = [](void *) -> trampoline_self_life_support * { return nullptr; };
 

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -314,8 +314,10 @@ struct type_record {
     void (*dealloc)(detail::value_and_holder &) = nullptr;
 
     /// Function pointer for casting alias class (aka trampoline) pointer to
-    /// trampoline_self_life_support pointer.
-    get_trampoline_self_life_support_fn get_trampoline_self_life_support = nullptr;
+    /// trampoline_self_life_support pointer. Sidesteps dynamic_cast RTTI issues
+    /// on platforms like macOS.
+    get_trampoline_self_life_support_fn get_trampoline_self_life_support
+        = [](void *) -> trampoline_self_life_support * { return nullptr; };
 
     /// List of base classes of the newly created type
     list bases;

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1240,7 +1240,7 @@ public:
 
     explicit operator std::unique_ptr<type, deleter>() {
         if (typeinfo->holder_enum_v == detail::holder_enum_t::smart_holder) {
-            return sh_load_helper.template load_as_unique_ptr<deleter>(value);
+            return sh_load_helper.template load_as_unique_ptr<deleter>(typeinfo, value);
         }
         pybind11_fail("Expected to be UNREACHABLE: " __FILE__ ":" PYBIND11_TOSTRING(__LINE__));
     }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -980,7 +980,7 @@ public:
 
     explicit operator std::shared_ptr<type> &() {
         if (typeinfo->holder_enum_v == detail::holder_enum_t::smart_holder) {
-            shared_ptr_storage = sh_load_helper.load_as_shared_ptr(value);
+            shared_ptr_storage = sh_load_helper.load_as_shared_ptr(typeinfo, value);
         }
         return shared_ptr_storage;
     }
@@ -989,7 +989,8 @@ public:
         if (typeinfo->holder_enum_v == detail::holder_enum_t::smart_holder) {
             // Reusing shared_ptr code to minimize code complexity.
             shared_ptr_storage
-                = sh_load_helper.load_as_shared_ptr(value,
+                = sh_load_helper.load_as_shared_ptr(typeinfo,
+                                                    value,
                                                     /*responsible_parent=*/nullptr,
                                                     /*force_potentially_slicing_shared_ptr=*/true);
         }
@@ -1019,7 +1020,8 @@ public:
         copyable_holder_caster loader;
         loader.load(responsible_parent, /*convert=*/false);
         assert(loader.typeinfo->holder_enum_v == detail::holder_enum_t::smart_holder);
-        return loader.sh_load_helper.load_as_shared_ptr(loader.value, responsible_parent);
+        return loader.sh_load_helper.load_as_shared_ptr(
+            loader.typeinfo, loader.value, responsible_parent);
     }
 
 protected:
@@ -1248,12 +1250,12 @@ public:
     explicit operator const std::unique_ptr<type, deleter> &() {
         if (typeinfo->holder_enum_v == detail::holder_enum_t::smart_holder) {
             // Get shared_ptr to ensure that the Python object is not disowned elsewhere.
-            shared_ptr_storage = sh_load_helper.load_as_shared_ptr(value);
+            shared_ptr_storage = sh_load_helper.load_as_shared_ptr(typeinfo, value);
             // Build a temporary unique_ptr that is meant to never expire.
             unique_ptr_storage = std::shared_ptr<std::unique_ptr<type, deleter>>(
                 new std::unique_ptr<type, deleter>{
                     sh_load_helper.template load_as_const_unique_ptr<deleter>(
-                        shared_ptr_storage.get())},
+                        typeinfo, shared_ptr_storage.get())},
                 [](std::unique_ptr<type, deleter> *ptr) {
                     if (!ptr) {
                         pybind11_fail("FATAL: `const std::unique_ptr<T, D> &` was disowned "

--- a/include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h
+++ b/include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h
@@ -32,7 +32,7 @@ template <typename To,
           typename From,
           detail::enable_if_t<dynamic_raw_ptr_cast_is_possible<To, From>::value, int> = 0>
 To *dynamic_raw_ptr_cast_if_possible(From *ptr) {
-    return dynamic_cast<To *>(ptr);
+    return ptr ? dynamic_cast<To *>(ptr) : nullptr;
 }
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h
+++ b/include/pybind11/detail/dynamic_raw_ptr_cast_if_possible.h
@@ -32,7 +32,7 @@ template <typename To,
           typename From,
           detail::enable_if_t<dynamic_raw_ptr_cast_is_possible<To, From>::value, int> = 0>
 To *dynamic_raw_ptr_cast_if_possible(From *ptr) {
-    return ptr ? dynamic_cast<To *>(ptr) : nullptr;
+    return dynamic_cast<To *>(ptr);
 }
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -13,6 +13,7 @@
 #include <pybind11/detail/struct_smart_holder.h>
 #include <pybind11/gil_simple.h>
 #include <pybind11/pytypes.h>
+#include <pybind11/trampoline_self_life_support.h>
 
 #include "common.h"
 
@@ -312,6 +313,7 @@ struct type_info {
     void *(*operator_new)(size_t);
     void (*init_instance)(instance *, const void *);
     void (*dealloc)(value_and_holder &v_h);
+    get_trampoline_self_life_support_fn get_trampoline_self_life_support = nullptr;
     std::vector<PyObject *(*) (PyObject *, PyTypeObject *)> implicit_conversions;
     std::vector<std::pair<const std::type_info *, void *(*) (void *)>> implicit_casts;
     std::vector<bool (*)(PyObject *, void *&)> *direct_conversions;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -18,7 +18,6 @@
 
 #include <atomic>
 #include <exception>
-#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -256,9 +255,7 @@ struct internals {
 
     type_map<PyObject *> native_enum_type_map;
 
-    using get_memory_guarded_delete_fn
-        = memory::guarded_delete *(*) (const std::shared_ptr<void> &);
-    get_memory_guarded_delete_fn get_memory_guarded_delete = nullptr;
+    memory::get_guarded_delete_fn get_memory_guarded_delete = memory::get_guarded_delete;
 
     internals()
         : static_property_type(make_static_property_type()),
@@ -278,9 +275,6 @@ struct internals {
         instance_shards.reset(new instance_map_shard[num_shards]);
         instance_shards_mask = num_shards - 1;
 #endif
-        get_memory_guarded_delete = [](const std::shared_ptr<void> &ptr) {
-            return std::get_deleter<memory::guarded_delete>(ptr);
-        };
     }
     internals(const internals &other) = delete;
     internals(internals &&other) = delete;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -255,6 +255,8 @@ struct internals {
 
     type_map<PyObject *> native_enum_type_map;
 
+    // Note: get_internals().get_memory_guarded_delete does
+    //       not need to be wrapped in with_internals().
     memory::get_guarded_delete_fn get_memory_guarded_delete = memory::get_guarded_delete;
 
     internals()

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -10,12 +10,12 @@
 #pragma once
 
 #include <pybind11/conduit/pybind11_platform_abi_id.h>
-#include <pybind11/detail/struct_smart_holder.h>
 #include <pybind11/gil_simple.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/trampoline_self_life_support.h>
 
 #include "common.h"
+#include "struct_smart_holder.h"
 
 #include <atomic>
 #include <exception>
@@ -311,7 +311,8 @@ struct type_info {
     void (*init_instance)(instance *, const void *);
     void (*dealloc)(value_and_holder &v_h);
 
-    // Cross-DSO-safe function pointers (to sidestep cross-DSO RTTI issues):
+    // Cross-DSO-safe function pointers, to sidestep cross-DSO RTTI issues
+    // on platforms like macOS (see PR #5728 for details):
     memory::get_guarded_delete_fn get_memory_guarded_delete = memory::get_guarded_delete;
     get_trampoline_self_life_support_fn get_trampoline_self_life_support = nullptr;
 

--- a/include/pybind11/detail/struct_smart_holder.h
+++ b/include/pybind11/detail/struct_smart_holder.h
@@ -79,6 +79,7 @@ static constexpr bool type_has_shared_from_this(const void *) {
 }
 
 struct guarded_delete {
+    // NOTE: PYBIND11_INTERNALS_VERSION needs to be bumped if changes are made to this struct.
     std::weak_ptr<void> released_ptr;    // Trick to keep the smart_holder memory footprint small.
     std::function<void(void *)> del_fun; // Rare case.
     void (*del_ptr)(void *);             // Common case.
@@ -126,6 +127,7 @@ guarded_delete make_guarded_builtin_delete(bool armed_flag) {
 
 template <typename T, typename D>
 struct custom_deleter {
+    // NOTE: PYBIND11_INTERNALS_VERSION needs to be bumped if changes are made to this struct.
     D deleter;
     explicit custom_deleter(D &&deleter) : deleter{std::forward<D>(deleter)} {}
     void operator()(void *raw_ptr) { deleter(static_cast<T *>(raw_ptr)); }
@@ -144,6 +146,7 @@ inline bool is_std_default_delete(const std::type_info &rtti_deleter) {
 }
 
 struct smart_holder {
+    // NOTE: PYBIND11_INTERNALS_VERSION needs to be bumped if changes are made to this struct.
     const std::type_info *rtti_uqp_del = nullptr;
     std::shared_ptr<void> vptr;
     bool vptr_is_using_noop_deleter : 1;
@@ -238,12 +241,12 @@ struct smart_holder {
     }
 
     void reset_vptr_deleter_armed_flag(const get_guarded_delete_fn ggd_fn, bool armed_flag) const {
-        auto *vptr_del_ptr = ggd_fn(vptr);
-        if (vptr_del_ptr == nullptr) {
+        auto *gd = ggd_fn(vptr);
+        if (gd == nullptr) {
             throw std::runtime_error(
                 "smart_holder::reset_vptr_deleter_armed_flag() called in an invalid context.");
         }
-        vptr_del_ptr->armed_flag = armed_flag;
+        gd->armed_flag = armed_flag;
     }
 
     // Caller is responsible for precondition: ensure_compatible_rtti_uqp_del<T, D>() must succeed.

--- a/include/pybind11/detail/struct_smart_holder.h
+++ b/include/pybind11/detail/struct_smart_holder.h
@@ -58,19 +58,6 @@ Details:
 #include <typeinfo>
 #include <utility>
 
-// IMPORTANT: This code block must stay BELOW the #include <stdexcept> above.
-// This is only required on some builds with libc++ (one of three implementations
-// in
-// https://github.com/llvm/llvm-project/blob/a9b64bb3180dab6d28bf800a641f9a9ad54d2c0c/libcxx/include/typeinfo#L271-L276
-// require it)
-#if !defined(PYBIND11_EXPORT_GUARDED_DELETE)
-#    if defined(_LIBCPP_VERSION) && !defined(WIN32) && !defined(_WIN32)
-#        define PYBIND11_EXPORT_GUARDED_DELETE __attribute__((visibility("default")))
-#    else
-#        define PYBIND11_EXPORT_GUARDED_DELETE
-#    endif
-#endif
-
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(memory)
 
@@ -91,7 +78,7 @@ static constexpr bool type_has_shared_from_this(const void *) {
     return false;
 }
 
-struct PYBIND11_EXPORT_GUARDED_DELETE guarded_delete {
+struct guarded_delete {
     std::weak_ptr<void> released_ptr;    // Trick to keep the smart_holder memory footprint small.
     std::function<void(void *)> del_fun; // Rare case.
     void (*del_ptr)(void *);             // Common case.

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -564,9 +564,7 @@ handle smart_holder_from_unique_ptr(std::unique_ptr<T, D> &&src,
     assert(st.second != nullptr);
     const detail::type_info *tinfo = st.second;
     if (handle existing_inst = find_registered_python_instance(src_raw_void_ptr, tinfo)) {
-        auto *self_life_support = tinfo->get_trampoline_self_life_support
-                                      ? tinfo->get_trampoline_self_life_support(src.get())
-                                      : nullptr;
+        auto *self_life_support = tinfo->get_trampoline_self_life_support(src.get());
         if (self_life_support != nullptr) {
             value_and_holder &v_h = self_life_support->v_h;
             if (v_h.inst != nullptr && v_h.vh != nullptr) {
@@ -815,9 +813,7 @@ struct load_helper : value_and_holder_helper {
 
         T *raw_type_ptr = static_cast<T *>(raw_void_ptr);
 
-        auto *self_life_support = tinfo->get_trampoline_self_life_support
-                                      ? tinfo->get_trampoline_self_life_support(raw_type_ptr)
-                                      : nullptr;
+        auto *self_life_support = tinfo->get_trampoline_self_life_support(raw_type_ptr);
         // This is enforced indirectly by a static_assert in the class_ implementation:
         assert(!python_instance_is_alias || self_life_support);
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -576,7 +576,7 @@ handle smart_holder_from_unique_ptr(std::unique_ptr<T, D> &&src,
                 }
                 // Critical transfer-of-ownership section. This must stay together.
                 self_life_support->deactivate_life_support();
-                holder.reclaim_disowned(get_internals().get_memory_guarded_delete(holder.vptr));
+                holder.reclaim_disowned(get_internals().get_memory_guarded_delete);
                 (void) src.release();
                 // Critical section end.
                 return existing_inst;
@@ -819,13 +819,13 @@ struct load_helper : value_and_holder_helper {
         assert(!python_instance_is_alias || self_life_support);
 
         std::unique_ptr<D> extracted_deleter = holder().template extract_deleter<T, D>(
-            context, get_internals().get_memory_guarded_delete(holder().vptr));
+            context, get_internals().get_memory_guarded_delete);
 
         // Critical transfer-of-ownership section. This must stay together.
         if (self_life_support != nullptr) {
-            holder().disown(get_internals().get_memory_guarded_delete(holder().vptr));
+            holder().disown(get_internals().get_memory_guarded_delete);
         } else {
-            holder().release_ownership(get_internals().get_memory_guarded_delete(holder().vptr));
+            holder().release_ownership(get_internals().get_memory_guarded_delete);
         }
         auto result = unique_with_deleter<T, D>(raw_type_ptr, std::move(extracted_deleter));
         if (self_life_support != nullptr) {
@@ -849,10 +849,9 @@ struct load_helper : value_and_holder_helper {
             return unique_with_deleter<T, D>(nullptr, std::unique_ptr<D>());
         }
         holder().template ensure_compatible_rtti_uqp_del<T, D>(context);
-        return unique_with_deleter<T, D>(
-            raw_type_ptr,
-            std::move(holder().template extract_deleter<T, D>(
-                context, get_internals().get_memory_guarded_delete(holder().vptr))));
+        return unique_with_deleter<T, D>(raw_type_ptr,
+                                         std::move(holder().template extract_deleter<T, D>(
+                                             context, get_internals().get_memory_guarded_delete)));
     }
 };
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -532,7 +532,7 @@ struct value_and_holder_helper {
 
     // have_holder() must be true or this function will fail.
     void throw_if_instance_is_currently_owned_by_shared_ptr() const {
-        auto *vptr_gd_ptr = get_internals().get_memory_guarded_delete(holder().vptr);
+        auto *vptr_gd_ptr = find_memory_guarded_delete(holder().vptr);
         if (vptr_gd_ptr != nullptr && !vptr_gd_ptr->released_ptr.expired()) {
             throw value_error("Python instance is currently owned by a std::shared_ptr.");
         }
@@ -576,7 +576,7 @@ handle smart_holder_from_unique_ptr(std::unique_ptr<T, D> &&src,
                 }
                 // Critical transfer-of-ownership section. This must stay together.
                 self_life_support->deactivate_life_support();
-                holder.reclaim_disowned(get_internals().get_memory_guarded_delete);
+                holder.reclaim_disowned(find_memory_guarded_delete);
                 (void) src.release();
                 // Critical section end.
                 return existing_inst;
@@ -763,7 +763,7 @@ struct load_helper : value_and_holder_helper {
         }
         auto *type_raw_ptr = static_cast<T *>(void_raw_ptr);
         if (python_instance_is_alias && !force_potentially_slicing_shared_ptr) {
-            auto *vptr_gd_ptr = get_internals().get_memory_guarded_delete(holder().vptr);
+            auto *vptr_gd_ptr = find_memory_guarded_delete(holder().vptr);
             if (vptr_gd_ptr != nullptr) {
                 std::shared_ptr<void> released_ptr = vptr_gd_ptr->released_ptr.lock();
                 if (released_ptr) {
@@ -818,14 +818,14 @@ struct load_helper : value_and_holder_helper {
         // This is enforced indirectly by a static_assert in the class_ implementation:
         assert(!python_instance_is_alias || self_life_support);
 
-        std::unique_ptr<D> extracted_deleter = holder().template extract_deleter<T, D>(
-            context, get_internals().get_memory_guarded_delete);
+        std::unique_ptr<D> extracted_deleter
+            = holder().template extract_deleter<T, D>(context, find_memory_guarded_delete);
 
         // Critical transfer-of-ownership section. This must stay together.
         if (self_life_support != nullptr) {
-            holder().disown(get_internals().get_memory_guarded_delete);
+            holder().disown(find_memory_guarded_delete);
         } else {
-            holder().release_ownership(get_internals().get_memory_guarded_delete);
+            holder().release_ownership(find_memory_guarded_delete);
         }
         auto result = unique_with_deleter<T, D>(raw_type_ptr, std::move(extracted_deleter));
         if (self_life_support != nullptr) {
@@ -851,7 +851,7 @@ struct load_helper : value_and_holder_helper {
         holder().template ensure_compatible_rtti_uqp_del<T, D>(context);
         return unique_with_deleter<T, D>(raw_type_ptr,
                                          std::move(holder().template extract_deleter<T, D>(
-                                             context, get_internals().get_memory_guarded_delete)));
+                                             context, find_memory_guarded_delete)));
     }
 };
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -808,7 +808,7 @@ struct load_helper : value_and_holder_helper {
         throw_if_uninitialized_or_disowned_holder(typeid(T));
         throw_if_instance_is_currently_owned_by_shared_ptr();
         holder().ensure_is_not_disowned(context);
-        holder().template ensure_compatible_rtti_uqp_del<T, D>(context);
+        holder().template ensure_compatible_uqp_del<T, D>(context);
         holder().ensure_use_count_1(context);
 
         T *raw_type_ptr = static_cast<T *>(raw_void_ptr);
@@ -848,7 +848,7 @@ struct load_helper : value_and_holder_helper {
         if (!have_holder()) {
             return unique_with_deleter<T, D>(nullptr, std::unique_ptr<D>());
         }
-        holder().template ensure_compatible_rtti_uqp_del<T, D>(context);
+        holder().template ensure_compatible_uqp_del<T, D>(context);
         return unique_with_deleter<T, D>(raw_type_ptr,
                                          std::move(holder().template extract_deleter<T, D>(
                                              context, find_memory_guarded_delete)));

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1571,6 +1571,7 @@ protected:
         tinfo->holder_size_in_ptrs = size_in_ptrs(rec.holder_size);
         tinfo->init_instance = rec.init_instance;
         tinfo->dealloc = rec.dealloc;
+        tinfo->get_trampoline_self_life_support = rec.get_trampoline_self_life_support;
         tinfo->simple_type = true;
         tinfo->simple_ancestors = true;
         tinfo->module_local = rec.module_local;
@@ -2064,6 +2065,13 @@ public:
             record.dealloc = dealloc_release_gil_before_calling_cpp_dtor;
         } else {
             record.dealloc = dealloc_without_manipulating_gil;
+        }
+
+        if (std::is_base_of<trampoline_self_life_support, type_alias>::value) {
+            record.get_trampoline_self_life_support = [](void *type_ptr) {
+                return dynamic_raw_ptr_cast_if_possible<trampoline_self_life_support>(
+                    static_cast<type *>(type_ptr));
+            };
         }
 
         generic_type::initialize(record);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2068,6 +2068,9 @@ public:
         }
 
         if (std::is_base_of<trampoline_self_life_support, type_alias>::value) {
+            // Store a cross-DSO-safe getter.
+            // This lambda is defined in the same DSO that instantiates
+            // class_<type, alias_type>, but it can be called safely from any other DSO.
             record.get_trampoline_self_life_support = [](void *type_ptr) {
                 return dynamic_raw_ptr_cast_if_possible<trampoline_self_life_support>(
                     static_cast<type *>(type_ptr));

--- a/include/pybind11/trampoline_self_life_support.h
+++ b/include/pybind11/trampoline_self_life_support.h
@@ -19,6 +19,7 @@ PYBIND11_NAMESPACE_END(detail)
 // https://github.com/google/clif/blob/07f95d7e69dca2fcf7022978a55ef3acff506c19/clif/python/runtime.cc#L37
 // URL provided here mainly to give proper credit.
 struct trampoline_self_life_support {
+    // NOTE: PYBIND11_INTERNALS_VERSION needs to be bumped if changes are made to this struct.
     detail::value_and_holder v_h;
 
     trampoline_self_life_support() = default;
@@ -56,5 +57,9 @@ struct trampoline_self_life_support {
     trampoline_self_life_support &operator=(const trampoline_self_life_support &) = delete;
     trampoline_self_life_support &operator=(trampoline_self_life_support &&) = delete;
 };
+
+PYBIND11_NAMESPACE_BEGIN(detail)
+using get_trampoline_self_life_support_fn = trampoline_self_life_support *(*) (void *);
+PYBIND11_NAMESPACE_END(detail)
 
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/tests/pure_cpp/smart_holder_poc.h
+++ b/tests/pure_cpp/smart_holder_poc.h
@@ -43,7 +43,7 @@ T *as_raw_ptr_release_ownership(smart_holder &hld,
 template <typename T, typename D = std::default_delete<T>>
 std::unique_ptr<T, D> as_unique_ptr(smart_holder &hld) {
     static const char *context = "as_unique_ptr";
-    hld.ensure_compatible_rtti_uqp_del<T, D>(context);
+    hld.ensure_compatible_uqp_del<T, D>(context);
     hld.ensure_use_count_1(context);
     T *raw_ptr = hld.as_raw_ptr_unowned<T>();
     hld.release_ownership(get_guarded_delete);

--- a/tests/pure_cpp/smart_holder_poc.h
+++ b/tests/pure_cpp/smart_holder_poc.h
@@ -36,7 +36,7 @@ T *as_raw_ptr_release_ownership(smart_holder &hld,
                                 const char *context = "as_raw_ptr_release_ownership") {
     hld.ensure_can_release_ownership(context);
     T *raw_ptr = hld.as_raw_ptr_unowned<T>();
-    hld.release_ownership(std::get_deleter<guarded_delete>(hld.vptr));
+    hld.release_ownership(get_guarded_delete);
     return raw_ptr;
 }
 
@@ -46,7 +46,7 @@ std::unique_ptr<T, D> as_unique_ptr(smart_holder &hld) {
     hld.ensure_compatible_rtti_uqp_del<T, D>(context);
     hld.ensure_use_count_1(context);
     T *raw_ptr = hld.as_raw_ptr_unowned<T>();
-    hld.release_ownership(std::get_deleter<guarded_delete>(hld.vptr));
+    hld.release_ownership(get_guarded_delete);
     // KNOWN DEFECT (see PR #4850): Does not copy the deleter.
     return std::unique_ptr<T, D>(raw_ptr);
 }

--- a/tests/pure_cpp/smart_holder_poc.h
+++ b/tests/pure_cpp/smart_holder_poc.h
@@ -36,7 +36,7 @@ T *as_raw_ptr_release_ownership(smart_holder &hld,
                                 const char *context = "as_raw_ptr_release_ownership") {
     hld.ensure_can_release_ownership(context);
     T *raw_ptr = hld.as_raw_ptr_unowned<T>();
-    hld.release_ownership();
+    hld.release_ownership(std::get_deleter<guarded_delete>(hld.vptr));
     return raw_ptr;
 }
 
@@ -46,7 +46,7 @@ std::unique_ptr<T, D> as_unique_ptr(smart_holder &hld) {
     hld.ensure_compatible_rtti_uqp_del<T, D>(context);
     hld.ensure_use_count_1(context);
     T *raw_ptr = hld.as_raw_ptr_unowned<T>();
-    hld.release_ownership();
+    hld.release_ownership(std::get_deleter<guarded_delete>(hld.vptr));
     // KNOWN DEFECT (see PR #4850): Does not copy the deleter.
     return std::unique_ptr<T, D>(raw_ptr);
 }

--- a/tests/pure_cpp/smart_holder_poc_test.cpp
+++ b/tests/pure_cpp/smart_holder_poc_test.cpp
@@ -161,12 +161,12 @@ TEST_CASE("from_raw_ptr_take_ownership+as_shared_ptr", "[S]") {
 TEST_CASE("from_raw_ptr_take_ownership+disown+reclaim_disowned", "[S]") {
     auto hld = smart_holder::from_raw_ptr_take_ownership(new int(19));
     std::unique_ptr<int> new_owner(hld.as_raw_ptr_unowned<int>());
-    hld.disown(std::get_deleter<guarded_delete>(hld.vptr));
+    hld.disown(pybind11::memory::get_guarded_delete);
     REQUIRE(poc::as_lvalue_ref<int>(hld) == 19);
     REQUIRE(*new_owner == 19);
     // Manually verified: without this, clang++ -fsanitize=address reports
     // "detected memory leaks".
-    hld.reclaim_disowned(std::get_deleter<guarded_delete>(hld.vptr));
+    hld.reclaim_disowned(pybind11::memory::get_guarded_delete);
     // NOLINTNEXTLINE(bugprone-unused-return-value)
     (void) new_owner.release(); // Manually verified: without this, clang++ -fsanitize=address
                                 // reports "attempting double-free".
@@ -177,7 +177,7 @@ TEST_CASE("from_raw_ptr_take_ownership+disown+reclaim_disowned", "[S]") {
 TEST_CASE("from_raw_ptr_take_ownership+disown+release_disowned", "[S]") {
     auto hld = smart_holder::from_raw_ptr_take_ownership(new int(19));
     std::unique_ptr<int> new_owner(hld.as_raw_ptr_unowned<int>());
-    hld.disown(std::get_deleter<guarded_delete>(hld.vptr));
+    hld.disown(pybind11::memory::get_guarded_delete);
     REQUIRE(poc::as_lvalue_ref<int>(hld) == 19);
     REQUIRE(*new_owner == 19);
     hld.release_disowned();
@@ -189,7 +189,7 @@ TEST_CASE("from_raw_ptr_take_ownership+disown+ensure_is_not_disowned", "[E]") {
     auto hld = smart_holder::from_raw_ptr_take_ownership(new int(19));
     hld.ensure_is_not_disowned(context); // Does not throw.
     std::unique_ptr<int> new_owner(hld.as_raw_ptr_unowned<int>());
-    hld.disown(std::get_deleter<guarded_delete>(hld.vptr));
+    hld.disown(pybind11::memory::get_guarded_delete);
     REQUIRE_THROWS_WITH(hld.ensure_is_not_disowned(context),
                         "Holder was disowned already (test_case).");
 }

--- a/tests/pure_cpp/smart_holder_poc_test.cpp
+++ b/tests/pure_cpp/smart_holder_poc_test.cpp
@@ -14,6 +14,7 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
+using pybind11::memory::guarded_delete;
 using pybind11::memory::smart_holder;
 namespace poc = pybind11::memory::smart_holder_poc;
 
@@ -160,11 +161,12 @@ TEST_CASE("from_raw_ptr_take_ownership+as_shared_ptr", "[S]") {
 TEST_CASE("from_raw_ptr_take_ownership+disown+reclaim_disowned", "[S]") {
     auto hld = smart_holder::from_raw_ptr_take_ownership(new int(19));
     std::unique_ptr<int> new_owner(hld.as_raw_ptr_unowned<int>());
-    hld.disown();
+    hld.disown(std::get_deleter<guarded_delete>(hld.vptr));
     REQUIRE(poc::as_lvalue_ref<int>(hld) == 19);
     REQUIRE(*new_owner == 19);
-    hld.reclaim_disowned(); // Manually veriified: without this, clang++ -fsanitize=address reports
-                            // "detected memory leaks".
+    // Manually verified: without this, clang++ -fsanitize=address reports
+    // "detected memory leaks".
+    hld.reclaim_disowned(std::get_deleter<guarded_delete>(hld.vptr));
     // NOLINTNEXTLINE(bugprone-unused-return-value)
     (void) new_owner.release(); // Manually verified: without this, clang++ -fsanitize=address
                                 // reports "attempting double-free".
@@ -175,7 +177,7 @@ TEST_CASE("from_raw_ptr_take_ownership+disown+reclaim_disowned", "[S]") {
 TEST_CASE("from_raw_ptr_take_ownership+disown+release_disowned", "[S]") {
     auto hld = smart_holder::from_raw_ptr_take_ownership(new int(19));
     std::unique_ptr<int> new_owner(hld.as_raw_ptr_unowned<int>());
-    hld.disown();
+    hld.disown(std::get_deleter<guarded_delete>(hld.vptr));
     REQUIRE(poc::as_lvalue_ref<int>(hld) == 19);
     REQUIRE(*new_owner == 19);
     hld.release_disowned();
@@ -187,7 +189,7 @@ TEST_CASE("from_raw_ptr_take_ownership+disown+ensure_is_not_disowned", "[E]") {
     auto hld = smart_holder::from_raw_ptr_take_ownership(new int(19));
     hld.ensure_is_not_disowned(context); // Does not throw.
     std::unique_ptr<int> new_owner(hld.as_raw_ptr_unowned<int>());
-    hld.disown();
+    hld.disown(std::get_deleter<guarded_delete>(hld.vptr));
     REQUIRE_THROWS_WITH(hld.ensure_is_not_disowned(context),
                         "Holder was disowned already (test_case).");
 }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Follow-on to PR #5700, specifically [this comment](https://github.com/pybind/pybind11/pull/5700#issuecomment-2915297794).
________

This PR addresses fragile RTTI-based operations across dynamic shared object (DSO) boundaries, which commonly cause failures on macOS (due to libc++'s RTTI implementation). This is achieved by capturing required RTTI-dependent behavior in the DSO that defines the type, and using only function pointers elsewhere.

**The three main changes:**

* **Cross-DSO-safe `get_guarded_delete`**

    The `pybind11::detail::type_info` struct now stores a function pointer (`get_guarded_delete`) for retrieving the `guarded_delete` from a `shared_ptr<void>`.

    This avoids direct use of `std::get_deleter<T>` across DSOs, where RTTI comparisons may fail.

* **Cross-DSO-safe `get_trampoline_self_life_support`**

    Similarly, `pybind11::detail::type_info` now includes a `get_trampoline_self_life_support` function pointer.

    The lambda is defined in the same DSO that instantiates `class_`, where the alias type (aka trampoline) is known and the cast is valid.

    This replaces `dynamic_cast<trampoline_self_life_support *>(...)` with a safer, cross-DSO-compatible mechanism.

* **Resilient handling of `std::unique_ptr` deleters in `struct smart_holder`**

    RTTI comparisons are made tolerant to DSO boundaries by comparing `typeid(...).name()` as a fallback.

    The boolean `vptr_is_using_std_default_delete` tracks whether `std::default_delete<T>` (or its `const` variant) was used.

    This allows correct ownership transfer and deletion logic even when RTTI identity fails across DSOs.

**Other details:**

* This PR removes `PYBIND11_EXPORT_GUARDED_DELETE` that was introduced as a stop-gap with PR #5700.

* `PYBIND11_INTERNALS_VERSION` was bumped from `10` to `11` to reflect these ABI-relevant changes.

* All uses of `std::get_deleter<guarded_delete>` have been replaced by `type_info->get_memory_guarded_delete(...)`.

* Unit tests in `smart_holder_poc_test.cpp` and elsewhere were updated to pass in `get_guarded_delete` explicitly where required.

These changes make trampoline support and smart_holder-based ownership transfer robust on macOS and other environments with strict DSO isolation.
________

See also: [claude.ai full review](https://claude.ai/share/a9f268ae-8bd1-4b59-977a-7ba5dbc7f786)

For completeness: [Extremely long ChatGPT conversation](https://chatgpt.com/share/684f3583-15e4-8008-b89d-9aedc0787ccb) related to the work on this PR.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Eliminate cross-DSO RTTI reliance from `trampoline_self_life_support` functionality, `smart_holder` deleter detection, and other `smart_holder` bookkeeping. Resolves platform-specific issues on macOS related to cross-DSO `dynamic_cast` and `typeid` mismatches.