### PR TITLE
Use pytest.importorskip to get _xxsubinterpreters

### DIFF
--- a/tests/test_multiple_interpreters.py
+++ b/tests/test_multiple_interpreters.py
@@ -19,9 +19,9 @@ def test_independent_subinterpreters():
     if sys.version_info >= (3, 15):
         import interpreters
     elif sys.version_info >= (3, 13):
-        import _interpreters as interpreters
+        interpreters = pytest.importorskip("_interpreters")
     elif sys.version_info >= (3, 12):
-        import _xxsubinterpreters as interpreters
+        interpreters = pytest.importorskip("_xxsubinterpreters")
     else:
         pytest.skip("Test requires the interpreters stdlib module")
 
@@ -93,9 +93,9 @@ def test_dependent_subinterpreters():
     if sys.version_info >= (3, 15):
         import interpreters
     elif sys.version_info >= (3, 13):
-        import _interpreters as interpreters
+        interpreters = pytest.importorskip("_interpreters")
     elif sys.version_info >= (3, 12):
-        import _xxsubinterpreters as interpreters
+        interpreters = pytest.importorskip("_xxsubinterpreters")
     else:
         pytest.skip("Test requires the interpreters stdlib module")
 


### PR DESCRIPTION
We're working on updating GraalPy to 2.13, but we're currently not planning to add this internal module yet, so the few tests using it should get skipped. (I'm doing this now because we run pybind11 tests from master in our CI)