### PR TITLE
docs: fix typo in multiple_interpreters

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -490,7 +490,8 @@ PyModuleDef_Init should be treated like any other PyObject (so not shared across
 
     - ``mod_gil_not_used()``
     - ``multiple_interpreters::per_interpreter_gil()``
-    - ``multiple_interpreters::per_interprshareeter_gil()``
+    - ``multiple_interpreters::shared_gil()``
+    - ``multiple_interpreters::not_supported()``
 
     .. code-block:: cpp
 

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -43,7 +43,8 @@
 
     - ``mod_gil_not_used()``
     - ``multiple_interpreters::per_interpreter_gil()``
-    - ``multiple_interpreters::per_interprshareeter_gil()``
+    - ``multiple_interpreters::shared_gil()``
+    - ``multiple_interpreters::not_supported()``
 
     .. code-block:: cpp
 


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Fix #5730.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Fix a typo in the docs.
