### PR TITLE
Explain: conduit feature only covers from-Python-to-C++ conversions

### DIFF
--- a/include/pybind11/conduit/pybind11_conduit_v1.h
+++ b/include/pybind11/conduit/pybind11_conduit_v1.h
@@ -6,6 +6,11 @@
 
 * including pybind11 versions with different PYBIND11_INTERNALS_VERSION's.
 
+    * NOTE: The conduit feature
+            only covers    from-Python-to-C++ conversions, it
+            does not cover from-C++-to-Python conversions.
+            (For the latter, a different feature would have to be added.)
+
 The naming of the feature is a bit misleading:
 
 * The feature is in no way tied to pybind11 internals.

--- a/tests/test_cpp_conduit.py
+++ b/tests/test_cpp_conduit.py
@@ -151,8 +151,8 @@ def test_exo_planet_c_api_premium_traveler(premium_traveler_type):
 
 def test_home_planet_wrap_very_lonely_traveler():
     # This does not exercise the cpp_conduit feature, but is here to
-    # demonstrate that the cpp_conduit feature does not solve all
-    # cross-extension interoperability issues.
+    # demonstrate that the cpp_conduit feature does not solve
+    # cross-extension base-and-derived class interoperability issues.
     # Here is the proof that the following works for extensions with
     # matching `PYBIND11_INTERNALS_ID`s:
     #     test_cpp_conduit.cpp:


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
(Late, sorry) Follow-on to: https://github.com/pybind/pybind11/discussions/5524

Related PRs:
* PR #5296
* PR #5375

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* A note was added to explain that the conduit feature (introduced with PR #5296) only covers from-Python-to-C++ conversions.
