### PR TITLE
Small `docs/release.rst` update, mainly to remove `git push --tags`.

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -65,7 +65,7 @@ If you don't have nox, you should either use ``pipx run nox`` instead, or use
 
     - Last-minute consistency check: same as tag?
 
-  - Push the new tag: ``git push upstream vX.Y.Z`` (do NOT use ``git push --tags``!)
+  - Push the new tag: ``git push upstream vX.Y.Z``
 
 - Update stable
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

## Improve release documentation safety and clarity

### Problem
The current release documentation has potential safety issues and unclear instructions:
- Uses `git push --tags` which pushes ALL local tags (potentially including experimental/unwanted tags)
- Unclear assumptions about remote repository naming (`origin`, `upstream`)

### Changes
- **Safety improvement**: Replace `git push --tags` with specific `git push upstream vX.Y.Z` command
- **Add explicit warning**: Include "do NOT use `git push --tags`!" to prevent accidental tag pushes
- **Clarify remote naming**: Add note that documentation assumes `upstream` refers to `https://github.com/pybind/pybind11.git`
- **Consistency**: Update all commands to use `upstream` remote consistently

### Why this matters
Using `git push --tags` in release documentation is dangerous because:
- It pushes ALL local tags, not just the intended release tag
- Could accidentally push experimental, personal, or malformed tags
- Makes it harder to control exactly what gets published

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5748.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->