### PR TITLE
Implement binary version of make_index_sequence

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -743,19 +743,26 @@ struct index_sequence {};
 // Ths process concludes with digit=0, in which case, end == N and S is 0...N-1.
 
 template <size_t digit, bool N_digit_is_1, size_t N, size_t end, size_t... S> // N_digit_is_1=false
-struct make_index_sequence_impl :
-    make_index_sequence_impl<digit/2, (N&(digit/2))!=0, N, 2*end, S..., (S+end)...> {};
+struct make_index_sequence_impl
+    : make_index_sequence_impl<digit / 2, (N & (digit / 2)) != 0, N, 2 * end, S..., (S + end)...> {
+};
 template <size_t digit, size_t N, size_t end, size_t... S>
-struct make_index_sequence_impl<digit, true, N, end, S...> :
-    make_index_sequence_impl<digit/2, (N&(digit/2))!=0, N, 2*end+1, S..., (S+end)..., 2*end> {};
+struct make_index_sequence_impl<digit, true, N, end, S...>
+    : make_index_sequence_impl<digit / 2,
+                               (N & (digit / 2)) != 0,
+                               N,
+                               2 * end + 1,
+                               S...,
+                               (S + end)...,
+                               2 * end> {};
 template <size_t N, size_t end, size_t... S>
 struct make_index_sequence_impl<0, false, N, end, S...> {
     using type = index_sequence<S...>;
 };
-constexpr size_t next_power_of_2(size_t N)
-{ return N == 0 ? 1 : next_power_of_2(N>>1)<<1; }
+constexpr size_t next_power_of_2(size_t N) { return N == 0 ? 1 : next_power_of_2(N >> 1) << 1; }
 template <size_t N>
-using make_index_sequence = typename make_index_sequence_impl<next_power_of_2(N), false, N, 0>::type;
+using make_index_sequence =
+    typename make_index_sequence_impl<next_power_of_2(N), false, N, 0>::type;
 #endif
 
 /// Make an index sequence of the indices of true arguments

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -740,7 +740,7 @@ struct index_sequence {};
 // - if digit > 0, end * digit * 2 <= N < (end+1) * digit * 2
 //
 // The process starts with digit > N, end = 0, and S is empty.
-// Ths process concludes with digit=0, in which case, end == N and S is 0...N-1.
+// The process concludes with digit=0, in which case, end == N and S is 0...N-1.
 
 template <size_t digit, bool N_digit_is_1, size_t N, size_t end, size_t... S> // N_digit_is_1=false
 struct make_index_sequence_impl


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

**TL;DR:** This replaces pybind11’s hand-rolled `make_index_sequence` with a more efficient `O(log N)` version. The old version had `O(N)` template recursion depth, which could trigger compiler limits or slow down builds—especially in code like `descr`, `io_name`, and other parts of pybind11 that use `make_index_sequence` to build long signature strings at compile time.
________

I started getting problems with template-recursion-depth starting with pybind version 3.0.  It seems that something caused the N values in `pybind11::detail::descr<N>` to get significantly larger.  doubles went from 7 to 30.  And pybind11:array_t<double> went from 30 to 81.  For one of my initializers with lots of parameters (including a bunch of numpy arrays), this led to a call of `pybind11::detail::make_index_sequence_impl<2251>`, which required a very high `-ftemplate-recursion-depth` value when compiling.  (At least 2260, due to a few extra levels beyond the 2251 for this class.)

Even once I made that high enough, I still got warnings of `stack nearly exhausted; compilation time may suffer, and crashes due to stack overflow are likely`, which is presumably why one of my CI runners crashed trying to compile my code, when it used to work just fine with pybind11 version 2.13.

The underlying problem is that the implementation of `make_index_sequence` is linear in N, so it requires making N template from 0 to N.  With N=2251, this exhausted the default allowed template depth and apparently used up most of the stack.

This PR switches the implementation to a binary version whose complexity is logarithmic, so it only requires a depth of `log(N)`.  For my use case mentioned above, it worked fine with a template depth of only 60, which is much lower than the default.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Implement binary version of make_index_sequence to reduce template depth requirements for functions with many parameters.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5751.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->