### PR TITLE
fix: don't force -fvisibility=hidden on Windows

### DIFF
--- a/include/pybind11/detail/pybind11_namespace_macros.h
+++ b/include/pybind11/detail/pybind11_namespace_macros.h
@@ -74,7 +74,7 @@
 // requires forcing hidden visibility on pybind code, so we enforce this by setting the attribute
 // on the main `pybind11` namespace.
 #if !defined(PYBIND11_NAMESPACE)
-#    ifdef __GNUG__
+#    if defined(__GNUG__) && !defined(_WIN32)
 #        define PYBIND11_NAMESPACE pybind11 __attribute__((visibility("hidden")))
 #    else
 #        define PYBIND11_NAMESPACE pybind11


### PR DESCRIPTION
Fix https://github.com/pybind/pybind11/discussions/5750

Do you want me to add a msys2 (that use clang) into the workflow so these kind of problem are catched by the CI?

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

This allow to compile on msys2 clang without any error.
Without this fix, I was getting the error: ``hidden visibility cannot be applied to 'dllexport' declaration``
This was probably affecting any environment of msys2, but I didn't verified.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Fix compilation with clang on msys2.
