### PR TITLE
Check for __cpp_lib_remove_cvref as well

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -697,7 +697,7 @@ template <typename T>
 using remove_reference_t = typename std::remove_reference<T>::type;
 #endif
 
-#if defined(PYBIND11_CPP20)
+#if defined(PYBIND11_CPP20) && defined(__cpp_lib_remove_cvref)
 using std::remove_cvref;
 using std::remove_cvref_t;
 #else


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

C++20 can be enabled while the C++ runtime is still much older so use the feature macro to check for it. 

For example, we are using the latest clang with c++23 on SLES, while the gcc version is 7.


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Support C++20 on platforms that have older c++ runtimes.
