### PR TITLE
tests: fix IsolatedConfig test

### DIFF
--- a/tests/test_embed/test_interpreter.cpp
+++ b/tests/test_embed/test_interpreter.cpp
@@ -199,8 +199,9 @@ TEST_CASE("Custom PyConfig") {
 
 TEST_CASE("scoped_interpreter with PyConfig_InitIsolatedConfig and argv") {
     std::vector<std::string> path;
-    for (auto p : py::module::import("sys").attr("path"))
+    for (auto p : py::module::import("sys").attr("path")) {
         path.emplace_back(py::str(p));
+    }
 
     py::finalize_interpreter();
     {
@@ -211,8 +212,9 @@ TEST_CASE("scoped_interpreter with PyConfig_InitIsolatedConfig and argv") {
         std::free(argv[0]);
         // Because this config is isolated, setting the path during init will not work, we have to
         // set it manually.  If we don't set it, then we can't import "test_interpreter"
-        for (auto &&p : path)
+        for (auto &&p : path) {
             py::list(py::module::import("sys").attr("path")).append(p);
+        }
         try {
             auto module = py::module::import("test_interpreter");
             auto py_widget = module.attr("DerivedWidget")("The question");


### PR DESCRIPTION
The test was throwing import errors past the lifetime of the owning scoped_interpreter

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

The test was supposed to import a test module, but because it is "isolated", the path is not set, so the module cannot be imported.  A `ModuleNotFound` error is thrown, but not caught, and then propagates past the `scoped_interpreter` which owns it.

The stack of the SEGV doesn't point to the test itself, so it was difficult to track down:
```
#0  0x0000000004b6fec9 in new_threadstate (interp=0x0) at ../Python/pystate.c:1388
#1  0x0000000004b726ad in PyGILState_Ensure () at ../Python/pystate.c:2218
#2  0x0000000000162821 in pybind11::gil_scoped_acquire_simple::gil_scoped_acquire_simple (this=0x1ffeffeb8c)
    at /home/user/pybind11/include/pybind11/gil_simple.h:17
#3  0x0000000000163cc8 in pybind11::error_already_set::what (this=0x6f58d60) at /home/user/pybind11/include/pybind11/pybind11.h:3345
#4  0x000000000012dd32 in Catch::ExceptionTranslatorRegistry::translateActiveException[abi:cxx11]() const (this=0x5729138)
    at /home/user/pybind11/build12/tests/catch/catch.hpp:10720
#5  0x00000000001343ca in Catch::translateActiveException[abi:cxx11]() () at /home/user/pybind11/build12/tests/catch/catch.hpp:12523
#6  0x00000000001369e0 in Catch::RunContext::runCurrentTest (this=0x1ffefff1f0, redirectedCout="", redirectedCerr="")
    at /home/user/pybind11/build12/tests/catch/catch.hpp:13008
#7  0x0000000000135236 in Catch::RunContext::runTest (this=0x1ffefff1f0, testCase=...) at /home/user/pybind11/build12/tests/catch/catch.hpp:12759
#8  0x0000000000138533 in Catch::(anonymous namespace)::TestGroup::execute (this=0x1ffefff1e0) at /home/user/pybind11/build12/tests/catch/catch.hpp:13352
#9  0x0000000000139abb in Catch::Session::runInternal (this=0x1ffefff510) at /home/user/pybind11/build12/tests/catch/catch.hpp:13562
#10 0x000000000013978e in Catch::Session::run (this=0x1ffefff510) at /home/user/pybind11/build12/tests/catch/catch.hpp:13518
#11 0x00000000001841af in Catch::Session::run<char> (this=0x1ffefff510, argc=2, argv=0x1ffefff7e8) at /home/user/pybind11/build12/tests/catch/catch.hpp:13236
#12 0x00000000001521bb in main (argc=2, argv=0x1ffefff7e8) at /home/user/pybind11/tests/test_embed/catch.cpp:40
```
I do not really understand how this passes as it is.

@rwgk this is what I found when investigating the flake from #5766.  I don't know if this is the actual cause....

## Suggested changelog entry:

* fix an IsolatedConfig test
