### PR TITLE
docs: show nogil in most examples

### DIFF
--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -108,7 +108,7 @@ type is explicitly allowed.
     } // namespace pybind11
 
     // Bind the negate function
-    PYBIND11_MODULE(docs_advanced_cast_custom, m) { m.def("negate", user_space::negate); }
+    PYBIND11_MODULE(docs_advanced_cast_custom, m, py::mod_gil_not_used()) { m.def("negate", user_space::negate); }
 
 .. note::
 

--- a/docs/advanced/cast/functional.rst
+++ b/docs/advanced/cast/functional.rst
@@ -56,7 +56,7 @@ trivial to generate binding code for all of these functions.
 
     #include <pybind11/functional.h>
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         m.def("func_arg", &func_arg);
         m.def("func_ret", &func_ret);
         m.def("func_cpp", &func_cpp);

--- a/docs/advanced/classes.rst
+++ b/docs/advanced/classes.rst
@@ -45,7 +45,7 @@ Normally, the binding code for these classes would look as follows:
 
 .. code-block:: cpp
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         py::class_<Animal>(m, "Animal")
             .def("go", &Animal::go);
 
@@ -112,7 +112,7 @@ The binding code also needs a few minor adaptations (highlighted):
 .. code-block:: cpp
     :emphasize-lines: 2,3
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         py::class_<Animal, PyAnimal /* <--- trampoline */, py::smart_holder>(m, "Animal")
             .def(py::init<>())
             .def("go", &Animal::go);
@@ -774,7 +774,7 @@ to Python.
 
     #include <pybind11/operators.h>
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         py::class_<Vector2>(m, "Vector2")
             .def(py::init<float, float>())
             .def(py::self + py::self)

--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -217,7 +217,7 @@ expects the type followed by field names:
     };
 
     // ...
-    PYBIND11_MODULE(test, m) {
+    PYBIND11_MODULE(test, m, py::mod_gil_not_used()) {
         // ...
 
         PYBIND11_NUMPY_DTYPE(A, x, y);
@@ -351,7 +351,7 @@ simply using ``vectorize``).
         return result;
     }
 
-    PYBIND11_MODULE(test, m) {
+    PYBIND11_MODULE(test, m, py::mod_gil_not_used()) {
         m.def("add_arrays", &add_arrays, "Add two NumPy arrays");
     }
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -112,7 +112,7 @@ a file named :file:`example.cpp` with the following contents:
         return i + j;
     }
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         m.doc() = "pybind11 example plugin"; // optional module docstring
 
         m.def("add", &add, "A function that adds two numbers");
@@ -288,7 +288,7 @@ converted using the function ``py::cast``.
 
 .. code-block:: cpp
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         m.attr("the_answer") = 42;
         py::object world = py::cast("World");
         m.attr("what") = world;

--- a/docs/benchmark.py
+++ b/docs/benchmark.py
@@ -33,7 +33,7 @@ def generate_dummy_code_pybind11(nclasses=10):
     result = "#include <pybind11/pybind11.h>\n\n"
     result += "namespace py = pybind11;\n\n"
     result += decl + "\n"
-    result += "PYBIND11_MODULE(example, m) {\n"
+    result += "PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {\n"
     result += bindings
     result += "}"
     return result

--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -31,7 +31,7 @@ Here is an example of the binding code for one class:
     };
     ...
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         ...
         py::class_<cl034>(m, "cl034")
             .def("fn_000", &cl034::fn_000)

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -27,7 +27,7 @@ The binding code for ``Pet`` looks as follows:
 
     namespace py = pybind11;
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         py::class_<Pet>(m, "Pet")
             .def(py::init<const std::string &>())
             .def("setName", &Pet::setName)
@@ -480,7 +480,7 @@ management. For example, ownership is inadvertently transferred here:
         std::shared_ptr<Child> child;
     };
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         py::class_<Child, std::shared_ptr<Child>>(m, "Child");
 
         py::class_<Parent, std::shared_ptr<Parent>>(m, "Parent")

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -90,7 +90,7 @@ following example:
     void init_ex2(py::module_ &);
     /* ... */
 
-    PYBIND11_MODULE(example, m) {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         init_ex1(m);
         init_ex2(m);
         /* ... */
@@ -235,8 +235,7 @@ been received, you must either explicitly interrupt execution by throwing
 
 .. code-block:: cpp
 
-    PYBIND11_MODULE(example, m)
-    {
+    PYBIND11_MODULE(example, m, py::mod_gil_not_used()) {
         m.def("long running_func", []()
         {
             for (;;) {


### PR DESCRIPTION
Now that free-threading is no longer experimental, I think we should either always show it, or switch the default to on with a way to opt-out instead. Always showing it doesn't require a bump, so maybe we do that for now?

---


Created using [mini-swe-agent](https://mini-swe-agent.com) and the propmt:

I'd like to find usages of PYBIND11_MODULE in the docs folder and add py::mod_gil_not_used() as a third argument if there ar
e only two arguments. These are examples, and it's really a good idea to always include that now.

I removed a few of the changes.

Signed-off-by: Henry Schreiner <henryschreineriii@gmail.com>

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5770.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->