### PR TITLE
Make function record subinterpreter safe

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -98,7 +98,7 @@ inline PyTypeObject *make_static_property_type() {
         pybind11_fail("make_static_property_type(): failure in PyType_Ready()!");
     }
 
-    setattr((PyObject *) type, "__module__", str("pybind11_builtins"));
+    setattr((PyObject *) type, "__module__", str(PYBIND11_INTERNAL_MODULE_NAME));
     PYBIND11_SET_OLDPY_QUALNAME(type, name_obj);
 
     return type;
@@ -282,7 +282,7 @@ inline PyTypeObject *make_default_metaclass() {
         pybind11_fail("make_default_metaclass(): failure in PyType_Ready()!");
     }
 
-    setattr((PyObject *) type, "__module__", str("pybind11_builtins"));
+    setattr((PyObject *) type, "__module__", str(PYBIND11_INTERNAL_MODULE_NAME));
     PYBIND11_SET_OLDPY_QUALNAME(type, name_obj);
 
     return type;
@@ -544,7 +544,7 @@ inline PyObject *make_object_base_type(PyTypeObject *metaclass) {
         pybind11_fail("PyType_Ready failed in make_object_base_type(): " + error_string());
     }
 
-    setattr((PyObject *) type, "__module__", str("pybind11_builtins"));
+    setattr((PyObject *) type, "__module__", str(PYBIND11_INTERNAL_MODULE_NAME));
     PYBIND11_SET_OLDPY_QUALNAME(type, name_obj);
 
     assert(!PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC));

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -98,7 +98,7 @@ inline PyTypeObject *make_static_property_type() {
         pybind11_fail("make_static_property_type(): failure in PyType_Ready()!");
     }
 
-    setattr((PyObject *) type, "__module__", str(PYBIND11_INTERNAL_MODULE_NAME));
+    setattr((PyObject *) type, "__module__", str(PYBIND11_DUMMY_MODULE_NAME));
     PYBIND11_SET_OLDPY_QUALNAME(type, name_obj);
 
     return type;
@@ -282,7 +282,7 @@ inline PyTypeObject *make_default_metaclass() {
         pybind11_fail("make_default_metaclass(): failure in PyType_Ready()!");
     }
 
-    setattr((PyObject *) type, "__module__", str(PYBIND11_INTERNAL_MODULE_NAME));
+    setattr((PyObject *) type, "__module__", str(PYBIND11_DUMMY_MODULE_NAME));
     PYBIND11_SET_OLDPY_QUALNAME(type, name_obj);
 
     return type;
@@ -544,7 +544,7 @@ inline PyObject *make_object_base_type(PyTypeObject *metaclass) {
         pybind11_fail("PyType_Ready failed in make_object_base_type(): " + error_string());
     }
 
-    setattr((PyObject *) type, "__module__", str(PYBIND11_INTERNAL_MODULE_NAME));
+    setattr((PyObject *) type, "__module__", str(PYBIND11_DUMMY_MODULE_NAME));
     PYBIND11_SET_OLDPY_QUALNAME(type, name_obj);
 
     assert(!PyType_HasFeature(type, Py_TPFLAGS_HAVE_GC));

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -91,15 +91,15 @@ static PyType_Spec function_record_PyType_Spec
        function_record_PyType_Slots};
 
 inline PyTypeObject *get_function_record_PyTypeObject() {
-    auto &type = detail::get_local_internals().function_record;
-    if (!type) {
-        PyObject *type_obj = PyType_FromSpec(&function_record_PyType_Spec);
-        if (type_obj == nullptr) {
+    PyTypeObject *&py_type_obj = detail::get_local_internals().function_record_py_type;
+    if (!py_type_obj) {
+        PyObject *py_obj = PyType_FromSpec(&function_record_PyType_Spec);
+        if (py_obj == nullptr) {
             throw error_already_set();
         }
-        type = reinterpret_cast<PyTypeObject *>(type_obj);
+        py_type_obj = reinterpret_cast<PyTypeObject *>(py_obj);
     }
-    return type;
+    return py_type_obj;
 }
 
 inline bool is_function_record_PyObject(PyObject *obj) {

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -47,7 +47,7 @@ static PyMethodDef tp_methods_impl[]
 
 // Note that this name is versioned.
 constexpr char tp_name_impl[]
-    = "__main__.pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
+    = "pybind11_builtins.pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
       "_" PYBIND11_PLATFORM_ABI_ID;
 
 PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -46,13 +46,12 @@ static PyMethodDef tp_methods_impl[]
        {nullptr, nullptr, 0, nullptr}};
 
 // Note that this name is versioned.
-constexpr char tp_qualname_impl[] = PYBIND11_INTERNAL_MODULE_NAME
-    "."
-    "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
-    "_" PYBIND11_PLATFORM_ABI_ID;
-constexpr char tp_plainname_impl[]
-    = "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
-      "_" PYBIND11_PLATFORM_ABI_ID;
+#define PYBIND11_DETAIL_FUNCTION_RECORD_TP_PLAINNAME                                              \
+    "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID                     \
+    "_" PYBIND11_PLATFORM_ABI_ID
+constexpr char tp_plainname_impl[] = PYBIND11_DETAIL_FUNCTION_RECORD_TP_PLAINNAME;
+constexpr char tp_qualname_impl[]
+    = PYBIND11_INTERNAL_MODULE_NAME "." PYBIND11_DETAIL_FUNCTION_RECORD_TP_PLAINNAME;
 
 PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)
 

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -52,14 +52,16 @@ constexpr char tp_name_impl[]
 
 PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)
 
-static PyType_Slot function_record_PyType_Slots[]
-    = {{Py_tp_dealloc, &function_record_PyTypeObject_methods::tp_dealloc_impl},
-       {Py_tp_methods, &function_record_PyTypeObject_methods::tp_methods_impl},
-       {Py_tp_init, &function_record_PyTypeObject_methods::tp_init_impl},
-       {Py_tp_alloc, &function_record_PyTypeObject_methods::tp_alloc_impl},
-       {Py_tp_new, &function_record_PyTypeObject_methods::tp_new_impl},
-       {Py_tp_free, &function_record_PyTypeObject_methods::tp_free_impl},
-       {0, nullptr}};
+static PyType_Slot function_record_PyType_Slots[] = {
+    {Py_tp_dealloc,
+     reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_dealloc_impl)},
+    {Py_tp_methods,
+     reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_methods_impl)},
+    {Py_tp_init, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_init_impl)},
+    {Py_tp_alloc, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_alloc_impl)},
+    {Py_tp_new, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_new_impl)},
+    {Py_tp_free, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_free_impl)},
+    {0, nullptr}};
 
 // Designated initializers are a C++20 feature:
 // https://en.cppreference.com/w/cpp/language/aggregate_initialization#Designated_initializers

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -51,7 +51,7 @@ static PyMethodDef tp_methods_impl[]
     "_" PYBIND11_PLATFORM_ABI_ID
 constexpr char tp_plainname_impl[] = PYBIND11_DETAIL_FUNCTION_RECORD_TP_PLAINNAME;
 constexpr char tp_qualname_impl[]
-    = PYBIND11_INTERNAL_MODULE_NAME "." PYBIND11_DETAIL_FUNCTION_RECORD_TP_PLAINNAME;
+    = PYBIND11_DUMMY_MODULE_NAME "." PYBIND11_DETAIL_FUNCTION_RECORD_TP_PLAINNAME;
 
 PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)
 

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -67,21 +67,12 @@ static PyType_Slot function_record_PyType_Slots[] = {
     {Py_tp_free, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_free_impl)},
     {0, nullptr}};
 
-// Designated initializers are a C++20 feature:
-// https://en.cppreference.com/w/cpp/language/aggregate_initialization#Designated_initializers
-// MSVC rejects them unless /std:c++20 is used (error code C7555).
-PYBIND11_WARNING_PUSH
-PYBIND11_WARNING_DISABLE_CLANG("-Wmissing-field-initializers")
-#if defined(__GNUC__) && __GNUC__ >= 8
-PYBIND11_WARNING_DISABLE_GCC("-Wmissing-field-initializers")
-#endif
 static PyType_Spec function_record_PyType_Spec
     = {function_record_PyTypeObject_methods::tp_qualname_impl,
        sizeof(function_record_PyObject),
        0,
        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE,
        function_record_PyType_Slots};
-PYBIND11_WARNING_POP
 
 inline PyTypeObject *get_function_record_PyTypeObject() {
     auto &type = detail::get_local_internals().function_record;

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -46,10 +46,13 @@ static PyMethodDef tp_methods_impl[]
        {nullptr, nullptr, 0, nullptr}};
 
 // Note that this name is versioned.
-constexpr char tp_qualname_impl[]
-    = PYBIND11_INTERNAL_MODULE_NAME "." "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID "_" PYBIND11_PLATFORM_ABI_ID;
+constexpr char tp_qualname_impl[] = PYBIND11_INTERNAL_MODULE_NAME
+    "."
+    "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
+    "_" PYBIND11_PLATFORM_ABI_ID;
 constexpr char tp_plainname_impl[]
-    = "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID "_" PYBIND11_PLATFORM_ABI_ID;
+    = "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
+      "_" PYBIND11_PLATFORM_ABI_ID;
 
 PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)
 
@@ -105,8 +108,9 @@ inline bool is_function_record_PyObject(PyObject *obj) {
         return true;
     }
     // This works across extension modules. Note that tp_name is versioned.
-    if (strcmp(obj_type->tp_name, function_record_PyTypeObject_methods::tp_qualname_impl) == 0 ||
-        strcmp(obj_type->tp_name, function_record_PyTypeObject_methods::tp_plainname_impl) == 0) {
+    if (strcmp(obj_type->tp_name, function_record_PyTypeObject_methods::tp_qualname_impl) == 0
+        || strcmp(obj_type->tp_name, function_record_PyTypeObject_methods::tp_plainname_impl)
+               == 0) {
         return true;
     }
     return false;

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -79,7 +79,7 @@ static PyType_Spec function_record_PyType_Spec
     = {function_record_PyTypeObject_methods::tp_qualname_impl,
        sizeof(function_record_PyObject),
        0,
-       Py_TPFLAGS_DEFAULT,
+       Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE,
        function_record_PyType_Slots};
 PYBIND11_WARNING_POP
 

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -46,9 +46,10 @@ static PyMethodDef tp_methods_impl[]
        {nullptr, nullptr, 0, nullptr}};
 
 // Note that this name is versioned.
-constexpr char tp_name_impl[]
-    = "pybind11_builtins.pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
-      "_" PYBIND11_PLATFORM_ABI_ID;
+constexpr char tp_qualname_impl[]
+    = PYBIND11_INTERNAL_MODULE_NAME "." "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID "_" PYBIND11_PLATFORM_ABI_ID;
+constexpr char tp_plainname_impl[]
+    = "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID "_" PYBIND11_PLATFORM_ABI_ID;
 
 PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)
 
@@ -72,7 +73,7 @@ PYBIND11_WARNING_DISABLE_CLANG("-Wmissing-field-initializers")
 PYBIND11_WARNING_DISABLE_GCC("-Wmissing-field-initializers")
 #endif
 static PyType_Spec function_record_PyType_Spec
-    = {function_record_PyTypeObject_methods::tp_name_impl,
+    = {function_record_PyTypeObject_methods::tp_qualname_impl,
        sizeof(function_record_PyObject),
        0,
        Py_TPFLAGS_DEFAULT,
@@ -80,7 +81,7 @@ static PyType_Spec function_record_PyType_Spec
 PYBIND11_WARNING_POP
 
 inline PyTypeObject *get_function_record_PyTypeObject() {
-    auto &type = detail::get_internals().function_record;
+    auto &type = detail::get_local_internals().function_record;
     if (!type) {
         PyObject *type_obj = PyType_FromSpec(&function_record_PyType_Spec);
         if (type_obj == nullptr) {
@@ -104,7 +105,8 @@ inline bool is_function_record_PyObject(PyObject *obj) {
         return true;
     }
     // This works across extension modules. Note that tp_name is versioned.
-    if (strcmp(obj_type->tp_name, frtype->tp_name) == 0) {
+    if (strcmp(obj_type->tp_name, function_record_PyTypeObject_methods::tp_qualname_impl) == 0 ||
+        strcmp(obj_type->tp_name, function_record_PyTypeObject_methods::tp_plainname_impl) == 0) {
         return true;
     }
     return false;

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -45,6 +45,23 @@ static PyMethodDef tp_methods_impl[]
         nullptr},
        {nullptr, nullptr, 0, nullptr}};
 
+// Python 3.12+ emits a DeprecationWarning for heap types whose tp_name does
+// not contain a dot ('.') and that lack a __module__ attribute. For pybind11's
+// internal function_record type, we do not have an actual module object to
+// attach, so we cannot use PyType_FromModuleAndSpec (introduced in Python 3.9)
+// to set __module__ automatically.
+//
+// As a workaround, we define a "qualified" type name that includes a dummy
+// module name (PYBIND11_DUMMY_MODULE_NAME). This is non‑idiomatic but avoids
+// the deprecation warning, and results in reprs like
+//
+//     <class 'pybind11_builtins.pybind11_detail_function_record_...'>
+//
+// even though no real pybind11_builtins module exists. If pybind11 gains an
+// actual module object in the future, this code should switch to
+// PyType_FromModuleAndSpec for Python 3.9+ and drop the dummy module
+// workaround.
+//
 // Note that this name is versioned.
 #define PYBIND11_DETAIL_FUNCTION_RECORD_TP_PLAINNAME                                              \
     "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID                     \

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -101,7 +101,7 @@ inline bool is_function_record_PyObject(PyObject *obj) {
     }
     PyTypeObject *obj_type = Py_TYPE(obj);
 
-    auto *frtype = get_function_record_PyTypeObject();
+    PyTypeObject *frtype = get_function_record_PyTypeObject();
 
     // Fast path (pointer comparison).
     if (obj_type == frtype) {

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -46,11 +46,7 @@ static PyMethodDef tp_methods_impl[]
        {nullptr, nullptr, 0, nullptr}};
 
 // Note that this name is versioned.
-constexpr char tp_qualname_impl[] = PYBIND11_INTERNAL_MODULE_NAME
-    "."
-    "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
-    "_" PYBIND11_PLATFORM_ABI_ID;
-constexpr char tp_plainname_impl[]
+constexpr char tp_name_impl[]
     = "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
       "_" PYBIND11_PLATFORM_ABI_ID;
 
@@ -76,10 +72,10 @@ PYBIND11_WARNING_DISABLE_CLANG("-Wmissing-field-initializers")
 PYBIND11_WARNING_DISABLE_GCC("-Wmissing-field-initializers")
 #endif
 static PyType_Spec function_record_PyType_Spec
-    = {function_record_PyTypeObject_methods::tp_qualname_impl,
+    = {function_record_PyTypeObject_methods::tp_name_impl,
        sizeof(function_record_PyObject),
        0,
-       Py_TPFLAGS_DEFAULT,
+       Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE,
        function_record_PyType_Slots};
 PYBIND11_WARNING_POP
 
@@ -90,6 +86,7 @@ inline PyTypeObject *get_function_record_PyTypeObject() {
         if (type_obj == nullptr) {
             throw error_already_set();
         }
+        setattr(type_obj, "__module__", str(PYBIND11_INTERNAL_MODULE_NAME));
         type = reinterpret_cast<PyTypeObject *>(type_obj);
     }
     return type;
@@ -108,9 +105,7 @@ inline bool is_function_record_PyObject(PyObject *obj) {
         return true;
     }
     // This works across extension modules. Note that tp_name is versioned.
-    if (strcmp(obj_type->tp_name, function_record_PyTypeObject_methods::tp_qualname_impl) == 0
-        || strcmp(obj_type->tp_name, function_record_PyTypeObject_methods::tp_plainname_impl)
-               == 0) {
+    if (strcmp(obj_type->tp_name, frtype->tp_name) == 0) {
         return true;
     }
     return false;

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -53,14 +53,15 @@ constexpr char tp_name_impl[]
 PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)
 
 static PyType_Slot function_record_PyType_Slots[] = {
-    {Py_tp_dealloc, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_dealloc_impl)},
-    {Py_tp_methods, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_methods_impl)},
+    {Py_tp_dealloc,
+     reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_dealloc_impl)},
+    {Py_tp_methods,
+     reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_methods_impl)},
     {Py_tp_init, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_init_impl)},
     {Py_tp_alloc, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_alloc_impl)},
     {Py_tp_new, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_new_impl)},
     {Py_tp_free, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_free_impl)},
-    {0, nullptr}
-};
+    {0, nullptr}};
 
 // Designated initializers are a C++20 feature:
 // https://en.cppreference.com/w/cpp/language/aggregate_initialization#Designated_initializers
@@ -70,17 +71,16 @@ PYBIND11_WARNING_DISABLE_CLANG("-Wmissing-field-initializers")
 #if defined(__GNUC__) && __GNUC__ >= 8
 PYBIND11_WARNING_DISABLE_GCC("-Wmissing-field-initializers")
 #endif
-static PyType_Spec function_record_PyType_Spec = {
-    function_record_PyTypeObject_methods::tp_name_impl,
-    sizeof(function_record_PyObject),
-    0,
-    Py_TPFLAGS_DEFAULT,
-    function_record_PyType_Slots
-};
+static PyType_Spec function_record_PyType_Spec
+    = {function_record_PyTypeObject_methods::tp_name_impl,
+       sizeof(function_record_PyObject),
+       0,
+       Py_TPFLAGS_DEFAULT,
+       function_record_PyType_Slots};
 PYBIND11_WARNING_POP
 
 inline void function_record_PyTypeObject_PyType_Ready() {
-    auto& type = detail::get_internals().function_record;
+    auto &type = detail::get_internals().function_record;
     if (!type) {
         PyObject *type_obj = PyType_FromSpec(&function_record_PyType_Spec);
         if (type_obj == nullptr) {
@@ -97,7 +97,7 @@ inline bool is_function_record_PyObject(PyObject *obj) {
     PyTypeObject *obj_type = Py_TYPE(obj);
 
     auto *frtype = detail::get_internals().function_record;
-    
+
     // Fast path (pointer comparison).
     if (obj_type == frtype) {
         return true;
@@ -117,7 +117,8 @@ inline function_record *function_record_ptr_from_PyObject(PyObject *obj) {
 }
 
 inline object function_record_PyObject_New() {
-    auto *py_func_rec = PyObject_New(function_record_PyObject, detail::get_internals().function_record);
+    auto *py_func_rec
+        = PyObject_New(function_record_PyObject, detail::get_internals().function_record);
     if (py_func_rec == nullptr) {
         throw error_already_set();
     }

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -47,7 +47,7 @@ static PyMethodDef tp_methods_impl[]
 
 // Note that this name is versioned.
 constexpr char tp_name_impl[]
-    = "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
+    = "__main__.pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
       "_" PYBIND11_PLATFORM_ABI_ID;
 
 PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -46,7 +46,11 @@ static PyMethodDef tp_methods_impl[]
        {nullptr, nullptr, 0, nullptr}};
 
 // Note that this name is versioned.
-constexpr char tp_name_impl[]
+constexpr char tp_qualname_impl[] = PYBIND11_INTERNAL_MODULE_NAME
+    "."
+    "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
+    "_" PYBIND11_PLATFORM_ABI_ID;
+constexpr char tp_plainname_impl[]
     = "pybind11_detail_function_record_" PYBIND11_DETAIL_FUNCTION_RECORD_ABI_ID
       "_" PYBIND11_PLATFORM_ABI_ID;
 
@@ -72,10 +76,10 @@ PYBIND11_WARNING_DISABLE_CLANG("-Wmissing-field-initializers")
 PYBIND11_WARNING_DISABLE_GCC("-Wmissing-field-initializers")
 #endif
 static PyType_Spec function_record_PyType_Spec
-    = {function_record_PyTypeObject_methods::tp_name_impl,
+    = {function_record_PyTypeObject_methods::tp_qualname_impl,
        sizeof(function_record_PyObject),
        0,
-       Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE,
+       Py_TPFLAGS_DEFAULT,
        function_record_PyType_Slots};
 PYBIND11_WARNING_POP
 
@@ -86,7 +90,6 @@ inline PyTypeObject *get_function_record_PyTypeObject() {
         if (type_obj == nullptr) {
             throw error_already_set();
         }
-        setattr(type_obj, "__module__", str(PYBIND11_INTERNAL_MODULE_NAME));
         type = reinterpret_cast<PyTypeObject *>(type_obj);
     }
     return type;
@@ -105,7 +108,9 @@ inline bool is_function_record_PyObject(PyObject *obj) {
         return true;
     }
     // This works across extension modules. Note that tp_name is versioned.
-    if (strcmp(obj_type->tp_name, frtype->tp_name) == 0) {
+    if (strcmp(obj_type->tp_name, function_record_PyTypeObject_methods::tp_qualname_impl) == 0
+        || strcmp(obj_type->tp_name, function_record_PyTypeObject_methods::tp_plainname_impl)
+               == 0) {
         return true;
     }
     return false;

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -52,6 +52,16 @@ constexpr char tp_name_impl[]
 
 PYBIND11_NAMESPACE_END(function_record_PyTypeObject_methods)
 
+static PyType_Slot function_record_PyType_Slots[] = {
+    {Py_tp_dealloc, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_dealloc_impl)},
+    {Py_tp_methods, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_methods_impl)},
+    {Py_tp_init, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_init_impl)},
+    {Py_tp_alloc, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_alloc_impl)},
+    {Py_tp_new, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_new_impl)},
+    {Py_tp_free, reinterpret_cast<void *>(function_record_PyTypeObject_methods::tp_free_impl)},
+    {0, nullptr}
+};
+
 // Designated initializers are a C++20 feature:
 // https://en.cppreference.com/w/cpp/language/aggregate_initialization#Designated_initializers
 // MSVC rejects them unless /std:c++20 is used (error code C7555).
@@ -60,67 +70,23 @@ PYBIND11_WARNING_DISABLE_CLANG("-Wmissing-field-initializers")
 #if defined(__GNUC__) && __GNUC__ >= 8
 PYBIND11_WARNING_DISABLE_GCC("-Wmissing-field-initializers")
 #endif
-static PyTypeObject function_record_PyTypeObject = {
-    PyVarObject_HEAD_INIT(nullptr, 0)
-    /* const char *tp_name */ function_record_PyTypeObject_methods::tp_name_impl,
-    /* Py_ssize_t tp_basicsize */ sizeof(function_record_PyObject),
-    /* Py_ssize_t tp_itemsize */ 0,
-    /* destructor tp_dealloc */ function_record_PyTypeObject_methods::tp_dealloc_impl,
-    /* Py_ssize_t tp_vectorcall_offset */ 0,
-    /* getattrfunc tp_getattr */ nullptr,
-    /* setattrfunc tp_setattr */ nullptr,
-    /* PyAsyncMethods *tp_as_async */ nullptr,
-    /* reprfunc tp_repr */ nullptr,
-    /* PyNumberMethods *tp_as_number */ nullptr,
-    /* PySequenceMethods *tp_as_sequence */ nullptr,
-    /* PyMappingMethods *tp_as_mapping */ nullptr,
-    /* hashfunc tp_hash */ nullptr,
-    /* ternaryfunc tp_call */ nullptr,
-    /* reprfunc tp_str */ nullptr,
-    /* getattrofunc tp_getattro */ nullptr,
-    /* setattrofunc tp_setattro */ nullptr,
-    /* PyBufferProcs *tp_as_buffer */ nullptr,
-    /* unsigned long tp_flags */ Py_TPFLAGS_DEFAULT,
-    /* const char *tp_doc */ nullptr,
-    /* traverseproc tp_traverse */ nullptr,
-    /* inquiry tp_clear */ nullptr,
-    /* richcmpfunc tp_richcompare */ nullptr,
-    /* Py_ssize_t tp_weaklistoffset */ 0,
-    /* getiterfunc tp_iter */ nullptr,
-    /* iternextfunc tp_iternext */ nullptr,
-    /* struct PyMethodDef *tp_methods */ function_record_PyTypeObject_methods::tp_methods_impl,
-    /* struct PyMemberDef *tp_members */ nullptr,
-    /* struct PyGetSetDef *tp_getset */ nullptr,
-    /* struct _typeobject *tp_base */ nullptr,
-    /* PyObject *tp_dict */ nullptr,
-    /* descrgetfunc tp_descr_get */ nullptr,
-    /* descrsetfunc tp_descr_set */ nullptr,
-    /* Py_ssize_t tp_dictoffset */ 0,
-    /* initproc tp_init */ function_record_PyTypeObject_methods::tp_init_impl,
-    /* allocfunc tp_alloc */ function_record_PyTypeObject_methods::tp_alloc_impl,
-    /* newfunc tp_new */ function_record_PyTypeObject_methods::tp_new_impl,
-    /* freefunc tp_free */ function_record_PyTypeObject_methods::tp_free_impl,
-    /* inquiry tp_is_gc */ nullptr,
-    /* PyObject *tp_bases */ nullptr,
-    /* PyObject *tp_mro */ nullptr,
-    /* PyObject *tp_cache */ nullptr,
-    /* PyObject *tp_subclasses */ nullptr,
-    /* PyObject *tp_weaklist */ nullptr,
-    /* destructor tp_del */ nullptr,
-    /* unsigned int tp_version_tag */ 0,
-    /* destructor tp_finalize */ nullptr,
-    /* vectorcallfunc tp_vectorcall */ nullptr,
+static PyType_Spec function_record_PyType_Spec = {
+    function_record_PyTypeObject_methods::tp_name_impl,
+    sizeof(function_record_PyObject),
+    0,
+    Py_TPFLAGS_DEFAULT,
+    function_record_PyType_Slots
 };
 PYBIND11_WARNING_POP
 
-static bool function_record_PyTypeObject_PyType_Ready_first_call = true;
-
 inline void function_record_PyTypeObject_PyType_Ready() {
-    if (function_record_PyTypeObject_PyType_Ready_first_call) {
-        if (PyType_Ready(&function_record_PyTypeObject) < 0) {
+    auto& type = detail::get_internals().function_record;
+    if (!type) {
+        PyObject *type_obj = PyType_FromSpec(&function_record_PyType_Spec);
+        if (type_obj == nullptr) {
             throw error_already_set();
         }
-        function_record_PyTypeObject_PyType_Ready_first_call = false;
+        type = reinterpret_cast<PyTypeObject *>(type_obj);
     }
 }
 
@@ -129,12 +95,15 @@ inline bool is_function_record_PyObject(PyObject *obj) {
         return false;
     }
     PyTypeObject *obj_type = Py_TYPE(obj);
+
+    auto *frtype = detail::get_internals().function_record;
+    
     // Fast path (pointer comparison).
-    if (obj_type == &function_record_PyTypeObject) {
+    if (obj_type == frtype) {
         return true;
     }
     // This works across extension modules. Note that tp_name is versioned.
-    if (strcmp(obj_type->tp_name, function_record_PyTypeObject.tp_name) == 0) {
+    if (frtype && strcmp(obj_type->tp_name, frtype->tp_name) == 0) {
         return true;
     }
     return false;
@@ -148,7 +117,7 @@ inline function_record *function_record_ptr_from_PyObject(PyObject *obj) {
 }
 
 inline object function_record_PyObject_New() {
-    auto *py_func_rec = PyObject_New(function_record_PyObject, &function_record_PyTypeObject);
+    auto *py_func_rec = PyObject_New(function_record_PyObject, detail::get_internals().function_record);
     if (py_func_rec == nullptr) {
         throw error_already_set();
     }

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -37,7 +37,7 @@
 /// further ABI-incompatible changes may be made before the ABI is officially
 /// changed to the new version.
 #ifndef PYBIND11_INTERNALS_VERSION
-#    define PYBIND11_INTERNALS_VERSION 12
+#    define PYBIND11_INTERNALS_VERSION 11
 #endif
 
 #if PYBIND11_INTERNALS_VERSION < 11
@@ -125,7 +125,7 @@ private:
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-constexpr const char *internals_function_record_capsule_name = "pybind11_function_record_capsule";
+#define PYBIND11_INTERNAL_MODULE_NAME "pybind11_builtins"
 
 // Forward declarations
 inline PyTypeObject *make_static_property_type();
@@ -247,7 +247,6 @@ struct internals {
                                                          // detail::c_str()
     PyTypeObject *static_property_type = nullptr;
     PyTypeObject *default_metaclass = nullptr;
-    PyTypeObject *function_record = nullptr;
     PyObject *instance_base = nullptr;
     // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
     thread_specific_storage<PyThreadState> tstate;
@@ -292,6 +291,7 @@ struct internals {
 struct local_internals {
     type_map<type_info *> registered_types_cpp;
     std::forward_list<ExceptionTranslator> registered_exception_translators;
+    PyTypeObject *function_record = nullptr;
 };
 
 enum class holder_enum_t : uint8_t {

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -37,7 +37,7 @@
 /// further ABI-incompatible changes may be made before the ABI is officially
 /// changed to the new version.
 #ifndef PYBIND11_INTERNALS_VERSION
-#    define PYBIND11_INTERNALS_VERSION 11
+#    define PYBIND11_INTERNALS_VERSION 12
 #endif
 
 #if PYBIND11_INTERNALS_VERSION < 11

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -247,6 +247,7 @@ struct internals {
                                                          // detail::c_str()
     PyTypeObject *static_property_type = nullptr;
     PyTypeObject *default_metaclass = nullptr;
+    PyTypeObject *function_record = nullptr;
     PyObject *instance_base = nullptr;
     // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
     thread_specific_storage<PyThreadState> tstate;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -132,7 +132,8 @@ private:
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
-#define PYBIND11_INTERNAL_MODULE_NAME "pybind11_builtins"
+// This does NOT actually exist as a module.
+#define PYBIND11_DUMMY_MODULE_NAME "pybind11_builtins"
 
 // Forward declarations
 inline PyTypeObject *make_static_property_type();

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -299,7 +299,7 @@ struct internals {
 struct local_internals {
     type_map<type_info *> registered_types_cpp;
     std::forward_list<ExceptionTranslator> registered_exception_translators;
-    PyTypeObject *function_record = nullptr;
+    PyTypeObject *function_record_py_type = nullptr;
 };
 
 enum class holder_enum_t : uint8_t {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -631,7 +631,6 @@ protected:
                 = reinterpret_cast<PyCFunction>(reinterpret_cast<void (*)()>(dispatcher));
             rec->def->ml_flags = METH_VARARGS | METH_KEYWORDS;
 
-            detail::function_record_PyTypeObject_PyType_Ready(); // Call-once initialization.
             object py_func_rec = detail::function_record_PyObject_New();
             ((detail::function_record_PyObject *) py_func_rec.ptr())->cpp_func_rec
                 = unique_rec.release();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3150,9 +3150,7 @@ template <typename InputType, typename OutputType>
 void implicitly_convertible() {
     struct set_flag {
         thread_specific_storage<set_flag> &flag;
-        explicit set_flag(thread_specific_storage<set_flag> &flag_) : flag(flag_) {
-            flag = this;
-        }
+        explicit set_flag(thread_specific_storage<set_flag> &flag_) : flag(flag_) { flag = this; }
         ~set_flag() { flag.reset(); }
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3154,7 +3154,8 @@ void implicitly_convertible() {
         ~set_flag() { flag = false; }
     };
     bool currently_used = false;
-    auto implicit_caster = [currently_used](PyObject *obj, PyTypeObject *type) mutable -> PyObject * {
+    auto implicit_caster
+        = [currently_used](PyObject *obj, PyTypeObject *type) mutable -> PyObject * {
         if (currently_used) { // implicit conversions are non-reentrant
             return nullptr;
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3153,12 +3153,8 @@ void implicitly_convertible() {
         explicit set_flag(bool &flag_) : flag(flag_) { flag_ = true; }
         ~set_flag() { flag = false; }
     };
-    auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {
-#ifdef Py_GIL_DISABLED
-        thread_local bool currently_used = false;
-#else
-        static bool currently_used = false;
-#endif
+    bool currently_used = false;
+    auto implicit_caster = [currently_used](PyObject *obj, PyTypeObject *type) mutable -> PyObject * {
         if (currently_used) { // implicit conversions are non-reentrant
             return nullptr;
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3150,7 +3150,9 @@ template <typename InputType, typename OutputType>
 void implicitly_convertible() {
     struct set_flag {
         thread_specific_storage<flag_reset> &flag;
-        explicit set_flag(thread_specific_storage<flag_reset> &flag_) : flag(flag_) { flag = this; }
+        explicit set_flag(thread_specific_storage<flag_reset> &flag_) : flag(flag_) {
+            flag = this;
+        }
         ~set_flag() { flag.reset(); }
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3148,17 +3148,17 @@ typing::Iterator<ValueType> make_value_iterator(Type &value, Extra &&...extra) {
 
 template <typename InputType, typename OutputType>
 void implicitly_convertible() {
-    struct flag_reset {
+    struct set_flag {
         thread_specific_storage<flag_reset> &flag;
-        flag_reset(thread_specific_storage<flag_reset> &flag_) : flag(flag_) { flag = this; }
-        ~flag_reset() { flag.reset(); }
+        explicit set_flag(thread_specific_storage<flag_reset> &flag_) : flag(flag_) { flag = this; }
+        ~set_flag() { flag.reset(); }
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {
         static thread_specific_storage<flag_reset> currently_used;
         if (currently_used) { // implicit conversions are non-reentrant
             return nullptr;
         }
-        flag_reset flag_helper(currently_used);
+        set_flag flag_helper(currently_used);
         if (!detail::make_caster<InputType>().load(obj, false)) {
             return nullptr;
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3149,14 +3149,14 @@ typing::Iterator<ValueType> make_value_iterator(Type &value, Extra &&...extra) {
 template <typename InputType, typename OutputType>
 void implicitly_convertible() {
     struct set_flag {
-        thread_specific_storage<flag_reset> &flag;
-        explicit set_flag(thread_specific_storage<flag_reset> &flag_) : flag(flag_) {
+        thread_specific_storage<set_flag> &flag;
+        explicit set_flag(thread_specific_storage<set_flag> &flag_) : flag(flag_) {
             flag = this;
         }
         ~set_flag() { flag.reset(); }
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {
-        static thread_specific_storage<flag_reset> currently_used;
+        static thread_specific_storage<set_flag> currently_used;
         if (currently_used) { // implicit conversions are non-reentrant
             return nullptr;
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3148,15 +3148,13 @@ typing::Iterator<ValueType> make_value_iterator(Type &value, Extra &&...extra) {
 
 template <typename InputType, typename OutputType>
 void implicitly_convertible() {
-    struct flag_reset;
-    using flag_type = thread_specific_storage<flag_reset>;
     struct flag_reset {
-        flag_type &flag;
-        flag_reset(flag_type &flag_) : flag(flag_) { flag = this; }
+        thread_specific_storage<flag_reset> &flag;
+        flag_reset(thread_specific_storage<flag_reset> &flag_) : flag(flag_) { flag = this; }
         ~flag_reset() { flag.reset(); }
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {
-        static flag_type currently_used;
+        static thread_specific_storage<flag_reset> currently_used;
         if (currently_used) { // implicit conversions are non-reentrant
             return nullptr;
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3148,12 +3148,16 @@ typing::Iterator<ValueType> make_value_iterator(Type &value, Extra &&...extra) {
 template <typename InputType, typename OutputType>
 void implicitly_convertible() {
     struct set_flag {
-        thread_specific_storage<set_flag> &flag;
-        explicit set_flag(thread_specific_storage<set_flag> &flag_) : flag(flag_) { flag = this; }
-        ~set_flag() { flag.reset(); }
+        bool &flag;
+        explicit set_flag(bool &flag_) : flag(flag_) { flag_ = true; }
+        ~set_flag() { flag = false; }
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {
-        static thread_specific_storage<set_flag> currently_used;
+#ifdef Py_GIL_DISABLED
+        thread_local bool currently_used = false;
+#else
+        static bool currently_used = false;
+#endif
         if (currently_used) { // implicit conversions are non-reentrant
             return nullptr;
         }

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -286,13 +286,7 @@ TEST_SUBMODULE(callbacks, m) {
         return &def;
     }();
 
-    // rec_capsule with name that has the same value (but not pointer) as our internal one
-    // This capsule should be detected by our code as foreign and not inspected as the pointers
-    // shouldn't match
-    constexpr const char *rec_capsule_name
-        = pybind11::detail::internals_function_record_capsule_name;
     py::capsule rec_capsule(std::malloc(1), [](void *data) { std::free(data); });
-    rec_capsule.set_name(rec_capsule_name);
     m.add_object("custom_function", PyCFunction_New(custom_def, rec_capsule.ptr()));
 
     // rec_capsule with nullptr name


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
I think I have tracked down the sporadic unit test failure/crash.  

The function record type is using a global static type definition, which is not subinterpreter safe. It needs to use a heap type which is registered with each (sub)interpreter.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Fixed potential crash when using cpp_function objects with sub-interpreters. 


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5771.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->