### PR TITLE
Fix `type_caster_enum_type` for pointer types

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -76,6 +76,11 @@ public:
             parent);
     }
 
+    template <typename SrcType>
+    static handle cast(SrcType *src, return_value_policy policy, handle parent) {
+        return cast(*src, policy, parent);
+    }
+
     bool load(handle src, bool convert) {
         handle native_enum
             = global_internals_native_enum_type_map_get_item(std::type_index(typeid(EnumType)));

--- a/tests/test_native_enum.cpp
+++ b/tests/test_native_enum.cpp
@@ -136,6 +136,15 @@ TEST_SUBMODULE(native_enum, m) {
     m.def("pass_color", [](color e) { return static_cast<int>(e); });
     m.def("return_color", [](int i) { return static_cast<color>(i); });
 
+    m.def("return_color_const_ptr", []() -> const color * {
+        static const color test_color = color::red;
+        return &test_color;
+    });
+    m.def("return_color_mutbl_ptr", []() -> color * {
+        static color test_color = color::green;
+        return &test_color;
+    });
+
     py::native_enum<func_sig_rendering>(m, "func_sig_rendering", "enum.Enum").finalize();
     m.def(
         "pass_and_return_func_sig_rendering",

--- a/tests/test_native_enum.py
+++ b/tests/test_native_enum.py
@@ -153,6 +153,11 @@ def test_return_color_fail():
     assert str(excinfo_cast.value) == str(excinfo_direct.value)
 
 
+def test_return_color_ptr():
+    assert m.return_color_const_ptr() == m.color.red
+    assert m.return_color_mutbl_ptr() == m.color.green
+
+
 def test_property_type_hint():
     prop = m.class_with_enum.__dict__["nested_value"]
     assert isinstance(prop, property)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Closes #5694

Add pointer overload to `type_caster_enum_type::cast` method to handle enum pointer casting. Fixes compilation error when returning pointers to enum types from bound functions.

Experiment for validation:

Temporarily undo the changes in include/pybind11/cast.h:

```
g++ -o pybind11/tests/test_native_enum.os -c -std=c++20 -fPIC -fvisibility=hidden -O0 -g -Wall -Wextra -Wconversion -Wcast-qual -Wdeprecated -Wundef -Wnon-virtual-dtor -Wunused-result -Werror -funsigned-char -Wpedantic -isystem /usr/include/python3.12 -isystem /usr/include/eigen3 -DPYBIND11_SMART_HOLDER_PADDING_ON -DPYBIND11_STRICT_ASSERTS_CLASS_HOLDER_VS_TYPE_CASTER_MIX -DPYBIND11_ENABLE_TYPE_CASTER_ODR_GUARD_IF_AVAILABLE -DPYBIND11_TEST_BOOST -Ipybind11/include -I/home/rgrossekunst/forked/pybind11/include -I/home/rgrossekunst/clone/pybind11/include /home/rgrossekunst/forked/pybind11/tests/test_native_enum.cpp
In file included from /home/rgrossekunst/forked/pybind11/include/pybind11/native_enum.h:10,
                 from /home/rgrossekunst/forked/pybind11/tests/test_native_enum.cpp:1:
/home/rgrossekunst/forked/pybind11/include/pybind11/cast.h: In instantiation of ‘static pybind11::handle pybind11::detail::type_caster_enum_type<EnumType>::cast(SrcType&&, pybind11::return_value_policy, pybind11::handle) [with SrcType = const test_native_enum::color*; EnumType = test_native_enum::color]’:
/home/rgrossekunst/forked/pybind11/include/pybind11/pybind11.h:429:40:   required from ‘void pybind11::cpp_function::initialize(Func&&, Return (*)(Args ...), const Extra& ...) [with Func = test_submodule_native_enum(pybind11::module_&)::<lambda()>; Return = const test_native_enum::color*; Args = {}; Extra = {pybind11::name, pybind11::scope, pybind11::sibling}]’
/home/rgrossekunst/forked/pybind11/include/pybind11/pybind11.h:274:19:   required from ‘pybind11::cpp_function::cpp_function(Func&&, const Extra& ...) [with Func = test_submodule_native_enum(pybind11::module_&)::<lambda()>; Extra = {pybind11::name, pybind11::scope, pybind11::sibling}; <template-parameter-1-3> = void]’
/home/rgrossekunst/forked/pybind11/include/pybind11/pybind11.h:1384:22:   required from ‘pybind11::module_& pybind11::module_::def(const char*, Func&&, const Extra& ...) [with Func = test_submodule_native_enum(pybind11::module_&)::<lambda()>; Extra = {}]’
/home/rgrossekunst/forked/pybind11/tests/test_native_enum.cpp:139:10:   required from here
/home/rgrossekunst/forked/pybind11/include/pybind11/cast.h:70:32: error: invalid ‘static_cast’ from type ‘const test_native_enum::color*’ to type ‘pybind11::detail::type_caster_enum_type<test_native_enum::color>::Underlying’ {aka ‘unsigned int’}
   70 |             return native_enum(static_cast<Underlying>(src)).release();
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rgrossekunst/forked/pybind11/include/pybind11/cast.h: In instantiation of ‘static pybind11::handle pybind11::detail::type_caster_enum_type<EnumType>::cast(SrcType&&, pybind11::return_value_policy, pybind11::handle) [with SrcType = test_native_enum::color*; EnumType = test_native_enum::color]’:
/home/rgrossekunst/forked/pybind11/include/pybind11/pybind11.h:429:40:   required from ‘void pybind11::cpp_function::initialize(Func&&, Return (*)(Args ...), const Extra& ...) [with Func = test_submodule_native_enum(pybind11::module_&)::<lambda()>; Return = test_native_enum::color*; Args = {}; Extra = {pybind11::name, pybind11::scope, pybind11::sibling}]’
/home/rgrossekunst/forked/pybind11/include/pybind11/pybind11.h:274:19:   required from ‘pybind11::cpp_function::cpp_function(Func&&, const Extra& ...) [with Func = test_submodule_native_enum(pybind11::module_&)::<lambda()>; Extra = {pybind11::name, pybind11::scope, pybind11::sibling}; <template-parameter-1-3> = void]’
/home/rgrossekunst/forked/pybind11/include/pybind11/pybind11.h:1384:22:   required from ‘pybind11::module_& pybind11::module_::def(const char*, Func&&, const Extra& ...) [with Func = test_submodule_native_enum(pybind11::module_&)::<lambda()>; Extra = {}]’
/home/rgrossekunst/forked/pybind11/tests/test_native_enum.cpp:143:10:   required from here
/home/rgrossekunst/forked/pybind11/include/pybind11/cast.h:70:32: error: invalid ‘static_cast’ from type ‘test_native_enum::color*’ to type ‘pybind11::detail::type_caster_enum_type<test_native_enum::color>::Underlying’ {aka ‘unsigned int’}
```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Fixed compilation error in `type_caster_enum_type` when casting pointer-to-enum types. Added pointer overload to handle dereferencing before enum conversion.
