### PR TITLE
Make implicitly_convertable sub-interpreter and free-threading safe

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -98,7 +98,9 @@ public:
         // Neither of those have anything to do with CPython internals. PyMem_RawFree *requires*
         // that the `key` be allocated with the CPython allocator (as it is by
         // PyThread_tss_create).
+#if !defined(GRAALVM_PYTHON)
         PYBIND11_TLS_FREE(key_);
+#endif
     }
 
     thread_specific_storage(thread_specific_storage const &) = delete;

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -101,7 +101,7 @@ public:
         // However, in GraalPy (as of v24.2 or older), TSS is implemented by Java and this call
         // requires a living Python interpreter.
 #ifdef GRAALVM_PYTHON
-        if (!Py_IsInitialized()) {
+        if (!Py_IsInitialized() || _Py_IsFinalizing()) {
             return;
         }
 #endif

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -656,6 +656,11 @@ inline local_internals &get_local_internals() {
     return *internals_ptr;
 }
 
+inline thread_specific_storage<int> &get_implicit_caster_recursion_guard() {
+    static thread_specific_storage<int> tss;
+    return tss;
+}
+
 #ifdef Py_GIL_DISABLED
 #    define PYBIND11_LOCK_INTERNALS(internals) std::unique_lock<pymutex> lock((internals).mutex)
 #else

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -663,11 +663,6 @@ inline local_internals &get_local_internals() {
     return *internals_ptr;
 }
 
-inline thread_specific_storage<int> &get_implicit_caster_recursion_guard() {
-    static thread_specific_storage<int> tss;
-    return tss;
-}
-
 #ifdef Py_GIL_DISABLED
 #    define PYBIND11_LOCK_INTERNALS(internals) std::unique_lock<pymutex> lock((internals).mutex)
 #else

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3163,7 +3163,7 @@ void implicitly_convertible() {
         set_flag &operator=(set_flag &&) = delete;
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {
-        auto &currently_used = detail::get_implicit_caster_recursion_guard();
+        static thread_specific_storage<int> currently_used;
         if (currently_used) { // implicit conversions are non-reentrant
             return nullptr;
         }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3155,6 +3155,12 @@ void implicitly_convertible() {
             flag = reinterpret_cast<int *>(1);
         }
         ~set_flag() { flag.reset(nullptr); }
+
+        // Prevent copying/moving to ensure RAII guard is used safely
+        set_flag(const set_flag &) = delete;
+        set_flag(set_flag &&) = delete;
+        set_flag &operator=(const set_flag &) = delete;
+        set_flag &operator=(set_flag &&) = delete;
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {
         auto &currently_used = detail::get_implicit_caster_recursion_guard();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3148,11 +3148,11 @@ typing::Iterator<ValueType> make_value_iterator(Type &value, Extra &&...extra) {
 
 template <typename InputType, typename OutputType>
 void implicitly_convertible() {
+    static int tss_sentinel_pointee = 1; // arbitrary value
     struct set_flag {
         thread_specific_storage<int> &flag;
-        // tss holds a pointer, we abuse it to hold an integral value instead
         explicit set_flag(thread_specific_storage<int> &flag_) : flag(flag_) {
-            flag = reinterpret_cast<int *>(1);
+            flag = &tss_sentinel_pointee; // trick: the pointer itself is the sentinel
         }
         ~set_flag() { flag.reset(nullptr); }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
This code in `implicitly_convertible()` was using a `static bool` which is not sub-interpreter safe.

The free-threading code attempted to make this thread safe by making it a `thread_local`, but `thread_local` does not work on some older macOS targets, so the correct way to fix this is to use thread-specific-storage.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Fixed non-entrant check in `implicitly_convertible()` 
