### PR TITLE
Allow multiphase modules to be re-imported

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -455,11 +455,9 @@ PyModuleDef_Init should be treated like any other PyObject (so not shared across
     int PYBIND11_CONCAT(pybind11_exec_, name)(PyObject * pm) {                                    \
         try {                                                                                     \
             auto m = pybind11::reinterpret_borrow<::pybind11::module_>(pm);                       \
-            auto mod_spec_name = pybind11::getattr(                                               \
-                pybind11::getattr(m, "__spec__", pybind11::none()), "name", pybind11::none());    \
-            if (!pybind11::detail::get_cached_module(mod_spec_name)) {                            \
+            if (!pybind11::detail::get_cached_module(m.attr("__spec__").attr("name"))) {          \
                 PYBIND11_CONCAT(pybind11_init_, name)(m);                                         \
-                pybind11::detail::cache_completed_module(mod_spec_name, m);                       \
+                pybind11::detail::cache_completed_module(m);                                      \
             }                                                                                     \
             return 0;                                                                             \
         }                                                                                         \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -455,7 +455,11 @@ PyModuleDef_Init should be treated like any other PyObject (so not shared across
     int PYBIND11_CONCAT(pybind11_exec_, name)(PyObject * pm) {                                    \
         try {                                                                                     \
             auto m = pybind11::reinterpret_borrow<::pybind11::module_>(pm);                       \
-            PYBIND11_CONCAT(pybind11_init_, name)(m);                                             \
+            if (!pybind11::detail::get_cached_module(pybind11::getattr(                           \
+                    pybind11::getattr(m, "__spec__", m), "name", pybind11::none()))) {            \
+                PYBIND11_CONCAT(pybind11_init_, name)(m);                                         \
+                pybind11::detail::cache_completed_module(m);                                      \
+            }                                                                                     \
             return 0;                                                                             \
         }                                                                                         \
         PYBIND11_CATCH_INIT_EXCEPTIONS                                                            \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -455,8 +455,9 @@ PyModuleDef_Init should be treated like any other PyObject (so not shared across
     int PYBIND11_CONCAT(pybind11_exec_, name)(PyObject * pm) {                                    \
         try {                                                                                     \
             auto m = pybind11::reinterpret_borrow<::pybind11::module_>(pm);                       \
-            if (!pybind11::detail::get_cached_module(pybind11::getattr(                           \
-                    pybind11::getattr(m, "__spec__", m), "name", pybind11::none()))) {            \
+            auto mod_spec_name = pybind11::getattr(                                               \
+                pybind11::getattr(m, "__spec__", pybind11::none()), "name", pybind11::none());    \
+            if (!pybind11::detail::get_cached_module(mod_spec_name)) {                            \
                 PYBIND11_CONCAT(pybind11_init_, name)(m);                                         \
                 pybind11::detail::cache_completed_module(m);                                      \
             }                                                                                     \

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -459,7 +459,7 @@ PyModuleDef_Init should be treated like any other PyObject (so not shared across
                 pybind11::getattr(m, "__spec__", pybind11::none()), "name", pybind11::none());    \
             if (!pybind11::detail::get_cached_module(mod_spec_name)) {                            \
                 PYBIND11_CONCAT(pybind11_init_, name)(m);                                         \
-                pybind11::detail::cache_completed_module(m);                                      \
+                pybind11::detail::cache_completed_module(mod_spec_name, m);                       \
             }                                                                                     \
             return 0;                                                                             \
         }                                                                                         \

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1348,16 +1348,14 @@ inline PyObject *get_cached_module(pybind11::str const &nameobj) {
 /*
 Add successfully initialized a module object to the internal cache.
 */
-inline void cache_completed_module(pybind11::object mod) {
-    auto spec = getattr(mod, "__spec__", none());
-    if (spec.is_none()) {
-        pybind11_fail("Module has no __spec__!");
+inline void cache_completed_module(pybind11::str const &nameobj, pybind11::object const &mod) {
+    if (!nameobj.is_none()) {
+        dict state = detail::get_python_state_dict();
+        if (!state.contains("__pybind11_module_cache")) {
+            state["__pybind11_module_cache"] = dict();
+        }
+        state["__pybind11_module_cache"][nameobj] = mod;
     }
-    dict state = detail::get_python_state_dict();
-    if (!state.contains("__pybind11_module_cache")) {
-        state["__pybind11_module_cache"] = dict();
-    }
-    state["__pybind11_module_cache"][spec.attr("name")] = mod;
 }
 
 /*

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1357,7 +1357,7 @@ inline void cache_completed_module(pybind11::object mod) {
     if (!state.contains("__pybind11_module_cache")) {
         state["__pybind11_module_cache"] = dict();
     }
-    state["__pybind11_module_cache"][spec.attr("name")(spec, "name")] = mod;
+    state["__pybind11_module_cache"][spec.attr("name")] = mod;
 }
 
 /*

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1363,7 +1363,7 @@ A Py_mod_create slot function which will return the previously created module fr
 exists, and otherwise will create a new module object.
 */
 inline PyObject *cached_create_module(PyObject *spec, PyModuleDef *) {
-    (void) cache_completed_module; // silence unused-function warnings, it is used in a macro
+    (void) &cache_completed_module; // silence unused-function warnings, it is used in a macro
 
     auto nameobj = getattr(reinterpret_borrow<object>(spec), "name", none());
     if (nameobj.is_none()) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1329,9 +1329,56 @@ inline void *multi_interp_slot(F &&, O &&...o) {
 }
 #endif
 
+/*
+Return a borrowed reference to the named module if it has been successfully initialized within this
+interpreter before. nullptr if it has not been successfully initialized.
+*/
+static PyObject *get_cached_module(pybind11::str const &nameobj) {
+    dict state = detail::get_python_state_dict();
+    if (!state.contains("__pybind11_module_cache")) {
+        return nullptr;
+    }
+    dict cache = state["__pybind11_module_cache"];
+    if (!cache.contains(nameobj)) {
+        return nullptr;
+    }
+    return cache[nameobj].ptr();
+}
+
+/*
+Add successfully initialized a module object to the internal cache.
+*/
+static void cache_completed_module(pybind11::object mod) {
+    auto nameobj = getattr(getattr(mod, "__spec__", mod), "name", none());
+    dict state = detail::get_python_state_dict();
+    if (!state.contains("__pybind11_module_cache")) {
+        state["__pybind11_module_cache"] = dict();
+    }
+    state["__pybind11_module_cache"][nameobj] = mod;
+}
+
+/*
+A Py_mod_create slot function which will return the previously created module from the cache if one
+exists, and otherwise will create a new module object.
+*/
+static PyObject *cached_create_module(PyObject *spec, PyModuleDef *) {
+    (void) &cache_completed_module; // silence unused-function warnings, it is used in a macro
+
+    auto nameobj = reinterpret_steal<str>(PyObject_GetAttrString(spec, "name"));
+    auto cached = get_cached_module(nameobj);
+
+    if (cached) {
+        Py_INCREF(cached);
+        return cached;
+    } else {
+        Py_INCREF(nameobj.ptr());
+        return PyModule_NewObject(nameobj.ptr());
+    }
+}
+
 /// Must be a POD type, and must hold enough entries for all of the possible slots PLUS ONE for
 /// the sentinel (0) end slot.
-using slots_array = std::array<PyModuleDef_Slot, 4>;
+using slots_array = std::array<PyModuleDef_Slot, 5>;
 
 /// Initialize an array of slots based on the supplied exec slot and options.
 template <typename... Options>
@@ -1340,6 +1387,8 @@ static slots_array init_slots(int (*exec_fn)(PyObject *), Options &&...options) 
     here, you MUST also increase the size of slots_array in the type alias above! */
     slots_array slots;
     size_t next_slot = 0;
+
+    slots[next_slot++] = {Py_mod_create, reinterpret_cast<void *>(&cached_create_module)};
 
     if (exec_fn != nullptr) {
         slots[next_slot++] = {Py_mod_exec, reinterpret_cast<void *>(exec_fn)};

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1365,15 +1365,16 @@ static inline PyObject *cached_create_module(PyObject *spec, PyModuleDef *) {
     (void) &cache_completed_module; // silence unused-function warnings, it is used in a macro
 
     auto nameobj = reinterpret_steal<str>(PyObject_GetAttrString(spec, "name"));
-    auto cached = get_cached_module(nameobj);
+    printf("WTF %s\n", cast<std::string>(str(spec)).c_str());
+    auto *cached = get_cached_module(nameobj);
 
     if (cached) {
         Py_INCREF(cached);
         return cached;
-    } else {
-        Py_INCREF(nameobj.ptr());
-        return PyModule_NewObject(nameobj.ptr());
     }
+
+    Py_INCREF(nameobj.ptr());
+    return PyModule_NewObject(nameobj.ptr());
 }
 
 /// Must be a POD type, and must hold enough entries for all of the possible slots PLUS ONE for

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1374,8 +1374,7 @@ inline PyObject *cached_create_module(PyObject *spec, PyModuleDef *) {
     auto *mod = get_cached_module(nameobj);
     if (mod) {
         Py_INCREF(mod);
-    }
-    else {
+    } else {
         mod = PyModule_NewObject(nameobj.ptr());
     }
     return mod;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1365,7 +1365,6 @@ static inline PyObject *cached_create_module(PyObject *spec, PyModuleDef *) {
     (void) &cache_completed_module; // silence unused-function warnings, it is used in a macro
 
     auto nameobj = reinterpret_steal<str>(PyObject_GetAttrString(spec, "name"));
-    printf("WTF %s\n", cast<std::string>(str(spec)).c_str());
     auto *cached = get_cached_module(nameobj);
 
     if (cached) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1333,7 +1333,7 @@ inline void *multi_interp_slot(F &&, O &&...o) {
 Return a borrowed reference to the named module if it has been successfully initialized within this
 interpreter before. nullptr if it has not been successfully initialized.
 */
-static inline PyObject *get_cached_module(pybind11::str const &nameobj) {
+inline PyObject *get_cached_module(pybind11::str const &nameobj) {
     dict state = detail::get_python_state_dict();
     if (!state.contains("__pybind11_module_cache")) {
         return nullptr;
@@ -1348,7 +1348,7 @@ static inline PyObject *get_cached_module(pybind11::str const &nameobj) {
 /*
 Add successfully initialized a module object to the internal cache.
 */
-static inline void cache_completed_module(pybind11::object mod) {
+inline void cache_completed_module(pybind11::object mod) {
     auto nameobj = getattr(getattr(mod, "__spec__", mod), "name", none());
     dict state = detail::get_python_state_dict();
     if (!state.contains("__pybind11_module_cache")) {
@@ -1361,7 +1361,7 @@ static inline void cache_completed_module(pybind11::object mod) {
 A Py_mod_create slot function which will return the previously created module from the cache if one
 exists, and otherwise will create a new module object.
 */
-static inline PyObject *cached_create_module(PyObject *spec, PyModuleDef *) {
+inline PyObject *cached_create_module(PyObject *spec, PyModuleDef *) {
     (void) &cache_completed_module; // silence unused-function warnings, it is used in a macro
 
     auto nameobj = reinterpret_steal<str>(PyObject_GetAttrString(spec, "name"));
@@ -1382,7 +1382,7 @@ using slots_array = std::array<PyModuleDef_Slot, 5>;
 
 /// Initialize an array of slots based on the supplied exec slot and options.
 template <typename... Options>
-static slots_array init_slots(int (*exec_fn)(PyObject *), Options &&...options) noexcept {
+inline slots_array init_slots(int (*exec_fn)(PyObject *), Options &&...options) noexcept {
     /* NOTE: slots_array MUST be large enough to hold all possible options.  If you add an option
     here, you MUST also increase the size of slots_array in the type alias above! */
     slots_array slots;

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1333,7 +1333,7 @@ inline void *multi_interp_slot(F &&, O &&...o) {
 Return a borrowed reference to the named module if it has been successfully initialized within this
 interpreter before. nullptr if it has not been successfully initialized.
 */
-static PyObject *get_cached_module(pybind11::str const &nameobj) {
+static inline PyObject *get_cached_module(pybind11::str const &nameobj) {
     dict state = detail::get_python_state_dict();
     if (!state.contains("__pybind11_module_cache")) {
         return nullptr;
@@ -1348,7 +1348,7 @@ static PyObject *get_cached_module(pybind11::str const &nameobj) {
 /*
 Add successfully initialized a module object to the internal cache.
 */
-static void cache_completed_module(pybind11::object mod) {
+static inline void cache_completed_module(pybind11::object mod) {
     auto nameobj = getattr(getattr(mod, "__spec__", mod), "name", none());
     dict state = detail::get_python_state_dict();
     if (!state.contains("__pybind11_module_cache")) {
@@ -1361,7 +1361,7 @@ static void cache_completed_module(pybind11::object mod) {
 A Py_mod_create slot function which will return the previously created module from the cache if one
 exists, and otherwise will create a new module object.
 */
-static PyObject *cached_create_module(PyObject *spec, PyModuleDef *) {
+static inline PyObject *cached_create_module(PyObject *spec, PyModuleDef *) {
     (void) &cache_completed_module; // silence unused-function warnings, it is used in a macro
 
     auto nameobj = reinterpret_steal<str>(PyObject_GetAttrString(spec, "name"));

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -78,7 +78,7 @@ def test_reimport():
 
     del sys.modules["pybind11_tests"]
 
-    # if something is wrong, this will throw import error ... otherwise nothing happens.
+    # exercise pybind11::detail::get_cached_module()
     import pybind11_tests as y
 
     assert x is y

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -71,6 +71,19 @@ def test_importing():
     assert OD is OrderedDict
 
 
+def test_reimport():
+    import sys
+
+    import pybind11_tests as x
+
+    del sys.modules["pybind11_tests"]
+
+    # if something is wrong, this will throw import error ... otherwise nothing happens.
+    import pybind11_tests as y
+
+    assert x is y
+
+
 def test_pydoc():
     """Pydoc needs to be able to provide help() for everything inside a pybind11 module"""
     import pydoc

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -84,7 +84,7 @@ def test_reimport():
     assert x is y
 
 
-@pytest.mark.xfail("env.GRAALPY", reason="TODO should be fixed on GraalPy side")
+@pytest.mark.xfail("env.GRAALPY", reason="TODO should be fixed on GraalPy side (failure was introduced by pr #5782)")
 def test_pydoc():
     """Pydoc needs to be able to provide help() for everything inside a pybind11 module"""
     import pydoc

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -84,6 +84,7 @@ def test_reimport():
     assert x is y
 
 
+@pytest.mark.xfail("env.GRAALPY", reason="TODO should be fixed on GraalPy side")
 def test_pydoc():
     """Pydoc needs to be able to provide help() for everything inside a pybind11 module"""
     import pydoc

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -84,7 +84,10 @@ def test_reimport():
     assert x is y
 
 
-@pytest.mark.xfail("env.GRAALPY", reason="TODO should be fixed on GraalPy side (failure was introduced by pr #5782)")
+@pytest.mark.xfail(
+    "env.GRAALPY",
+    reason="TODO should be fixed on GraalPy side (failure was introduced by pr #5782)",
+)
 def test_pydoc():
     """Pydoc needs to be able to provide help() for everything inside a pybind11 module"""
     import pydoc


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

This fixes the exception reported in #5780 and gets things *close* to the behavior of single-phase module initialization.  When import is done on a single-phase module after a `del sys.modules[...]`, the single-phase module is completely reloaded and reinitialized.  

I could not get CPython will not do this to multi-phase modules (I tried a few different things).. Instead, this PR keeps a cache of fully created and initialized modules (in the interpreter state dict).  When creating a module, we look in the cache first and use the already created and initialized one if it is in there.  Otherwise we create a new one.  And then also before running the user's exec function we check in the cache.

So, with this PR, the difference is that single-phase modules are reinitialized after a `del`, and multi-phase modules silently return a cached handle to the previously initialized instance.  I think this difference is probably OK because doing a `del sys.modules[...]` is probably not very common, and even in this case it was done as part of a test setup.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Fixed issue that caused ``PYBIND11_MODULE`` code to run again if the module was re-imported after being deleted from ``sys.modules``.
