### PR TITLE
Add 'inline' keyword to fix duplicate symbols

### DIFF
--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -21,7 +21,7 @@
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
-PyInterpreterState *get_interpreter_state_unchecked() {
+inline PyInterpreterState *get_interpreter_state_unchecked() {
     auto cur_tstate = get_thread_state_unchecked();
     if (cur_tstate)
         return cur_tstate->interp;


### PR DESCRIPTION
## Description

Using `pybind11/subinterpreter.h` in multiple translation units causes duplicate symbol linking errors on `pybind11::detail::get_interpreter_state_unchecked`.  This function is defined inline but lacks the `inline` keyword, resulting in a definition of the function in every translation unit.

Example error message:
```
mold: error: duplicate symbol: .../serve.cpp.o: .../embedded_python.cpp.o: pybind11::detail::get_interpreter_state_unchecked()
mold: error: duplicate symbol: .../main.cpp.o: .../embedded_python.cpp.o: pybind11::detail::get_interpreter_state_unchecked()
mold: error: duplicate symbol: .../template_controller.cpp.o: .../embedded_python.cpp.o: pybind11::detail::get_interpreter_state_unchecked()
```

This PR simply adds the inline keyword.
