### PR TITLE
fix(cmake): LTO warning of gcc >= 11.4

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -364,6 +364,11 @@ function(_pybind11_generate_lto target prefer_thin_lto)
     endif()
     if(NOT HAS_FLTO_THIN)
       _pybind11_return_if_cxx_and_linker_flags_work(
+        HAS_FLTO_AUTO "-flto=auto${cxx_append}" "-flto=auto${linker_append}"
+        PYBIND11_LTO_CXX_FLAGS PYBIND11_LTO_LINKER_FLAGS)
+    endif()
+    if(NOT HAS_FLTO_AUTO)
+      _pybind11_return_if_cxx_and_linker_flags_work(
         HAS_FLTO "-flto${cxx_append}" "-flto${linker_append}" PYBIND11_LTO_CXX_FLAGS
         PYBIND11_LTO_LINKER_FLAGS)
     endif()


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

gcc >= 11.4 issues the following warning with `-flto`:
`lto-wrapper: warning: using serial compilation of n LTRANS jobs`

According to [this stackoverflow issue](https://stackoverflow.com/questions/72218980/gcc-v12-1-warning-about-serial-compilation), we need to use `-flto=auto`.


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Fix gcc 11.4+ warning about serial compilation.