### PR TITLE
Fix subinterpreter exception handling SEGFAULT

### DIFF
--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -280,22 +280,6 @@ inline subinterpreter_scoped_activate::~subinterpreter_scoped_activate() {
         // We were on this interpreter already, so just make sure the GIL goes back as it was
         PyGILState_Release(gil_state_);
     } else {
-#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
-        try {
-            const auto ex = std::current_exception();
-            if (ex) {
-                std::rethrow_exception(ex);
-            }
-        } catch (error_already_set &) {
-            // Because error_already_set holds python objects and what() acquires the GIL, it
-            // is basically never OK to let these exceptions propagate outside the current
-            // active interpreter.
-            pybind11_fail("~subinterpreter_scoped_activate: cannot propagate Python "
-                          "exceptions outside of their owning interpreter");
-        } catch (...) {
-        }
-#endif
-
         if (tstate_) {
 #if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
             if (detail::get_thread_state_unchecked() != tstate_) {


### PR DESCRIPTION
## Description

pybind11 version: b67d07eea6b6091854d70b13d2fde65fc984f2d9

The [destructor](https://github.com/pybind/pybind11/blob/master/include/pybind11/subinterpreter.h#L284-L293) of `subinterpreter_scoped_activate` tests for `std::uncaught_exceptions` to throw `std::current_exception`. These are two independent states that are unrelated to each other. As such, the destructor can easily SEGFAULT when throwing a `nullptr` from `std::current_exception()`. The following example causes a SEGFAULT on `std::rethrow_exception`, [here](https://github.com/pybind/pybind11/blob/master/include/pybind11/subinterpreter.h#L293)

```c++
#include <pybind11/embed.h>
#include <pybind11/subinterpreter.h>

int main()
{
  namespace py = pybind11;
  try {
    const py::scoped_interpreter python{};
    const py::scoped_subinterpreter subpy{};
    throw "ahhh";
  }
  catch (...) {
    // try-catch avoids immediately terminating at 'throw' from main
  }
}
``` 

### Explaining the issue:

The `subinterpreter_scoped_activate` inside `scoped_subinterpreter` is being destroyed from stack unwinding. Therefore, `std::uncaught_exceptions` is 1, since this merely counts the number of in-flight exceptions. The current destructor would consequently try to throw `std::current_exception()`. However, `std::current_exception()` returns `nullptr`, as the destructor is not called from a catch block, where `std::current_exception()` returns the currently handled exception of the enclosing catch block - for which there is none.


## Changes

The intention of the original code seems to be halting the stack unwinding of any in-flight exception that happens to be a `py::error_already_set`. I don't believe that's possible. In any case, checking the result of `std::current_exception()` is necessary to avoid the SEGFAULT, and removing the check on `std::uncaught_exceptions()` retains the existing behaviour, but not what I perceive the intention to be.