### PR TITLE
ci: avoid macOS 15 image change for iOS

### DIFF
--- a/.github/workflows/tests-cibw.yml
+++ b/.github/workflows/tests-cibw.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-latest, macos-13]
+        runs-on: [macos-14, macos-13]
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


See if we can work around the image change while we find a better solution.

See https://github.com/pypa/cibuildwheel/pull/2558
