### PR TITLE
docs: improve buffer_info type checking in numpy docs

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -88,7 +88,7 @@ buffer objects (e.g. a NumPy matrix).
             py::buffer_info info = b.request();
 
             /* Some basic validation checks ... */
-            if (info.format != py::format_descriptor<Scalar>::format())
+            if (!info.item_type_is_equivalent_to<Scalar>())
                 throw std::runtime_error("Incompatible format: expected a double array!");
 
             if (info.ndim != 2)


### PR DESCRIPTION
## Description

When comparing buffer types there are some edge cases on some platforms that are equivalent but the format string is not identical.
`item_type_is_equivalent_to` is more forgiving than direct string comparison.

## Suggested changelog entry:

* Improve `buffer_info` type checking in numpy docs.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5805.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->