### PR TITLE
chore: bump to 3.0.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ Changes will be added here periodically from the "Suggested changelog
 entry" block in pull request descriptions.
 
 
-## Version 3.0.1 (August 21, 2025)
+## Version 3.0.1 (August 22, 2025)
 
 Bug fixes:
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,92 @@ versioning](http://semver.org) policy.
 Changes will be added here periodically from the "Suggested changelog
 entry" block in pull request descriptions.
 
+
+## Version 3.0.1 (August 21, 2025)
+
+Bug fixes:
+
+- Fixed compilation error in `type_caster_enum_type` when casting
+  pointer-to-enum types. Added pointer overload to handle dereferencing before
+  enum conversion.
+  [#5776](https://github.com/pybind/pybind11/pull/5776)
+
+- Implement binary version of `make_index_sequence` to reduce template depth
+  requirements for functions with many parameters.
+  [#5751](https://github.com/pybind/pybind11/pull/5751)
+
+- Subinterpreter-specific exception handling code was removed to resolve segfaults.
+  [#5795](https://github.com/pybind/pybind11/pull/5795)
+
+- Fixed issue that caused ``PYBIND11_MODULE`` code to run again if the module
+  was re-imported after being deleted from ``sys.modules``.
+  [#5782](https://github.com/pybind/pybind11/pull/5782)
+
+- Prevent concurrent creation of sub-interpreters as a workaround for stdlib
+  concurrency issues in Python 3.12.
+  [#5779](https://github.com/pybind/pybind11/pull/5779)
+
+- Fixed potential crash when using `cpp_function` objects with sub-interpreters.
+  [#5771](https://github.com/pybind/pybind11/pull/5771)
+
+- Fixed non-entrant check in `implicitly_convertible()`.
+  [#5777](https://github.com/pybind/pybind11/pull/5777)
+
+- Support C++20 on platforms that have older c++ runtimes.
+  [#5761](https://github.com/pybind/pybind11/pull/5761)
+
+- Fix compilation with clang on msys2.
+  [#5757](https://github.com/pybind/pybind11/pull/5757)
+
+- Avoid `nullptr` dereference warning with GCC 13.3.0 and python 3.11.13.
+  [#5756](https://github.com/pybind/pybind11/pull/5756)
+
+- Fix potential warning about number of threads being too large.
+  [#5807](https://github.com/pybind/pybind11/pull/5807)
+
+
+<!-- fix(cmake) -->
+
+- Fix gcc 11.4+ warning about serial compilation using CMake.
+  [#5791](https://github.com/pybind/pybind11/pull/5791)
+
+
+Documentation:
+
+- Improve `buffer_info` type checking in numpy docs.
+  [#5805](https://github.com/pybind/pybind11/pull/5805)
+
+- Replace `robotpy-build` with `semiwrap` in the binding tool list.
+  [#5804](https://github.com/pybind/pybind11/pull/5804)
+
+- Show nogil in most examples.
+  [#5770](https://github.com/pybind/pybind11/pull/5770)
+
+- Fix `py::trampoline_self_life_support` visibility in docs.
+  [#5766](https://github.com/pybind/pybind11/pull/5766)
+
+
+Tests:
+
+- Avoid a spurious warning about `DOWNLOAD_CATCH` being manually specified.
+  [#5803](https://github.com/pybind/pybind11/pull/5803)
+
+- Fix an IsolatedConfig test.
+  [#5768](https://github.com/pybind/pybind11/pull/5768)
+
+
+CI:
+
+- Add CI testing for Android.
+  [#5714](https://github.com/pybind/pybind11/pull/5714)
+
+
+Internal:
+
+- Rename internal variables to avoid the word `slots` (reads better).
+  [#5793](https://github.com/pybind/pybind11/pull/5793)
+
+
 ## Version 3.0.0 (July 10, 2025)
 
 Pybind11 3.0 includes an ABI bump, the first required bump in many years

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -24,10 +24,10 @@
 // - The release level is set to "alpha" for development versions.
 //   Use 0xA0 (LEVEL=0xA, SERIAL=0) for development versions.
 // - For stable releases, set the serial to 0.
-#define PYBIND11_VERSION_RELEASE_LEVEL PY_RELEASE_LEVEL_ALPHA
+#define PYBIND11_VERSION_RELEASE_LEVEL PY_RELEASE_LEVEL_FINAL
 #define PYBIND11_VERSION_RELEASE_SERIAL 0
 // String version of (micro, release level, release serial), e.g.: 0a0, 0b1, 0rc1, 0
-#define PYBIND11_VERSION_PATCH 1a0
+#define PYBIND11_VERSION_PATCH 1
 /* -- end version constants -- */
 
 #if !defined(Py_PACK_FULL_VERSION)

--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -65,12 +65,18 @@ for issue in issues:
         continue
 
     msg = changelog.group("content").strip()
+    if not msg:
+        missing.append(issue)
+        continue
     if msg.startswith("* "):
         msg = msg[2:]
     if not msg.startswith("- "):
         msg = "- " + msg
     if not msg.endswith("."):
         msg += "."
+    if msg == "- Placeholder.":
+        missing.append(issue)
+        continue
 
     msg += f"\n  [#{issue.number}]({issue.html_url})"
     for cat, cat_list in cats.items():


### PR DESCRIPTION
- **docs: prepare for 3.0.1**
- **chore: bump for 3.0.1**

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Prepare for 3.0.1. We might be able to get #5797 in too.

Some minor touchups to the changelog tool to handle empty descriptions better based on what people are leaving in them.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5810.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->