### PR TITLE
Fix compiler detection with clang-cl

### DIFF
--- a/include/pybind11/detail/pybind11_namespace_macros.h
+++ b/include/pybind11/detail/pybind11_namespace_macros.h
@@ -16,12 +16,7 @@
 // possible using these macros. Please also be sure to push/pop with the pybind11 macros. Please
 // only use compiler specifics if you need to check specific versions, e.g. Apple Clang vs. vanilla
 // Clang.
-#if defined(_MSC_VER) && !defined(__clang__) // clang-cl also defines _MSC_VER
-#    define PYBIND11_COMPILER_MSVC
-#    define PYBIND11_PRAGMA(...) __pragma(__VA_ARGS__)
-#    define PYBIND11_WARNING_PUSH PYBIND11_PRAGMA(warning(push))
-#    define PYBIND11_WARNING_POP PYBIND11_PRAGMA(warning(pop))
-#elif defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER)
 #    define PYBIND11_COMPILER_INTEL
 #    define PYBIND11_PRAGMA(...) _Pragma(#__VA_ARGS__)
 #    define PYBIND11_WARNING_PUSH PYBIND11_PRAGMA(warning push)
@@ -36,6 +31,11 @@
 #    define PYBIND11_PRAGMA(...) _Pragma(#__VA_ARGS__)
 #    define PYBIND11_WARNING_PUSH PYBIND11_PRAGMA(GCC diagnostic push)
 #    define PYBIND11_WARNING_POP PYBIND11_PRAGMA(GCC diagnostic pop)
+#elif defined(_MSC_VER) // Must be after the clang branch because clang-cl also defines _MSC_VER
+#    define PYBIND11_COMPILER_MSVC
+#    define PYBIND11_PRAGMA(...) __pragma(__VA_ARGS__)
+#    define PYBIND11_WARNING_PUSH PYBIND11_PRAGMA(warning(push))
+#    define PYBIND11_WARNING_POP PYBIND11_PRAGMA(warning(pop))
 #endif
 
 #ifdef PYBIND11_COMPILER_MSVC

--- a/include/pybind11/detail/pybind11_namespace_macros.h
+++ b/include/pybind11/detail/pybind11_namespace_macros.h
@@ -16,7 +16,7 @@
 // possible using these macros. Please also be sure to push/pop with the pybind11 macros. Please
 // only use compiler specifics if you need to check specific versions, e.g. Apple Clang vs. vanilla
 // Clang.
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__) // clang-cl also defines _MSC_VER
 #    define PYBIND11_COMPILER_MSVC
 #    define PYBIND11_PRAGMA(...) __pragma(__VA_ARGS__)
 #    define PYBIND11_WARNING_PUSH PYBIND11_PRAGMA(warning(push))


### PR DESCRIPTION
## Description

I am getting compiler warnings using clang-cl on Windows. These warnings are suppressed in pybind11 using `PYBIND11_WARNING_DISABLE_CLANG` which is defined as
```c++
#ifdef PYBIND11_COMPILER_CLANG
#    define PYBIND11_WARNING_DISABLE_CLANG(name) PYBIND11_PRAGMA(clang diagnostic ignored name)
#else
#    define PYBIND11_WARNING_DISABLE_CLANG(name)
#endif
```
However, for clang-cl, `PYBIND11_COMPILER_CLANG` is undefined because clang-cl also defines `_MSC_VER` and thus the compiler is detected as msvc.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Fix compiler detection in `pybind11/detail/pybind11_namespace_macros.h` for clang-cl on Windows, to fix warning suppression macros.