### PR TITLE
Fix typo in error message

### DIFF
--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -17,7 +17,7 @@
 #elif defined(PYBIND11_HAS_EXPERIMENTAL_FILESYSTEM)
 #    include <experimental/filesystem>
 #else
-#    error "Neither #include <filesystem> nor #include <experimental/filesystem is available."
+#    error "Neither #include <filesystem> nor #include <experimental/filesystem> is available."
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

There was a missing `>` in the error message.


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
