### PR TITLE
Fix "🐍 3 • windows-latest • mingw64" CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1019,8 +1019,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { sys: mingw64, env: x86_64 }
-          - { sys: mingw32, env: i686 }
+          - sys: mingw32
+            env: i686
+            install_mingw64_only: ""
+          - sys: mingw64
+            env: x86_64
+            install_mingw64_only: |
+              mingw-w64-x86_64-python-numpy
+              mingw-w64-x86_64-python-scipy
+              mingw-w64-x86_64-eigen3
     steps:
     - uses: msys2/setup-msys2@v2
       with:
@@ -1034,15 +1041,7 @@ jobs:
           mingw-w64-${{matrix.env}}-python-pytest
           mingw-w64-${{matrix.env}}-boost
           mingw-w64-${{matrix.env}}-catch
-
-    - uses: msys2/setup-msys2@v2
-      if: matrix.sys == 'mingw64'
-      with:
-        msystem: ${{matrix.sys}}
-        install: >-
-          mingw-w64-${{matrix.env}}-python-numpy
-          mingw-w64-${{matrix.env}}-python-scipy
-          mingw-w64-${{matrix.env}}-eigen3
+          ${{ matrix.install_mingw64_only }}
 
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
 <!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Apparently `msys2/setup-msys2@v2` cannot be run twice anymore:

* https://github.com/pybind/pybind11/actions/runs/17394902023/job/49417376616?pr=5796

```
Run msys2/setup-msys2@v2
  with:
    msystem: mingw64
    install: mingw-w64-x86_64-python-numpy mingw-w64-x86_64-python-scipy mingw-w64-x86_64-eigen3
    path-type: minimal
    update: false
    pacboy: false
    release: true
    location: RUNNER_TEMP
    platform-check-severity: fatal
    cache: true
  env:
    PYTHONDEVMODE: 1
    PIP_BREAK_SYSTEM_PACKAGES: 1
    PIP_ONLY_BINARY: numpy
    FORCE_COLOR: 3
    PYTEST_TIMEOUT: 300
    VERBOSE: 1
    CMAKE_COLOR_DIAGNOSTICS: 1
    MSYSTEM: MINGW64
Error: Trying to install MSYS2 to D:\a\_temp\msys64 but that already exists, cannot continue.
```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
