### PR TITLE
Fix the first example in the first steps guide not compiling

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -108,6 +108,8 @@ a file named :file:`example.cpp` with the following contents:
 
     #include <pybind11/pybind11.h>
 
+    namespace py = pybind11;
+
     int add(int i, int j) {
         return i + j;
     }


### PR DESCRIPTION
The alias of the pybind11 namespace is missing
