### PR TITLE
NOT FOR MERGE -- testing to see if windows-latest jobs are broken

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+// kick CI -- are we broken on windows-latest?
 #include <pybind11/conduit/wrap_include_python_h.h>
 #if PY_VERSION_HEX < 0x03080000
 #    error "PYTHON < 3.8 IS UNSUPPORTED. pybind11 v2.13 was the last to support Python 3.7."


### PR DESCRIPTION
## Description

https://github.com/pybind/pybind11/pull/5824 looks like it might simply be the first PR where windows-latest means windows-2025. checking to see if CI is broken on main..
