### PR TITLE
Fix crash in `gil_scoped_acquire`

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -103,6 +103,10 @@
 #    define PYBIND11_DTOR_CONSTEXPR
 #endif
 
+#if defined(PYBIND11_CPP20) && defined(__has_include) && __has_include(<barrier>)
+#    define PYBIND11_HAS_STD_BARRIER 1
+#endif
+
 // Compiler version assertions
 #if defined(__INTEL_COMPILER)
 #    if __INTEL_COMPILER < 1800

--- a/include/pybind11/gil.h
+++ b/include/pybind11/gil.h
@@ -120,7 +120,11 @@ public:
                 pybind11_fail("scoped_acquire::dec_ref(): internal error!");
             }
 #    endif
+            // Make sure that PyThreadState_Clear is not recursively called by finalizers.
+            // See issue #5827
+            ++tstate->gilstate_counter;
             PyThreadState_Clear(tstate);
+            --tstate->gilstate_counter;
             if (active) {
                 PyThreadState_DeleteCurrent();
             }

--- a/tests/test_scoped_critical_section.cpp
+++ b/tests/test_scoped_critical_section.cpp
@@ -7,8 +7,7 @@
 #include <thread>
 #include <utility>
 
-#if defined(PYBIND11_CPP20) && defined(__has_include) && __has_include(<barrier>)
-#    define PYBIND11_HAS_BARRIER 1
+#if defined(PYBIND11_HAS_STD_BARRIER)
 #    include <barrier>
 #endif
 
@@ -39,7 +38,7 @@ private:
     std::atomic_bool value_{false};
 };
 
-#if defined(PYBIND11_HAS_BARRIER)
+#if defined(PYBIND11_HAS_STD_BARRIER)
 
 // Modifying the C/C++ members of a Python object from multiple threads requires a critical section
 // to ensure thread safety and data integrity.
@@ -259,7 +258,7 @@ TEST_SUBMODULE(scoped_critical_section, m) {
     (void) BoolWrapperHandle.ptr(); // suppress unused variable warning
 
     m.attr("has_barrier") =
-#ifdef PYBIND11_HAS_BARRIER
+#ifdef PYBIND11_HAS_STD_BARRIER
         true;
 #else
         false;

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -16,7 +16,7 @@
 #include <thread>
 
 #if defined(PYBIND11_CPP20) && defined(__has_include) && __has_include(<barrier>)
-#    define PYBIND11_HAS_BARRIER 1
+#    define PYBIND11_HAS_STD_BARRIER 1
 #    include <barrier>
 #endif
 
@@ -71,7 +71,7 @@ TEST_SUBMODULE(thread, m) {
     py::class_<EmptyStruct>(m, "EmptyStruct")
         .def_readonly_static("SharedInstance", &SharedInstance);
 
-#if defined(PYBIND11_HAS_BARRIER)
+#if defined(PYBIND11_HAS_STD_BARRIER)
     // In the free-threaded build, during PyThreadState_Clear, removing the thread from the biased
     // reference counting table may call destructors. Make sure that it doesn't crash.
     m.def("test_pythread_state_clear_destructor", [](py::type cls) {
@@ -97,7 +97,7 @@ TEST_SUBMODULE(thread, m) {
 #endif
 
     m.attr("has_barrier") =
-#ifdef PYBIND11_HAS_BARRIER
+#ifdef PYBIND11_HAS_STD_BARRIER
         true;
 #else
         false;

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -15,6 +15,11 @@
 #include <chrono>
 #include <thread>
 
+#if defined(PYBIND11_CPP20) && defined(__has_include) && __has_include(<barrier>)
+#    define PYBIND11_HAS_BARRIER 1
+#    include <barrier>
+#endif
+
 namespace py = pybind11;
 
 namespace {
@@ -34,7 +39,6 @@ EmptyStruct SharedInstance;
 } // namespace
 
 TEST_SUBMODULE(thread, m) {
-
     py::class_<IntStruct>(m, "IntStruct").def(py::init([](const int i) { return IntStruct(i); }));
 
     // implicitly_convertible uses loader_life_support when an implicit
@@ -66,6 +70,39 @@ TEST_SUBMODULE(thread, m) {
 
     py::class_<EmptyStruct>(m, "EmptyStruct")
         .def_readonly_static("SharedInstance", &SharedInstance);
+
+#if defined(PYBIND11_HAS_BARRIER)
+    // In the free-threaded build, during PyThreadState_Clear, removing the thread from the biased
+    // reference counting table may call destructors. Make sure that it doesn't crash.
+    m.def("test_pythread_state_clear_destructor", [](py::type cls) {
+        py::handle obj;
+
+        std::barrier barrier{2};
+        std::thread thread1{[&]() {
+            py::gil_scoped_acquire gil;
+            obj = cls().release();
+            barrier.arrive_and_wait();
+        }};
+        std::thread thread2{[&]() {
+            py::gil_scoped_acquire gil;
+            barrier.arrive_and_wait();
+            // ob_ref_shared becomes negative; transition to the queued state
+            obj.dec_ref();
+        }};
+
+        // jthread is not supported by Apple Clang
+        thread1.join();
+        thread2.join();
+    });
+#endif
+
+    m.attr("has_barrier") =
+#ifdef PYBIND11_HAS_BARRIER
+        true;
+#else
+        false;
+#endif
+    m.def("acquire_gil", []() { py::gil_scoped_acquire gil_acquired; });
 
     // NOTE: std::string_view also uses loader_life_support to ensure that
     // the string contents remain alive, but that's a C++ 17 feature.

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -15,8 +15,7 @@
 #include <chrono>
 #include <thread>
 
-#if defined(PYBIND11_CPP20) && defined(__has_include) && __has_include(<barrier>)
-#    define PYBIND11_HAS_STD_BARRIER 1
+#if defined(PYBIND11_HAS_STD_BARRIER)
 #    include <barrier>
 #endif
 
@@ -96,7 +95,7 @@ TEST_SUBMODULE(thread, m) {
     });
 #endif
 
-    m.attr("has_barrier") =
+    m.attr("defined_PYBIND11_HAS_STD_BARRIER") =
 #ifdef PYBIND11_HAS_STD_BARRIER
         true;
 #else

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -5,6 +5,7 @@ import threading
 
 import pytest
 
+import env
 from pybind11_tests import thread as m
 
 
@@ -66,3 +67,14 @@ def test_bind_shared_instance():
         thread.start()
     for thread in threads:
         thread.join()
+
+
+@pytest.mark.skipif(sys.platform.startswith("emscripten"), reason="Requires threads")
+@pytest.mark.skipif(not m.has_barrier, reason="no <barrier>")
+@pytest.mark.skipif(env.sys_is_gil_enabled(), reason="Deadlock with the GIL")
+def test_pythread_state_clear_destructor():
+    class Foo:
+        def __del__(self):
+            m.acquire_gil()
+
+    m.test_pythread_state_clear_destructor(Foo)

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -70,7 +70,7 @@ def test_bind_shared_instance():
 
 
 @pytest.mark.skipif(sys.platform.startswith("emscripten"), reason="Requires threads")
-@pytest.mark.skipif(not m.has_barrier, reason="no <barrier>")
+@pytest.mark.skipif(not m.defined_PYBIND11_HAS_STD_BARRIER, reason="no <barrier>")
 @pytest.mark.skipif(env.sys_is_gil_enabled(), reason="Deadlock with the GIL")
 def test_pythread_state_clear_destructor():
     class Foo:


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Increase `gilstate_counter` before calling `PyThreadState_Clear` in `gil_scoped_acquire` to prevent finalizers to try to create and destroy a new thread state while the current thread state is being cleared.

Fixes #5827

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

Fix crash that can occur when finalizers acquire and release the GIL.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5828.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->