### PR TITLE
fix: cross-compilation updates

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -495,7 +495,7 @@ FindPython, pybind11 will detect this and use the existing targets instead:
     cmake_minimum_required(VERSION 3.15...4.0)
     project(example LANGUAGES CXX)
 
-    find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
+    find_package(Python COMPONENTS Development.Module REQUIRED)
     find_package(pybind11 CONFIG REQUIRED)
     # or add_subdirectory(pybind11)
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -324,7 +324,7 @@ There are three possible solutions:
    from CMake and rely on pybind11 in detecting Python version. If this is not
    possible, the CMake machinery should be called *before* including pybind11.
 2. Set ``PYBIND11_FINDPYTHON`` to ``True`` or use ``find_package(Python
-   COMPONENTS Interpreter Development)`` on modern CMake ( 3.18.2+ best).
+   COMPONENTS Development.Module)`` on modern CMake ( 3.18.2+ best).
    Pybind11 in these cases uses the new CMake FindPython instead of the old,
    deprecated search tools, and these modules are much better at finding the
    correct Python. If FindPythonLibs/Interp are not available (CMake 3.27+),

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -332,7 +332,7 @@ In addition, the following changes may be of interest:
   ``pybind11_add_module`` if set instead of linking to ``pybind11::lto`` or
   ``pybind11::thin_lto``.
 
-* Using ``find_package(Python COMPONENTS Interpreter Development)`` before
+* Using ``find_package(Python COMPONENTS Development.Module)`` before
   pybind11 will cause pybind11 to use the new Python mechanisms instead of its
   own custom search, based on a patched version of classic ``FindPythonInterp``
   / ``FindPythonLibs``. In the future, this may become the default. A recent

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -543,7 +543,9 @@ source_group(
   FILES ${PYBIND11_HEADERS})
 
 # Make sure pytest is found or produce a warning
-pybind11_find_import(pytest VERSION 3.1)
+if(NOT CMAKE_CROSSCOMPILING)
+  pybind11_find_import(pytest VERSION 3.1)
+endif()
 
 if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
   # This is not used later in the build, so it's okay to regenerate each time.

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -41,6 +41,15 @@ set(pybind11_INCLUDE_DIRS
     "${pybind11_INCLUDE_DIR}"
     CACHE INTERNAL "Include directory for pybind11 (Python not requested)")
 
+# CMP0190 prohibits calling FindPython with both Interpreter and Development components
+# when cross-compiling, unless the CMAKE_CROSSCOMPILING_EMULATOR variable is defined.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.1")
+  cmake_policy(GET CMP0190 _pybind11_cmp0190)
+  if(_pybind11_cmp0190 STREQUAL "NEW")
+    set(PYBIND11_USE_CROSSCOMPILING "ON")
+  endif()
+endif()
+
 if(CMAKE_CROSSCOMPILING AND PYBIND11_USE_CROSSCOMPILING)
   set(_PYBIND11_CROSSCOMPILING
       ON

--- a/tools/pybind11Config.cmake.in
+++ b/tools/pybind11Config.cmake.in
@@ -77,13 +77,13 @@ default to ``ON``.
 New FindPython mode
 ^^^^^^^^^^^^^^^^^^^
 
-To activate this mode, either call ``find_package(Python COMPONENTS Interpreter Development)``
+To activate this mode, either call ``find_package(Python COMPONENTS Development.Module)``
 before finding this package, or set the ``PYBIND11_FINDPYTHON`` variable to ON. In this mode,
 you can either use the basic targets, or use the FindPython tools:
 
 .. code-block:: cmake
 
-  find_package(Python COMPONENTS Interpreter Development)
+  find_package(Python COMPONENTS Development.Module)
   find_package(pybind11 CONFIG)
 
   # pybind11 method:

--- a/tools/pybind11GuessPythonExtSuffix.cmake
+++ b/tools/pybind11GuessPythonExtSuffix.cmake
@@ -14,15 +14,23 @@ function(pybind11_guess_python_module_extension python)
           STRING
           "Extension suffix for Python extension modules (Initialized from SETUPTOOLS_EXT_SUFFIX)")
   endif()
+
+  # The final extension depends on the system
+  set(_PY_BUILD_EXTENSION "${CMAKE_SHARED_MODULE_SUFFIX}")
+  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(_PY_BUILD_EXTENSION ".pyd")
+  endif()
+
+  # If running under scikit-build-core, use the SKBUILD_SOABI variable:
+  if(NOT DEFINED PYTHON_MODULE_EXT_SUFFIX AND DEFINED SKBUILD_SOABI)
+    message(STATUS "Determining Python extension suffix based on SKBUILD_SOABI: ${SKBUILD_SOABI}")
+    set(PYTHON_MODULE_EXT_SUFFIX ".${SKBUILD_SOABI}${_PY_BUILD_EXTENSION}")
+  endif()
+
   # If that didn't work, use the Python_SOABI variable:
   if(NOT DEFINED PYTHON_MODULE_EXT_SUFFIX AND DEFINED ${python}_SOABI)
     message(
       STATUS "Determining Python extension suffix based on ${python}_SOABI: ${${python}_SOABI}")
-    # The final extension depends on the system
-    set(_PY_BUILD_EXTENSION "${CMAKE_SHARED_MODULE_SUFFIX}")
-    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-      set(_PY_BUILD_EXTENSION ".pyd")
-    endif()
     # If the SOABI already has an extension, use it as the full suffix
     # (used for debug versions of Python on Windows)
     if(${python}_SOABI MATCHES "\\.")
@@ -43,9 +51,9 @@ function(pybind11_guess_python_module_extension python)
 
   # If we could not deduce the extension suffix, unset the results:
   if(NOT DEFINED PYTHON_MODULE_EXT_SUFFIX)
-    unset(PYTHON_MODULE_DEBUG_POSTFIX PARENT_SCOPE)
-    unset(PYTHON_MODULE_EXTENSION PARENT_SCOPE)
-    unset(PYTHON_IS_DEBUG PARENT_SCOPE)
+    unset(PYTHON_MODULE_DEBUG_POSTFIX CACHE)
+    unset(PYTHON_MODULE_EXTENSION CACHE)
+    unset(PYTHON_IS_DEBUG CACHE)
     return()
   endif()
 
@@ -75,12 +83,12 @@ function(pybind11_guess_python_module_extension python)
   # Return results
   set(PYTHON_MODULE_DEBUG_POSTFIX
       "${_PYTHON_MODULE_DEBUG_POSTFIX}"
-      PARENT_SCOPE)
+      CACHE INTERNAL "")
   set(PYTHON_MODULE_EXTENSION
       "${_PYTHON_MODULE_EXTENSION}"
-      PARENT_SCOPE)
+      CACHE INTERNAL "")
   set(PYTHON_IS_DEBUG
       "${_PYTHON_IS_DEBUG}"
-      PARENT_SCOPE)
+      CACHE INTERNAL "")
 
 endfunction()

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -106,18 +106,7 @@ if(PYBIND11_MASTER_PROJECT)
   endif()
 endif()
 
-if(NOT _PYBIND11_CROSSCOMPILING)
-  # If a user finds Python, they may forget to include the Interpreter component
-  # and the following two steps require it. It is highly recommended by CMake
-  # when finding development libraries anyway, so we will require it.
-  if(NOT DEFINED ${_Python}_EXECUTABLE)
-    message(
-      FATAL_ERROR
-        "${_Python} was found without the Interpreter component. Pybind11 requires this component."
-    )
-
-  endif()
-
+if(NOT _PYBIND11_CROSSCOMPILING AND DEFINED ${_Python}_EXECUTABLE)
   if(DEFINED PYBIND11_PYTHON_EXECUTABLE_LAST AND NOT ${_Python}_EXECUTABLE STREQUAL
                                                  PYBIND11_PYTHON_EXECUTABLE_LAST)
     # Detect changes to the Python version/binary in subsequent CMake runs, and refresh config if needed
@@ -190,15 +179,15 @@ else()
     include("${CMAKE_CURRENT_LIST_DIR}/pybind11GuessPythonExtSuffix.cmake")
     pybind11_guess_python_module_extension("${_Python}")
   endif()
-  # When cross-compiling, we cannot query the Python interpreter, so we require
-  # the user to set these variables explicitly.
   if(NOT DEFINED PYTHON_IS_DEBUG
      OR NOT DEFINED PYTHON_MODULE_EXTENSION
      OR NOT DEFINED PYTHON_MODULE_DEBUG_POSTFIX)
     message(
       FATAL_ERROR
-        "When cross-compiling, you should set the PYTHON_IS_DEBUG, PYTHON_MODULE_EXTENSION and PYTHON_MODULE_DEBUG_POSTFIX \
-        variables appropriately before loading pybind11 (e.g. in your CMake toolchain file)")
+        "A Python interpreter was not found, or you are cross-compiling, and the "
+        "PYTHON_IS_DEBUG, PYTHON_MODULE_EXTENSION and PYTHON_MODULE_DEBUG_POSTFIX "
+        "variables could not be guessed. Set these variables appropriately before "
+        "loading pybind11 (e.g. in your CMake toolchain file)")
   endif()
 endif()
 
@@ -248,10 +237,7 @@ if(TARGET ${_Python}::Module)
   # files.
   get_target_property(module_target_type ${_Python}::Module TYPE)
   if(ANDROID AND module_target_type STREQUAL INTERFACE_LIBRARY)
-    set_property(
-      TARGET ${_Python}::Module
-      APPEND
-      PROPERTY INTERFACE_LINK_LIBRARIES "${${_Python}_LIBRARIES}")
+    target_link_libraries(${_Python}::Module INTERFACE ${${_Python}_LIBRARIES})
   endif()
 
   set_property(

--- a/tools/test-pybind11GuessPythonExtSuffix.cmake
+++ b/tools/test-pybind11GuessPythonExtSuffix.cmake
@@ -87,6 +87,30 @@ unset(PYTHON_MODULE_EXT_SUFFIX)
 unset(PYTHON_MODULE_EXT_SUFFIX CACHE)
 unset(ENV{SETUPTOOLS_EXT_SUFFIX})
 
+# Check the priority of the possible suffix sources.
+set(ENV{SETUPTOOLS_EXT_SUFFIX} ".from-setuptools.pyd")
+set(SKBUILD_SOABI "from-skbuild")
+set(Python3_SOABI "from-python3")
+pybind11_guess_python_module_extension("Python3")
+expect_streq("${PYTHON_MODULE_EXTENSION}" ".from-setuptools.pyd")
+
+unset(PYTHON_MODULE_EXT_SUFFIX CACHE)
+unset(ENV{SETUPTOOLS_EXT_SUFFIX})
+pybind11_guess_python_module_extension("Python3")
+expect_streq("${PYTHON_MODULE_EXTENSION}" ".from-skbuild.pyd")
+
+unset(SKBUILD_SOABI)
+pybind11_guess_python_module_extension("Python3")
+expect_streq("${PYTHON_MODULE_EXTENSION}" ".from-python3.pyd")
+
+set(Python3_SOABI "")
+pybind11_guess_python_module_extension("Python3")
+expect_streq("${PYTHON_MODULE_EXTENSION}" ".pyd")
+
+unset(Python3_SOABI)
+pybind11_guess_python_module_extension("Python3")
+expect_streq("${PYTHON_MODULE_EXTENSION}" "")
+
 # macOS
 set(CMAKE_SYSTEM_NAME "Darwin")
 set(CMAKE_SHARED_MODULE_SUFFIX ".so")


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Updated the Android linking workaround in pybind11NewTools.cmake to be compatible with vcpkg, as discussed at https://github.com/pybind/pybind11/pull/5733#pullrequestreview-3045634533. I've also submitted an [upstream fix to CMake](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11153), so this workaround can eventually be removed.

However, most of this PR is about CMake policy [CMP0190](https://cmake.org/cmake/help/latest/policy/CMP0190.html), which prohibits calling FindPython with both the `Interpreter` and `Development` components at the same time when cross-compiling:

* Enabled `PYBIND11_USE_CROSSCOMPILING` whenever CMP0190 is in effect.

* Updated pybind11NewTools.cmake so it no longer requires the `Interpreter` component, whether cross-compiling or not. This allows packages to use the same configuration for both cases.

* Improved pybind11GuessPythonExtSuffix.cmake:
  * Added `SKBUILD_SOABI` as another possible source of the Python module suffix.
  * Set result variables to the `CACHE`, just as they are when they're detected from the interpreter. Previously they were set to the `PARENT_SCOPE`, but that's the module scope of pybind11NewTools.cmake, which isn't accessible when calling functions from a different module. As a result, modules created using `pybind11_add_module` were being built with no extension at all!

* To encourage packages to be compatible with cross-compilation, I've removed `Interpreter` from all the documentation, examples and tests, except for the places which actually needed it.

The new policy can be tested by changing the `cmake_minimum_required` upper limit in CMakeLists.txt from 4.0 to 4.1, and then using cibuildwheel to build the `tests` project. However, I haven't changed the `cmake_minimum_required` in this PR, because I'm not sure what other effects it might have.

See also: 
* https://github.com/scikit-build/scikit-build-core/pull/1142

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Fix compatibility with CMake policy [CMP0190](https://cmake.org/cmake/help/latest/policy/CMP0190.html), which prohibits calling FindPython with both the `Interpreter` and `Development` components at the same time when cross-compiling. 