### PR TITLE
pytypes.h: constrain accessor::operator= templates so that they do not obscure special members

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -1039,13 +1039,11 @@ public:
     void operator=(const accessor &a) & { operator=(handle(a)); }
 
     template <typename T>
-    enable_if_t<!std::is_same<accessor, remove_reference_t<T>>::value>
-    operator=(T &&value) && {
+    enable_if_t<!std::is_same<accessor, remove_reference_t<T>>::value> operator=(T &&value) && {
         Policy::set(obj, key, object_or_cast(std::forward<T>(value)));
     }
     template <typename T>
-    enable_if_t<!std::is_same<accessor, remove_reference_t<T>>::value>
-    operator=(T &&value) & {
+    enable_if_t<!std::is_same<accessor, remove_reference_t<T>>::value> operator=(T &&value) & {
         get_cache() = ensure_object(object_or_cast(std::forward<T>(value)));
     }
 


### PR DESCRIPTION
## Description
Constraints the templates `accessor::operator=` so that they are not selected in overload resolution when the special members should be selected.

Found by an experimental, new clang-tidy check.

While we may not know the exact design decisions now, it seems unlikely that the special members were deliberately meant to not be selected (for otherwise they could have been defined differently to make this clear). Rather, it seems like an oversight that the operator templates win in overload resolution, and we should restore the intended resolution.

Should not have any observable behaviour.