### PR TITLE
tests: add or delete copy/move ctors where needed to make type traits match reality

### DIFF
--- a/tests/test_buffers.cpp
+++ b/tests/test_buffers.cpp
@@ -227,7 +227,7 @@ TEST_SUBMODULE(buffers, m) {
                               + std::to_string(cols) + "(*" + std::to_string(col_factor)
                               + ") matrix");
         }
-
+        DiscontiguousMatrix(const DiscontiguousMatrix &) = delete;
         ~DiscontiguousMatrix() {
             print_destroyed(this,
                             std::to_string(rows() / m_row_factor) + "(*"

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -521,6 +521,7 @@ TEST_SUBMODULE(class_, m) {
     // test_exception_rvalue_abort
     struct PyPrintDestructor {
         PyPrintDestructor() = default;
+        PyPrintDestructor(const PyPrintDestructor &) = default;
         ~PyPrintDestructor() { py::print("Print from destructor"); }
         void throw_something() { throw std::runtime_error("error"); }
     };

--- a/tests/test_class_release_gil_before_calling_cpp_dtor.cpp
+++ b/tests/test_class_release_gil_before_calling_cpp_dtor.cpp
@@ -22,6 +22,7 @@ private:
 
 public:
     explicit ProbeType(const std::string &unique_key) : unique_key{unique_key} {}
+    ProbeType(const ProbeType &) = default;
 
     ~ProbeType() {
         RegistryType &reg = PyGILState_Check_Results();

--- a/tests/test_class_sh_property_non_owning.cpp
+++ b/tests/test_class_sh_property_non_owning.cpp
@@ -33,6 +33,8 @@ public:
         }
     }
 
+    DataFieldsHolder(DataFieldsHolder &&) noexcept = default;
+
     DataField *vec_at(std::size_t index) {
         if (index >= vec.size()) {
             return nullptr;

--- a/tests/test_cross_module_rtti/lib.h
+++ b/tests/test_cross_module_rtti/lib.h
@@ -12,6 +12,7 @@ __pragma(warning(disable : 4251))
     class TEST_CROSS_MODULE_RTTI_LIB_EXPORT Base : public std::enable_shared_from_this<Base> {
     public:
         Base(int a, int b);
+        Base(const Base &) = default;
         virtual ~Base() = default;
 
         virtual int get() const;

--- a/tests/test_eigen_matrix.cpp
+++ b/tests/test_eigen_matrix.cpp
@@ -237,6 +237,7 @@ TEST_SUBMODULE(eigen_matrix, m) {
 
     public:
         ReturnTester() { print_created(this); }
+        ReturnTester(const ReturnTester &) = default;
         ~ReturnTester() { print_destroyed(this); }
         static Eigen::MatrixXd create() { return Eigen::MatrixXd::Ones(10, 10); }
         // NOLINTNEXTLINE(readability-const-return-type)

--- a/tests/test_numpy_array.cpp
+++ b/tests/test_numpy_array.cpp
@@ -282,6 +282,7 @@ TEST_SUBMODULE(numpy_array, sm) {
     struct ArrayClass {
         int data[2] = {1, 2};
         ArrayClass() { py::print("ArrayClass()"); }
+        ArrayClass(const ArrayClass &) = default;
         ~ArrayClass() { py::print("~ArrayClass()"); }
     };
     py::class_<ArrayClass>(sm, "ArrayClass")

--- a/tests/test_potentially_slicing_weak_ptr.cpp
+++ b/tests/test_potentially_slicing_weak_ptr.cpp
@@ -11,7 +11,9 @@ namespace potentially_slicing_weak_ptr {
 
 template <int> // Using int as a trick to easily generate multiple types.
 struct VirtBase {
+    VirtBase() = default;
     virtual ~VirtBase() = default;
+    VirtBase(const VirtBase &) = delete;
     virtual int get_code() { return 100; }
 };
 

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -161,6 +161,8 @@ public:
         print_created(this);
         pointer_set<MyObject4a>().insert(this);
     };
+    MyObject4a(const MyObject4a &) = delete;
+
     int value;
 
     static void cleanupAllInstances() {
@@ -182,6 +184,7 @@ protected:
 class MyObject4b : public MyObject4a {
 public:
     explicit MyObject4b(int i) : MyObject4a(i) { print_created(this); }
+    MyObject4b(const MyObject4b &) = delete;
     ~MyObject4b() override { print_destroyed(this); }
 };
 
@@ -189,6 +192,7 @@ public:
 class MyObject5 { // managed by huge_unique_ptr
 public:
     explicit MyObject5(int value) : value{value} { print_created(this); }
+    MyObject5(const MyObject5 &) = delete;
     ~MyObject5() { print_destroyed(this); }
     int value;
 };
@@ -245,6 +249,7 @@ struct SharedFromThisVirt : virtual SharedFromThisVBase {};
 // test_move_only_holder
 struct C {
     C() { print_created(this); }
+    C(const C &) = delete;
     ~C() { print_destroyed(this); }
 };
 
@@ -265,6 +270,7 @@ struct TypeForHolderWithAddressOf {
 // test_move_only_holder_with_addressof_operator
 struct TypeForMoveOnlyHolderWithAddressOf {
     explicit TypeForMoveOnlyHolderWithAddressOf(int value) : value{value} { print_created(this); }
+    TypeForMoveOnlyHolderWithAddressOf(const TypeForMoveOnlyHolderWithAddressOf &) = delete;
     ~TypeForMoveOnlyHolderWithAddressOf() { print_destroyed(this); }
     std::string toString() const {
         return "MoveOnlyHolderWithAddressOf[" + std::to_string(value) + "]";

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -99,6 +99,7 @@ public:
     using OptionalEnumValue = OptionalImpl<EnumType>;
 
     OptionalProperties() : value(EnumType::kSet) {}
+    OptionalProperties(const OptionalProperties &) = default;
     ~OptionalProperties() {
         // Reset value to detect use-after-destruction.
         // This is set to a specific value rather than nullopt to ensure that

--- a/tests/test_tagbased_polymorphic.cpp
+++ b/tests/test_tagbased_polymorphic.cpp
@@ -17,6 +17,8 @@ struct Animal {
     // (https://github.com/pybind/pybind11/pull/2016/).
     virtual ~Animal() = default;
 
+    Animal(const Animal &) = delete;
+
     // Enum for tag-based polymorphism.
     enum class Kind {
         Unknown = 0,


### PR DESCRIPTION
#5800 will attempt to instantiate copy/move constructors for every bound type that appears copy/move constructible. (Currently, only types that are returned from a bound function will try to use these constructors, so if a type is used only in argument position, it's possible that it satisfies `is_copy_constructible` but actually odr-using the copy constructor would fail. Ditto for moves.) See that PR for more on the rationale.

There are several classes used in pybind11's test suite that satisfy `is_copy_constructible`, but produce warnings or errors if you try to actually odr-use their (implicitly-defined) copy constructor:
* In recent C++ versions, use of the implicitly-defaulted copy constructor is deprecated for any class with a nontrivial (including virtual) destructor. This produces several warnings due to the test suite's frequent use of patterns that count how many destructions have occurred.
* If a type has no copy constructor and none of its immediate members are non-copyable but some of their subobjects are non-copyable, it will look copyable to std type traits, but actually generating the copy constructor produces an error. This is relevant to `DataFieldsHolder` in `test_class_sh_property_non_owning.cpp`, which contains a std::vector of move-only type `DataField`.

This PR adds defaulted or deleted copy constructors for these cases, as semantically appropriate.

(No user-visible impact, so no changelog entry.)