### PR TITLE
Restore `runs-on: windows-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           - runs-on: macos-latest
             python-version: 'graalpy-24.2'
 
-          - runs-on: windows-2022
+          - runs-on: windows-latest
             python-version: '3.9'
             cmake-args: -DPYBIND11_TEST_SMART_HOLDER=ON
           - runs-on: windows-2022
@@ -138,19 +138,19 @@ jobs:
           - runs-on: windows-2022
             python-version: '3.13'
             cmake-args: -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebugDLL
-          - runs-on: windows-2022
+          - runs-on: windows-latest
             python-version: '3.13t'
             cmake-args: -DCMAKE_CXX_STANDARD=17
-          - runs-on: windows-2022
+          - runs-on: windows-latest
             python-version: '3.14'
             cmake-args: -DCMAKE_CXX_STANDARD=20
-          - runs-on: windows-2022
+          - runs-on: windows-latest
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=23
-          - runs-on: windows-2022
+          - runs-on: windows-latest
             python-version: 'pypy-3.10'
             cmake-args: -DCMAKE_CXX_STANDARD=17
-          - runs-on: windows-2022
+          - runs-on: windows-latest
             python-version: 'pypy3.11'
             cmake-args: -DCMAKE_CXX_STANDARD=20
           # The setup-python action currently doesn't have graalpy for windows
@@ -174,7 +174,7 @@ jobs:
             python-version: '3.9'
           - runs-on: macos-latest
             python-version: '3.12'
-          - runs-on: windows-2022
+          - runs-on: windows-latest
             python-version: '3.11'
 
     name: "🐍 ${{ matrix.python-version }} • ${{ matrix.runs-on }} • x64 inplace C++14"
@@ -1010,8 +1010,8 @@ jobs:
 
   mingw:
     if: github.event.pull_request.draft == false
-    name: "🐍 3 • windows-2022 • ${{ matrix.sys }}"
-    runs-on: windows-2022
+    name: "🐍 3 • windows-latest • ${{ matrix.sys }}"
+    runs-on: windows-latest
     defaults:
       run:
         shell: msys2 {0}
@@ -1121,7 +1121,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2022]
+        os: [windows-latest]
         python: ['3.10']
 
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -19,8 +19,8 @@ jobs:
   # This builds the sdists and wheels and makes sure the files are exactly as
   # expected.
   test-packaging:
-    name: 🐍 3.8 • 📦 tests • windows-2022
-    runs-on: windows-2022
+    name: 🐍 3.8 • 📦 tests • windows-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v5

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -8,6 +8,16 @@ import pytest
 
 from pybind11_tests import iostream as m
 
+if sys.platform == "win32":
+    wv_build = sys.getwindowsversion().build
+    skip_if_ge = 26100
+    if wv_build >= skip_if_ge:
+        pytest.skip(
+            f"Windows build {wv_build} >= {skip_if_ge}:"
+            " Skipping iostream capture (redirection regression under investigation)",
+            allow_module_level=True,
+        )
+
 
 def test_captured(capsys):
     msg = "I've been redirected to Python, I hope!"

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -6,15 +6,16 @@ from io import StringIO
 
 import pytest
 
+import env
 from pybind11_tests import iostream as m
 
-if sys.platform == "win32":
+if env.WIN:
     wv_build = sys.getwindowsversion().build
     skip_if_ge = 26100
     if wv_build >= skip_if_ge:
         pytest.skip(
             f"Windows build {wv_build} >= {skip_if_ge}:"
-            " Skipping iostream capture (redirection regression under investigation)",
+            " Skipping iostream capture (redirection regression needs investigation)",
             allow_module_level=True,
         )
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
1. Revert PR #5826 
2. Add module-level skip for Windows build >= 26100 in `test_iostream.py`

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
