### PR TITLE
`.gitignore`: exclude `__pycache__` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ MANIFEST
 /.ninja_*
 /*.ninja
 /docs/.build
+__pycache__/
 *.py[co]
 *.egg-info
 *~


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Python may leave behind temporary `.pyc.*` files inside `__pycache__` on some filesystems (e.g. WSL2 mounts). Adding `__pycache__/` ensures these directories and any leftover files are consistently ignored.

Background: Python writes bytecode to a temp file with an extra suffix before renaming it to `.pyc`. If the process is interrupted or the filesystem rename isn’t fully atomic, those temp files may remain.

See: https://docs.python.org/3/library/py_compile.html#py_compile.compile

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
