### PR TITLE
Fix thread-safety in `get_local_type_info()`

### DIFF
--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -91,6 +91,7 @@ static PyType_Spec function_record_PyType_Spec
        function_record_PyType_Slots};
 
 inline PyTypeObject *get_function_record_PyTypeObject() {
+    PYBIND11_LOCK_INTERNALS(get_internals());
     PyTypeObject *&py_type_obj = detail::get_local_internals().function_record_py_type;
     if (!py_type_obj) {
         PyObject *py_obj = PyType_FromSpec(&function_record_PyType_Spec);


### PR DESCRIPTION
## Description

Fixes potential thread-safety issues if types are concurrently registered while `get_local_type_info()` is called in free threaded Python.

Use the `internals` mutex to also protect `local_internals`. This keeps the locking strategy simpler, and we already follow this pattern in some places, such as `pybind11_meta_dealloc`.

Fixes #5799 

## Suggested changelog entry:

* Fix thread-safety issues if types are concurrently registered while `get_local_type_info()` is called in free threaded Python.
