### PR TITLE
Factor out readable function signatures to avoid duplication

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -279,32 +279,17 @@ public:
 #undef PYBIND11_READABLE_FUNCTION_SIGNATURE_EXPR
 
 // Prior to C++17, we don't have inline variables, so we have to
-// provide an out-of-line definition of the class member. We should
-// remove the following chunk of code (until the PYBIND11_WARNING_POP)
-// if/when we drop support for C++11 and C++14.
-PYBIND11_WARNING_PUSH
-#if defined(PYBIND11_CPP17)
-#    if defined(__clang_major__)                                                                  \
-        && (__clang_major__ >= 17 || (defined(__APPLE__) && __clang_major__ >= 15))
-// Even with the above gating, there's one straggler CI job that
-// claims it doesn't know what
-// -Wdeprecated-redundant-constexpr-static-def is despite being on
-// Apple Clang 15. Just suppress -Wunknown-warning-option.
-PYBIND11_WARNING_DISABLE_CLANG("-Wunknown-warning-option")
-PYBIND11_WARNING_DISABLE_CLANG("-Wdeprecated-redundant-constexpr-static-def")
-#    endif
-PYBIND11_WARNING_DISABLE_CLANG("-Wdeprecated")
-PYBIND11_WARNING_DISABLE_GCC("-Wdeprecated")
-#endif
+// provide an out-of-line definition of the class member.
+#if !defined(PYBIND11_CPP17)
 template <typename cast_in, typename cast_out>
 constexpr typename ReadableFunctionSignature<cast_in, cast_out>::sig_type
     ReadableFunctionSignature<cast_in, cast_out>::kSig;
-#if !defined(_MSC_VER)
+#    if !defined(_MSC_VER)
 template <typename cast_in, typename cast_out>
 constexpr typename ReadableFunctionSignature<cast_in, cast_out>::types_type
     ReadableFunctionSignature<cast_in, cast_out>::kTypes;
+#    endif
 #endif
-PYBIND11_WARNING_POP
 
 PYBIND11_NAMESPACE_END(detail)
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

This should provide a nice to have size optimization for programs that use pybind11 in general. I wrote it because it seems to reduce size costs of adding enum_-specific implementations of dunder methods, but since it seems generally useful, I thought it might be a good idea to send as a separate PR.

Concretely, for the pybind11_tests.cpython-313-darwin.so file built as part of pybind11's tests, I see the following size delta (output is `sdiff` of `size -m`):

```
pybind11_tests.cpython-313-darwin.so:                           pybind11_tests.cpython-313-darwin.so:
Segment __TEXT: 5668864                                       | Segment __TEXT: 5619712
        Section __text: 4660144                                         Section __text: 4660144
        Section __stubs: 4068                                           Section __stubs: 4068
        Section __stub_helper: 4008                                     Section __stub_helper: 4008
        Section __init_offsets: 288                                     Section __init_offsets: 288
        Section __const: 277048                               |         Section __const: 232528
        Section __gcc_except_tab: 543816                                Section __gcc_except_tab: 543816
        Section __cstring: 57906                                        Section __cstring: 57906
        Section __ustring: 32                                           Section __ustring: 32
        Section __unwind_info: 103928                                   Section __unwind_info: 103928
        Section __eh_frame: 280                                         Section __eh_frame: 280
        total 5651518                                         |         total 5606998
Segment __DATA_CONST: 98304                                     Segment __DATA_CONST: 98304
        Section __got: 968                                              Section __got: 968
        Section __const: 92840                                |         Section __const: 83016
        total 93808                                           |         total 83984
Segment __DATA: 16384                                           Segment __DATA: 16384
        Section __la_symbol_ptr: 2656                                   Section __la_symbol_ptr: 2656
        Section __data: 595                                             Section __data: 595
        Section __thread_vars: 120                                      Section __thread_vars: 120
        Section __thread_bss: 40 (zerofill)                             Section __thread_bss: 40 (zerofill)
        Section __bss: 2960 (zerofill)                                  Section __bss: 2960 (zerofill)
        total 6371                                                      total 6371
Segment __LINKEDIT: 114688                                      Segment __LINKEDIT: 114688
total 5898240                                                 | total 5849088
```

Full disclosure: Not all of the other .sos improved (though none regressed). For this to show a benefit, users' pybind11 extensions would have to define multiple pybind11 functions or methods with the same signature.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Reduced size overhead by deduplicating functions' readable signatures and type information.
