### PR TITLE
[WIP] Improve guarding of `Py_DECREF`, `Py_XDECREF` triggered from C++ dtors

### DIFF
--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -77,7 +77,7 @@ public:
         }
         frame = parent;
         for (auto *item : keep_alive) {
-            Py_DECREF(item);
+            Py_DECREF(item); // decref in C++ dtor: always safe?
         }
     }
 
@@ -727,7 +727,7 @@ struct shared_ptr_parent_life_support {
     // NOLINTNEXTLINE(readability-make-member-function-const)
     void operator()(void *) {
         gil_scoped_acquire gil;
-        Py_DECREF(parent);
+        Py_DECREF(parent); // decref in C++ dtor: NEEDS can_decref_now
     }
 };
 
@@ -741,7 +741,7 @@ struct shared_ptr_trampoline_self_life_support {
     // NOLINTNEXTLINE(readability-make-member-function-const)
     void operator()(void *) {
         gil_scoped_acquire gil;
-        Py_DECREF(self);
+        Py_DECREF(self); // decref in C++ dtor: NEEDS can_decref_now
     }
 };
 

--- a/include/pybind11/trampoline_self_life_support.h
+++ b/include/pybind11/trampoline_self_life_support.h
@@ -42,7 +42,9 @@ struct trampoline_self_life_support {
                 v_h.value_ptr() = nullptr;
                 v_h.holder<smart_holder>().release_disowned();
                 detail::deregister_instance(v_h.inst, value_void_ptr, v_h.type);
-                Py_DECREF((PyObject *) v_h.inst); // Must be after deregister.
+                Py_DECREF(
+                    (PyObject *)
+                        v_h.inst); // Must be after deregister. // decref in C++ dtor: always safe?
                 PyGILState_Release(threadstate);
             }
         }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Currently this PR is only pin-pointing code we need to review, based on a quick manual review (`master` @ commit aa4259b4f835177cdd1da81ca1221f77cd84d5c8) of:

```
$ cd include/pybind11/
$ git grep -e Py_DECREF -e Py_XDECREF | cut -d: -f1 | uniq conduit/pybind11_conduit_v1.h
detail/class.h
detail/cpp_conduit.h
detail/type_caster_base.h
gil_safe_call_once.h
numpy.h
pybind11.h
pytypes.h
stl.h
stl/filesystem.h
trampoline_self_life_support.h
```

I think we should look into the suggestions here:

* https://chatgpt.com/share/68ebe31b-5a28-8008-983d-0b2c682600c7

Related: We should also look into our existing uses of `_Py_IsFinalizing()`. I think we should (or even need to later) have an `is_finalizing()` helper:

* https://chatgpt.com/share/68ebe381-dd9c-8008-9731-e8306cd23617

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
