### PR TITLE
Avoid _PyObject_GetDictPtr() function

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -476,10 +476,14 @@ inline void clear_instance(PyObject *self) {
         PyObject_ClearWeakRefs(self);
     }
 
+#if PY_VERSION_HEX >= 0x030D0000
+    PyObject_ClearManagedDict(self);
+#else
     PyObject **dict_ptr = _PyObject_GetDictPtr(self);
     if (dict_ptr) {
         Py_CLEAR(*dict_ptr);
     }
+#endif
 
     if (instance->has_patients) {
         clear_patients(self);


### PR DESCRIPTION
This function is also broken on free-threading because free-threading stores and reads dictionary pointer atomically, it is not safe to read the dictionary pointer directly as returned by this function.

Use PyObject_ClearManagedDict() instead in clear_instance().

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
