### PR TITLE
fix dangling thread state issue

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -286,11 +286,9 @@ struct internals {
     internals()
         : static_property_type(make_static_property_type()),
           default_metaclass(make_default_metaclass()) {
-        tstate.set(nullptr);
+        tstate.set(nullptr); // See PR #5870
         PyThreadState *cur_tstate = PyThreadState_Get();
-        // The PyThreadState that is returned by PyThreadState_Get is not owned by us and may be
-        // destroyed by the owner at some point in the future.  Saving this PyThreadState here can
-        // lead to dangling pointer undefined behavior in complex multi-threaded scenarios.
+
         istate = cur_tstate->interp;
         registered_exception_translators.push_front(&translate_exception);
 #ifdef Py_GIL_DISABLED

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -271,7 +271,7 @@ inline subinterpreter_scoped_activate::subinterpreter_scoped_activate(subinterpr
     // make the interpreter active and acquire the GIL
     old_tstate_ = PyThreadState_Swap(tstate_);
 
-    // save this in internals for scoped_gil calls
+    // save this in internals for scoped_gil calls (see also: PR #5870)
     detail::get_internals().tstate = tstate_;
 }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

fix https://github.com/pybind/pybind11/issues/2888

This fixes undefined behavior in Gil handling associated with storing a dangling pointer.  Saving this pointer is not functionally needed, because if the TLS tstate lookup returns a nullptr in gil_scoped_acquire(), the next bit of code does tstate=PyGILState_GetThisThreadState().  In the cases where the tstate wasn't dangling the results will be the same with one extra TLS lookup (minor penalty for correctness), in the cases where the saved tstate was dangling the correct one will be loaded from PyGILState_GetThisThreadState().

## Suggested changelog entry:

Fix undefined behavior that occurred when importing pybind11 modules from non-main threads created by C API modules or embedded python interpreters.

