### PR TITLE
Repro for lack of set operations

### DIFF
--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -164,6 +164,7 @@ def test_map_string_double():
     keys = mm.keys()
     values = mm.values()
     items = mm.items()
+    assert keys & {"a", "c"} == {"a"}
     assert list(keys) == ["a", "b"]
     assert len(keys) == 2
     assert "a" in keys


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Shows the lack of set operation on keys() result.

