### PR TITLE
Replace `env.deprecated_call()` with `pytest.deprecated_call()`

### DIFF
--- a/tests/env.py
+++ b/tests/env.py
@@ -4,8 +4,6 @@ import platform
 import sys
 import sysconfig
 
-import pytest
-
 ANDROID = sys.platform.startswith("android")
 LINUX = sys.platform.startswith("linux")
 MACOS = sys.platform.startswith("darwin")
@@ -29,19 +27,3 @@ TYPES_ARE_IMMORTAL = (
     or GRAALPY
     or (CPYTHON and PY_GIL_DISABLED and (3, 13) <= sys.version_info < (3, 14))
 )
-
-
-def deprecated_call():
-    """
-    pytest.deprecated_call() seems broken in pytest<3.9.x; concretely, it
-    doesn't work on CPython 3.8.0 with pytest==3.3.2 on Ubuntu 18.04 (#2922).
-
-    This is a narrowed reimplementation of the following PR :(
-    https://github.com/pytest-dev/pytest/pull/4104
-    """
-    # TODO: Remove this when testing requires pytest>=3.9.
-    pieces = pytest.__version__.split(".")
-    pytest_major_minor = (int(pieces[0]), int(pieces[1]))
-    if pytest_major_minor < (3, 9):
-        return pytest.warns((DeprecationWarning, PendingDeprecationWarning))
-    return pytest.deprecated_call()

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -304,7 +304,7 @@ def test_int_convert(doc):
     # TODO: Avoid DeprecationWarning in `PyLong_AsLong` (and similar)
     # TODO: PyPy 3.8 does not behave like CPython 3.8 here yet (7.3.7)
     if sys.version_info < (3, 10) and env.CPYTHON:
-        with env.deprecated_call():
+        with pytest.deprecated_call():
             assert convert(Int()) == 42
     else:
         assert convert(Int()) == 42
@@ -377,7 +377,7 @@ def test_numpy_int_convert():
     # TODO: PyPy 3.8 does not behave like CPython 3.8 here yet (7.3.7)
     # https://github.com/pybind/pybind11/issues/3408
     if (3, 8) <= sys.version_info < (3, 10) and env.CPYTHON:
-        with env.deprecated_call():
+        with pytest.deprecated_call():
             assert convert(np.float32(3.14159)) == 3
     else:
         assert convert(np.float32(3.14159)) == 3


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Since we already require `pytest>=6` (see tests/requirements.txt), the old compatibility function is obsolete and `pytest.deprecated_call()` can be used directly.

Extracted from PR #5879, to make that PR as lean and clean as possible.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* `pytest.deprecated_call()` is now called directly.