### PR TITLE
Fix build with gcc-4.x(#5901)

### DIFF
--- a/include/pybind11/conduit/pybind11_platform_abi_id.h
+++ b/include/pybind11/conduit/pybind11_platform_abi_id.h
@@ -71,6 +71,8 @@
 #        define PYBIND11_BUILD_ABI                                                                \
             "_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_" PYBIND11_PLATFORM_ABI_ID_TOSTRING(           \
                 _GLIBCXX_USE_CXX11_ABI)
+#    elif defined(__GNUC__) && (__GNUC__ < 5)
+#        define PYBIND11_BUILD_ABI "_gcc_4.x"
 #    else
 #        error "Unknown platform or compiler: PLEASE REVISE THIS CODE."
 #    endif

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -209,9 +209,10 @@
 #    define PYBIND11_HAS_VARIANT 1
 #endif
 
-#if defined(PYBIND11_CPP17)                                                                       \
-    && ((defined(__has_include) && __has_include(<string_view>)) || defined(_MSC_VER))
-#    define PYBIND11_HAS_STRING_VIEW 1
+#if defined(PYBIND11_CPP17)
+#    if (defined(__has_include) && __has_include(<string_view>)) || defined(_MSC_VER)
+#        define PYBIND11_HAS_STRING_VIEW 1
+#    endif
 #endif
 
 #if (defined(PYPY_VERSION) || defined(GRAALVM_PYTHON)) && !defined(PYBIND11_SIMPLE_GIL_MANAGEMENT)


### PR DESCRIPTION
## Description
https://github.com/pybind/pybind11/issues/5901
fixed compiler abi checks for gcc-4.8.5

## Suggested changelog entry:
