### PR TITLE
Remove enum from bold in doc

### DIFF
--- a/docs/advanced/functions.rst
+++ b/docs/advanced/functions.rst
@@ -85,7 +85,7 @@ The following table provides an overview of available policies:
 |                                                  | (the implicit ``this``, or ``self`` argument of the called method or       |
 |                                                  | property) is kept alive for at least the lifespan of the return value.     |
 |                                                  | **Otherwise this policy falls back to** :enum:`return_value_policy::move`  |
-|                                                  | **(see #5528).** Internally, this policy works just like                   |
+|                                                  | (see #5528). Internally, this policy works just like                       |
 |                                                  | :enum:`return_value_policy::reference` but additionally applies a          |
 |                                                  | ``keep_alive<0, 1>`` *call policy* (described in the next section) that    |
 |                                                  | prevents the parent object from being garbage collected as long as the     |


### PR DESCRIPTION
## Description

@ax3l reported in #5528 that the documentation formatting was broken.
I think this should fix it. I don't know if there is a more elegant fix.

## Suggested changelog entry:

* Fix documentation formatting.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--5903.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->