### PR TITLE
Point main README.rst to CI for supported platforms and compilers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,8 +135,8 @@ versions of a tested compiler or platform will often work as well in practice,
 but we cannot promise to validate every possible combination. If a
 configuration you rely on is missing from the matrix or regresses, issues and
 pull requests to extend coverage are very welcome. At the same time, we need
-to balance the size of the test matrix with the available CI resources (for
-example, GitHub's free minutes).
+to balance the size of the test matrix with the available CI resources,
+such as GitHub's limits on concurrent jobs under the free tier.
 
 About
 -----


### PR DESCRIPTION
- **Replace** the hard-coded “Supported compilers” and “Supported platforms” lists in `README.rst`.
- **Point** readers to the current GitHub Actions matrix as the source of truth for tested platforms, compilers, and Python/C++ versions.
- **Clarify** that the matrix evolves over time and that configurations users care about can be kept working via contributions.

- **Avoid stale documentation**: Enumerating specific compiler and platform versions in the README is both burdensome and error-prone, and tends to drift out of sync with reality.
- **Align “supported” with “tested”**: In practice, the CI configuration is the only place where we can say with confidence which combinations are exercised. Nearby versions (e.g., adjacent compiler minor releases) will often work, but we cannot test every variant.
- **Reflect actual maintenance capacity**: pybind11 is maintained by a small, volunteer-based community, so support is necessarily best-effort. Pointing to CI and inviting contributions better matches how support is provided in practice.

- **No behavior change**: This PR updates documentation only.
- **Living source of truth**: As CI jobs are added or removed, the linked Actions view will automatically reflect the set of configurations we actively test. Keeping a configuration in CI is the best way to keep it “supported”.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* The “Supported compilers” and “Supported platforms” sections in the main `README.rst` were replaced with a new “Supported platforms & compilers“ section that points to the CI test matrix as the living source of truth.
