### PR TITLE
Disable Android cibuildwheel tests only on `ubuntu-latest`

### DIFF
--- a/.github/workflows/tests-cibw.yml
+++ b/.github/workflows/tests-cibw.yml
@@ -71,12 +71,12 @@ jobs:
       run: echo "CIBW_TEST_COMMAND=" >> "$GITHUB_ENV"
 
     # Temporarily disable Android tests on ubuntu-latest due to emulator issues.
-    # See https://github.com/pybind/pybind11/issues/5913.
+    # See https://github.com/pybind/pybind11/pull/5914.
     - name: "NOTE: Android tests are disabled on ubuntu-latest"
       if: contains(matrix.runs-on, 'ubuntu')
       run: |
         echo "CIBW_TEST_COMMAND=" >> "$GITHUB_ENV"
-        echo '::warning::Android cibuildwheel tests are disabled on ubuntu-latest (CIBW_TEST_COMMAND is empty). See issue 5913.'
+        echo '::warning::Android cibuildwheel tests are disabled on ubuntu-latest (CIBW_TEST_COMMAND is empty). See PR 5914.'
 
     # https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/
     - name: Enable KVM for Android emulator


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The change included with PR #5912 was unintentionally not specific to `ubuntu-latest`. Fixing the oversight here.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
