### PR TITLE
Replace deprecated `macos-13` runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,22 +96,22 @@ jobs:
             python-version: 'graalpy-24.1'
 
           # No SciPy for macOS ARM
-          - runs-on: macos-13
+          - runs-on: macos-15-intel
             python-version: '3.8'
             cmake-args: -DCMAKE_CXX_STANDARD=14
-          - runs-on: macos-13
+          - runs-on: macos-15-intel
             python-version: '3.11'
             cmake-args: -DPYBIND11_TEST_SMART_HOLDER=ON
           - runs-on: macos-latest
             python-version: '3.12'
             cmake-args: -DCMAKE_CXX_STANDARD=17 -DPYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION=ON
-          - runs-on: macos-13
+          - runs-on: macos-15-intel
             python-version: '3.13t'
             cmake-args: -DCMAKE_CXX_STANDARD=11
           - runs-on: macos-latest
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=20
-          - runs-on: macos-13
+          - runs-on: macos-15-intel
             python-version: 'pypy-3.10'
             cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: macos-latest

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -35,7 +35,7 @@ jobs:
         - runs-on: ubuntu-24.04
           cmake: "3.29"
 
-        - runs-on: macos-13
+        - runs-on: macos-15-intel
           cmake: "3.15"
 
         - runs-on: macos-14

--- a/.github/workflows/tests-cibw.yml
+++ b/.github/workflows/tests-cibw.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-14, macos-13]
+        runs-on: [macos-14, macos-15-intel]
     steps:
     - uses: actions/checkout@v6
       with:
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-latest, macos-13, ubuntu-latest]
+        runs-on: [macos-latest, macos-15-intel, ubuntu-latest]
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Systematically replace all `macos-13` with `macos-15-intel`.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
