### PR TITLE
Updating widows arm visibility

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -139,7 +139,11 @@
 
 #if !defined(PYBIND11_EXPORT)
 #    if defined(WIN32) || defined(_WIN32)
-#        define PYBIND11_EXPORT __declspec(dllexport)
+#        if defined(__aarch64__)
+#            define PYBIND11_EXPORT __declspec(dllexport) __attribute__((visibility("default")))
+#        else
+#            define PYBIND11_EXPORT __declspec(dllexport)
+#        endif
 #    else
 #        define PYBIND11_EXPORT __attribute__((visibility("default")))
 #    endif


### PR DESCRIPTION
## Description

This fixes #5883. 

Really, I've just applied the patch that @baburton pasted in the mentioned issue
This checks whether we are compiling on Windows with ARM; if so, we export default visibility.

You can see passing actions that build on arm-windows in this [successful github action in my scratch repository](https://github.com/K20shores/scratch/actions/runs/19967183449), so it appears to work

## Suggested changelog entry:

Exports default visibility on ARM-based Windows builds
