### PR TITLE
Modernize NVHPC CI job (to make it working again): Ubuntu-24.04 runner, NVHPC 25.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,7 +470,7 @@ jobs:
 
 
   # Testing on Ubuntu + NVHPC (previous PGI) compilers, which seems to require more workarounds
-  ubuntu-nvhpc7:
+  ubuntu-nvhpc:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     name: "🐍 3 • NVHPC 25.11 • C++17 • x64"


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

This PR updates the NVHPC CI job to run on a newer Ubuntu image and the latest NVIDIA HPC SDK release, in order to fix a persistent "no space left on device" failure, while keeping the rest of the CI configuration unchanged.

Concretely:

- Switch the NVHPC job from `ubuntu-22.04` to `ubuntu-24.04`.
- Bump the NVHPC package from `nvhpc-23-5` to `nvhpc-25-11` and load the matching module file.
- Keep the NVHPC job configuration (CMake arguments, test filter, etc.) otherwise identical to the previous setup, with only a minor build parallelism tweak (`-j $(nproc)`).

___

### Original failure (ubuntu-22.04 + NVHPC 23.5)

On the existing CI configuration, the NVHPC job (`ubuntu-nvhpc7`) was running on `ubuntu-22.04` and using `nvhpc-23-5`. Starting in early December 2025, these jobs began to fail in a way that was clearly environmental rather than code-related:

- The job progressed into the CMake/`nvc++` compilation of the C++ test suite.
- Compilation failed with errors of the form:
  - `catastrophic error: error while writing intermediate language file: No space left on device`
  - Followed by `gmake`/`cmake --build` errors and job termination.
- In some runs, the GitHub Actions runner itself also reported warnings like:
  - `You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 34 MB`.

The failure was not specific to `pybind11` or to a particular test. Instead, it was the combination of:

- The `ubuntu-22.04` runner image, whose available free disk shrank with newer image releases.
- The relatively heavy disk footprint of the NVHPC toolchain and its intermediate IR/object files when compiling the full C++ test suite.

Other `ubuntu-22.04` jobs in this repository did not hit the same limit, which is consistent with the NVHPC job simply being the heaviest consumer of disk space.

### First experiment: change runner only

To separate runner effects from NVHPC version effects, the first experiment was to change **only** the runner image for the NVHPC job:

- `runs-on: ubuntu-22.04` → `runs-on: ubuntu-24.04`.
- Keep `nvhpc-23-5` and all CMake/test settings exactly the same.

Result:

- The job failed very quickly, but still with a **disk-related** failure rather than a compiler bug or test regression.
- This confirmed that simply moving to `ubuntu-24.04` with the old NVHPC package was not sufficient to get the job working again.

### Second experiment: newer NVHPC on ubuntu-24.04

The next step was to also upgrade NVHPC to the latest release and adjust the module path accordingly:

- `nvhpc-23-5` → `nvhpc-25-11` in the `apt-get install` step.
- `module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/23.5` → `module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/25.11`.
- While touching the job, the `cmake --build` invocation was also updated to use all available cores (`-j $(nproc)`) instead of a fixed `-j 2`.

With that the NVHPC job completed successfully.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* n/a
