### PR TITLE
fix: define _BACKUP_ITERATOR_DEBUG_LEVEL for MSVC 17.12+ compatibility

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -10,11 +10,12 @@
 
 #pragma once
 
-// See Issue #5956. This fixes compilation failure with MSVC 17.12 (v14.44) and C++20: '_BACKUP_ITERATOR_DEBUG_LEVEL' undeclared when including span header from STL.
+// See Issue #5956. This fixes compilation failure with MSVC 17.12 (v14.44) and C++20:
+// '_BACKUP_ITERATOR_DEBUG_LEVEL' undeclared when including span header from STL.
 #if defined(_MSC_VER)
-#ifndef _BACKUP_ITERATOR_DEBUG_LEVEL
-#define _BACKUP_ITERATOR_DEBUG_LEVEL 0
-#endif
+#    ifndef _BACKUP_ITERATOR_DEBUG_LEVEL
+#        define _BACKUP_ITERATOR_DEBUG_LEVEL 0
+#    endif
 #endif
 
 #include "detail/class.h"


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->

## Description

This PR fixes a compilation error encountered when using **Visual Studio 2022 version 17.12 (MSVC 14.44)** in **C++20** mode.

The MSVC STL (specifically the `<span` header) has introduced internal checks that reference the macro `_BACKUP_ITERATOR_DEBUG_LEVEL`. In certain build environments—particularly those involving complex Python bindings like **Kratos Multiphysics**—this macro is expected by the STL but remains undeclared, leading to the following error:

```text
error C2065: '_BACKUP_ITERATOR_DEBUG_LEVEL' : undeclared identifier
error C3861: '_BACKUP_ITERATOR_DEBUG_LEVEL': identifier not found

```

### Proposed Changes

Inserted a preprocessor guard in `include/pybind11/pybind11.h` to ensure `_BACKUP_ITERATOR_DEBUG_LEVEL` is defined to `0` if it is not already set. This allows the MSVC STL headers to resolve their internal iterator debugging logic correctly. I understand that maybe the placement can be improved in order to not add "garbage" to the main include file, I am open to suggestions.

```cpp
// See Issue #5956. This fixes compilation failure with MSVC 17.12 (v14.44) and C++20: 
// '_BACKUP_ITERATOR_DEBUG_LEVEL' undeclared when including span header from STL.
#if defined(_MSC_VER)
    #ifndef _BACKUP_ITERATOR_DEBUG_LEVEL
        #define _BACKUP_ITERATOR_DEBUG_LEVEL 0
    #endif
#endif

```

## Motivation and Context

* **Fixes:** #5956
* **Related Context:** This issue was identified during the integration of pybind11 with Kratos Multiphysics (see [[Kratos PR #14105](https://github.com/KratosMultiphysics/Kratos/pull/14105)](https://github.com/KratosMultiphysics/Kratos/pull/14105)).
* **Environment:** MSVC 14.44.35207 + C++20.
* **Impact:** Without this fix, users on the latest MSVC stable/preview releases cannot compile projects that include `<span` through or alongside `pybind11`.

## How Has This Been Tested?

* Confirmed that the error is resolved in the Kratos Multiphysics build pipeline using the specified MSVC version.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

- [f[ix: Fixes compilation failure with MSVC 17.12 (v14.44) and C++20: '_…](fix: Fixes compilation failure with MSVC 17.12 (v14.44) and C++20: '_BACKUP_ITERATOR_DEBUG_LEVEL' undeclared when including span header from STL.)](https://github.com/pybind/pybind11/commit/a3bdd9da0866c61c8c532afeee584683adc1b890)
