### PR TITLE
Cursor-generated: Add leak_detach path for internals after shutdown

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -143,6 +143,38 @@ inline PyTypeObject *make_default_metaclass();
 inline PyObject *make_object_base_type(PyTypeObject *metaclass);
 inline void translate_exception(std::exception_ptr p);
 
+inline PyThreadState *get_thread_state_unchecked() {
+#if defined(PYPY_VERSION) || defined(GRAALVM_PYTHON)
+    return PyThreadState_GET();
+#elif PY_VERSION_HEX < 0x030D0000
+    return _PyThreadState_UncheckedGet();
+#else
+    return PyThreadState_GetUnchecked();
+#endif
+}
+
+inline PyInterpreterState *get_interpreter_state_unchecked() {
+    auto *tstate = get_thread_state_unchecked();
+    return tstate ? tstate->interp : nullptr;
+}
+
+inline object get_python_state_dict() {
+    object state_dict;
+#if defined(PYPY_VERSION) || defined(GRAALVM_PYTHON)
+    state_dict = reinterpret_borrow<object>(PyEval_GetBuiltins());
+#else
+    auto *istate = get_interpreter_state_unchecked();
+    if (istate) {
+        state_dict = reinterpret_borrow<object>(PyInterpreterState_GetDict(istate));
+    }
+#endif
+    if (!state_dict) {
+        raise_from(PyExc_SystemError, "pybind11::detail::get_python_state_dict() FAILED");
+        throw error_already_set();
+    }
+    return state_dict;
+}
+
 // Python loads modules by default with dlopen with the RTLD_LOCAL flag; under libc++ and possibly
 // other STLs, this means `typeid(A)` from one module won't equal `typeid(A)` from another module
 // even when `A` is the same, non-hidden-visibility type (e.g. from a common include).  Under
@@ -285,11 +317,8 @@ struct internals {
 
     internals()
         : static_property_type(make_static_property_type()),
-          default_metaclass(make_default_metaclass()) {
+          default_metaclass(make_default_metaclass()), istate(get_interpreter_state_unchecked()) {
         tstate.set(nullptr); // See PR #5870
-        PyThreadState *cur_tstate = PyThreadState_Get();
-
-        istate = cur_tstate->interp;
         registered_exception_translators.push_front(&translate_exception);
 #ifdef Py_GIL_DISABLED
         // Scale proportional to the number of cores. 2x is a heuristic to reduce contention.
@@ -308,21 +337,28 @@ struct internals {
     internals(internals &&other) = delete;
     internals &operator=(const internals &other) = delete;
     internals &operator=(internals &&other) = delete;
+
     void leak_detach() noexcept {
         // Used when internals must be destroyed after interpreter teardown.
         // Avoid touching the Python C-API by clearing pointers only.
         instance_base = nullptr;
         default_metaclass = nullptr;
         static_property_type = nullptr;
+        istate = nullptr;
     }
 
     ~internals() {
-        // Destruction is expected to run while the interpreter is still intact
-        // (e.g., during state-dict teardown). If we must destroy after shutdown,
-        // leak_detach() must have been called first.
-        Py_CLEAR(instance_base);
-        Py_CLEAR(default_metaclass);
-        Py_CLEAR(static_property_type);
+        // Normally this destructor runs during interpreter finalization and it may DECREF things.
+        // In odd finalization scenarios it might end up running after the interpreter has
+        // completely shut down, In that case, we should not decref these objects because pymalloc
+        // is gone.  This also applies across sub-interpreters, we should only DECREF when the
+        // original owning interpreter is active.
+        auto *cur_istate = get_interpreter_state_unchecked();
+        if (cur_istate && cur_istate == istate) {
+            Py_CLEAR(instance_base);
+            Py_CLEAR(default_metaclass);
+            Py_CLEAR(static_property_type);
+        }
     }
 };
 
@@ -333,6 +369,8 @@ struct internals {
 // impact any other modules, because the only things accessing the local internals is the
 // module that contains them.
 struct local_internals {
+    local_internals() : istate(get_interpreter_state_unchecked()) {}
+
     // It should be safe to use fast_type_map here because this entire
     // data structure is scoped to our single module, and thus a single
     // DSO and single instance of type_info for any particular type.
@@ -340,17 +378,24 @@ struct local_internals {
 
     std::forward_list<ExceptionTranslator> registered_exception_translators;
     PyTypeObject *function_record_py_type = nullptr;
+    PyInterpreterState *istate = nullptr;
 
     void leak_detach() noexcept {
         // Used when local internals must be destroyed after interpreter teardown.
         function_record_py_type = nullptr;
+        istate = nullptr;
     }
 
     ~local_internals() {
-        // Destruction is expected to run while the interpreter is still intact
-        // (e.g., during state-dict teardown). If we must destroy after shutdown,
-        // leak_detach() must have been called first.
-        Py_CLEAR(function_record_py_type);
+        // Normally this destructor runs during interpreter finalization and it may DECREF things.
+        // In odd finalization scenarios it might end up running after the interpreter has
+        // completely shut down, In that case, we should not decref these objects because pymalloc
+        // is gone.  This also applies across sub-interpreters, we should only DECREF when the
+        // original owning interpreter is active.
+        auto *cur_istate = get_interpreter_state_unchecked();
+        if (cur_istate && cur_istate == istate) {
+            Py_CLEAR(function_record_py_type);
+        }
     }
 };
 
@@ -434,16 +479,6 @@ struct native_enum_record {
 #define PYBIND11_MODULE_LOCAL_ID                                                                  \
     "__pybind11_module_local_v" PYBIND11_TOSTRING(PYBIND11_INTERNALS_VERSION)                     \
         PYBIND11_COMPILER_TYPE_LEADING_UNDERSCORE PYBIND11_PLATFORM_ABI_ID "__"
-
-inline PyThreadState *get_thread_state_unchecked() {
-#if defined(PYPY_VERSION) || defined(GRAALVM_PYTHON)
-    return PyThreadState_GET();
-#elif PY_VERSION_HEX < 0x030D0000
-    return _PyThreadState_UncheckedGet();
-#else
-    return PyThreadState_GetUnchecked();
-#endif
-}
 
 /// We use this to figure out if there are or have been multiple subinterpreters active at any
 /// point. This must never go from true to false while any interpreter may be running in any
@@ -556,27 +591,6 @@ inline void translate_local_exception(std::exception_ptr p) {
     }
 }
 #endif
-
-inline object get_python_state_dict() {
-    object state_dict;
-#if defined(PYPY_VERSION) || defined(GRAALVM_PYTHON)
-    state_dict = reinterpret_borrow<object>(PyEval_GetBuiltins());
-#else
-#    if PY_VERSION_HEX < 0x03090000
-    PyInterpreterState *istate = _PyInterpreterState_Get();
-#    else
-    PyInterpreterState *istate = PyInterpreterState_Get();
-#    endif
-    if (istate) {
-        state_dict = reinterpret_borrow<object>(PyInterpreterState_GetDict(istate));
-    }
-#endif
-    if (!state_dict) {
-        raise_from(PyExc_SystemError, "pybind11::detail::get_python_state_dict() FAILED");
-        throw error_already_set();
-    }
-    return state_dict;
-}
 
 // Get or create per-storage capsule in the current interpreter's state dict.
 //   - The storage is interpreter-dependent: different interpreters will have different storage.
@@ -716,7 +730,10 @@ public:
             if (!tstate || tstate->interp == last_istate_tls()) {
                 auto tpp = internals_p_tls();
                 if (tpp && tpp->get()) {
-                    tpp->get()->leak_detach();
+                    auto *cur_istate = get_interpreter_state_unchecked();
+                    if (!cur_istate || cur_istate != tpp->get()->istate) {
+                        tpp->get()->leak_detach();
+                    }
                 }
                 delete tpp;
             }
@@ -725,7 +742,10 @@ public:
         }
 #endif
         if (internals_singleton_pp_ && internals_singleton_pp_->get()) {
-            internals_singleton_pp_->get()->leak_detach();
+            auto *cur_istate = get_interpreter_state_unchecked();
+            if (!cur_istate || cur_istate != internals_singleton_pp_->get()->istate) {
+                internals_singleton_pp_->get()->leak_detach();
+            }
         }
         delete internals_singleton_pp_;
         unref();

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -20,15 +20,6 @@
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
-PYBIND11_NAMESPACE_BEGIN(detail)
-inline PyInterpreterState *get_interpreter_state_unchecked() {
-    auto *cur_tstate = get_thread_state_unchecked();
-    if (cur_tstate) {
-        return cur_tstate->interp;
-    }
-    return nullptr;
-}
-PYBIND11_NAMESPACE_END(detail)
 
 class subinterpreter;
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Py_IsInitialized/Py_IsFinalizing are runtime-wide, not per-interpreter, and Py_IsFinalizing stays set after Py_Finalize until the next init. Using those checks to decide whether to DECREF internals can skip cleanup or touch the C-API after a specific interpreter is gone.

Add internals::leak_detach() and local_internals::leak_detach() to clear the owned PyType/PyObject pointers without calling into Python, and invoke that from internals_pp_manager::destroy() before deleting the pp in the post- Py_Finalize/Py_EndInterpreter paths. The destructors now always Py_CLEAR when invoked during state-dict teardown, preserving cleanup of the pybind11 heap types while avoiding UB in late-destroy scenarios.

___

Cursor GPT-5.2 Codex Extra High
 
```
 ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │ → Could you please read this file for context: /wrk/logs/gh_pr_info_pybind_pybind11_5958_2026-01-19+100747.md                                                                    │
 │                                                                                                                                                                                  │
 │   In my last comment there I wrote: I'll point Cursor to this, the pybind11 sources, and the CPython 3.14 sources, and ask it to look very thoroughly to figure out what is the  │
 │   best achievable solution in terms of avoiding UB but leaking as little as possible.                                                                                            │
 │                                                                                                                                                                                  │
 │   The up-to-date pybind11 sources are right here (master branch).                                                                                                                │
 │                                                                                                                                                                                  │
 │   The CPython sources are here:                                                                                                                                                  │
 │                                                                                                                                                                                  │
 │   smc120-0009.ipp2a2.colossus.nvidia.com:/wrk/clone/cpython $ git branch                                                                                                         │
 │   * 3.14                                                                                                                                                                         │
 │     main                                                                                                                                                                         │
 │     v3.14.2_release                                                                                                                                                              │
 │                                                                                                                                                                                  │
 │   JIC we need this for your analysis:                                                                                                                                            │
 │                                                                                                                                                                                  │
 │   I last git pulled the CPython 3.14 branch yesterday and built from sources using this script:                                                                                  │
 │                                                                                                                                                                                  │
 │   /home/rgrossekunst/rwgk_config/bin/build_cpython_from_git_twice.sh                                                                                                             │
 │                                                                                                                                                                                  │
 │   The installations are here:                                                                                                                                                    │
 │                                                                                                                                                                                  │
 │   /wrk/cpython_installs/3.14_branch_23e3c0ae867_default                                                                                                                          │
 │   /wrk/cpython_installs/3.14_branch_23e3c0ae867_freethreaded                                                                                                                     │
 │                                                                                                                                                                                  │
 │   Could you please "look very thoroughly to figure out what is the best achievable solution in terms of avoiding UB but leaking as little as possible.", also taking Joshua's "I │
 │    think the correct solution is a internals::leak_detach() method" comment into account?                                                                                        │
 │                                                                                                                                                                                  │
 │   Please use the cursor_workspace/ subdirectly here for all intermediate/temporary files. Do NOT use /tmp.                                                                       │
 │                                                                                                                                                                                  │
 │   If you want to rebuild the pybind11 unit tests for your analysis, please do NOT use cmake. Use this command instead:                                                           │
 │                                                                                                                                                                                  │
 │   cd /wrk/bld/pybind11_gcc_v3.14.2_df793163d58_default/ && scons -j $(nproc) && TestVenv/bin/python3 ../../clone/pybind11_scons/run_tests.py ../../forked/pybind11 24            │
 │                                                                                                                                                                                  │
 │   Currently I want to focus on the "default" cpython build. We can leave any "freethreaded" considerations for later.                                                            │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
