### PR TITLE
Exclude MSVC up to 19.16 from using std::launder

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -87,7 +87,7 @@
 #    endif
 #endif
 
-#if defined(__cpp_lib_launder) && !(defined(_MSC_VER) && (_MSC_VER < 1920))
+#if defined(__cpp_lib_launder) && !(defined(_MSC_VER) && (_MSC_VER < 1920)) // See PR #5968
 #    define PYBIND11_STD_LAUNDER std::launder
 #    define PYBIND11_HAS_STD_LAUNDER 1
 #else


### PR DESCRIPTION
## Description

This PR fixes/works around an internal compiler error triggered by MSVC 19.16 in [our CI](https://ci.appveyor.com/project/ax3l/openpmd-api/builds/53395897/job/ntw4987jmiy84ypp) when trying to upgrade to pybind11 v3.0.1:

```
_deps\fetchedpybind11-src\include\pybind11\pybind11.h(3008): fatal error C1001: An internal error has occurred in the compiler. [C:\projects\openpmd-api\build\openPMD.py.vcxproj]
  (compiler file 'd:\agent\_work\8\s\src\vctools\compiler\utc\src\p2\main.c', line 187)
   To work around this problem, try simplifying or changing the program near the locations listed above.
  Please choose the Technical Support command on the Visual C++
   Help menu, or open the Technical Support help file for more information
```
With git-bisect, I found [this commit](https://github.com/pybind/pybind11/commit/57b9a0af815d19b236b74be06a172bc5c9956618) as the first failing commit. More precisely, the compiler crash is caused by this single line:
https://github.com/pybind/pybind11/blob/57b9a0af815d19b236b74be06a172bc5c9956618/include/pybind11/pybind11.h#L364

This PR now raises the minimum MSVC version with support for `std::launder` to 19.20, thus excluding also 19.14, 19.15 and 19.16. This locally fixes the error for me.


## Suggested changelog entry:

Block MSVC up to 19.16 from use of std::launder due to internal compiler errors

## Other

This PR is for the master branch, upon which I cannot test its effect since our project does not seem to compile against the current master branch: `_deps/fetchedpybind11-src/include/pybind11/pybind11.h:2462:25: error: static assertion failed: def_property family does not currently support keep_alive. Use a py::cpp_function instead.`.
Should I additionally submit a PR for `v3.0`?
