### PR TITLE
Fix CI issue: numpy requirement for Python 3.14 on ARM64 Windows

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,7 +10,7 @@ numpy~=1.22.2; platform_python_implementation=="CPython" and python_version=="3.
 numpy~=1.26.0; platform_python_implementation=="CPython" and python_version>="3.11" and python_version<"3.13" and platform_machine!="ARM64"
 numpy>=2.3.0; platform_python_implementation=="CPython" and python_version>="3.11" and platform_machine=="ARM64"
 numpy~=2.2.0; platform_python_implementation=="CPython" and python_version=="3.13" and platform_machine!="ARM64"
-numpy==2.4.0; platform_python_implementation=="CPython" and python_version>="3.14"
+numpy>=2.4.0; platform_python_implementation=="CPython" and python_version>="3.14"
 pytest>=6
 pytest-timeout
 scipy~=1.5.4; platform_python_implementation=="CPython" and python_version<"3.10"


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Change `numpy==2.4.0` to `numpy>=2.4.0` for Python 3.14+, to allow pip to install numpy 2.4.1 or later versions, which are available for Python 3.14 on ARM64 Windows (MSYS2) (where numpy 2.4.0 is apparently no longer available).

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
