### PR TITLE
fix(tests): make async callback test deterministic

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -179,10 +179,11 @@ def test_async_callbacks():
     # do some work async
     work = [1, 2, 3, 4]
     m.test_async_callback(gen_f(), work)
-    # wait until work is done
-    from time import sleep
-
-    sleep(0.5)
+    # Wait for all detached worker threads to finish.
+    deadline = time.monotonic() + 5.0
+    while len(res) < len(work) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert len(res) == len(work), f"Timed out waiting for callbacks: res={res!r}"
     assert sum(res) == sum(x + 3 for x in work)
 
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Replace the fixed sleep in test_async_callbacks with a bounded wait for all expected callback results, so detached worker scheduling no longer causes sporadic CI failures.

xref: https://github.com/pybind/pybind11/pull/5985#issuecomment-3910094815

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Placeholder.
