### PR TITLE
Move tomlkit dependency to dev group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,11 @@ pybind11 = "pybind11.share.pkgconfig"
 test = [
   "pytest",
   "build",
-  "tomlkit",
 ]
-dev = [{ include-group = "test" }]
+dev = [
+  "tomlkit",
+  { include-group = "test" }
+]
 
 
 [tool.scikit-build]


### PR DESCRIPTION
## Description

tomlkit is used only in the packaging tests which are not ordinarily run as part of the normal workflow of a user or downstream packager.
