### PR TITLE
gh-5991: Fix segfault during finalization related to function_record

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -601,6 +601,15 @@ enum class return_value_policy : uint8_t {
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 
+// Py_IsFinalizing() is a public API since 3.13; before that use _Py_IsFinalizing().
+inline bool py_is_finalizing() {
+#if PY_VERSION_HEX >= 0x030D0000
+    return Py_IsFinalizing() != 0;
+#else
+    return _Py_IsFinalizing() != 0;
+#endif
+}
+
 static constexpr int log2(size_t n, int k = 0) { return (n <= 1) ? k : log2(n >> 1, k + 1); }
 
 // Returns the size as a multiple of sizeof(void *), rounded up.

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -847,13 +847,7 @@ protected:
                 }
             }
             // During finalization, default arg values may already be freed by GC.
-            // Py_IsFinalizing() is public API since 3.13; before that use the
-            // private _Py_IsFinalizing().
-#if PY_VERSION_HEX >= 0x030D0000
-            if (!Py_IsFinalizing()) {
-#else
-            if (!_Py_IsFinalizing()) {
-#endif
+            if (!detail::py_is_finalizing()) {
                 for (auto &arg : rec->args) {
                     arg.value.dec_ref();
                 }
@@ -1354,13 +1348,7 @@ inline void tp_dealloc_impl(PyObject *self) {
     // Skip dealloc during finalization — GC may have already freed objects
     // reachable from the function record (e.g. default arg values), causing
     // use-after-free in destruct().
-    // Py_IsFinalizing() is public API since 3.13; before that use the
-    // private _Py_IsFinalizing().
-#if PY_VERSION_HEX >= 0x030D0000
-    if (Py_IsFinalizing()) {
-#else
-    if (_Py_IsFinalizing()) {
-#endif
+    if (detail::py_is_finalizing()) {
         return;
     }
     // Save type before PyObject_Free invalidates self.


### PR DESCRIPTION
**EDIT (2026-03-27):** This PR masks rather than fixes the root cause identified in #5976: `def_property_static` adds a `"self"` arg with a string literal *after* the strdup loop in `initialize_generic` has already run. The `py_is_finalizing()` guard in `tp_dealloc_impl` prevents the crash but leaks all function records during finalization. Once the root cause is properly fixed, parts of this PR may need to be revisited. See #5486 for how the bug was introduced.

___

This patch was developed with assistance from  Claude Code Opus 4.6

Here's Claude's explanation of the crash mechanism and some reasoning for the difficulty to create a minimal reproducer:

`tp_dealloc_impl` calls `cpp_function::destruct` which:
1. Calls `std::free()` on function_record string members (`name`, `doc`, `signature`)
2. Calls `arg.value.dec_ref()` on default argument values
3. Calls `delete rec` on the function_record

But it never calls `PyObject_Free(self)` or `Py_DECREF(Py_TYPE(self))`, which are required for heap types.

During `_Py_Finalize`, final GC collects the heap types (which survive module dict clearing via `tp_mro` self-references). This triggers a massive cascade: `type_dealloc → property_dealloc → meth_dealloc → tp_dealloc_impl → destruct`.

At scale (~1,200+ function_records), the volume of `delete`/`free` calls corrupts heap metadata, causing subsequent `std::free()` to receive garbage pointers → SEGV.