### PR TITLE
Resolve ambiguous factory specialization with nvcc+GCC

### DIFF
--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -367,8 +367,15 @@ template <typename CFunc,
 struct factory;
 
 // Specialization for py::init(Func)
+// Note: The 4th template parameter `void_type()` is explicitly specified to resolve a
+// template ambiguity with the dual-factory specialization below when compiled with
+// nvcc + GCC (see #5565). Without it, both specializations match equally well for the
+// single-factory case, since the 4th parameter defaults to
+// `function_signature_t<void_type(*)()>` = `void_type()`, which the dual-factory
+// specialization can also decompose as `AReturn(AArgs...)` with `AReturn=void_type`
+// and `AArgs={}`.
 template <typename Func, typename Return, typename... Args>
-struct factory<Func, void_type (*)(), Return(Args...)> {
+struct factory<Func, void_type (*)(), Return(Args...), void_type()> {
     remove_reference_t<Func> class_factory;
 
     // NOLINTNEXTLINE(google-explicit-constructor)


### PR DESCRIPTION
## Description

Fixes #5565 and https://github.com/BLAST-WarpX/warpx/issues/6702.

When compiling with nvcc + GCC 14, the single-factory specialization
`factory<Func, void_type (*)(), Return(Args...)>` and the dual-factory
specialization `factory<CFunc, AFunc, CReturn(CArgs...), AReturn(AArgs...)>`
are considered ambiguous by the compiler. The single-factory spec only
specifies 3 of 4 template parameters (the 4th defaults to `void_type()`),
while the dual-factory spec decomposes all 4 — so neither is strictly
more specialized than the other.

The fix explicitly specifies the 4th parameter as `void_type()` in the
single-factory specialization, making it unambiguously more specialized.

## Suggested changelog entry:

* Fixed ambiguous `factory` template specialization in `detail/init.h`
  that caused compilation failure with nvcc + GCC 14.
  `#5565 <https://github.com/pybind/pybind11/issues/5565>`_