### PR TITLE
fix: prevent crash when calling pybind11::print in a subsystem:windows build

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3548,6 +3548,9 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         }
     }
 
+    if (file.is_none())
+        return;
+
     auto write = file.attr("write");
     write(std::move(line));
     write(kwargs.contains("end") ? kwargs["end"] : str("\n"));

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3548,8 +3548,9 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         }
     }
 
-    if (file.is_none())
+    if (file.is_none()) {
         return;
+    }
 
     auto write = file.attr("write");
     write(std::move(line));


### PR DESCRIPTION
fix: prevent crash when calling pybind11::print in a subsystem:windows build

## Description
Calling pybind11::print() crash in MSVC v19.44 with /subsystem:windows given.

In line: `file = module_::import("sys").attr("stdout"); `  the file will be none in a windows application build. won't be catched since there's no exception, and crashed in later access.

Add check before accessing `file` to prevent crash.


