### PR TITLE
fix: detect virtual inheritance in `add_base` to prevent pointer offset crash

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -1043,6 +1043,17 @@ struct is_instantiation<Class, Class<Us...>> : std::true_type {};
 template <typename T>
 using is_shared_ptr = is_instantiation<std::shared_ptr, T>;
 
+/// Detects whether static_cast<Derived*>(Base*) is valid, i.e. the inheritance is non-virtual.
+/// Used to detect virtual bases: if this is false, pointer adjustments require the implicit_casts
+/// chain rather than reinterpret_cast.
+template <typename Base, typename Derived, typename = void>
+struct is_static_downcastable : std::false_type {};
+template <typename Base, typename Derived>
+struct is_static_downcastable<Base,
+                              Derived,
+                              void_t<decltype(static_cast<Derived *>(std::declval<Base *>()))>>
+    : std::true_type {};
+
 /// Check if T looks like an input iterator
 template <typename T, typename = void>
 struct is_input_iterator : std::false_type {};

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2425,6 +2425,13 @@ public:
         rec.add_base(typeid(Base), [](void *src) -> void * {
             return static_cast<Base *>(reinterpret_cast<type *>(src));
         });
+        // Virtual inheritance means the base subobject is at a dynamic offset,
+        // so the reinterpret_cast shortcut in load_impl Case 2a is invalid.
+        // Force the MI path (implicit_casts) for correct pointer adjustment.
+        // Detection: static_cast<Derived*>(Base*) is ill-formed for virtual bases.
+        if PYBIND11_MAYBE_CONSTEXPR (!detail::is_static_downcastable<Base, type>::value) {
+            rec.multiple_inheritance = true;
+        }
     }
 
     template <typename Base, detail::enable_if_t<!is_base<Base>::value, int> = 0>

--- a/tests/test_smart_ptr.cpp
+++ b/tests/test_smart_ptr.cpp
@@ -553,10 +553,6 @@ TEST_SUBMODULE(smart_ptr, m) {
     py::class_<SftVirtDerived2, SftVirtDerived, std::shared_ptr<SftVirtDerived2>>(
         m, "SftVirtDerived2")
         .def(py::init<>(&SftVirtDerived2::create))
-        // TODO: Remove this once inherited methods work through virtual bases.
-        //       Without it, d2.name() segfaults because pybind11 uses an incorrect
-        //       pointer offset when dispatching through the virtual inheritance chain.
-        .def("name", &SftVirtDerived2::name)
         .def("call_name", &SftVirtDerived2::call_name, py::arg("d2"));
 
     // test_move_only_holder


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

The bug fixed in this PR was discovered by chance while working on tests for PR #6014.

Note that [this bug existed "forever"](https://github.com/pybind/pybind11/pull/6017#issuecomment-4146976716).

# Summary

- Fix segfault when dispatching inherited methods through virtual bases (e.g. `SftVirtDerived2::name()` via `SftVirtBase::name()`)
- Add `is_static_downcastable` SFINAE trait to detect virtual inheritance at compile time
- Automatically set `multiple_inheritance = true` for virtual bases, forcing `load_impl` to use `implicit_casts` instead of `reinterpret_cast`
- Remove the `.def("name", &SftVirtDerived2::name)` workaround from `test_smart_ptr.cpp`

## Background

When a class uses virtual inheritance (e.g. `struct D : virtual Base`), the base subobject is at a *dynamic* offset determined at runtime via the vtable. However, `load_impl` Case 2a uses `reinterpret_cast` to convert between base and derived pointers, which assumes a fixed offset. This produces a corrupted pointer, leading to segfaults in `shared_ptr` control block operations or method dispatch.

The existing test (`test_shared_from_this_virt_shared_ptr_arg`) had a TODO workaround: an explicit `.def("name", ...)` re-binding on `SftVirtDerived2` to avoid the inherited method dispatch path. This PR fixes the root cause so the workaround is no longer needed.

## Approach

`static_cast<Derived*>(Base*)` is ill-formed when `Base` is a virtual base of `Derived`. We use this as a SFINAE probe:

```cpp
template <typename Base, typename Derived, typename = void>
struct is_static_downcastable : std::false_type {};
template <typename Base, typename Derived>
struct is_static_downcastable<Base, Derived,
    void_t<decltype(static_cast<Derived *>(std::declval<Base *>()))>>
    : std::true_type {};
```

In `class_::add_base`, when `is_static_downcastable<Base, type>` is `false`, we set `rec.multiple_inheritance = true`. This forces `load_impl` to use the `implicit_casts` path, which walks the registered base chain and applies `static_cast` in the *upcast* direction (derived-to-base), which is always valid even for virtual inheritance.

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

*  Fixed segfault when dispatching inherited methods through virtual bases. `load_impl` Case 2a used `reinterpret_cast` to adjust pointers, which is invalid for virtual inheritance where the base subobject is at a dynamic offset. This bug existed since the initial commit but was never triggered until virtual inheritance tests exercised inherited method dispatch.