### PR TITLE
Fix heap-buffer-overflow in `pythonbuf` with undersized buffers

### DIFF
--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -122,8 +122,12 @@ public:
     static constexpr size_t minimum_buffer_size = 4;
 
     explicit pythonbuf(const object &pyostream, size_t buffer_size = 1024)
-        : buf_size(std::max(buffer_size, minimum_buffer_size)), d_buffer(new char[buf_size]),
-          pywrite(pyostream.attr("write")), pyflush(pyostream.attr("flush")) {
+        : buf_size(buffer_size < minimum_buffer_size // ternary avoids C++14 std::max ODR-use of
+                                                     // static constexpr
+                       ? minimum_buffer_size
+                       : buffer_size),
+          d_buffer(new char[buf_size]), pywrite(pyostream.attr("write")),
+          pyflush(pyostream.attr("flush")) {
         setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
     }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Fixes #5886

- Fix a heap-buffer-overflow in `pythonbuf::overflow()` triggered when the buffer size is smaller than 4 bytes. 
- The `_sync()` UTF-8 remainder logic moves up to 3 bytes of an incomplete UTF-8 sequence to the front of the buffer via `pbump(remainder)`. When `buf_size < 4`, this pushes `pptr()` past `epptr()` and the buffer boundary. The next `overflow()` call then writes out of bounds.
- Fix: clamp the buffer size to a minimum of 4 in the constructor (`std::max(buffer_size, minimum_buffer_size)`), ensuring the maximum UTF-8 remainder (3 bytes) plus the one-byte overflow slot always fits within the allocated buffer.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

- Fixed a heap-buffer-overflow in `pythonbuf` when the buffer size was less than 4 bytes: the UTF-8 remainder logic in `_sync()` could push the write pointer past the buffer, causing an out-of-bounds write on the next `overflow()` call. The buffer size is now clamped to a minimum of 4.