### PR TITLE
Fix TSS key exhaustion in `implicitly_convertible()`

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3557,13 +3557,10 @@ typing::Iterator<ValueType> make_value_iterator(Type &value, Extra &&...extra) {
 
 template <typename InputType, typename OutputType>
 void implicitly_convertible() {
-    static int tss_sentinel_pointee = 1; // arbitrary value
     struct set_flag {
-        thread_specific_storage<int> &flag;
-        explicit set_flag(thread_specific_storage<int> &flag_) : flag(flag_) {
-            flag = &tss_sentinel_pointee; // trick: the pointer itself is the sentinel
-        }
-        ~set_flag() { flag.reset(nullptr); }
+        bool &flag;
+        explicit set_flag(bool &flag_) : flag(flag_) { flag_ = true; }
+        ~set_flag() { flag = false; }
 
         // Prevent copying/moving to ensure RAII guard is used safely
         set_flag(const set_flag &) = delete;
@@ -3572,7 +3569,7 @@ void implicitly_convertible() {
         set_flag &operator=(set_flag &&) = delete;
     };
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {
-        static thread_specific_storage<int> currently_used;
+        thread_local bool currently_used = false;
         if (currently_used) { // implicit conversions are non-reentrant
             return nullptr;
         }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Fixes #5975

PR #5777 (included in v3.0.1) replaced the `static bool` / `thread_local bool` reentrancy guard in `implicitly_convertible()` with `static thread_specific_storage<int>` to make it sub-interpreter and free-threading safe. Because `implicitly_convertible` is a template function parametrized on `<InputType, OutputType>`, every unique type pair instantiation creates its own static `thread_specific_storage`, each of which allocates a TSS key via `PyThread_tss_create()`.

Projects with hundreds of modules and many implicit conversions (the reporters have 590+ and 1000+ `PYBIND11_MODULE`s) exhaust the OS TSS key limit (`PTHREAD_KEYS_MAX`: 1024 on Linux, 512 on macOS). The problem manifests on Python 3.12+ because CPython itself consumes more TSS keys for subinterpreter support, reducing the budget available to user code.

The fix replaces `static thread_specific_storage<int>` with `thread_local bool`:

- **Thread-safe**: each thread gets its own copy, so it handles free-threading correctly.
- **No TSS key allocation**: `thread_local` uses compiler/OS TLS storage (e.g., `__thread` segment on Linux), which has effectively unlimited capacity.
- **Subinterpreter sharing is benign**: the guard only prevents recursive implicit conversions on the same thread — the correct behavior regardless of which interpreter is active.
- **Trivially destructible**: `bool` does not require `__cxa_thread_atexit` runtime support, so it works on all C++11 platforms including older macOS targets. (This was the concern that motivated using TSS in #5777, but it only applies to types with non-trivial destructors.)
- **Precedent**: the v3.0.0 code already used `thread_local bool` under `#ifdef Py_GIL_DISABLED`.

The non-copyable/non-movable `set_flag` RAII guard (added in #5777) is retained but simplified back to wrapping `bool&`.

<!-- Include relevant issues or PRs here, describe what changed and why -->

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

- Fixed TSS key exhaustion when using many implicit conversions across hundreds of modules, caused by per-template-instantiation `thread_specific_storage` allocation in `implicitly_convertible()`.