### PR TITLE
docs: add v3.0.3 and v3.1.0 changelog updates.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,7 +29,7 @@ Internal:
   [#5960](https://github.com/pybind/pybind11/pull/5960)
 
 
-## Version 3.0.3 (release date TBD)
+## Version 3.0.3 (March 31, 2026)
 
 Bug fixes:
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Preparation for v3.0.3 release (#6022).

The v3.1.0 section will be removed when cherry-picking from master to PR #6022.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6023.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->