### PR TITLE
ignore maybe-initialized warning in `map_caster::convert_elements` field `conv`

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -326,9 +326,9 @@ private:
 
     bool convert_elements(handle seq, bool convert) {
         auto s = reinterpret_borrow<sequence>(seq);
-PYBIND11_WARNING_PUSH
+        PYBIND11_WARNING_PUSH
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 13
-PYBIND11_WARNING_DISABLE_GCC("-Wmaybe-uninitialized")
+        PYBIND11_WARNING_DISABLE_GCC("-Wmaybe-uninitialized")
 #endif
         value.clear();
         reserve_maybe(s, &value);
@@ -339,7 +339,7 @@ PYBIND11_WARNING_DISABLE_GCC("-Wmaybe-uninitialized")
             }
             value.push_back(cast_op<Value &&>(std::move(conv)));
         }
-PYBIND11_WARNING_POP
+        PYBIND11_WARNING_POP
         return true;
     }
 

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -326,6 +326,10 @@ private:
 
     bool convert_elements(handle seq, bool convert) {
         auto s = reinterpret_borrow<sequence>(seq);
+PYBIND11_WARNING_PUSH
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 13
+PYBIND11_WARNING_DISABLE_GCC("-Wmaybe-uninitialized")
+#endif
         value.clear();
         reserve_maybe(s, &value);
         for (const auto &it : seq) {
@@ -335,6 +339,7 @@ private:
             }
             value.push_back(cast_op<Value &&>(std::move(conv)));
         }
+PYBIND11_WARNING_POP
         return true;
     }
 


### PR DESCRIPTION
In `map_caster::convert_elements`, `conv` is initialized with a call to `::load`, and GCC 13 sees that as a maybe-uninitialized error to call it later:

```
for (const auto &it : seq) {
    value_conv conv;              // line 332: declared, "uninitialized"
    if (!conv.load(it, convert)) { // line 333: conv.load() initializes conv's internal state
        return false;
    }
    value.push_back(cast_op<Value &&>(std::move(conv)));  // line 336: uses conv
}
```

By adding ignores around this area, we can avoid the compilation failure.