### PR TITLE
fix: handle result from PyObject_VisitManagedDict

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -578,9 +578,9 @@ inline PyObject *make_object_base_type(PyTypeObject *metaclass) {
 /// dynamic_attr: Allow the garbage collector to traverse the internal instance `__dict__`.
 extern "C" inline int pybind11_traverse(PyObject *self, visitproc visit, void *arg) {
 #if PY_VERSION_HEX >= 0x030D0000
-    int vret = PyObject_VisitManagedDict(self, visit, arg);
-    if (vret) {
-        return vret;
+    int ret = PyObject_VisitManagedDict(self, visit, arg);
+    if (ret) {
+        return ret;
     }
 #else
     PyObject *&dict = *_PyObject_GetDictPtr(self);

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -578,7 +578,10 @@ inline PyObject *make_object_base_type(PyTypeObject *metaclass) {
 /// dynamic_attr: Allow the garbage collector to traverse the internal instance `__dict__`.
 extern "C" inline int pybind11_traverse(PyObject *self, visitproc visit, void *arg) {
 #if PY_VERSION_HEX >= 0x030D0000
-    PyObject_VisitManagedDict(self, visit, arg);
+    int vret = PyObject_VisitManagedDict(self, visit, arg);
+    if (vret) {
+        return vret;
+    }
 #else
     PyObject *&dict = *_PyObject_GetDictPtr(self);
     Py_VISIT(dict);

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -104,6 +104,10 @@ TEST_SUBMODULE(class_, m) {
         ~NoConstructorNew() { print_destroyed(this); }
     };
 
+    struct DynamicAttr {
+        DynamicAttr() = default;
+    };
+
     py::class_<NoConstructor>(m, "NoConstructor")
         .def_static("new_instance", &NoConstructor::new_instance, "Return an instance");
 
@@ -111,6 +115,9 @@ TEST_SUBMODULE(class_, m) {
         .def(py::init([]() { return nullptr; })) // Need a NOOP __init__
         .def_static("__new__",
                     [](const py::object &) { return NoConstructorNew::new_instance(); });
+
+    py::class_<DynamicAttr>(m, "DynamicAttr", py::dynamic_attr())
+        .def(py::init<>());
 
     // test_pass_unique_ptr
     struct ToBeHeldByUniquePtr {};

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -116,8 +116,7 @@ TEST_SUBMODULE(class_, m) {
         .def_static("__new__",
                     [](const py::object &) { return NoConstructorNew::new_instance(); });
 
-    py::class_<DynamicAttr>(m, "DynamicAttr", py::dynamic_attr())
-        .def(py::init<>());
+    py::class_<DynamicAttr>(m, "DynamicAttr", py::dynamic_attr()).def(py::init<>());
 
     // test_pass_unique_ptr
     struct ToBeHeldByUniquePtr {};

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import sys
 from unittest import mock
 
@@ -43,6 +44,12 @@ def test_instance(msg):
     assert cstats.alive() == 1
     del instance
     assert cstats.alive() == 0
+
+
+def test_get_referrers():
+    instance = m.DynamicAttr()
+    instance.a = "test"
+    assert instance in gc.get_referrers(instance.__dict__)
 
 
 def test_instance_new():

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -19,6 +19,13 @@ def refcount_immortal(ob: object) -> int:
     return sys.getrefcount(ob)
 
 
+MANAGED_DICT_GET_REFERRERS_SUPPORTED = (
+    env.CPYTHON
+    and sys.version_info >= (3, 13, 13)
+    and (sys.version_info < (3, 14) or sys.version_info >= (3, 14, 4))
+)
+
+
 def test_obj_class_name():
     expected_name = "UserType" if env.PYPY else "pybind11_tests.UserType"
     assert m.obj_class_name(UserType(1)) == expected_name
@@ -46,6 +53,10 @@ def test_instance(msg):
     assert cstats.alive() == 0
 
 
+@pytest.mark.skipif(
+    not MANAGED_DICT_GET_REFERRERS_SUPPORTED,
+    reason="Requires CPython 3.13.13+ or 3.14.4+ managed dict traversal support",
+)
 def test_get_referrers():
     instance = m.DynamicAttr()
     instance.a = "test"


### PR DESCRIPTION
Cursor-generated:

## Summary

This PR fixes `pybind11_traverse()` for `py::dynamic_attr()` instances on Python 3.13+ by propagating the return value from `PyObject_VisitManagedDict()`.

Without this, pybind11 could silently swallow a non-zero return from the GC/referrer visitor callback. In practice, that means the relationship between an instance and its managed `__dict__` can be missed during traversal-based operations. A visible symptom is that `gc.get_referrers(instance.__dict__)` can fail to report the owning pybind11 instance.

This PR also adds a regression test for that behavior, together with version/runtime skips so the test only runs where the interpreter behavior is known to be reliable.

## Background

Types created with `py::dynamic_attr()` store per-instance attributes in a Python `__dict__`. For garbage collection and related traversal-based introspection to work correctly, pybind11's `tp_traverse` implementation must expose that dictionary to the visitor callback.

Historically, pybind11 did this by obtaining the instance dict pointer directly and visiting it with `Py_VISIT(dict)`. That matters because `Py_VISIT` does not just call the visitor: it also immediately propagates a non-zero return value.

On Python 3.13+, CPython moved dynamic instance dictionaries to the managed-dict APIs, so pybind11 uses `PyObject_VisitManagedDict(self, visit, arg)` instead. However, pybind11 did not check or return that function's integer result.

That changed the semantics of `pybind11_traverse()` on the managed-dict path:

- before: visiting the instance dict behaved like `Py_VISIT(dict)`, including early return on non-zero visitor results
- after the switch to `PyObject_VisitManagedDict()`: pybind11 always continued and eventually returned `0`, even if the visitor had requested an early exit

This is subtle, but it changes the contract of `tp_traverse`. The concrete user-visible failure that motivated this PR is:

```python
instance = m.DynamicAttr()
instance.a = "test"
assert instance in gc.get_referrers(instance.__dict__)
```

Without this PR, that assertion can fail because the traversal machinery does not correctly report the instance as a referrer of its managed `__dict__`.

## Why this fix is correct

The implementation change is intentionally small:

```c
int ret = PyObject_VisitManagedDict(self, visit, arg);
if (ret) {
    return ret;
}
```

This is the same behavior pybind11 already had on the pre-3.13 path via `Py_VISIT(dict)`: if the visitor returns non-zero, propagate that result immediately instead of discarding it.

That makes the Python 3.13+ managed-dict path match the long-standing non-managed-dict path and restores the expected `tp_traverse` behavior rather than introducing new semantics.

In other words, this PR does not change what pybind11 traverses. It only fixes how pybind11 handles the visitor result while traversing managed dicts.

## Test coverage

This PR adds a focused regression test for the exact externally observable behavior:

- a minimal `DynamicAttr` test type is added with `py::dynamic_attr()`
- the Python test creates an instance, writes an attribute into `__dict__`, and checks that `gc.get_referrers(instance.__dict__)` includes the owning instance

This test is intentionally high-level. Instead of asserting on implementation details, it checks the behavior that users actually care about: whether the runtime can discover the instance-to-dict relationship through traversal.

## Why the new test is version- and runtime-gated

While working on the regression test, it became clear that CPython itself has version-specific managed-dict behavior in this area.

Relevant upstream context:

- `python/cpython` issue: [#130327](https://github.com/python/cpython/issues/130327)
- `python/cpython` follow-up/fix discussion: [#148275](https://github.com/python/cpython/pull/148275)

Based on local testing and the PR discussion, the new regression test is currently treated as reliable only on:

- CPython `>= 3.13.13`
- CPython `>= 3.14.4`

Accordingly, the test is skipped on:

- CPython `< 3.13.13`
- CPython `3.14.0` through `3.14.3`
- non-CPython interpreters for now

The non-CPython skip is deliberate. PyPy and GraalPy already differ from CPython in several GC- and referrer-sensitive cases, and this PR is about restoring correct CPython managed-dict traversal semantics. Skipping other interpreters avoids overstating what has been verified there.

This is also why the skip is expressed in terms of interpreter behavior, not platform behavior. Android, iOS, and Emscripten are handled elsewhere in CI as platform targets; the uncertainty here is specifically about interpreter traversal semantics.

## Validation and debugging history

This PR had an awkward testing window because CI was still installing CPython 3.14.3 for a while even after 3.14.4 had been released. That made the new regression test appear to fail in CI even though the underlying pybind11 fix looked correct.

The version split was later confirmed locally:

- on CPython 3.14.2, the regression still fails due to the interpreter-side issue
- on CPython 3.14.4, the regression passes

With the version/runtime gating in place:

- `pre-commit` passes
- local testing passes on CPython 3.14.2
- local testing passes on CPython 3.14.4

## Net effect

After this PR:

- pybind11 correctly propagates `PyObject_VisitManagedDict()` return values
- the Python 3.13+ managed-dict path behaves consistently with the older `Py_VISIT(dict)` path
- the bug is covered by a targeted regression test
- that test only runs where the interpreter result is known to be trustworthy

## Suggested changelog entry:

* Handle result from `PyObject_VisitManagedDict`
