### PR TITLE
fix: segfault when moving `scoped_ostream_redirect`

### DIFF
--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -186,10 +186,14 @@ public:
     }
 
     scoped_ostream_redirect(const scoped_ostream_redirect &) = delete;
-    scoped_ostream_redirect(scoped_ostream_redirect &&other) noexcept
-        : old(other.old), costream(other.costream), buffer(std::move(other.buffer)) {
-        other.active = false;    // Disarm moved-from destructor
-        costream.rdbuf(&buffer); // Re-point stream to our buffer
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    scoped_ostream_redirect(scoped_ostream_redirect &&other)
+        : old(other.old), costream(other.costream), buffer(std::move(other.buffer)),
+          active(other.active) {
+        if (active) {
+            costream.rdbuf(&buffer); // Re-point stream to our buffer
+            other.active = false;
+        }
     }
     scoped_ostream_redirect &operator=(const scoped_ostream_redirect &) = delete;
     scoped_ostream_redirect &operator=(scoped_ostream_redirect &&) = delete;

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -178,10 +178,18 @@ public:
         old = costream.rdbuf(&buffer);
     }
 
-    ~scoped_ostream_redirect() { costream.rdbuf(old); }
+    ~scoped_ostream_redirect() {
+        if (old) {
+            costream.rdbuf(old);
+        }
+    }
 
     scoped_ostream_redirect(const scoped_ostream_redirect &) = delete;
-    scoped_ostream_redirect(scoped_ostream_redirect &&other) = default;
+    scoped_ostream_redirect(scoped_ostream_redirect &&other)
+        : old(other.old), costream(other.costream), buffer(std::move(other.buffer)) {
+        other.old = nullptr;     // Disarm moved-from destructor
+        costream.rdbuf(&buffer); // Re-point stream to our buffer
+    }
     scoped_ostream_redirect &operator=(const scoped_ostream_redirect &) = delete;
     scoped_ostream_redirect &operator=(scoped_ostream_redirect &&) = delete;
 };

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -131,7 +131,22 @@ public:
         setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
     }
 
-    pythonbuf(pythonbuf &&) = default;
+    pythonbuf(pythonbuf &&other) noexcept
+        : buf_size(other.buf_size), d_buffer(std::move(other.d_buffer)),
+          pywrite(std::move(other.pywrite)), pyflush(std::move(other.pyflush)) {
+        const auto pending = (other.pbase() != nullptr && other.pptr() != nullptr)
+                                 ? static_cast<int>(other.pptr() - other.pbase())
+                                 : 0;
+        if (d_buffer != nullptr) {
+            // Rebuild the put area from the transferred storage.
+            setp(d_buffer.get(), d_buffer.get() + buf_size - 1);
+            pbump(pending);
+        } else {
+            setp(nullptr, nullptr);
+        }
+        // Prevent the moved-from destructor from flushing through moved-out handles.
+        other.setp(nullptr, nullptr);
+    }
 
     /// Sync before destroy
     ~pythonbuf() override { _sync(); }

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -169,6 +169,7 @@ protected:
     std::streambuf *old;
     std::ostream &costream;
     detail::pythonbuf buffer;
+    bool active = true;
 
 public:
     explicit scoped_ostream_redirect(std::ostream &costream = std::cout,
@@ -179,7 +180,7 @@ public:
     }
 
     ~scoped_ostream_redirect() {
-        if (old) {
+        if (active) {
             costream.rdbuf(old);
         }
     }
@@ -187,7 +188,7 @@ public:
     scoped_ostream_redirect(const scoped_ostream_redirect &) = delete;
     scoped_ostream_redirect(scoped_ostream_redirect &&other) noexcept
         : old(other.old), costream(other.costream), buffer(std::move(other.buffer)) {
-        other.old = nullptr;     // Disarm moved-from destructor
+        other.active = false;    // Disarm moved-from destructor
         costream.rdbuf(&buffer); // Re-point stream to our buffer
     }
     scoped_ostream_redirect &operator=(const scoped_ostream_redirect &) = delete;

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -185,7 +185,7 @@ public:
     }
 
     scoped_ostream_redirect(const scoped_ostream_redirect &) = delete;
-    scoped_ostream_redirect(scoped_ostream_redirect &&other)
+    scoped_ostream_redirect(scoped_ostream_redirect &&other) noexcept
         : old(other.old), costream(other.costream), buffer(std::move(other.buffer)) {
         other.old = nullptr;     // Disarm moved-from destructor
         costream.rdbuf(&buffer); // Re-point stream to our buffer

--- a/tests/test_iostream.cpp
+++ b/tests/test_iostream.cpp
@@ -123,4 +123,11 @@ TEST_SUBMODULE(iostream, m) {
         .def("stop", &TestThread::stop)
         .def("join", &TestThread::join)
         .def("sleep", &TestThread::sleep);
+
+    m.def("move_redirect_output", [](const std::string &msg) {
+        py::scoped_ostream_redirect redir1(std::cout, py::module_::import("sys").attr("stdout"));
+        std::cout << "before" << std::flush;
+        py::scoped_ostream_redirect redir2(std::move(redir1));
+        std::cout << msg << std::flush;
+    });
 }

--- a/tests/test_iostream.cpp
+++ b/tests/test_iostream.cpp
@@ -131,6 +131,15 @@ TEST_SUBMODULE(iostream, m) {
         std::cout << msg_after << std::flush;
     });
 
+    m.def("move_redirect_output_unflushed",
+          [](const std::string &msg_before, const std::string &msg_after) {
+              py::scoped_ostream_redirect redir1(std::cout,
+                                                 py::module_::import("sys").attr("stdout"));
+              std::cout << msg_before;
+              py::scoped_ostream_redirect redir2(std::move(redir1));
+              std::cout << msg_after << std::flush;
+          });
+
     // Redirect a stream whose original rdbuf is nullptr, then move the redirect.
     // Verifies that nullptr is correctly restored (not confused with a moved-from sentinel).
     m.def("move_redirect_null_rdbuf", [](const std::string &msg) {

--- a/tests/test_iostream.cpp
+++ b/tests/test_iostream.cpp
@@ -124,10 +124,30 @@ TEST_SUBMODULE(iostream, m) {
         .def("join", &TestThread::join)
         .def("sleep", &TestThread::sleep);
 
-    m.def("move_redirect_output", [](const std::string &msg) {
+    m.def("move_redirect_output", [](const std::string &msg_before, const std::string &msg_after) {
         py::scoped_ostream_redirect redir1(std::cout, py::module_::import("sys").attr("stdout"));
-        std::cout << "before" << std::flush;
+        std::cout << msg_before << std::flush;
         py::scoped_ostream_redirect redir2(std::move(redir1));
-        std::cout << msg << std::flush;
+        std::cout << msg_after << std::flush;
+    });
+
+    // Redirect a stream whose original rdbuf is nullptr, then move the redirect.
+    // Verifies that nullptr is correctly restored (not confused with a moved-from sentinel).
+    m.def("move_redirect_null_rdbuf", [](const std::string &msg) {
+        std::ostream os(nullptr);
+        py::scoped_ostream_redirect redir1(os, py::module_::import("sys").attr("stdout"));
+        os << msg << std::flush;
+        py::scoped_ostream_redirect redir2(std::move(redir1));
+        os << msg << std::flush;
+        // After redir2 goes out of scope, os.rdbuf() should be restored to nullptr.
+    });
+
+    m.def("get_null_rdbuf_restored", [](const std::string &msg) -> bool {
+        std::ostream os(nullptr);
+        {
+            py::scoped_ostream_redirect redir(os, py::module_::import("sys").attr("stdout"));
+            os << msg << std::flush;
+        }
+        return os.rdbuf() == nullptr;
     });
 }

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -291,6 +291,13 @@ def test_move_redirect(capsys):
     assert not stderr
 
 
+def test_move_redirect_unflushed(capsys):
+    m.move_redirect_output_unflushed("before_move", "after_move")
+    stdout, stderr = capsys.readouterr()
+    assert stdout == "before_moveafter_move"
+    assert not stderr
+
+
 def test_move_redirect_null_rdbuf(capsys):
     m.move_redirect_null_rdbuf("hello")
     stdout, stderr = capsys.readouterr()

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -285,10 +285,21 @@ def test_redirect_both(capfd):
 
 
 def test_move_redirect(capsys):
-    m.move_redirect_output("after")
+    m.move_redirect_output("before_move", "after_move")
     stdout, stderr = capsys.readouterr()
-    assert stdout == "beforeafter"
+    assert stdout == "before_moveafter_move"
     assert not stderr
+
+
+def test_move_redirect_null_rdbuf(capsys):
+    m.move_redirect_null_rdbuf("hello")
+    stdout, stderr = capsys.readouterr()
+    assert stdout == "hellohello"
+    assert not stderr
+
+
+def test_null_rdbuf_restored():
+    assert m.get_null_rdbuf_restored("test")
 
 
 @pytest.mark.skipif(sys.platform.startswith("emscripten"), reason="Requires threads")

--- a/tests/test_iostream.py
+++ b/tests/test_iostream.py
@@ -284,6 +284,13 @@ def test_redirect_both(capfd):
     assert stream2.getvalue() == msg2
 
 
+def test_move_redirect(capsys):
+    m.move_redirect_output("after")
+    stdout, stderr = capsys.readouterr()
+    assert stdout == "beforeafter"
+    assert not stderr
+
+
 @pytest.mark.skipif(sys.platform.startswith("emscripten"), reason="Requires threads")
 def test_threading():
     with m.ostream_redirect(stdout=True, stderr=False):


### PR DESCRIPTION
Cursor GPT-5.4 Extra High Fast generated:

___


## Summary

Fix the move semantics of `py::scoped_ostream_redirect`.

Moving a redirect has to transfer two kinds of state together:

1. redirect ownership: which object is responsible for restoring the original `rdbuf()`
2. buffered output state: any bytes already staged inside `detail::pythonbuf`

The destination object must become the only active redirect, the stream must be re-pointed at the destination buffer, and any already-buffered bytes must move with it. If any of that state stays behind in the moved-from object, later writes or destruction can still touch stale moved-from state and crash.

This PR makes that transfer explicit and internally consistent.

## What changes

- `scoped_ostream_redirect` now uses an explicit move constructor that rebinds the stream to the destination `pythonbuf`.
- Redirect ownership is tracked with an `active` flag, so only the live redirect restores the original `rdbuf()` in its destructor.
- `active` replaces the old `nullptr`-sentinel style of representing moved-from state, which also allows a real `nullptr` original `rdbuf()` to be handled correctly.
- `detail::pythonbuf` now has an explicit move constructor that rebuilds the destination put area from the transferred storage and clears the source put area.
- This ensures that buffered-but-unflushed output follows the active redirect instead of being flushed later through moved-from Python handles.

## Tests

Add regression coverage for:

- moving a redirect after a flushed write
- moving a redirect with buffered, unflushed output already pending
- moving a redirect when the original stream `rdbuf()` is `nullptr`
- restoring a `nullptr` `rdbuf()` after destruction

Together these tests cover the final move contract: stream rebinding, moved-from destructor disarming, preservation of pending buffered data, and correct handling of `nullptr` as a legitimate original stream buffer.

## Suggested changelog entry

- Fixed `scoped_ostream_redirect` move semantics so moved redirects preserve buffered output, restore the original stream buffer exactly once, and correctly handle streams whose original `rdbuf()` is `nullptr`.