### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         allow-prereleases: true
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         enable-cache: true
 

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -56,7 +56,7 @@ jobs:
         python-version: 3.11
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
 
     - name: Prepare env
       run: uv pip install --python=python --system -r tests/requirements.txt

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Build SDist and wheels
         run: |

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -31,7 +31,7 @@ jobs:
         python-version: 3.8
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
 
     - name: Prepare env
       run: uv pip install --system -r tests/requirements.txt
@@ -55,7 +55,7 @@ jobs:
         python-version: 3.8
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
 
     - name: Prepare env
       run: uv pip install --system -r tests/requirements.txt twine nox

--- a/.github/workflows/reusable-standard.yml
+++ b/.github/workflows/reusable-standard.yml
@@ -51,7 +51,7 @@ jobs:
         run: brew install boost
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos