### PR TITLE
build: support Eigen 5

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,9 @@ Internal:
 
 Bug fixes:
 
+- Fixed test builds with installed Eigen 5 by improving `Eigen3` CMake package detection.
+  [#6036](https://github.com/pybind/pybind11/pull/6036)
+
 - Fixed move semantics of `scoped_ostream_redirect` to preserve buffered output and avoid crashes when moved redirects restore stream buffers.
   [#6033](https://github.com/pybind/pybind11/pull/6033)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -299,11 +299,14 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
     set(EIGEN3_VERSION "${PYBIND11_EIGEN_VERSION_STRING}")
 
   else()
-    find_package(Eigen3 3.2.7 QUIET CONFIG)
+    find_package(Eigen3 3.2.7...5 QUIET CONFIG)
+    set(EIGEN3_FOUND ${Eigen3_FOUND})
+    set(EIGEN3_VERSION ${Eigen3_VERSION})
 
     if(NOT EIGEN3_FOUND)
       # Couldn't load via target, so fall back to allowing module mode finding, which will pick up
       # tools/FindEigen3.cmake
+      # XXX: MODULE mode does not work with Eigen 5
       find_package(Eigen3 3.2.7 QUIET)
     endif()
   endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -299,7 +299,10 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
     set(EIGEN3_VERSION "${PYBIND11_EIGEN_VERSION_STRING}")
 
   else()
-    find_package(Eigen3 3.2.7...5 QUIET CONFIG)
+    find_package(Eigen3 3.2.7 QUIET CONFIG)
+    if(NOT Eigen3_FOUND)
+      find_package(Eigen3 5 QUIET CONFIG)
+    endif()
     set(EIGEN3_FOUND ${Eigen3_FOUND})
     set(EIGEN3_VERSION ${Eigen3_VERSION})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -309,7 +309,8 @@ if(PYBIND11_TEST_FILES_EIGEN_I GREATER -1)
     if(NOT EIGEN3_FOUND)
       # Couldn't load via target, so fall back to allowing module mode finding, which will pick up
       # tools/FindEigen3.cmake
-      # XXX: MODULE mode does not work with Eigen 5
+      # This MODULE-mode fallback is for older Eigen 3 setups; Eigen 5 is expected to be found
+      # via the CONFIG-mode probes above.
       find_package(Eigen3 3.2.7 QUIET)
     endif()
   endif()


### PR DESCRIPTION
Fix #6034.

This PR improves test-time Eigen discovery so environments with an installed Eigen 5 package can be found through `Eigen3Config.cmake` without regressing older Eigen 3 setups.

## What changes

- Probe `CONFIG` mode explicitly for Eigen 3 first, then for Eigen 5.
- Normalize the legacy `EIGEN3_FOUND` and `EIGEN3_VERSION` variables after a successful `CONFIG`-mode probe so the existing test logic continues to work regardless of which config package was found.
- Keep the existing `MODULE`-mode fallback for older Eigen 3 environments.
- Add a `v3.0.4` changelog entry.

## Why this approach

This intentionally fixes the `CONFIG`-mode path and normalizes the legacy `EIGEN3_*` variables after the `CONFIG` probe. It does not try to update the old `tools/FindEigen3.cmake` logic to understand Eigen 5, because that path is more invasive and easier to get wrong. In other words, this is a targeted compatibility fix for environments that provide an `Eigen3Config.cmake`, while leaving the legacy `MODULE`-mode finder as a fallback for older Eigen 3 setups.

This also avoids relying on package-specific handling of a bounded CMake version range for Eigen 5 discovery. The separate probes make the intent explicit: accept supported Eigen 3 installs first, and if that does not match, try Eigen 5 directly.

<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6036.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->