### PR TITLE
fix: allow native_enum to shadow an Enum member with the same name in export_values

### DIFF
--- a/include/pybind11/detail/native_enum_data.h
+++ b/include/pybind11/detail/native_enum_data.h
@@ -200,9 +200,13 @@ inline void native_enum_data::finalize() {
     }
     parent_scope.attr(enum_name) = py_enum;
     if (export_values_flag) {
+        // Allow an already-exported Enum member with the same name to be replaced,
+        // so two native_enums can share exported value names (see issue #6031).
+        auto enum_base = import_or_getattr("enum.Enum", " (native_enum export_values)");
         for (auto member : members) {
             auto member_name = member[int_(0)];
-            if (hasattr(parent_scope, member_name)) {
+            if (hasattr(parent_scope, member_name)
+                && !isinstance(parent_scope.attr(member_name), enum_base)) {
                 pybind11_fail("pybind11::native_enum<...>(\"" + enum_name_encoded + "\").value(\""
                               + member_name.cast<std::string>()
                               + "\"): an object with that name is already defined");

--- a/tests/test_native_enum.cpp
+++ b/tests/test_native_enum.cpp
@@ -25,6 +25,8 @@ enum class flags_uint : unsigned int { bit0 = 0x1u, bit1 = 0x2u, bit2 = 0x4u };
 
 enum class export_values { exv0, exv1 };
 
+enum class export_values2 { exv0, exv2 };
+
 enum class member_doc { mem0, mem1, mem2 };
 
 struct class_with_enum {
@@ -117,6 +119,13 @@ TEST_SUBMODULE(native_enum, m) {
     py::native_enum<export_values>(m, "export_values", "enum.IntEnum")
         .value("exv0", export_values::exv0)
         .value("exv1", export_values::exv1)
+        .export_values()
+        .finalize();
+
+    // Shares "exv0" with export_values above (issue #6031).
+    py::native_enum<export_values2>(m, "export_values2", "enum.IntEnum")
+        .value("exv0", export_values2::exv0)
+        .value("exv2", export_values2::exv2)
         .export_values()
         .finalize();
 

--- a/tests/test_native_enum.py
+++ b/tests/test_native_enum.py
@@ -48,6 +48,11 @@ EXPORT_VALUES_MEMBERS = (
     ("exv1", 1),
 )
 
+EXPORT_VALUES2_MEMBERS = (
+    ("exv0", 0),
+    ("exv2", 1),
+)
+
 MEMBER_DOC_MEMBERS = (
     ("mem0", 0),
     ("mem1", 1),
@@ -62,6 +67,7 @@ ENUM_TYPES_AND_MEMBERS = (
     (m.flags_uchar, FLAGS_UCHAR_MEMBERS),
     (m.flags_uint, FLAGS_UINT_MEMBERS),
     (m.export_values, EXPORT_VALUES_MEMBERS),
+    (m.export_values2, EXPORT_VALUES2_MEMBERS),
     (m.member_doc, MEMBER_DOC_MEMBERS),
     (m.func_sig_rendering, FUNC_SIG_RENDERING_MEMBERS),
     (m.class_with_enum.in_class, CLASS_WITH_ENUM_IN_CLASS_MEMBERS),
@@ -101,8 +107,11 @@ def test_enum_flag(enum_type):
 
 
 def test_export_values():
-    assert m.exv0 is m.export_values.exv0
+    # Regression test for issue #6031.
     assert m.exv1 is m.export_values.exv1
+    assert m.exv2 is m.export_values2.exv2
+    assert m.export_values.exv0 is not m.export_values2.exv0
+    assert m.exv0 is m.export_values2.exv0
 
 
 def test_class_doc():


### PR DESCRIPTION
## Description

Fixes #6031.

Two `native_enum` types that both call `.export_values()` currently fail to import when they share a value name. The second binding hits the "an object with that name is already defined" check, even though the existing attribute is just an Enum member from the first binding.

The collision check in `native_enum_data::finalize()` now only treats an existing parent-scope attribute as a conflict when it is not already an Enum instance. Collisions with non-Enum attributes are still rejected, so names the user has explicitly set in the parent scope remain protected (the existing `test_native_enum_value_name_clash` still passes).

Classic `py::enum_::export_values()` has no collision check at all, so two classic enums sharing a value name have always worked with last-wins semantics. `native_enum` now behaves consistently in this respect, while keeping a stricter check against non-Enum attributes.

### Test

A second `native_enum`, `export_values2`, is added to the test submodule. It shares `exv0` with the existing `export_values` enum. `test_export_values` verifies:

* both enums import successfully;
* each enum keeps its own distinct members (`export_values.exv0 is not export_values2.exv0`);
* the shared parent-scope attribute points to the later binding (`m.exv0 is m.export_values2.exv0`).

Confirmed by reverting just the header change: the test module then fails to import with exactly the error from the issue.

## Suggested changelog entry:

* Fix ``ImportError`` when two ``native_enum`` types call ``export_values()`` and share a value name.