### PR TITLE
[skip ci] docs: add v3.0.4 changelog updates.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,31 @@ Internal:
   [#5960](https://github.com/pybind/pybind11/pull/5960)
 
 
+## Version 3.0.4 (April 18, 2026)
+
+Bug fixes:
+
+- Fixed move semantics of `scoped_ostream_redirect` to preserve buffered output and avoid crashes when moved redirects restore stream buffers.
+  [#6033](https://github.com/pybind/pybind11/pull/6033)
+
+- Fixed `py::dynamic_attr()` traversal on Python 3.13+ to correctly propagate `PyObject_VisitManagedDict()` results.
+  [#6032](https://github.com/pybind/pybind11/pull/6032)
+
+- Fixed `std::shared_ptr<T>` fallback casting to avoid unnecessary copy-constructor instantiation in `reference_internal` paths.
+  [#6028](https://github.com/pybind/pybind11/pull/6028)
+
+CI:
+
+- Updated `setup-uv` to the maintained GitHub Action tag scheme.
+  [#6035](https://github.com/pybind/pybind11/pull/6035)
+
+- Updated pre-commit hooks.
+  [#6029](https://github.com/pybind/pybind11/pull/6029)
+
+- Updated GitHub Actions dependencies, including `actions-setup-cmake` and `cibuildwheel`.
+  [#6027](https://github.com/pybind/pybind11/pull/6027)
+
+
 ## Version 3.0.3 (March 31, 2026)
 
 Bug fixes:


### PR DESCRIPTION
Document the post-v3.0.3 fixes and CI changes ahead of the patch release.

This change is LLM-generated and so simple, I'll merge without a review.

Made-with: Cursor

<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6041.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->