### PR TITLE
[ci] Remove GitHub Action seanmiddleditch/gha-setup-ninja

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1191,9 +1191,6 @@ jobs:
       - name: Update CMake
         uses: jwlawson/actions-setup-cmake@v2.2
 
-      - name: Install ninja-build tool
-        uses: seanmiddleditch/gha-setup-ninja@v6
-
       - name: Run pip installs
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Description

From the GitHubAction [README](https://github.com/seanmiddleditch/gha-setup-ninja/blob/master/README.md):
"This action is no longer necessary, as ninja is now
included on all default GitHub runner instances."
