### PR TITLE
ci: pin PyPy 3.11 to 7.3.21 on macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,8 @@ jobs:
             python-version: 'pypy-3.10'
             cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: macos-latest
-            python-version: 'pypy-3.11'
+            # Temporarily pinned pending investigation in issue #6049.
+            python-version: 'pypy-3.11-v7.3.21'
           - runs-on: macos-latest
             python-version: 'graalpy-24.2'
 
@@ -151,7 +152,8 @@ jobs:
             python-version: 'pypy-3.10'
             cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: windows-latest
-            python-version: 'pypy3.11'
+            # Temporarily pinned pending investigation in issue #6049.
+            python-version: 'pypy3.11-v7.3.21'
             cmake-args: -DCMAKE_CXX_STANDARD=20
           # The setup-python action currently doesn't have graalpy for windows
           # See https://github.com/actions/setup-python/pull/880


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Temporarily pin the two failing PyPy 3.11 jobs while investigating the PyPy 7.3.22 `instance layout conflicts in multiple inheritance` regression.

Refs #6049.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* N/A