### PR TITLE
ci: Pass explicit ARM64 Python artifacts to CMake on windows-11-arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1271,15 +1271,23 @@ jobs:
           python -m pip install -r tests/requirements.txt
 
       - name: Configure CMake
-        run: >
-          cmake -G Ninja -S . -B .
-          -DPYBIND11_WERROR=OFF
-          -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF
-          -DDOWNLOAD_CATCH=ON
-          -DDOWNLOAD_EIGEN=ON
-          -DCMAKE_CXX_COMPILER=clang++
-          -DCMAKE_CXX_STANDARD=20
-          -DPython_ROOT_DIR="$env:Python_ROOT_DIR"
+        run: |
+          $pythonExecutable = Join-Path $env:pythonLocation "python.exe"
+          $pythonIncludeDir = Join-Path $env:pythonLocation "include"
+          $pythonVersion = (python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')").Trim()
+          # PR 6051: FindPython can still resolve the x64 python.org install on
+          # windows-11-arm, so pass the ARM64 interpreter, headers, and import lib.
+          $pythonLibrary = Join-Path (Join-Path $env:pythonLocation "libs") "python$pythonVersion.lib"
+          cmake -G Ninja -S . -B . `
+            -DPYBIND11_WERROR=OFF `
+            -DPYBIND11_SIMPLE_GIL_MANAGEMENT=OFF `
+            -DDOWNLOAD_CATCH=ON `
+            -DDOWNLOAD_EIGEN=ON `
+            -DCMAKE_CXX_COMPILER=clang++ `
+            -DCMAKE_CXX_STANDARD=20 `
+            -DPython_EXECUTABLE="$pythonExecutable" `
+            -DPython_INCLUDE_DIR="$pythonIncludeDir" `
+            -DPython_LIBRARY="$pythonLibrary"
 
       - name: Build
         run: cmake --build . -j 2


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Summary

- pass the ARM64 interpreter, include directory, and import library from `actions/setup-python` directly to CMake in the `🐍 3.13 • windows-11-arm • clang-msvc` job
- stop relying on `Python_ROOT_DIR` alone for that job, because CMake `FindPython` can still resolve the hosted x64 python.org installation on the ARM64 runner

## Background

After the PyPy 3.11 pinning in PR #6050, the remaining CI failures to investigate were:

- `CI / 🐍 3.11 (deadsnakes) • x64 (pull_request)`
- `CI / 🐍 3.13 • windows-11-arm • clang-msvc (pull_request)`

This PR addresses the `windows-11-arm` failure.

We saw the same `windows-11-arm` failure pattern across multiple reruns:

- PR #6047: run `25198984162`, job `74063792256`
  - <https://github.com/pybind/pybind11/actions/runs/25198984162/job/74063792256?pr=6047>
- PR #5850: run `25258404339`, job `74063820144`
  - <https://github.com/pybind/pybind11/actions/runs/25258404339/job/74063820144?pr=5850>
- PR #6050: run `25263057197`, job `74073354028`
  - <https://github.com/pybind/pybind11/actions/runs/25263057197/job/74073354028?pr=6050>

In the same runs, the sibling `windows-11-arm • clang-msys2` job passed, which helps isolate the problem to the `python.org CPython + CMake FindPython + clang-msvc` path rather than Windows ARM in general.

## What is going wrong

In the latest failing run (`25263057197` / `74073354028`):

- the runner image is `windows-11-arm64`
- `actions/setup-python@v6` is configured with `architecture: arm64`
- the job environment before the CMake configure step shows:
  - `pythonLocation = C:\hostedtoolcache\windows\Python\3.13.13\arm64`
  - `Python_ROOT_DIR = C:\hostedtoolcache\windows\Python\3.13.13\arm64`
- despite that, the configure log says:
  - `-- Found Python: C:/hostedtoolcache/windows/Python/3.13.13/x64/python3.exe`
- later, the failing link step tries to build:
  - `test_cross_module_rtti_bindings.cp313-win_amd64.pyd`
- and links against:
  - `C:/hostedtoolcache/windows/Python/3.13.13/x64/libs/python313.lib`
- which fails with:
  - `lld-link: error: python313.lib(python313.dll): machine type x64 conflicts with arm64`

So the problem is not that `setup-python` selected the wrong interpreter. It did activate the ARM64 Python. The mismatch happens afterwards, when CMake `FindPython` resolves a separate x64 CPython installation that is also present on the hosted runner image.

## Why this fix

Pybind11's top-level build uses modern CMake `FindPython` in this configuration. Before this change, the workflow only passed:

- `-DPython_ROOT_DIR="$env:Python_ROOT_DIR"`

That is only a hint. The [CMake `FindPython` documentation](https://cmake.org/cmake/help/latest/module/FindPython.html) explicitly distinguishes between:

- search hints such as `Python_ROOT_DIR`
- explicit artifact specification such as `Python_EXECUTABLE`, `Python_INCLUDE_DIR`, and `Python_LIBRARY`

The same docs say that when an artifact is specified directly, CMake does not search for that artifact.

That makes passing all three artifacts the most robust low-risk fix here:

- it pins CMake to the exact ARM64 interpreter, headers, and import library that `actions/setup-python` already installed
- it avoids depending on Windows registry lookup or other `FindPython` search heuristics
- it is more deterministic than trying to steer the search with additional hints or policy tweaks such as `Python_FIND_REGISTRY=NEVER`
- it keeps the change narrowly scoped to the one affected job

## Implementation

The `Configure CMake` step in the `windows_arm_clang_msvc` job now:

- derives `python.exe` from `$env:pythonLocation`
- derives the include directory from `$env:pythonLocation`
- derives the versioned import library path (`pythonXY.lib`) from the active Python version and `$env:pythonLocation\libs`
- passes those paths via:
  - `-DPython_EXECUTABLE=...`
  - `-DPython_INCLUDE_DIR=...`
  - `-DPython_LIBRARY=...`

This leaves the rest of the job unchanged.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* N/A