### PR TITLE
fix: Invert input/output context if a Python function is called from C++

### DIFF
--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -222,5 +222,10 @@ constexpr descr<N + 4, Ts...> return_descr(const descr<N, Ts...> &descr) {
     return const_name("@$") + descr + const_name("@!");
 }
 
+template <size_t N, typename... Ts>
+constexpr descr<N + 4, Ts...> inv_descr(const descr<N, Ts...> &descr) {
+    return const_name("@~") + descr + const_name("@!");
+}
+
 PYBIND11_NAMESPACE_END(detail)
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -138,9 +138,8 @@ public:
     PYBIND11_TYPE_CASTER(
         type,
         const_name("collections.abc.Callable[[")
-            + ::pybind11::detail::concat(::pybind11::detail::arg_descr(make_caster<Args>::name)...)
-            + const_name("], ") + ::pybind11::detail::return_descr(make_caster<retval_type>::name)
-            + const_name("]"));
+            + ::pybind11::detail::concat(::pybind11::detail::inv_descr(make_caster<Args>::name)...)
+            + const_name("], ") + make_caster<retval_type>::name + const_name("]"));
 };
 
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -185,7 +185,8 @@ inline std::string generate_function_signature(const char *type_caster_name_fiel
             signature += *++pc;
         } else if (c == '@') {
             // `@^ ... @!` and `@$ ... @!` are used to force arg/return value type (see
-            // typing::Callable/detail::arg_descr/detail::return_descr)
+            // typing::Callable/detail::arg_descr/detail::return_descr).
+            // `@~ ... @!` inverts the current context (see detail::inv_descr).
             if (*(pc + 1) == '^') {
                 is_return_value.emplace(false);
                 ++pc;
@@ -193,6 +194,11 @@ inline std::string generate_function_signature(const char *type_caster_name_fiel
             }
             if (*(pc + 1) == '$') {
                 is_return_value.emplace(true);
+                ++pc;
+                continue;
+            }
+            if (*(pc + 1) == '~') {
+                is_return_value.emplace(!is_return_value.top());
                 ++pc;
                 continue;
             }

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -194,9 +194,8 @@ struct handle_type_name<typing::Callable<Return(Args...)>> {
     using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
     static constexpr auto name
         = const_name("collections.abc.Callable[[")
-          + ::pybind11::detail::concat(::pybind11::detail::arg_descr(make_caster<Args>::name)...)
-          + const_name("], ") + ::pybind11::detail::return_descr(make_caster<retval_type>::name)
-          + const_name("]");
+          + ::pybind11::detail::concat(::pybind11::detail::inv_descr(make_caster<Args>::name)...)
+          + const_name("], ") + make_caster<retval_type>::name + const_name("]");
 };
 
 template <typename Return>
@@ -204,8 +203,7 @@ struct handle_type_name<typing::Callable<Return(ellipsis)>> {
     // PEP 484 specifies this syntax for defining only return types of callables
     using retval_type = conditional_t<std::is_same<Return, void>::value, void_type, Return>;
     static constexpr auto name = const_name("collections.abc.Callable[..., ")
-                                 + ::pybind11::detail::return_descr(make_caster<retval_type>::name)
-                                 + const_name("]");
+                                 + make_caster<retval_type>::name + const_name("]");
 };
 
 template <typename T>

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -140,7 +140,7 @@ def test_cpp_function_roundtrip():
 def test_function_signatures(doc):
     assert (
         doc(m.test_callback3)
-        == "test_callback3(arg0: collections.abc.Callable[[typing.SupportsInt | typing.SupportsIndex], int]) -> str"
+        == "test_callback3(arg0: collections.abc.Callable[[int], typing.SupportsInt | typing.SupportsIndex]) -> str"
     )
     assert (
         doc(m.test_callback4)

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -976,14 +976,14 @@ def test_iterator_annotations(doc):
 def test_fn_annotations(doc):
     assert (
         doc(m.annotate_fn)
-        == "annotate_fn(arg0: collections.abc.Callable[[list[str], str], int]) -> None"
+        == "annotate_fn(arg0: collections.abc.Callable[[list[str], str], typing.SupportsInt | typing.SupportsIndex]) -> None"
     )
 
 
 def test_fn_return_only(doc):
     assert (
         doc(m.annotate_fn_only_return)
-        == "annotate_fn_only_return(arg0: collections.abc.Callable[..., int]) -> None"
+        == "annotate_fn_only_return(arg0: collections.abc.Callable[..., typing.SupportsInt | typing.SupportsIndex]) -> None"
     )
 
 
@@ -1085,7 +1085,7 @@ def test_literal(doc):
     )
     assert (
         doc(m.identity_literal_arrow_with_callable)
-        == 'identity_literal_arrow_with_callable(arg0: collections.abc.Callable[[typing.Literal["->"], float | int], float]) -> collections.abc.Callable[[typing.Literal["->"], float | int], float]'
+        == 'identity_literal_arrow_with_callable(arg0: collections.abc.Callable[[typing.Literal["->"], float], float | int]) -> collections.abc.Callable[[typing.Literal["->"], float | int], float]'
     )
     assert (
         doc(m.identity_literal_all_special_chars)
@@ -1325,27 +1325,27 @@ def test_arg_return_type_hints(doc, backport_typehints):
     # Callable<R(A)> identity
     assert (
         doc(m.identity_callable)
-        == "identity_callable(arg0: collections.abc.Callable[[float | int], float]) -> collections.abc.Callable[[float | int], float]"
+        == "identity_callable(arg0: collections.abc.Callable[[float], float | int]) -> collections.abc.Callable[[float | int], float]"
     )
     # Callable<R(...)> identity
     assert (
         doc(m.identity_callable_ellipsis)
-        == "identity_callable_ellipsis(arg0: collections.abc.Callable[..., float]) -> collections.abc.Callable[..., float]"
+        == "identity_callable_ellipsis(arg0: collections.abc.Callable[..., float | int]) -> collections.abc.Callable[..., float]"
     )
     # Nested Callable<R(A)> identity
     assert (
         doc(m.identity_nested_callable)
-        == "identity_nested_callable(arg0: collections.abc.Callable[[collections.abc.Callable[[float | int], float]], collections.abc.Callable[[float | int], float]]) -> collections.abc.Callable[[collections.abc.Callable[[float | int], float]], collections.abc.Callable[[float | int], float]]"
+        == "identity_nested_callable(arg0: collections.abc.Callable[[collections.abc.Callable[[float | int], float]], collections.abc.Callable[[float], float | int]]) -> collections.abc.Callable[[collections.abc.Callable[[float], float | int]], collections.abc.Callable[[float | int], float]]"
     )
     # Callable<R(A)>
     assert (
         doc(m.apply_callable)
-        == "apply_callable(arg0: float | int, arg1: collections.abc.Callable[[float | int], float]) -> float"
+        == "apply_callable(arg0: float | int, arg1: collections.abc.Callable[[float], float | int]) -> float"
     )
     # Callable<R(...)>
     assert (
         doc(m.apply_callable_ellipsis)
-        == "apply_callable_ellipsis(arg0: float | int, arg1: collections.abc.Callable[..., float]) -> float"
+        == "apply_callable_ellipsis(arg0: float | int, arg1: collections.abc.Callable[..., float | int]) -> float"
     )
     # Union<T1, T2>
     assert (


### PR DESCRIPTION
## Summary

* Add an internal "invert current I/O context" marker to the signature-description parser so nested callable types can flip argument/return annotation direction relative to the enclosing function signature.
* Apply that marker to `std::function` and `py::typing::Callable`, which fixes generated annotations for Python callbacks passed into C++ while preserving the existing Python-facing direction for callables returned from C++ to Python.
* Update callable annotation tests to cover simple callbacks, `Callable[..., T]`, nested callables, and literals containing signature-parser special characters.

___

Hi!

## Description

In my project, I have a type `ByteVector` with a type-caster defined like this:
`PYBIND11_TYPE_CASTER(ByteVector, io_name("bytes | bytearray", "bytes"));`
So, we accept any `bytes` or `bytearray` to turn into a `ByteVector`, but when passing it to Python, it's always `bytes` (because Python can't modify the vector, which is alright in this case).

API users pass in Python functions as callbacks that are called on specific events that the C++ interface processes. This currently leads to type annotations that look like this:
```python
@property
def on_save_settings(self) -> collections.abc.Callable[[os.PathLike | str | bytes], bytes]:
    ...
@on_save_settings.setter
def on_save_settings(self, arg1: collections.abc.Callable[[os.PathLike | str | bytes], bytes]) -> None:
    ...
```

The function return type is only `bytes` even though it is input to C++ and therefore should accept both byte-like types. Similar things apply for the path.

Currently, pybind11 expects Python to call C++ functions when receiving a callback, not the opposite.
This patch fixes the type annotations by inverting them if Python passes in a function into C++, and leaving them the same in the other direction. This leads to type annotations that look like this:

```python
@property
def on_save_settings(self) -> collections.abc.Callable[[os.PathLike | str | bytes], bytes]:
    ...
@on_save_settings.setter
def on_save_settings(self, arg1: collections.abc.Callable[[pathlib.Path], bytes | bytearray]) -> None:
    ...
```

Now, if you pass in a function Python -> C++, its i/o context is inverted, as it will be called from C++. However, in the other direction (receiving one from C++) everything stays the same as before.

I think this is probably the best we can do to address both cases automatically in pybind11, or do you have a better solution to this problem?

Thank you for making pybind11, it's an incredibly helpful project!

## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Fix generated `Callable` type annotations for Python callbacks passed into C++ by inverting the callback's argument/return I/O context relative to the enclosing function signature.