### PR TITLE
fix: relink pybind11::embed after partial FindPython

### DIFF
--- a/tests/test_cmake_build/installed_embed/CMakeLists.txt
+++ b/tests/test_cmake_build/installed_embed/CMakeLists.txt
@@ -2,21 +2,27 @@ cmake_minimum_required(VERSION 3.15...4.2)
 
 project(test_installed_embed CXX)
 
-find_package(
-  Python
-  COMPONENTS Interpreter
-  REQUIRED)
+if(PYBIND11_FINDPYTHON)
+  find_package(Python COMPONENTS Interpreter REQUIRED)
+endif()
 find_package(pybind11 CONFIG REQUIRED)
 message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
 
-find_package(
-  Python REQUIRED
-  COMPONENTS Development.Module
-  OPTIONAL_COMPONENTS Development.Embed)
-get_target_property(_pybind11_embed_links pybind11::embed INTERFACE_LINK_LIBRARIES)
-if(TARGET Python::Python AND NOT "Python::Python" IN_LIST _pybind11_embed_links)
-  message(
-    FATAL_ERROR "pybind11::embed must link to Python::Python when Python::Python is available")
+if(PYBIND11_FINDPYTHON)
+  if(CMAKE_VERSION VERSION_LESS 3.18)
+    find_package(Python REQUIRED COMPONENTS Development)
+  else()
+    find_package(
+      Python REQUIRED
+      COMPONENTS Development.Module
+      OPTIONAL_COMPONENTS Development.Embed)
+  endif()
+
+  get_target_property(_pybind11_embed_links pybind11::embed INTERFACE_LINK_LIBRARIES)
+  if(TARGET Python::Python AND NOT "Python::Python" IN_LIST _pybind11_embed_links)
+    message(
+      FATAL_ERROR "pybind11::embed must link to Python::Python when Python::Python is available")
+  endif()
 endif()
 
 add_executable(test_installed_embed ../embed.cpp)

--- a/tests/test_cmake_build/installed_embed/CMakeLists.txt
+++ b/tests/test_cmake_build/installed_embed/CMakeLists.txt
@@ -3,7 +3,10 @@ cmake_minimum_required(VERSION 3.15...4.2)
 project(test_installed_embed CXX)
 
 if(PYBIND11_FINDPYTHON)
-  find_package(Python COMPONENTS Interpreter REQUIRED)
+  find_package(
+    Python
+    COMPONENTS Interpreter
+    REQUIRED)
 endif()
 find_package(pybind11 CONFIG REQUIRED)
 message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")

--- a/tests/test_cmake_build/installed_embed/CMakeLists.txt
+++ b/tests/test_cmake_build/installed_embed/CMakeLists.txt
@@ -2,8 +2,15 @@ cmake_minimum_required(VERSION 3.15...4.2)
 
 project(test_installed_embed CXX)
 
+find_package(Python COMPONENTS Interpreter REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
 message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
+
+find_package(Python REQUIRED COMPONENTS Development.Module OPTIONAL_COMPONENTS Development.Embed)
+get_target_property(_pybind11_embed_links pybind11::embed INTERFACE_LINK_LIBRARIES)
+if(TARGET Python::Python AND NOT "Python::Python" IN_LIST _pybind11_embed_links)
+  message(FATAL_ERROR "pybind11::embed must link to Python::Python when Python::Python is available")
+endif()
 
 add_executable(test_installed_embed ../embed.cpp)
 target_link_libraries(test_installed_embed PRIVATE pybind11::embed)

--- a/tests/test_cmake_build/installed_embed/CMakeLists.txt
+++ b/tests/test_cmake_build/installed_embed/CMakeLists.txt
@@ -2,14 +2,21 @@ cmake_minimum_required(VERSION 3.15...4.2)
 
 project(test_installed_embed CXX)
 
-find_package(Python COMPONENTS Interpreter REQUIRED)
+find_package(
+  Python
+  COMPONENTS Interpreter
+  REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
 message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
 
-find_package(Python REQUIRED COMPONENTS Development.Module OPTIONAL_COMPONENTS Development.Embed)
+find_package(
+  Python REQUIRED
+  COMPONENTS Development.Module
+  OPTIONAL_COMPONENTS Development.Embed)
 get_target_property(_pybind11_embed_links pybind11::embed INTERFACE_LINK_LIBRARIES)
 if(TARGET Python::Python AND NOT "Python::Python" IN_LIST _pybind11_embed_links)
-  message(FATAL_ERROR "pybind11::embed must link to Python::Python when Python::Python is available")
+  message(
+    FATAL_ERROR "pybind11::embed must link to Python::Python when Python::Python is available")
 endif()
 
 add_executable(test_installed_embed ../embed.cpp)

--- a/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
+++ b/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
@@ -3,7 +3,10 @@ cmake_minimum_required(VERSION 3.15...4.2)
 project(test_subdirectory_embed CXX)
 
 if(PYBIND11_FINDPYTHON)
-  find_package(Python COMPONENTS Interpreter REQUIRED)
+  find_package(
+    Python
+    COMPONENTS Interpreter
+    REQUIRED)
 endif()
 
 set(PYBIND11_INSTALL

--- a/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
+++ b/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.15...4.2)
 
 project(test_subdirectory_embed CXX)
 
+find_package(Python COMPONENTS Interpreter REQUIRED)
+
 set(PYBIND11_INSTALL
     ON
     CACHE BOOL "")
@@ -14,6 +16,12 @@ if(DEFINED PYTHON_EXECUTABLE AND NOT DEFINED Python_EXECUTABLE)
 endif()
 
 add_subdirectory("${pybind11_SOURCE_DIR}" pybind11)
+
+find_package(Python REQUIRED COMPONENTS Development.Module OPTIONAL_COMPONENTS Development.Embed)
+get_target_property(_pybind11_embed_links pybind11::embed INTERFACE_LINK_LIBRARIES)
+if(TARGET Python::Python AND NOT "Python::Python" IN_LIST _pybind11_embed_links)
+  message(FATAL_ERROR "pybind11::embed must link to Python::Python when Python::Python is available")
+endif()
 
 # Test basic target functionality
 add_executable(test_subdirectory_embed ../embed.cpp)

--- a/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
+++ b/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
@@ -2,7 +2,10 @@ cmake_minimum_required(VERSION 3.15...4.2)
 
 project(test_subdirectory_embed CXX)
 
-find_package(Python COMPONENTS Interpreter REQUIRED)
+find_package(
+  Python
+  COMPONENTS Interpreter
+  REQUIRED)
 
 set(PYBIND11_INSTALL
     ON
@@ -17,10 +20,14 @@ endif()
 
 add_subdirectory("${pybind11_SOURCE_DIR}" pybind11)
 
-find_package(Python REQUIRED COMPONENTS Development.Module OPTIONAL_COMPONENTS Development.Embed)
+find_package(
+  Python REQUIRED
+  COMPONENTS Development.Module
+  OPTIONAL_COMPONENTS Development.Embed)
 get_target_property(_pybind11_embed_links pybind11::embed INTERFACE_LINK_LIBRARIES)
 if(TARGET Python::Python AND NOT "Python::Python" IN_LIST _pybind11_embed_links)
-  message(FATAL_ERROR "pybind11::embed must link to Python::Python when Python::Python is available")
+  message(
+    FATAL_ERROR "pybind11::embed must link to Python::Python when Python::Python is available")
 endif()
 
 # Test basic target functionality

--- a/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
+++ b/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.15...4.2)
 
 project(test_subdirectory_embed CXX)
 
-find_package(
-  Python
-  COMPONENTS Interpreter
-  REQUIRED)
+if(PYBIND11_FINDPYTHON)
+  find_package(Python COMPONENTS Interpreter REQUIRED)
+endif()
 
 set(PYBIND11_INSTALL
     ON
@@ -20,14 +19,21 @@ endif()
 
 add_subdirectory("${pybind11_SOURCE_DIR}" pybind11)
 
-find_package(
-  Python REQUIRED
-  COMPONENTS Development.Module
-  OPTIONAL_COMPONENTS Development.Embed)
-get_target_property(_pybind11_embed_links pybind11::embed INTERFACE_LINK_LIBRARIES)
-if(TARGET Python::Python AND NOT "Python::Python" IN_LIST _pybind11_embed_links)
-  message(
-    FATAL_ERROR "pybind11::embed must link to Python::Python when Python::Python is available")
+if(PYBIND11_FINDPYTHON)
+  if(CMAKE_VERSION VERSION_LESS 3.18)
+    find_package(Python REQUIRED COMPONENTS Development)
+  else()
+    find_package(
+      Python REQUIRED
+      COMPONENTS Development.Module
+      OPTIONAL_COMPONENTS Development.Embed)
+  endif()
+
+  get_target_property(_pybind11_embed_links pybind11::embed INTERFACE_LINK_LIBRARIES)
+  if(TARGET Python::Python AND NOT "Python::Python" IN_LIST _pybind11_embed_links)
+    message(
+      FATAL_ERROR "pybind11::embed must link to Python::Python when Python::Python is available")
+  endif()
 endif()
 
 # Test basic target functionality

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -86,6 +86,16 @@ if(_pybind11_findpython_required)
     endif()
   endif()
 
+  # Record which Python targets already exist (e.g. from a find_package call
+  # before pybind11). Targets created in an outer scope cannot be promoted to
+  # IMPORTED_GLOBAL from here on CMake < 3.24, so we only promote our own.
+  set(_pybind11_preexisting_targets "")
+  foreach(_pybind11_py_target Python Interpreter Module)
+    if(TARGET ${_pybind11_findpython_package}::${_pybind11_py_target})
+      list(APPEND _pybind11_preexisting_targets ${_pybind11_py_target})
+    endif()
+  endforeach()
+
   find_package(
     ${_pybind11_findpython_package} 3.8 REQUIRED
     COMPONENTS ${_pybind11_interp_component} ${_pybind11_dev_component} ${_pybind11_quiet}
@@ -96,16 +106,13 @@ if(_pybind11_findpython_required)
   if(NOT is_config
      AND ${_pybind11_artifacts_interactive}
      AND _pybind11_global_keyword STREQUAL "")
-    if(TARGET ${_pybind11_findpython_package}::Python)
-      set_property(TARGET ${_pybind11_findpython_package}::Python PROPERTY IMPORTED_GLOBAL TRUE)
-    endif()
-    if(TARGET ${_pybind11_findpython_package}::Interpreter)
-      set_property(TARGET ${_pybind11_findpython_package}::Interpreter PROPERTY IMPORTED_GLOBAL
-                                                                                TRUE)
-    endif()
-    if(TARGET ${_pybind11_findpython_package}::Module)
-      set_property(TARGET ${_pybind11_findpython_package}::Module PROPERTY IMPORTED_GLOBAL TRUE)
-    endif()
+    foreach(_pybind11_py_target Python Interpreter Module)
+      if(TARGET ${_pybind11_findpython_package}::${_pybind11_py_target}
+         AND NOT "${_pybind11_py_target}" IN_LIST _pybind11_preexisting_targets)
+        set_property(TARGET ${_pybind11_findpython_package}::${_pybind11_py_target}
+                     PROPERTY IMPORTED_GLOBAL TRUE)
+      endif()
+    endforeach()
   endif()
 
   # Explicitly export version for callers (including our own functions)

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -78,8 +78,7 @@ if(_pybind11_findpython_required)
 
   # Callers need to be able to access Python_EXECUTABLE
   set(_pybind11_global_keyword "")
-  set(_pybind11_artifacts_interactive
-      ${_pybind11_findpython_package}_ARTIFACTS_INTERACTIVE)
+  set(_pybind11_artifacts_interactive ${_pybind11_findpython_package}_ARTIFACTS_INTERACTIVE)
   if(NOT is_config AND NOT DEFINED ${_pybind11_artifacts_interactive})
     set(${_pybind11_artifacts_interactive} TRUE)
     if(NOT CMAKE_VERSION VERSION_LESS 3.24)
@@ -88,10 +87,9 @@ if(_pybind11_findpython_required)
   endif()
 
   find_package(
-    ${_pybind11_findpython_package} 3.8 REQUIRED COMPONENTS ${_pybind11_interp_component}
-                                                            ${_pybind11_dev_component}
-                                                            ${_pybind11_quiet}
-                                                            ${_pybind11_global_keyword})
+    ${_pybind11_findpython_package} 3.8 REQUIRED
+    COMPONENTS ${_pybind11_interp_component} ${_pybind11_dev_component} ${_pybind11_quiet}
+               ${_pybind11_global_keyword})
 
   # If we are in submodule mode, export the Python targets to global targets.
   # If this behavior is not desired, FindPython _before_ pybind11.
@@ -102,7 +100,8 @@ if(_pybind11_findpython_required)
       set_property(TARGET ${_pybind11_findpython_package}::Python PROPERTY IMPORTED_GLOBAL TRUE)
     endif()
     if(TARGET ${_pybind11_findpython_package}::Interpreter)
-      set_property(TARGET ${_pybind11_findpython_package}::Interpreter PROPERTY IMPORTED_GLOBAL TRUE)
+      set_property(TARGET ${_pybind11_findpython_package}::Interpreter PROPERTY IMPORTED_GLOBAL
+                                                                                TRUE)
     endif()
     if(TARGET ${_pybind11_findpython_package}::Module)
       set_property(TARGET ${_pybind11_findpython_package}::Module PROPERTY IMPORTED_GLOBAL TRUE)

--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -18,14 +18,48 @@ else()
   set(_pybind11_quiet "")
 endif()
 
-if(NOT Python_FOUND AND NOT Python3_FOUND)
-  if(NOT DEFINED Python_FIND_IMPLEMENTATIONS)
-    set(Python_FIND_IMPLEMENTATIONS CPython PyPy)
+if(Python_FOUND)
+  set(_pybind11_findpython_package Python)
+elseif(Python3_FOUND)
+  set(_pybind11_findpython_package Python3)
+else()
+  set(_pybind11_findpython_package Python)
+endif()
+
+set(_pybind11_findpython_required FALSE)
+if(DEFINED ${_pybind11_findpython_package}_FOUND)
+  if(${_pybind11_findpython_package}_FOUND)
+    if(NOT _PYBIND11_CROSSCOMPILING AND NOT DEFINED ${_pybind11_findpython_package}_EXECUTABLE)
+      set(_pybind11_findpython_required TRUE)
+    endif()
+
+    if(CMAKE_VERSION VERSION_LESS 3.18) # Development.Module is not available yet
+      if(NOT DEFINED ${_pybind11_findpython_package}_INCLUDE_DIRS
+         OR NOT TARGET ${_pybind11_findpython_package}::Python)
+        set(_pybind11_findpython_required TRUE)
+      endif()
+    else()
+      if(NOT DEFINED ${_pybind11_findpython_package}_INCLUDE_DIRS
+         OR NOT TARGET ${_pybind11_findpython_package}::Module
+         OR NOT TARGET ${_pybind11_findpython_package}::Python)
+        set(_pybind11_findpython_required TRUE)
+      endif()
+    endif()
+  else()
+    set(_pybind11_findpython_required TRUE)
+  endif()
+else()
+  set(_pybind11_findpython_required TRUE)
+endif()
+
+if(_pybind11_findpython_required)
+  if(NOT DEFINED ${_pybind11_findpython_package}_FIND_IMPLEMENTATIONS)
+    set(${_pybind11_findpython_package}_FIND_IMPLEMENTATIONS CPython PyPy)
   endif()
 
   # GitHub Actions like activation
-  if(NOT DEFINED Python_ROOT_DIR AND DEFINED ENV{pythonLocation})
-    set(Python_ROOT_DIR "$ENV{pythonLocation}")
+  if(NOT DEFINED ${_pybind11_findpython_package}_ROOT_DIR AND DEFINED ENV{pythonLocation})
+    set(${_pybind11_findpython_package}_ROOT_DIR "$ENV{pythonLocation}")
   endif()
 
   # Interpreter should not be found when cross-compiling
@@ -44,46 +78,50 @@ if(NOT Python_FOUND AND NOT Python3_FOUND)
 
   # Callers need to be able to access Python_EXECUTABLE
   set(_pybind11_global_keyword "")
-  if(NOT is_config AND NOT DEFINED Python_ARTIFACTS_INTERACTIVE)
-    set(Python_ARTIFACTS_INTERACTIVE TRUE)
+  set(_pybind11_artifacts_interactive
+      ${_pybind11_findpython_package}_ARTIFACTS_INTERACTIVE)
+  if(NOT is_config AND NOT DEFINED ${_pybind11_artifacts_interactive})
+    set(${_pybind11_artifacts_interactive} TRUE)
     if(NOT CMAKE_VERSION VERSION_LESS 3.24)
       set(_pybind11_global_keyword "GLOBAL")
     endif()
   endif()
 
   find_package(
-    Python 3.8 REQUIRED COMPONENTS ${_pybind11_interp_component} ${_pybind11_dev_component}
-                                   ${_pybind11_quiet} ${_pybind11_global_keyword})
+    ${_pybind11_findpython_package} 3.8 REQUIRED COMPONENTS ${_pybind11_interp_component}
+                                                            ${_pybind11_dev_component}
+                                                            ${_pybind11_quiet}
+                                                            ${_pybind11_global_keyword})
 
   # If we are in submodule mode, export the Python targets to global targets.
   # If this behavior is not desired, FindPython _before_ pybind11.
   if(NOT is_config
-     AND Python_ARTIFACTS_INTERACTIVE
+     AND ${_pybind11_artifacts_interactive}
      AND _pybind11_global_keyword STREQUAL "")
-    if(TARGET Python::Python)
-      set_property(TARGET Python::Python PROPERTY IMPORTED_GLOBAL TRUE)
+    if(TARGET ${_pybind11_findpython_package}::Python)
+      set_property(TARGET ${_pybind11_findpython_package}::Python PROPERTY IMPORTED_GLOBAL TRUE)
     endif()
-    if(TARGET Python::Interpreter)
-      set_property(TARGET Python::Interpreter PROPERTY IMPORTED_GLOBAL TRUE)
+    if(TARGET ${_pybind11_findpython_package}::Interpreter)
+      set_property(TARGET ${_pybind11_findpython_package}::Interpreter PROPERTY IMPORTED_GLOBAL TRUE)
     endif()
-    if(TARGET Python::Module)
-      set_property(TARGET Python::Module PROPERTY IMPORTED_GLOBAL TRUE)
+    if(TARGET ${_pybind11_findpython_package}::Module)
+      set_property(TARGET ${_pybind11_findpython_package}::Module PROPERTY IMPORTED_GLOBAL TRUE)
     endif()
   endif()
 
   # Explicitly export version for callers (including our own functions)
-  if(NOT is_config AND Python_ARTIFACTS_INTERACTIVE)
-    set(Python_VERSION
-        "${Python_VERSION}"
+  if(NOT is_config AND ${_pybind11_artifacts_interactive})
+    set(${_pybind11_findpython_package}_VERSION
+        "${${_pybind11_findpython_package}_VERSION}"
         CACHE INTERNAL "")
-    set(Python_VERSION_MAJOR
-        "${Python_VERSION_MAJOR}"
+    set(${_pybind11_findpython_package}_VERSION_MAJOR
+        "${${_pybind11_findpython_package}_VERSION_MAJOR}"
         CACHE INTERNAL "")
-    set(Python_VERSION_MINOR
-        "${Python_VERSION_MINOR}"
+    set(${_pybind11_findpython_package}_VERSION_MINOR
+        "${${_pybind11_findpython_package}_VERSION_MINOR}"
         CACHE INTERNAL "")
-    set(Python_VERSION_PATCH
-        "${Python_VERSION_PATCH}"
+    set(${_pybind11_findpython_package}_VERSION_PATCH
+        "${${_pybind11_findpython_package}_VERSION_PATCH}"
         CACHE INTERNAL "")
   endif()
 endif()


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary
Re-run the new FindPython lookup when pybind11 is loaded after an earlier `find_package(Python COMPONENTS Interpreter)` call that did not create the development targets needed by `pybind11::embed`.

This keeps `pybind11::embed` linking `Python::Python` in the partial-discovery case reported in #6063, while preserving the existing `Python` versus `Python3` handling.

## Testing
Add CMake embed tests for both subdirectory and installed usage that start with an interpreter-only `find_package(Python)` call and then assert `pybind11::embed` links `Python::Python` once the development components are available.

Fixes #6063

Assisted-by: GitHub Copilot CLI:GPT-5.4
