### PR TITLE
ci: pin Ubuntu PyPy 3.11 to 7.3.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,8 @@ jobs:
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=17 -DPYBIND11_TEST_SMART_HOLDER=ON
           - runs-on: ubuntu-latest
-            python-version: 'pypy3.11'
+            # Temporarily pinned pending investigation in issue #6049.
+            python-version: 'pypy-3.11-v7.3.21'
             cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: ubuntu-latest
             python-version: 'graalpy-24.2'


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Summary

Pin the Ubuntu `pypy3.11` CI job to `pypy-3.11-v7.3.21`.

Extract this CI-only fix from #6068 so it can be merged independently while the #6064 / #6066 / #6069 discussion is on hold.

## Rationale

A few days ago, PyPy 7.3.22 started to also trigger the issue already tracked in #6049. Other PyPy 3.11 jobs were already pinned; this applies the same temporary pin to the Ubuntu job so CI can return to a useful green baseline.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* N/A