### PR TITLE
ci: unpin pypy-3.11 version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,7 @@ jobs:
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=17 -DPYBIND11_TEST_SMART_HOLDER=ON
           - runs-on: ubuntu-latest
-            # Temporarily pinned pending investigation in issue #6049.
-            python-version: 'pypy-3.11-v7.3.21'
+            python-version: 'pypy-3.11'
             cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: ubuntu-latest
             python-version: 'graalpy-24.2'
@@ -119,8 +118,7 @@ jobs:
             python-version: 'pypy-3.10'
             cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: macos-latest
-            # Temporarily pinned pending investigation in issue #6049.
-            python-version: 'pypy-3.11-v7.3.21'
+            python-version: 'pypy-3.11'
           - runs-on: macos-latest
             python-version: 'graalpy-24.2'
 
@@ -153,8 +151,7 @@ jobs:
             python-version: 'pypy-3.10'
             cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: windows-latest
-            # Temporarily pinned pending investigation in issue #6049.
-            python-version: 'pypy3.11-v7.3.21'
+            python-version: 'pypy-3.11'
             cmake-args: -DCMAKE_CXX_STANDARD=20
           # The setup-python action currently doesn't have graalpy for windows
           # See https://github.com/actions/setup-python/pull/880


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

Remove temporary `pypy-3.11-v7.3.21` pins that were added pending investigation of issue #6049. Use unversioned `pypy-3.11` to allow setup-python to resolve the latest available version across all three platforms (ubuntu, macos, windows).

Assisted-by: OpenCode:glm-5