### PR TITLE
feat(subinterpreter): reusable PyThreadState via subinterpreter_thread_state

### DIFF
--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -407,6 +407,9 @@ also exist for the same sub-interpreter on the same thread.
       ``PyThreadState`` is bound to its creating thread; deleting it on another
       thread is undefined behavior. Holding the object as a ``thread_local``
       satisfies this automatically.
+    - It must only be activated (with :class:`subinterpreter_scoped_activate`)
+      on the **same OS thread** that constructed it. Activating it on a
+      different thread is illegal.
     - It must be destroyed while its sub-interpreter is still alive.
     - It must **not** be destroyed while a :class:`subinterpreter_scoped_activate`
       referring to it is alive — the activator holds a reference into it.

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -345,6 +345,66 @@ Example:
     }
 
 
+Reusing a thread state (cached activation)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, when a thread activates a sub-interpreter it is not already running,
+:class:`subinterpreter_scoped_activate` creates a fresh ``PyThreadState`` and
+destroys it when the scope ends. A thread that repeatedly enters the same
+sub-interpreter therefore allocates and frees a thread state every time, and
+does **not** preserve any per-thread interpreter state between activations.
+
+For workloads that repeatedly re-enter the same sub-interpreter from the same OS
+thread, you can opt into a cached mode by passing
+:enum:`subinterpreter_thread_state::cached`:
+
+.. code-block:: cpp
+
+    {
+        // First activation on this OS thread creates a PyThreadState and caches it
+        // in thread-local storage, keyed by the target interpreter.
+        py::subinterpreter_scoped_activate guard(
+            sub, py::subinterpreter_thread_state::cached);
+        // ... use the sub-interpreter ...
+    }
+    // The PyThreadState is swapped out but NOT destroyed.
+
+    {
+        // Subsequent activations on the same OS thread reuse the cached
+        // PyThreadState (only a swap, no allocation) and preserve its
+        // per-thread interpreter state.
+        py::subinterpreter_scoped_activate guard(
+            sub, py::subinterpreter_thread_state::cached);
+    }
+
+The default behavior is unchanged: the parameter defaults to
+:enum:`subinterpreter_thread_state::transient`, and the cache is only consulted
+when ``cached`` is explicitly requested. ``transient`` and ``cached``
+activations never share a thread state, even for the same interpreter on the
+same thread.
+
+Because pybind11 does not control thread creation or destruction, a cached
+``PyThreadState`` is **not** destroyed automatically. The owning OS thread must
+explicitly release it before the sub-interpreter is destroyed (and before that
+thread exits, to avoid a leak):
+
+- :func:`subinterpreter::release_cached_thread_state` destroys the cached
+  thread state that the **calling** OS thread created for **that one**
+  sub-interpreter.
+- :func:`subinterpreter::release_all_cached_thread_states` destroys every
+  cached thread state the **calling** OS thread created (for any
+  sub-interpreter); it is a convenient end-of-thread cleanup hook.
+
+.. warning::
+
+    Call the release functions on the same OS thread that activated the
+    sub-interpreter, while that sub-interpreter is still alive, and while no
+    :class:`subinterpreter_scoped_activate` scope using the cached state is
+    active on that thread. Destroying a cached ``PyThreadState`` whose
+    interpreter has already been finalized is undefined behavior. The cache is
+    per OS thread: a thread cannot release another thread's cached states, so
+    each worker thread is responsible for its own cleanup before it exits.
+
 GIL API for sub-interpreters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -345,65 +345,71 @@ Example:
     }
 
 
-Reusing a thread state (cached activation)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Reusing a thread state across activations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, when a thread activates a sub-interpreter it is not already running,
-:class:`subinterpreter_scoped_activate` creates a fresh ``PyThreadState`` and
-destroys it when the scope ends. A thread that repeatedly enters the same
-sub-interpreter therefore allocates and frees a thread state every time, and
-does **not** preserve any per-thread interpreter state between activations.
+By default, :class:`subinterpreter_scoped_activate` creates a fresh
+``PyThreadState`` on entry and destroys it on exit. A thread that repeatedly
+re-enters the same sub-interpreter therefore allocates and frees a thread state
+every time, and does **not** preserve any per-thread interpreter state between
+activations.
 
-For workloads that repeatedly re-enter the same sub-interpreter from the same OS
-thread, you can opt into a cached mode by passing
-:enum:`subinterpreter_thread_state::cached`:
+For workloads where a single OS thread re-enters one or more sub-interpreters
+many times, pybind11 provides :class:`subinterpreter_thread_state` — an RAII
+object that owns a ``PyThreadState`` and lets you swap it in for the duration
+of each :class:`subinterpreter_scoped_activate` scope without destroying it
+between activations:
 
 .. code-block:: cpp
 
+    // Create the PyThreadState once. It is created in a "released" state:
+    // not current, no GIL acquired.
+    thread_local py::subinterpreter_thread_state ts(sub);
+
     {
-        // First activation on this OS thread creates a PyThreadState and caches it
-        // in thread-local storage, keyed by the target interpreter.
-        py::subinterpreter_scoped_activate guard(
-            sub, py::subinterpreter_thread_state::cached);
+        // Swap it in; the subinterpreter's GIL is acquired.
+        py::subinterpreter_scoped_activate guard(ts);
         // ... use the sub-interpreter ...
     }
-    // The PyThreadState is swapped out but NOT destroyed.
+    // Swap-out only; the PyThreadState is kept alive in `ts`.
 
     {
-        // Subsequent activations on the same OS thread reuse the cached
-        // PyThreadState (only a swap, no allocation) and preserve its
-        // per-thread interpreter state.
-        py::subinterpreter_scoped_activate guard(
-            sub, py::subinterpreter_thread_state::cached);
+        py::subinterpreter_scoped_activate guard(ts);
+        // The same PyThreadState is re-used; its per-thread interpreter state
+        // is preserved across activations.
     }
 
-The default behavior is unchanged: the parameter defaults to
-:enum:`subinterpreter_thread_state::transient`, and the cache is only consulted
-when ``cached`` is explicitly requested. ``transient`` and ``cached``
-activations never share a thread state, even for the same interpreter on the
-same thread.
+This composes naturally with multiple sub-interpreters on the same OS thread:
+hold one :class:`subinterpreter_thread_state` per sub-interpreter and alternate
+between them. Each ``PyThreadState`` is independent and is preserved across
+activations.
 
-Because pybind11 does not control thread creation or destruction, a cached
-``PyThreadState`` is **not** destroyed automatically. The owning OS thread must
-explicitly release it before the sub-interpreter is destroyed (and before that
-thread exits, to avoid a leak):
+.. code-block:: cpp
 
-- :func:`subinterpreter::release_cached_thread_state` destroys the cached
-  thread state that the **calling** OS thread created for **that one**
-  sub-interpreter.
-- :func:`subinterpreter::release_all_cached_thread_states` destroys every
-  cached thread state the **calling** OS thread created (for any
-  sub-interpreter); it is a convenient end-of-thread cleanup hook.
+    thread_local py::subinterpreter_thread_state ts_a(sub_a);
+    thread_local py::subinterpreter_thread_state ts_b(sub_b);
+
+    { py::subinterpreter_scoped_activate guard(ts_a); /* in sub_a */ }
+    { py::subinterpreter_scoped_activate guard(ts_b); /* in sub_b */ }
+    { py::subinterpreter_scoped_activate guard(ts_a); /* same PyThreadState as before */ }
+
+The default behavior is unchanged: the
+:class:`subinterpreter_scoped_activate(subinterpreter const&)` overload still
+creates and destroys a transient ``PyThreadState`` per scope, and it never
+shares a thread state with any :class:`subinterpreter_thread_state` that may
+also exist for the same sub-interpreter on the same thread.
 
 .. warning::
 
-    Call the release functions on the same OS thread that activated the
-    sub-interpreter, while that sub-interpreter is still alive, and while no
-    :class:`subinterpreter_scoped_activate` scope using the cached state is
-    active on that thread. Destroying a cached ``PyThreadState`` whose
-    interpreter has already been finalized is undefined behavior. The cache is
-    per OS thread: a thread cannot release another thread's cached states, so
-    each worker thread is responsible for its own cleanup before it exits.
+    Lifetime and threading requirements for :class:`subinterpreter_thread_state`:
+
+    - It must be constructed and destroyed on the **same OS thread**. A
+      ``PyThreadState`` is bound to its creating thread; deleting it on another
+      thread is undefined behavior. Holding the object as a ``thread_local``
+      satisfies this automatically.
+    - It must be destroyed while its sub-interpreter is still alive.
+    - It must **not** be destroyed while a :class:`subinterpreter_scoped_activate`
+      referring to it is alive — the activator holds a reference into it.
 
 GIL API for sub-interpreters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/advanced/embedding.rst
+++ b/docs/advanced/embedding.rst
@@ -375,7 +375,7 @@ between activations:
 
     {
         py::subinterpreter_scoped_activate guard(ts);
-        // The same PyThreadState is re-used; its per-thread interpreter state
+        // The same PyThreadState is reused; its per-thread interpreter state
         // is preserved across activations.
     }
 

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -14,12 +14,49 @@
 #include "gil.h"
 
 #include <stdexcept>
+#include <unordered_map>
 
 #ifndef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 #    error "This platform does not support subinterpreters, do not include this file."
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+/// OS-thread-local cache mapping a target interpreter to the PyThreadState that was created for
+/// it *on the current OS thread*.  Used by subinterpreter_scoped_activate when
+/// subinterpreter_thread_state::cached is requested, so that repeatedly entering the same
+/// interpreter from the same OS thread reuses one PyThreadState (swapped in/out) instead of
+/// allocating and destroying a fresh one each time.
+///
+/// The values are raw, non-owning pointers.  At thread exit the map's destructor only frees its
+/// own nodes; it deliberately does NOT touch the Python C API (which may be unusable at that
+/// point), so a cached PyThreadState is leaked unless the owning thread first calls
+/// subinterpreter::release_cached_thread_state() or
+/// subinterpreter::release_all_cached_thread_states().
+inline std::unordered_map<PyInterpreterState *, PyThreadState *> &
+subinterpreter_thread_state_cache() {
+    thread_local std::unordered_map<PyInterpreterState *, PyThreadState *> cache;
+    return cache;
+}
+
+PYBIND11_NAMESPACE_END(detail)
+
+/// Selects how subinterpreter_scoped_activate obtains a PyThreadState when the calling OS thread
+/// is not already running the target interpreter.
+enum class subinterpreter_thread_state {
+    /// Default / legacy behavior: a fresh PyThreadState is created on activation and destroyed
+    /// when the scope exits.
+    transient,
+    /// Reuse (or, on first use, create-and-cache) a PyThreadState held in OS-thread-local
+    /// storage, keyed by the target interpreter.  The scope only swaps it in and out and never
+    /// destroys it.  The owning thread is responsible for eventually destroying it via
+    /// subinterpreter::release_cached_thread_state() /
+    /// subinterpreter::release_all_cached_thread_states(); see those functions for the
+    /// preconditions.
+    cached
+};
 
 class subinterpreter;
 
@@ -28,7 +65,9 @@ class subinterpreter;
 /// associated GIL are restored to their state as they were before the scope was entered.
 class subinterpreter_scoped_activate {
 public:
-    explicit subinterpreter_scoped_activate(subinterpreter const &si);
+    explicit subinterpreter_scoped_activate(
+        subinterpreter const &si,
+        subinterpreter_thread_state ts_policy = subinterpreter_thread_state::transient);
     ~subinterpreter_scoped_activate();
 
     subinterpreter_scoped_activate(subinterpreter_scoped_activate &&) = delete;
@@ -41,6 +80,9 @@ private:
     PyThreadState *tstate_ = nullptr;
     PyGILState_STATE gil_state_;
     bool simple_gil_ = false;
+    // When true, tstate_ is owned by the OS-thread-local cache and must NOT be destroyed when
+    // this scope exits (only swapped out).
+    bool cached_ = false;
 };
 
 /// Holds a Python subinterpreter instance
@@ -216,6 +258,26 @@ public:
     /// Get the interpreter's state dict.  This interpreter's GIL must be held before calling!
     dict state_dict() { return reinterpret_borrow<dict>(PyInterpreterState_GetDict(istate_)); }
 
+    /// Destroy the PyThreadState (if any) that subinterpreter_thread_state::cached created for
+    /// THIS interpreter on the CURRENT OS thread, and drop it from that thread's cache.
+    ///
+    /// Call this on the same OS thread that activated the interpreter, while this subinterpreter
+    /// is still alive, and while no subinterpreter_scoped_activate scope for it is active on this
+    /// thread.  It is a no-op if this thread has no cached state for this interpreter.  The caller
+    /// need not hold any GIL: the cached state is briefly swapped in (acquiring this interpreter's
+    /// GIL) to be cleared and deleted, then whatever was active before is restored.
+    void release_cached_thread_state() const;
+
+    /// Destroy every cached PyThreadState that was created on the CURRENT OS thread (for any
+    /// interpreter) and clear this thread's cache.  Intended as an end-of-thread cleanup hook for
+    /// embedder worker threads.
+    ///
+    /// Every interpreter that still has a cached state on this thread MUST still be alive when
+    /// this is called (deleting a PyThreadState whose interpreter was already finalized is
+    /// undefined behavior).  Must be called on the OS thread that owns the cache, with no
+    /// subinterpreter_scoped_activate scope using a cached state active on this thread.
+    static void release_all_cached_thread_states();
+
     /// abandon cleanup of this subinterpreter (leak it). this might be needed during
     /// finalization...
     void disarm() { creation_tstate_ = nullptr; }
@@ -244,7 +306,8 @@ private:
     subinterpreter_scoped_activate scope_;
 };
 
-inline subinterpreter_scoped_activate::subinterpreter_scoped_activate(subinterpreter const &si) {
+inline subinterpreter_scoped_activate::subinterpreter_scoped_activate(
+    subinterpreter const &si, subinterpreter_thread_state ts_policy) {
     if (!si.istate_) {
         pybind11_fail("null subinterpreter");
     }
@@ -256,9 +319,25 @@ inline subinterpreter_scoped_activate::subinterpreter_scoped_activate(subinterpr
         return;
     }
 
-    // we can't really interact with the interpreter at all until we switch to it
-    // not even to, for example, look in its state dict or touch its internals
-    tstate_ = PyThreadState_New(si.istate_);
+    if (ts_policy == subinterpreter_thread_state::cached) {
+        // Reuse a PyThreadState held in this OS thread's cache, or create one and cache it.
+        // This preserves PyThreadState identity (and its per-thread interpreter state) across
+        // repeated activations of the same interpreter from the same OS thread, instead of
+        // creating and destroying a fresh state every time.
+        auto &cache = detail::subinterpreter_thread_state_cache();
+        auto it = cache.find(si.istate_);
+        if (it != cache.end()) {
+            tstate_ = it->second;
+        } else {
+            tstate_ = PyThreadState_New(si.istate_);
+            cache.emplace(si.istate_, tstate_);
+        }
+        cached_ = true;
+    } else {
+        // we can't really interact with the interpreter at all until we switch to it
+        // not even to, for example, look in its state dict or touch its internals
+        tstate_ = PyThreadState_New(si.istate_);
+    }
 
     // make the interpreter active and acquire the GIL
     old_tstate_ = PyThreadState_Swap(tstate_);
@@ -279,13 +358,51 @@ inline subinterpreter_scoped_activate::~subinterpreter_scoped_activate() {
             }
 #endif
             detail::get_internals().tstate.reset();
-            PyThreadState_Clear(tstate_);
-            PyThreadState_DeleteCurrent();
+            if (!cached_) {
+                PyThreadState_Clear(tstate_);
+                PyThreadState_DeleteCurrent();
+            }
+            // When cached_, tstate_ stays alive in the OS-thread-local cache for reuse; the
+            // PyThreadState_Swap below merely detaches it from this thread.
         }
 
         // Go back the previous interpreter (if any) and acquire THAT gil
         PyThreadState_Swap(old_tstate_);
     }
+}
+
+inline void subinterpreter::release_cached_thread_state() const {
+    if (istate_ == nullptr) {
+        return;
+    }
+    auto &cache = detail::subinterpreter_thread_state_cache();
+    auto it = cache.find(istate_);
+    if (it == cache.end()) {
+        return;
+    }
+    PyThreadState *cached = it->second;
+    cache.erase(it);
+
+    // Make the cached state current (acquiring this interpreter's GIL) so it can be cleared and
+    // destroyed on the OS thread that created it, then restore whatever was active before.
+    PyThreadState *prev = PyThreadState_Swap(cached);
+    PyThreadState_Clear(cached);
+    PyThreadState_DeleteCurrent();
+    PyThreadState_Swap(prev);
+}
+
+inline void subinterpreter::release_all_cached_thread_states() {
+    auto &cache = detail::subinterpreter_thread_state_cache();
+    for (auto const &entry : cache) {
+        PyThreadState *cached = entry.second;
+        // prev is the state active before this swap; it is restored after each deletion, so it is
+        // never one of the cached states being destroyed here.
+        PyThreadState *prev = PyThreadState_Swap(cached);
+        PyThreadState_Clear(cached);
+        PyThreadState_DeleteCurrent();
+        PyThreadState_Swap(prev);
+    }
+    cache.clear();
 }
 
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -364,6 +364,20 @@ inline subinterpreter_scoped_activate::subinterpreter_scoped_activate(
         return;
     }
 
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
+    {
+        // A PyThreadState is bound to its creating OS thread; it may only be activated there.
+        bool same_thread = true;
+#    ifdef PY_HAVE_THREAD_NATIVE_ID
+        same_thread = PyThread_get_thread_native_id() == ts.tstate_->native_thread_id;
+#    endif
+        if (!same_thread) {
+            pybind11_fail("subinterpreter_scoped_activate: a subinterpreter_thread_state must be "
+                          "activated on the same OS thread that constructed it!");
+        }
+    }
+#endif
+
     tstate_ = ts.tstate_;
     borrowed_ = true;
 
@@ -417,6 +431,19 @@ inline subinterpreter_thread_state::~subinterpreter_thread_state() {
     if (tstate_ == nullptr) {
         return;
     }
+#if defined(PYBIND11_DETAILED_ERROR_MESSAGES)
+    {
+        // A PyThreadState must be cleared and deleted on the OS thread that created it.
+        bool same_thread = true;
+#    ifdef PY_HAVE_THREAD_NATIVE_ID
+        same_thread = PyThread_get_thread_native_id() == tstate_->native_thread_id;
+#    endif
+        if (!same_thread) {
+            pybind11_fail("~subinterpreter_thread_state: must be destroyed on the same OS thread "
+                          "that constructed it!");
+        }
+    }
+#endif
     // The PyThreadState must be made current to be cleared and deleted on the owning OS thread.
     // Swap it in (which acquires the subinterpreter's GIL), clear+delete, then restore whatever
     // was active before.

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -65,9 +65,9 @@ class subinterpreter;
 /// associated GIL are restored to their state as they were before the scope was entered.
 class subinterpreter_scoped_activate {
 public:
-    explicit subinterpreter_scoped_activate(
-        subinterpreter const &si,
-        subinterpreter_thread_state ts_policy = subinterpreter_thread_state::transient);
+    explicit subinterpreter_scoped_activate(subinterpreter const &si,
+                                            subinterpreter_thread_state ts_policy
+                                            = subinterpreter_thread_state::transient);
     ~subinterpreter_scoped_activate();
 
     subinterpreter_scoped_activate(subinterpreter_scoped_activate &&) = delete;

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -14,7 +14,6 @@
 #include "gil.h"
 
 #include <stdexcept>
-#include <unordered_map>
 
 #ifndef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 #    error "This platform does not support subinterpreters, do not include this file."
@@ -22,52 +21,28 @@
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
-PYBIND11_NAMESPACE_BEGIN(detail)
-
-/// OS-thread-local cache mapping a target interpreter to the PyThreadState that was created for
-/// it *on the current OS thread*.  Used by subinterpreter_scoped_activate when
-/// subinterpreter_thread_state::cached is requested, so that repeatedly entering the same
-/// interpreter from the same OS thread reuses one PyThreadState (swapped in/out) instead of
-/// allocating and destroying a fresh one each time.
-///
-/// The values are raw, non-owning pointers.  At thread exit the map's destructor only frees its
-/// own nodes; it deliberately does NOT touch the Python C API (which may be unusable at that
-/// point), so a cached PyThreadState is leaked unless the owning thread first calls
-/// subinterpreter::release_cached_thread_state() or
-/// subinterpreter::release_all_cached_thread_states().
-inline std::unordered_map<PyInterpreterState *, PyThreadState *> &
-subinterpreter_thread_state_cache() {
-    thread_local std::unordered_map<PyInterpreterState *, PyThreadState *> cache;
-    return cache;
-}
-
-PYBIND11_NAMESPACE_END(detail)
-
-/// Selects how subinterpreter_scoped_activate obtains a PyThreadState when the calling OS thread
-/// is not already running the target interpreter.
-enum class subinterpreter_thread_state {
-    /// Default / legacy behavior: a fresh PyThreadState is created on activation and destroyed
-    /// when the scope exits.
-    transient,
-    /// Reuse (or, on first use, create-and-cache) a PyThreadState held in OS-thread-local
-    /// storage, keyed by the target interpreter.  The scope only swaps it in and out and never
-    /// destroys it.  The owning thread is responsible for eventually destroying it via
-    /// subinterpreter::release_cached_thread_state() /
-    /// subinterpreter::release_all_cached_thread_states(); see those functions for the
-    /// preconditions.
-    cached
-};
-
 class subinterpreter;
+class subinterpreter_thread_state;
 
 /// Activate the subinterpreter and acquire its GIL, while also releasing any GIL and interpreter
 /// currently held. Upon exiting the scope, the previous subinterpreter (if any) and its
 /// associated GIL are restored to their state as they were before the scope was entered.
+///
+/// Two construction modes are supported:
+///
+/// 1. `subinterpreter_scoped_activate(subinterpreter const &)`:
+///    Transient mode (the default).  A fresh PyThreadState is created on entry and destroyed on
+///    exit.  This is the established behavior; existing code is unaffected.
+///
+/// 2. `subinterpreter_scoped_activate(subinterpreter_thread_state &)`:
+///    Reuse mode.  The PyThreadState owned by the given subinterpreter_thread_state is swapped
+///    in on entry and swapped out (but NOT destroyed) on exit, so repeated activations on the
+///    same OS thread reuse the same PyThreadState and preserve its per-thread interpreter state.
+///    Use this when a single OS thread re-enters one or more subinterpreters many times.
 class subinterpreter_scoped_activate {
 public:
-    explicit subinterpreter_scoped_activate(subinterpreter const &si,
-                                            subinterpreter_thread_state ts_policy
-                                            = subinterpreter_thread_state::transient);
+    explicit subinterpreter_scoped_activate(subinterpreter const &si);
+    explicit subinterpreter_scoped_activate(subinterpreter_thread_state &ts);
     ~subinterpreter_scoped_activate();
 
     subinterpreter_scoped_activate(subinterpreter_scoped_activate &&) = delete;
@@ -80,9 +55,9 @@ private:
     PyThreadState *tstate_ = nullptr;
     PyGILState_STATE gil_state_;
     bool simple_gil_ = false;
-    // When true, tstate_ is owned by the OS-thread-local cache and must NOT be destroyed when
-    // this scope exits (only swapped out).
-    bool cached_ = false;
+    // When true, tstate_ is owned by a subinterpreter_thread_state and must NOT be destroyed
+    // when this scope exits (only swapped out).
+    bool borrowed_ = false;
 };
 
 /// Holds a Python subinterpreter instance
@@ -258,26 +233,6 @@ public:
     /// Get the interpreter's state dict.  This interpreter's GIL must be held before calling!
     dict state_dict() { return reinterpret_borrow<dict>(PyInterpreterState_GetDict(istate_)); }
 
-    /// Destroy the PyThreadState (if any) that subinterpreter_thread_state::cached created for
-    /// THIS interpreter on the CURRENT OS thread, and drop it from that thread's cache.
-    ///
-    /// Call this on the same OS thread that activated the interpreter, while this subinterpreter
-    /// is still alive, and while no subinterpreter_scoped_activate scope for it is active on this
-    /// thread.  It is a no-op if this thread has no cached state for this interpreter.  The caller
-    /// need not hold any GIL: the cached state is briefly swapped in (acquiring this interpreter's
-    /// GIL) to be cleared and deleted, then whatever was active before is restored.
-    void release_cached_thread_state() const;
-
-    /// Destroy every cached PyThreadState that was created on the CURRENT OS thread (for any
-    /// interpreter) and clear this thread's cache.  Intended as an end-of-thread cleanup hook for
-    /// embedder worker threads.
-    ///
-    /// Every interpreter that still has a cached state on this thread MUST still be alive when
-    /// this is called (deleting a PyThreadState whose interpreter was already finalized is
-    /// undefined behavior).  Must be called on the OS thread that owns the cache, with no
-    /// subinterpreter_scoped_activate scope using a cached state active on this thread.
-    static void release_all_cached_thread_states();
-
     /// abandon cleanup of this subinterpreter (leak it). this might be needed during
     /// finalization...
     void disarm() { creation_tstate_ = nullptr; }
@@ -290,8 +245,69 @@ public:
 
 private:
     friend class subinterpreter_scoped_activate;
+    friend class subinterpreter_thread_state;
     PyInterpreterState *istate_ = nullptr;
     PyThreadState *creation_tstate_ = nullptr;
+};
+
+/// RAII wrapper that owns a PyThreadState bound to a specific subinterpreter on the OS thread
+/// that constructed it.  Intended to be held long-lived (e.g. as a `thread_local`, or inside a
+/// per-thread struct) so that many subinterpreter_scoped_activate scopes on the same OS thread
+/// can reuse a single PyThreadState instead of creating and destroying one each time.
+///
+/// The PyThreadState is created on construction in a *released* state: it is NOT made current,
+/// and no GIL is acquired.  Activation is the job of subinterpreter_scoped_activate.
+///
+/// A single OS thread can hold one of these per subinterpreter and alternate between them via
+/// subinterpreter_scoped_activate without churning PyThreadState objects.
+///
+/// Lifetime / threading requirements:
+///
+/// - Construction and destruction must happen on the SAME OS thread (a PyThreadState is bound
+///   to the OS thread that created it; deleting it on a different thread is undefined behavior).
+/// - The owning subinterpreter must still be alive when this object is destroyed.
+/// - This object must NOT be destroyed while a subinterpreter_scoped_activate referring to it is
+///   still alive (the activator holds a reference into it).
+///
+/// Typical usage:
+///
+/// @code
+///   thread_local py::subinterpreter_thread_state ts(sub);
+///   {
+///       py::subinterpreter_scoped_activate guard(ts);   // swap-in only
+///       // ... use the subinterpreter ...
+///   }                                                    // swap-out, tstate kept alive
+///   {
+///       py::subinterpreter_scoped_activate guard(ts);   // reuses the same PyThreadState
+///       // ...
+///   }
+/// @endcode
+class subinterpreter_thread_state {
+public:
+    /// Create a PyThreadState for `si` on the calling OS thread.  The new state is left in a
+    /// released state (not current, no GIL acquired).
+    explicit subinterpreter_thread_state(subinterpreter const &si);
+
+    /// Destroy the owned PyThreadState.  Must run on the same OS thread that constructed this
+    /// object, while the owning subinterpreter is still alive, and while no
+    /// subinterpreter_scoped_activate referring to this object is alive.
+    ~subinterpreter_thread_state();
+
+    subinterpreter_thread_state(subinterpreter_thread_state const &) = delete;
+    subinterpreter_thread_state(subinterpreter_thread_state &&) = delete;
+    subinterpreter_thread_state &operator=(subinterpreter_thread_state const &) = delete;
+    subinterpreter_thread_state &operator=(subinterpreter_thread_state &&) = delete;
+
+    /// The interpreter this thread state belongs to.
+    PyInterpreterState *interpreter_state() const { return istate_; }
+
+    /// The owned PyThreadState pointer; valid for the lifetime of this object.
+    PyThreadState *raw_thread_state() const { return tstate_; }
+
+private:
+    friend class subinterpreter_scoped_activate;
+    PyThreadState *tstate_ = nullptr;
+    PyInterpreterState *istate_ = nullptr;
 };
 
 class scoped_subinterpreter {
@@ -306,8 +322,9 @@ private:
     subinterpreter_scoped_activate scope_;
 };
 
-inline subinterpreter_scoped_activate::subinterpreter_scoped_activate(
-    subinterpreter const &si, subinterpreter_thread_state ts_policy) {
+// --- subinterpreter_scoped_activate -----------------------------------------------------------
+
+inline subinterpreter_scoped_activate::subinterpreter_scoped_activate(subinterpreter const &si) {
     if (!si.istate_) {
         pybind11_fail("null subinterpreter");
     }
@@ -319,25 +336,36 @@ inline subinterpreter_scoped_activate::subinterpreter_scoped_activate(
         return;
     }
 
-    if (ts_policy == subinterpreter_thread_state::cached) {
-        // Reuse a PyThreadState held in this OS thread's cache, or create one and cache it.
-        // This preserves PyThreadState identity (and its per-thread interpreter state) across
-        // repeated activations of the same interpreter from the same OS thread, instead of
-        // creating and destroying a fresh state every time.
-        auto &cache = detail::subinterpreter_thread_state_cache();
-        auto it = cache.find(si.istate_);
-        if (it != cache.end()) {
-            tstate_ = it->second;
-        } else {
-            tstate_ = PyThreadState_New(si.istate_);
-            cache.emplace(si.istate_, tstate_);
-        }
-        cached_ = true;
-    } else {
-        // we can't really interact with the interpreter at all until we switch to it
-        // not even to, for example, look in its state dict or touch its internals
-        tstate_ = PyThreadState_New(si.istate_);
+    // we can't really interact with the interpreter at all until we switch to it
+    // not even to, for example, look in its state dict or touch its internals
+    tstate_ = PyThreadState_New(si.istate_);
+
+    // make the interpreter active and acquire the GIL
+    old_tstate_ = PyThreadState_Swap(tstate_);
+
+    // save this in internals for scoped_gil calls (see also: PR #5870)
+    detail::get_internals().tstate = tstate_;
+}
+
+inline subinterpreter_scoped_activate::subinterpreter_scoped_activate(
+    subinterpreter_thread_state &ts) {
+    if (ts.tstate_ == nullptr) {
+        pybind11_fail("subinterpreter_scoped_activate: empty subinterpreter_thread_state");
     }
+
+    if (detail::get_interpreter_state_unchecked() == ts.istate_) {
+        // We are already on this interpreter -- e.g. nested activation, or a different
+        // PyThreadState for the same interpreter is already current on this thread.  Match the
+        // fast path of the (subinterpreter const&) overload: just ensure the GIL is held.  The
+        // `ts` argument's PyThreadState is intentionally NOT swapped to here; the already-current
+        // tstate keeps being used until the outer scope exits.
+        simple_gil_ = true;
+        gil_state_ = PyGILState_Ensure();
+        return;
+    }
+
+    tstate_ = ts.tstate_;
+    borrowed_ = true;
 
     // make the interpreter active and acquire the GIL
     old_tstate_ = PyThreadState_Swap(tstate_);
@@ -358,12 +386,12 @@ inline subinterpreter_scoped_activate::~subinterpreter_scoped_activate() {
             }
 #endif
             detail::get_internals().tstate.reset();
-            if (!cached_) {
+            if (!borrowed_) {
                 PyThreadState_Clear(tstate_);
                 PyThreadState_DeleteCurrent();
             }
-            // When cached_, tstate_ stays alive in the OS-thread-local cache for reuse; the
-            // PyThreadState_Swap below merely detaches it from this thread.
+            // When borrowed_, tstate_ stays alive in its owning subinterpreter_thread_state for
+            // reuse; the PyThreadState_Swap below merely detaches it from this thread.
         }
 
         // Go back the previous interpreter (if any) and acquire THAT gil
@@ -371,38 +399,37 @@ inline subinterpreter_scoped_activate::~subinterpreter_scoped_activate() {
     }
 }
 
-inline void subinterpreter::release_cached_thread_state() const {
-    if (istate_ == nullptr) {
-        return;
-    }
-    auto &cache = detail::subinterpreter_thread_state_cache();
-    auto it = cache.find(istate_);
-    if (it == cache.end()) {
-        return;
-    }
-    PyThreadState *cached = it->second;
-    cache.erase(it);
+// --- subinterpreter_thread_state --------------------------------------------------------------
 
-    // Make the cached state current (acquiring this interpreter's GIL) so it can be cleared and
-    // destroyed on the OS thread that created it, then restore whatever was active before.
-    PyThreadState *prev = PyThreadState_Swap(cached);
-    PyThreadState_Clear(cached);
-    PyThreadState_DeleteCurrent();
-    PyThreadState_Swap(prev);
+inline subinterpreter_thread_state::subinterpreter_thread_state(subinterpreter const &si) {
+    if (!si.istate_) {
+        pybind11_fail("subinterpreter_thread_state: null subinterpreter");
+    }
+    istate_ = si.istate_;
+    // PyThreadState_New does not require holding any GIL and does not make the new state current.
+    tstate_ = PyThreadState_New(istate_);
+    if (tstate_ == nullptr) {
+        pybind11_fail("subinterpreter_thread_state: PyThreadState_New returned null");
+    }
 }
 
-inline void subinterpreter::release_all_cached_thread_states() {
-    auto &cache = detail::subinterpreter_thread_state_cache();
-    for (auto const &entry : cache) {
-        PyThreadState *cached = entry.second;
-        // prev is the state active before this swap; it is restored after each deletion, so it is
-        // never one of the cached states being destroyed here.
-        PyThreadState *prev = PyThreadState_Swap(cached);
-        PyThreadState_Clear(cached);
-        PyThreadState_DeleteCurrent();
+inline subinterpreter_thread_state::~subinterpreter_thread_state() {
+    if (tstate_ == nullptr) {
+        return;
+    }
+    // The PyThreadState must be made current to be cleared and deleted on the owning OS thread.
+    // Swap it in (which acquires the subinterpreter's GIL), clear+delete, then restore whatever
+    // was active before.
+    PyThreadState *prev = PyThreadState_Swap(tstate_);
+    PyThreadState_Clear(tstate_);
+    PyThreadState_DeleteCurrent();
+    // If `prev` is tstate_ itself, the user destroyed this object while it was active via a
+    // subinterpreter_scoped_activate -- a contract violation, but be defensive: do NOT swap back
+    // to a now-deleted pointer.  Leaving the thread with no current interpreter is consistent
+    // with the cached state having just been destroyed.
+    if (prev != nullptr && prev != tstate_) {
         PyThreadState_Swap(prev);
     }
-    cache.clear();
 }
 
 PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/tests/test_with_catch/test_subinterpreter.cpp
+++ b/tests/test_with_catch/test_subinterpreter.cpp
@@ -188,8 +188,7 @@ TEST_CASE("Cached Subinterpreter thread state") {
         py::gil_scoped_release nogil;
         std::thread([&]() {
             {
-                py::subinterpreter_scoped_activate a(sub,
-                                                     py::subinterpreter_thread_state::cached);
+                py::subinterpreter_scoped_activate a(sub, py::subinterpreter_thread_state::cached);
                 worker_ts = PyThreadState_Get();
             }
             // The owning thread releases its own cached state before exiting.

--- a/tests/test_with_catch/test_subinterpreter.cpp
+++ b/tests/test_with_catch/test_subinterpreter.cpp
@@ -153,56 +153,99 @@ TEST_CASE("Move Subinterpreter") {
 }
 #    endif
 
-TEST_CASE("Cached Subinterpreter thread state") {
+TEST_CASE("Reused Subinterpreter thread state (single interpreter)") {
     py::subinterpreter sub = py::subinterpreter::create();
 
-    PyThreadState *main_a = nullptr;
-    PyThreadState *main_b = nullptr;
+    PyThreadState *first = nullptr;
+    PyThreadState *second = nullptr;
     PyThreadState *transient_ts = nullptr;
     PyThreadState *worker_ts = nullptr;
 
     {
-        py::subinterpreter_scoped_activate a(sub, py::subinterpreter_thread_state::cached);
-        main_a = PyThreadState_Get();
-        py::list(py::module_::import("sys").attr("path")).append(py::str("."));
-    }
-    {
-        py::subinterpreter_scoped_activate a(sub, py::subinterpreter_thread_state::cached);
-        main_b = PyThreadState_Get();
-    }
+        py::subinterpreter_thread_state ts(sub);
 
-    // Same OS thread + same interpreter + cached policy => the PyThreadState is reused.
-    REQUIRE(main_a != nullptr);
-    REQUIRE(main_a == main_b);
+        {
+            py::subinterpreter_scoped_activate guard(ts);
+            first = PyThreadState_Get();
+            py::list(py::module_::import("sys").attr("path")).append(py::str("."));
+        }
+        {
+            py::subinterpreter_scoped_activate guard(ts);
+            second = PyThreadState_Get();
+        }
 
-    // The default (transient) policy must not reuse the cached state: while the cached state is
-    // still alive, a transient activation gets a distinct PyThreadState.
-    {
-        py::subinterpreter_scoped_activate a(sub);
-        transient_ts = PyThreadState_Get();
-    }
-    REQUIRE(transient_ts != main_a);
+        // Same OS thread + same subinterpreter_thread_state => the PyThreadState is reused.
+        REQUIRE(first != nullptr);
+        REQUIRE(first == second);
 
-    // A different OS thread gets its own cached state (both alive => distinct pointers).
-    {
-        py::gil_scoped_release nogil;
-        std::thread([&]() {
-            {
-                py::subinterpreter_scoped_activate a(sub, py::subinterpreter_thread_state::cached);
+        // The (subinterpreter const&) ctor does not share with the reusable tstate: while `ts`
+        // is still alive, a transient activation gets a distinct PyThreadState.
+        {
+            py::subinterpreter_scoped_activate guard(sub);
+            transient_ts = PyThreadState_Get();
+        }
+        REQUIRE(transient_ts != first);
+
+        // A different OS thread holds its own subinterpreter_thread_state (both alive
+        // concurrently => distinct PyThreadState pointers).
+        {
+            py::gil_scoped_release nogil;
+            std::thread([&]() {
+                py::subinterpreter_thread_state worker_ts_owner(sub);
+                py::subinterpreter_scoped_activate guard(worker_ts_owner);
                 worker_ts = PyThreadState_Get();
-            }
-            // The owning thread releases its own cached state before exiting.
-            sub.release_cached_thread_state();
-        }).join();
-    }
-    REQUIRE(worker_ts != nullptr);
-    REQUIRE(worker_ts != main_a);
+                // worker_ts_owner is destroyed at scope exit, on the same OS thread that
+                // constructed it.
+            }).join();
+        }
+        REQUIRE(worker_ts != nullptr);
+        REQUIRE(worker_ts != first);
 
-    // Release this thread's cached state; a second release is a safe no-op, and release_all on a
-    // now-empty cache must not crash.
-    sub.release_cached_thread_state();
-    sub.release_cached_thread_state();
-    py::subinterpreter::release_all_cached_thread_states();
+        // ts is still alive here; it will be destructed at the end of this block on this same
+        // OS thread, deleting its PyThreadState.
+    }
+
+    unsafe_reset_internals_for_single_interpreter();
+}
+
+TEST_CASE("Reused Subinterpreter thread state (multiple interpreters)") {
+    // The core multi-subinterpreter use case: one OS thread alternates between two
+    // subinterpreters and each PyThreadState is preserved across activations.
+    py::subinterpreter sub_a = py::subinterpreter::create();
+    py::subinterpreter sub_b = py::subinterpreter::create();
+
+    py::subinterpreter_thread_state ts_a(sub_a);
+    py::subinterpreter_thread_state ts_b(sub_b);
+
+    PyThreadState *a1 = nullptr;
+    PyThreadState *a2 = nullptr;
+    PyThreadState *b1 = nullptr;
+    PyThreadState *b2 = nullptr;
+
+    {
+        py::subinterpreter_scoped_activate guard(ts_a);
+        a1 = PyThreadState_Get();
+    }
+    {
+        py::subinterpreter_scoped_activate guard(ts_b);
+        b1 = PyThreadState_Get();
+    }
+    {
+        py::subinterpreter_scoped_activate guard(ts_a);
+        a2 = PyThreadState_Get();
+    }
+    {
+        py::subinterpreter_scoped_activate guard(ts_b);
+        b2 = PyThreadState_Get();
+    }
+
+    REQUIRE(a1 != nullptr);
+    REQUIRE(b1 != nullptr);
+    // Identity is preserved across activations for each interpreter independently.
+    REQUIRE(a1 == a2);
+    REQUIRE(b1 == b2);
+    // And the two interpreters have distinct thread states (both alive => reliable comparison).
+    REQUIRE(a1 != b1);
 
     unsafe_reset_internals_for_single_interpreter();
 }

--- a/tests/test_with_catch/test_subinterpreter.cpp
+++ b/tests/test_with_catch/test_subinterpreter.cpp
@@ -154,55 +154,61 @@ TEST_CASE("Move Subinterpreter") {
 #    endif
 
 TEST_CASE("Reused Subinterpreter thread state (single interpreter)") {
-    py::subinterpreter sub = py::subinterpreter::create();
-
     PyThreadState *first = nullptr;
     PyThreadState *second = nullptr;
     PyThreadState *transient_ts = nullptr;
     PyThreadState *worker_ts = nullptr;
 
+    // The subinterpreter is kept in this enclosing scope so that every
+    // subinterpreter_thread_state is destroyed first, then the subinterpreter, and only then
+    // unsafe_reset_internals_for_single_interpreter() runs (after the scope closes).
     {
-        py::subinterpreter_thread_state ts(sub);
+        py::subinterpreter sub = py::subinterpreter::create();
 
         {
-            py::subinterpreter_scoped_activate guard(ts);
-            first = PyThreadState_Get();
-            py::list(py::module_::import("sys").attr("path")).append(py::str("."));
-        }
-        {
-            py::subinterpreter_scoped_activate guard(ts);
-            second = PyThreadState_Get();
-        }
+            py::subinterpreter_thread_state ts(sub);
 
-        // Same OS thread + same subinterpreter_thread_state => the PyThreadState is reused.
-        REQUIRE(first != nullptr);
-        REQUIRE(first == second);
+            {
+                py::subinterpreter_scoped_activate guard(ts);
+                first = PyThreadState_Get();
+                py::list(py::module_::import("sys").attr("path")).append(py::str("."));
+            }
+            {
+                py::subinterpreter_scoped_activate guard(ts);
+                second = PyThreadState_Get();
+            }
 
-        // The (subinterpreter const&) ctor does not share with the reusable tstate: while `ts`
-        // is still alive, a transient activation gets a distinct PyThreadState.
-        {
-            py::subinterpreter_scoped_activate guard(sub);
-            transient_ts = PyThreadState_Get();
+            // Same OS thread + same subinterpreter_thread_state => the PyThreadState is reused.
+            REQUIRE(first != nullptr);
+            REQUIRE(first == second);
+
+            // The (subinterpreter const&) ctor does not share with the reusable tstate: while
+            // `ts` is still alive, a transient activation gets a distinct PyThreadState.
+            {
+                py::subinterpreter_scoped_activate guard(sub);
+                transient_ts = PyThreadState_Get();
+            }
+            REQUIRE(transient_ts != first);
+
+            // A different OS thread holds its own subinterpreter_thread_state (both alive
+            // concurrently => distinct PyThreadState pointers).
+            {
+                py::gil_scoped_release nogil;
+                std::thread([&]() {
+                    py::subinterpreter_thread_state worker_ts_owner(sub);
+                    py::subinterpreter_scoped_activate guard(worker_ts_owner);
+                    worker_ts = PyThreadState_Get();
+                    // worker_ts_owner is destroyed at scope exit, on the same OS thread that
+                    // constructed it.
+                }).join();
+            }
+            REQUIRE(worker_ts != nullptr);
+            REQUIRE(worker_ts != first);
+
+            // ts is destructed at the end of this block on this same OS thread (deleting its
+            // PyThreadState), while `sub` is still alive.
         }
-        REQUIRE(transient_ts != first);
-
-        // A different OS thread holds its own subinterpreter_thread_state (both alive
-        // concurrently => distinct PyThreadState pointers).
-        {
-            py::gil_scoped_release nogil;
-            std::thread([&]() {
-                py::subinterpreter_thread_state worker_ts_owner(sub);
-                py::subinterpreter_scoped_activate guard(worker_ts_owner);
-                worker_ts = PyThreadState_Get();
-                // worker_ts_owner is destroyed at scope exit, on the same OS thread that
-                // constructed it.
-            }).join();
-        }
-        REQUIRE(worker_ts != nullptr);
-        REQUIRE(worker_ts != first);
-
-        // ts is still alive here; it will be destructed at the end of this block on this same
-        // OS thread, deleting its PyThreadState.
+        // sub is destructed at the end of this block.
     }
 
     unsafe_reset_internals_for_single_interpreter();
@@ -211,41 +217,47 @@ TEST_CASE("Reused Subinterpreter thread state (single interpreter)") {
 TEST_CASE("Reused Subinterpreter thread state (multiple interpreters)") {
     // The core multi-subinterpreter use case: one OS thread alternates between two
     // subinterpreters and each PyThreadState is preserved across activations.
-    py::subinterpreter sub_a = py::subinterpreter::create();
-    py::subinterpreter sub_b = py::subinterpreter::create();
-
-    py::subinterpreter_thread_state ts_a(sub_a);
-    py::subinterpreter_thread_state ts_b(sub_b);
-
     PyThreadState *a1 = nullptr;
     PyThreadState *a2 = nullptr;
     PyThreadState *b1 = nullptr;
     PyThreadState *b2 = nullptr;
 
+    // Everything is kept in this enclosing scope. Destruction order at the closing brace is
+    // ts_b, ts_a, sub_b, sub_a -- i.e. each subinterpreter_thread_state is destroyed before its
+    // subinterpreter -- and unsafe_reset_internals_for_single_interpreter() only runs afterwards.
     {
-        py::subinterpreter_scoped_activate guard(ts_a);
-        a1 = PyThreadState_Get();
-    }
-    {
-        py::subinterpreter_scoped_activate guard(ts_b);
-        b1 = PyThreadState_Get();
-    }
-    {
-        py::subinterpreter_scoped_activate guard(ts_a);
-        a2 = PyThreadState_Get();
-    }
-    {
-        py::subinterpreter_scoped_activate guard(ts_b);
-        b2 = PyThreadState_Get();
-    }
+        py::subinterpreter sub_a = py::subinterpreter::create();
+        py::subinterpreter sub_b = py::subinterpreter::create();
 
-    REQUIRE(a1 != nullptr);
-    REQUIRE(b1 != nullptr);
-    // Identity is preserved across activations for each interpreter independently.
-    REQUIRE(a1 == a2);
-    REQUIRE(b1 == b2);
-    // And the two interpreters have distinct thread states (both alive => reliable comparison).
-    REQUIRE(a1 != b1);
+        py::subinterpreter_thread_state ts_a(sub_a);
+        py::subinterpreter_thread_state ts_b(sub_b);
+
+        {
+            py::subinterpreter_scoped_activate guard(ts_a);
+            a1 = PyThreadState_Get();
+        }
+        {
+            py::subinterpreter_scoped_activate guard(ts_b);
+            b1 = PyThreadState_Get();
+        }
+        {
+            py::subinterpreter_scoped_activate guard(ts_a);
+            a2 = PyThreadState_Get();
+        }
+        {
+            py::subinterpreter_scoped_activate guard(ts_b);
+            b2 = PyThreadState_Get();
+        }
+
+        REQUIRE(a1 != nullptr);
+        REQUIRE(b1 != nullptr);
+        // Identity is preserved across activations for each interpreter independently.
+        REQUIRE(a1 == a2);
+        REQUIRE(b1 == b2);
+        // And the two interpreters have distinct thread states (both alive => reliable
+        // comparison).
+        REQUIRE(a1 != b1);
+    }
 
     unsafe_reset_internals_for_single_interpreter();
 }

--- a/tests/test_with_catch/test_subinterpreter.cpp
+++ b/tests/test_with_catch/test_subinterpreter.cpp
@@ -153,6 +153,61 @@ TEST_CASE("Move Subinterpreter") {
 }
 #    endif
 
+TEST_CASE("Cached Subinterpreter thread state") {
+    py::subinterpreter sub = py::subinterpreter::create();
+
+    PyThreadState *main_a = nullptr;
+    PyThreadState *main_b = nullptr;
+    PyThreadState *transient_ts = nullptr;
+    PyThreadState *worker_ts = nullptr;
+
+    {
+        py::subinterpreter_scoped_activate a(sub, py::subinterpreter_thread_state::cached);
+        main_a = PyThreadState_Get();
+        py::list(py::module_::import("sys").attr("path")).append(py::str("."));
+    }
+    {
+        py::subinterpreter_scoped_activate a(sub, py::subinterpreter_thread_state::cached);
+        main_b = PyThreadState_Get();
+    }
+
+    // Same OS thread + same interpreter + cached policy => the PyThreadState is reused.
+    REQUIRE(main_a != nullptr);
+    REQUIRE(main_a == main_b);
+
+    // The default (transient) policy must not reuse the cached state: while the cached state is
+    // still alive, a transient activation gets a distinct PyThreadState.
+    {
+        py::subinterpreter_scoped_activate a(sub);
+        transient_ts = PyThreadState_Get();
+    }
+    REQUIRE(transient_ts != main_a);
+
+    // A different OS thread gets its own cached state (both alive => distinct pointers).
+    {
+        py::gil_scoped_release nogil;
+        std::thread([&]() {
+            {
+                py::subinterpreter_scoped_activate a(sub,
+                                                     py::subinterpreter_thread_state::cached);
+                worker_ts = PyThreadState_Get();
+            }
+            // The owning thread releases its own cached state before exiting.
+            sub.release_cached_thread_state();
+        }).join();
+    }
+    REQUIRE(worker_ts != nullptr);
+    REQUIRE(worker_ts != main_a);
+
+    // Release this thread's cached state; a second release is a safe no-op, and release_all on a
+    // now-empty cache must not crash.
+    sub.release_cached_thread_state();
+    sub.release_cached_thread_state();
+    py::subinterpreter::release_all_cached_thread_states();
+
+    unsafe_reset_internals_for_single_interpreter();
+}
+
 TEST_CASE("GIL Subinterpreter") {
 
     PyInterpreterState *main_interp = PyInterpreterState_Get();


### PR DESCRIPTION
## Description

Resolves #6040.

`subinterpreter_scoped_activate(subinterpreter const &)` creates a fresh `PyThreadState` on entry and destroys it on exit. A thread that repeatedly re-enters the same sub-interpreter therefore churns thread states and does not preserve per-thread interpreter state between activations.

This adds **`subinterpreter_thread_state`**, an RAII type that owns one `PyThreadState` for a given sub-interpreter, created on construction in a *released* state (not current, no GIL held). A new **`subinterpreter_scoped_activate(subinterpreter_thread_state &)`** overload swaps that thread state in on entry and out (without destroying it) on exit, so repeated activations reuse it and preserve its per-thread interpreter state. The original `(subinterpreter const &)` overload is unchanged, so existing code is unaffected.

Because the thread state's lifetime is an ordinary C++ object owned by the caller (typically a `thread_local`), a single OS thread can hold one per sub-interpreter and alternate between several of them — the multi-sub-interpreter case that `gil_scoped_release` / `gil_scoped_acquire` plus a long-lived scope cannot cover, since `internals.tstate` is a single per-thread slot. No global cache and no explicit release API are required; cleanup happens through the object's destructor on its owning OS thread.

`PYBIND11_DETAILED_ERROR_MESSAGES` builds additionally check that a `subinterpreter_thread_state` is activated and destroyed on the same OS thread that created it.

Includes test coverage (single- and multi-sub-interpreter reuse) and embedding docs.

This replaces the earlier opt-in `cached` enum + thread-local cache + `release_*` API design, per the review discussion in #6040 and on this PR.

## Suggested changelog entry:

* Added ``subinterpreter_thread_state``, an RAII wrapper that owns a reusable ``PyThreadState`` for a sub-interpreter, together with a ``subinterpreter_scoped_activate`` overload that activates it. This lets an OS thread re-enter one or more sub-interpreters without creating and destroying a ``PyThreadState`` on every activation.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6073.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->