### PR TITLE
fix(cmake): Apply -undefined dynamic_lookup to all Apple platforms

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -114,7 +114,8 @@ add_library(pybind11::python_link_helper IMPORTED INTERFACE ${optional_global})
 set_property(
   TARGET pybind11::python_link_helper
   APPEND
-  PROPERTY INTERFACE_LINK_OPTIONS "$<$<PLATFORM_ID:Darwin,iOS,tvOS,watchOS,visionOS>:LINKER:-undefined,dynamic_lookup>")
+  PROPERTY INTERFACE_LINK_OPTIONS
+           "$<$<PLATFORM_ID:Darwin,iOS,tvOS,watchOS,visionOS>:LINKER:-undefined,dynamic_lookup>")
 
 # ------------------------ Windows extras -------------------------
 

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -114,7 +114,7 @@ add_library(pybind11::python_link_helper IMPORTED INTERFACE ${optional_global})
 set_property(
   TARGET pybind11::python_link_helper
   APPEND
-  PROPERTY INTERFACE_LINK_OPTIONS "$<$<PLATFORM_ID:Darwin>:LINKER:-undefined,dynamic_lookup>")
+  PROPERTY INTERFACE_LINK_OPTIONS "$<$<PLATFORM_ID:Darwin,iOS,tvOS,watchOS,visionOS>:LINKER:-undefined,dynamic_lookup>")
 
 # ------------------------ Windows extras -------------------------
 


### PR DESCRIPTION
The `-undefined dynamic_lookup` flag is an Apple linker (ld64) feature, it works on all Apple platforms, not just macOS. Gating it behind `$<PLATFORM_ID:Darwin>` means it breaks for anyone cross-compiling Python extensions for iOS/tvOS/watchOS/visionOS.

## Suggested changelog entry:

* Apply `-undefined dynamic_lookup` to all Apple platforms.