### PR TITLE
tests: Pypy testing no longer xfails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=17 -DPYBIND11_TEST_SMART_HOLDER=ON
           - runs-on: ubuntu-latest
-            python-version: 'pypy-3.11'
+            python-version: 'pypy-3.11-v7.3.23'
             cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: ubuntu-latest
             python-version: 'graalpy-24.2'
@@ -93,7 +93,7 @@ jobs:
             python-version: '3.14'
             cmake-args: -DCMAKE_CXX_STANDARD=14
           - runs-on: ubuntu-latest
-            python-version: 'pypy-3.11'
+            python-version: 'pypy-3.11-v7.3.23'
             cmake-args: -DCMAKE_CXX_STANDARD=14
           - runs-on: ubuntu-latest
             python-version: 'graalpy-24.1'
@@ -115,7 +115,7 @@ jobs:
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=20
           - runs-on: macos-latest
-            python-version: 'pypy-3.11'
+            python-version: 'pypy-3.11-v7.3.23'
           - runs-on: macos-latest
             python-version: 'graalpy-24.2'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,7 @@ jobs:
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=17 -DPYBIND11_TEST_SMART_HOLDER=ON
           - runs-on: ubuntu-latest
-            # Temporarily pinned pending investigation in issue #6049.
-            python-version: 'pypy-3.11-v7.3.21'
+            python-version: 'pypy-3.11'
             cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: ubuntu-latest
             python-version: 'graalpy-24.2'
@@ -94,7 +93,7 @@ jobs:
             python-version: '3.14'
             cmake-args: -DCMAKE_CXX_STANDARD=14
           - runs-on: ubuntu-latest
-            python-version: 'pypy-3.10'
+            python-version: 'pypy-3.11'
             cmake-args: -DCMAKE_CXX_STANDARD=14
           - runs-on: ubuntu-latest
             python-version: 'graalpy-24.1'
@@ -115,12 +114,8 @@ jobs:
           - runs-on: macos-latest
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=20
-          - runs-on: macos-15-intel
-            python-version: 'pypy-3.10'
-            cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: macos-latest
-            # Temporarily pinned pending investigation in issue #6049.
-            python-version: 'pypy-3.11-v7.3.21'
+            python-version: 'pypy-3.11'
           - runs-on: macos-latest
             python-version: 'graalpy-24.2'
 
@@ -150,11 +145,7 @@ jobs:
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=23
           - runs-on: windows-latest
-            python-version: 'pypy-3.10'
-            cmake-args: -DCMAKE_CXX_STANDARD=17
-          - runs-on: windows-latest
-            # Temporarily pinned pending investigation in issue #6049.
-            python-version: 'pypy3.11-v7.3.21'
+            python-version: 'pypy3.11'
             cmake-args: -DCMAKE_CXX_STANDARD=20
           # The setup-python action currently doesn't have graalpy for windows
           # See https://github.com/actions/setup-python/pull/880

--- a/tests/env.py
+++ b/tests/env.py
@@ -27,6 +27,7 @@ if LINUX:
 
 CPYTHON = platform.python_implementation() == "CPython"
 PYPY = platform.python_implementation() == "PyPy"
+PYPY_PRE_7_3_23 = PYPY and sys.pypy_version_info < (7, 3, 23)
 GRAALPY = sys.implementation.name == "graalpy"
 _graalpy_version = (
     sys.modules["__graalpython__"].get_graalvm_version() if GRAALPY else "0.0.0"

--- a/tests/test_class_sh_disowning_mi.py
+++ b/tests/test_class_sh_disowning_mi.py
@@ -145,7 +145,7 @@ class MI8b(B3, MI6):
         MI6.__init__(self, i)
 
 
-@pytest.mark.xfail("env.PYPY", strict=False)
+@pytest.mark.xfail("env.PYPY_PRE_7_3_23")
 def test_multiple_inheritance_python():
     # Based on test_multiple_inheritance.py:test_multiple_inheritance_python.
     # Exercises values_and_holders with 2 value_and_holder instances.

--- a/tests/test_class_sh_disowning_mi.py
+++ b/tests/test_class_sh_disowning_mi.py
@@ -145,7 +145,7 @@ class MI8b(B3, MI6):
         MI6.__init__(self, i)
 
 
-@pytest.mark.xfail("env.PYPY")
+@pytest.mark.xfail("env.PYPY", strict=False)
 def test_multiple_inheritance_python():
     # Based on test_multiple_inheritance.py:test_multiple_inheritance_python.
     # Exercises values_and_holders with 2 value_and_holder instances.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -74,13 +74,6 @@ def test_cross_module_exceptions(msg):
     assert str(excinfo.value) == "'just local'"
 
 
-# TODO: FIXME
-@pytest.mark.xfail(
-    "(env.MACOS and env.PYPY) or env.ANDROID or env.FREEBSD",
-    raises=RuntimeError,
-    reason="See Issue #2847, PR #2999, PR #4324, PR #5925",
-    strict=not env.PYPY,  # PR 5569
-)
 def test_cross_module_exception_translator():
     with pytest.raises(KeyError):
         # translator registered in cross_module_tests

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -74,6 +74,11 @@ def test_cross_module_exceptions(msg):
     assert str(excinfo.value) == "'just local'"
 
 
+@pytest.mark.xfail(
+    "(env.MACOS and env.PYPY_PRE_7_3_23) or env.ANDROID or env.FREEBSD",
+    raises=RuntimeError,
+    reason="See Issue #2847, PR #2999, PR #4324, PR #5925",
+)
 def test_cross_module_exception_translator():
     with pytest.raises(KeyError):
         # translator registered in cross_module_tests

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -14,7 +14,7 @@ def test_multiple_inheritance_cpp():
     assert mt.bar() == 4
 
 
-@pytest.mark.xfail("env.PYPY")
+@pytest.mark.xfail("env.PYPY", strict=False)
 def test_multiple_inheritance_mix1():
     class Base1:
         def __init__(self, i):
@@ -53,7 +53,7 @@ def test_multiple_inheritance_mix2():
     assert mt.bar() == 4
 
 
-@pytest.mark.xfail("env.PYPY")
+@pytest.mark.xfail("env.PYPY", strict=False)
 def test_multiple_inheritance_python():
     class MI1(m.Base1, m.Base2):
         def __init__(self, i, j):

--- a/tests/test_multiple_inheritance.py
+++ b/tests/test_multiple_inheritance.py
@@ -14,7 +14,7 @@ def test_multiple_inheritance_cpp():
     assert mt.bar() == 4
 
 
-@pytest.mark.xfail("env.PYPY", strict=False)
+@pytest.mark.xfail("env.PYPY_PRE_7_3_23")
 def test_multiple_inheritance_mix1():
     class Base1:
         def __init__(self, i):
@@ -53,7 +53,7 @@ def test_multiple_inheritance_mix2():
     assert mt.bar() == 4
 
 
-@pytest.mark.xfail("env.PYPY", strict=False)
+@pytest.mark.xfail("env.PYPY_PRE_7_3_23")
 def test_multiple_inheritance_python():
     class MI1(m.Base1, m.Base2):
         def __init__(self, i, j):


### PR DESCRIPTION

## Description

Working through pypy/pypy#5481 and pybind/pybind11#6049. Fixes to PyPy no longer fail some tests. The xfail tests were marked with `xfail(strict=True)` (by default `strict` value), so now that they pass they are marked as failing. I run weekly testing of pybind11 HEAD + pypy HEAD at https://github.com/pypy/binary-testing, you can see the three unexpected tests pass [here](https://github.com/pypy/binary-testing/actions/runs/26353444519/job/77575648580#step:12:1329)

## Suggested changelog entry:

No changlog entry needed, these are really minor changes in multi-inheritance behavior that I doubt many users hit in practice.

<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6077.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->