### PR TITLE
fix: allow custom __str__ for enum_

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3171,7 +3171,6 @@ class enum_ : public class_<Type> {
 public:
     using Base = class_<Type>;
     using Base::attr;
-    using Base::def;
     using Base::def_property_readonly;
     using Base::def_property_readonly_static;
     using Underlying = typename std::underlying_type<Type>::type;
@@ -3282,6 +3281,18 @@ public:
         } else {
             Base::def(name_, std::forward<Func>(f), extra...);
         }
+        return *this;
+    }
+
+    // Avoid using Base::def here: GCC 15/MinGW sees the duplicate dependent-base
+    // def(const char *, ...) template as ambiguous with enum_::def(const char *, ...).
+    template <typename T,
+              typename... Extra,
+              detail::enable_if_t<
+                  !std::is_convertible<typename std::decay<T>::type, const char *>::value,
+                  int> = 0>
+    enum_ &def(T &&op, const Extra &...extra) {
+        Base::def(std::forward<T>(op), extra...);
         return *this;
     }
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2436,6 +2436,16 @@ public:
 
     template <typename Func, typename... Extra>
     PYBIND11_ALWAYS_INLINE class_ &def(const char *name_, Func &&f, const Extra &...extra) {
+        if (std::strcmp(name_, "__str__") == 0 && hasattr(*this, "__entries")) {
+            cpp_function cf(method_adaptor<type>(std::forward<Func>(f)),
+                            name(name_),
+                            is_method(*this),
+                            sibling(getattr(*this, name_, none())),
+                            prepend{},
+                            extra...);
+            add_class_method(*this, name_, cf);
+            return *this;
+        }
         cpp_function cf(method_adaptor<type>(std::forward<Func>(f)),
                         name(name_),
                         is_method(*this),

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -2436,16 +2436,6 @@ public:
 
     template <typename Func, typename... Extra>
     PYBIND11_ALWAYS_INLINE class_ &def(const char *name_, Func &&f, const Extra &...extra) {
-        if (std::strcmp(name_, "__str__") == 0 && hasattr(*this, "__entries")) {
-            cpp_function cf(method_adaptor<type>(std::forward<Func>(f)),
-                            name(name_),
-                            is_method(*this),
-                            sibling(getattr(*this, name_, none())),
-                            prepend{},
-                            extra...);
-            add_class_method(*this, name_, cf);
-            return *this;
-        }
         cpp_function cf(method_adaptor<type>(std::forward<Func>(f)),
                         name(name_),
                         is_method(*this),
@@ -3283,6 +3273,16 @@ public:
             is_method(*this),
             arg("state"),
             pos_only());
+    }
+
+    template <typename Func, typename... Extra>
+    enum_ &def(const char *name_, Func &&f, const Extra &...extra) {
+        if (std::strcmp(name_, "__str__") == 0) {
+            Base::def(name_, std::forward<Func>(f), prepend{}, extra...);
+        } else {
+            Base::def(name_, std::forward<Func>(f), extra...);
+        }
+        return *this;
     }
 
     /// Export enumeration entries into the parent scope

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -24,6 +24,13 @@ TEST_SUBMODULE(enums, m) {
         .value("Two", ScopedEnum::Two)
         .value("Three", ScopedEnum::Three);
 
+    // test_enum_custom_str
+    enum class CustomStrEnum { A = 1, B = 2 };
+    py::enum_<CustomStrEnum>(m, "CustomStrEnum")
+        .value("A", CustomStrEnum::A)
+        .value("B", CustomStrEnum::B)
+        .def("__str__", [](CustomStrEnum) { return "custom str"; });
+
     m.def("test_scoped_enum", [](ScopedEnum z) {
         return "ScopedEnum::" + std::string(z == ScopedEnum::Two ? "Two" : "Three");
     });

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -29,7 +29,9 @@ TEST_SUBMODULE(enums, m) {
     py::enum_<CustomStrEnum>(m, "CustomStrEnum")
         .value("A", CustomStrEnum::A)
         .value("B", CustomStrEnum::B)
-        .def("__str__", [](CustomStrEnum) { return "custom str"; });
+        .def("__str__", [](CustomStrEnum value) {
+            return "CustomStrEnum value " + std::to_string(static_cast<int>(value));
+        });
 
     m.def("test_scoped_enum", [](ScopedEnum z) {
         return "ScopedEnum::" + std::string(z == ScopedEnum::Two ? "Two" : "Three");

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -278,9 +278,12 @@ def test_str_signature():
 
 
 def test_enum_custom_str_keeps_name_property():
-    assert str(m.CustomStrEnum.A) == "custom str"
+    assert str(m.CustomStrEnum.A) == "CustomStrEnum value 1"
+    assert str(m.CustomStrEnum.B) == "CustomStrEnum value 2"
     assert m.CustomStrEnum.A.name == "A"
     assert m.CustomStrEnum.A.value == 1
+    assert m.CustomStrEnum.B.name == "B"
+    assert m.CustomStrEnum.B.value == 2
 
 
 def test_generated_dunder_methods_pos_only():

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -277,6 +277,12 @@ def test_str_signature():
         assert enum_type.__str__.__doc__.startswith("__str__")
 
 
+def test_enum_custom_str_keeps_name_property():
+    assert str(m.CustomStrEnum.A) == "custom str"
+    assert m.CustomStrEnum.A.name == "A"
+    assert m.CustomStrEnum.A.value == 1
+
+
 def test_generated_dunder_methods_pos_only():
     for enum_type in [m.ScopedEnum, m.UnscopedEnum]:
         for binary_op in [


### PR DESCRIPTION
Fixes #4585.

This makes user-defined `enum_` `__str__` methods take precedence over the default `enum_` `__str__` implementation by prepending the custom overload. A regression test verifies that a custom `__str__` works while the generated name and value properties remain intact.

## Suggested changelog entry:

* Allow user defined `__str__` on `enum_`.