### PR TITLE
chore(setup_helpers): remove dead cpp_flag_cache and fix parameter typo

### DIFF
--- a/pybind11/setup_helpers.py
+++ b/pybind11/setup_helpers.py
@@ -245,10 +245,6 @@ def has_flag(compiler: Any, flag: str) -> bool:
         return True
 
 
-# Every call will cache the result
-cpp_flag_cache = None
-
-
 @lru_cache
 def auto_cpp_level(compiler: Any) -> str | int:
     """
@@ -338,7 +334,7 @@ def naive_recompile(obj: str, src: str) -> bool:
     return os.stat(obj).st_mtime < os.stat(src).st_mtime
 
 
-def no_recompile(obg: str, src: str) -> bool:  # noqa: ARG001
+def no_recompile(obj: str, src: str) -> bool:  # noqa: ARG001
     """
     This is the safest but slowest choice (and is the default) - will always
     recompile sources.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #6084

## Summary

- Remove the dead module-level variable `cpp_flag_cache = None` and its stale comment `# Every call will cache the result`. The actual caching is already handled by the `@lru_cache` decorator on `auto_cpp_level` just below it; the variable was never read anywhere in the codebase.
- Rename the typo'd parameter `obg` to `obj` in `no_recompile(obg: str, src: str)`. Nothing passes this argument by keyword (it is only used as a `needs_recompile` callback passed positionally), so there is no API break.

