### PR TITLE
fix: data race on last_storage_ptr_ cache in gil_safe_call_once_and_store

### DIFF
--- a/include/pybind11/gil_safe_call_once.h
+++ b/include/pybind11/gil_safe_call_once.h
@@ -193,6 +193,8 @@ public:
                 ::new (value->storage) T(fn());
                 value->finalize = finalize_fn;
                 value->is_initialized = true;
+                // Publish the cached pointer before setting the validity flag, so that any reader
+                // which observes the flag as true is guaranteed to also observe this pointer.
                 last_storage_ptr_ = reinterpret_cast<T *>(value->storage);
                 is_initialized_by_at_least_one_interpreter_ = true;
             });
@@ -204,11 +206,17 @@ public:
 
     // This must only be called after `call_once_and_store_result()` was called.
     T &get_stored() {
-        T *result = last_storage_ptr_;
-        if (!is_last_storage_valid()) {
+        T *result = nullptr;
+        // Check the validity flag *before* loading the cached pointer: the writer publishes the
+        // pointer before setting the flag, so observing the flag as true guarantees the load below
+        // sees the published pointer.
+        if (is_last_storage_valid()) {
+            result = last_storage_ptr_;
+        } else {
             gil_scoped_acquire gil_acq;
             auto *value = get_or_create_storage_in_state_dict();
-            result = last_storage_ptr_ = reinterpret_cast<T *>(value->storage);
+            result = reinterpret_cast<T *>(value->storage);
+            last_storage_ptr_ = result;
         }
         assert(result != nullptr);
         return *result;
@@ -260,10 +268,12 @@ private:
 
     // Fast local cache to avoid repeated lookups when there are no multiple interpreters.
     // This is only valid if there is a single interpreter. Otherwise, it is not used.
+    // It is atomic because under free-threading (`Py_GIL_DISABLED`) the GIL provides no mutual
+    // exclusion, so this pointer may be read and written concurrently by multiple threads.
     // WARNING: We cannot use thread local cache similar to `internals_pp_manager::internals_p_tls`
     //          because the thread local storage cannot be explicitly invalidated when interpreters
     //          are destroyed (unlike `internals_pp_manager` which has explicit hooks for that).
-    T *last_storage_ptr_ = nullptr;
+    std::atomic<T *> last_storage_ptr_{nullptr};
     // This flag is true if the value has been initialized by any interpreter (may not be the
     // current one).
     detail::atomic_bool is_initialized_by_at_least_one_interpreter_{false};


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

In `include/pybind11/gil_safe_call_once.h`, the `PYBIND11_HAS_SUBINTERPRETER_SUPPORT` branch of `gil_safe_call_once_and_store` caches the per-interpreter storage pointer in `T *last_storage_ptr_` as a fast path for the single-interpreter case.

This plain pointer is:
- **written** in `call_once_and_store_result()` (inside the `std::call_once` lambda) and in `get_stored()`, and
- **read** in `get_stored()`.

Under free-threaded CPython (`Py_GIL_DISABLED`), `gil_scoped_acquire` provides no mutual exclusion, so these concurrent unsynchronized reads/writes of a plain pointer are a C++ data race (undefined behavior).

Additionally, `get_stored()` loaded the cached pointer *before* calling `is_last_storage_valid()`. The writer publishes the pointer (`last_storage_ptr_`) before setting the validity flag (`is_initialized_by_at_least_one_interpreter_`), so a reader must observe the flag first and only then load the pointer to get correct acquire/release ordering.

## Fix

- Make `last_storage_ptr_` a `std::atomic<T *>` (`<atomic>` is already included in this branch). Default seq_cst operations pair with the existing atomic validity flag.
- Restructure `get_stored()` to check `is_last_storage_valid()` first, and only load `last_storage_ptr_` on the fast path; on the slow path, look up the per-interpreter storage and update the cache as before.

The change is minimal and behavior-preserving on the non-free-threaded build.

## Not addressed here

The separate embedded finalize / re-init staleness concern (a stale `last_storage_ptr_` surviving interpreter finalize + re-init within the same process) is **not** fixed by this PR. It is tracked separately in the issue.

Part of #6084

## Suggested changelog entry:

* Fix data race on last_storage_ptr_ cache in gil_safe_call_once_and_store.
