### PR TITLE
fix(stl_bind): correct __delitem__ for negative-step slices and re-enable contiguous erase fast path

### DIFF
--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -288,7 +288,8 @@ void vector_modifiers(
         [](Vector &v, const slice &slice) {
             ssize_t start = 0, stop = 0, step = 0, slicelength = 0;
 
-            if (!slice.compute((ssize_t) v.size(), &start, &stop, &step, &slicelength)) {
+            if (!slice.compute(
+                    static_cast<ssize_t>(v.size()), &start, &stop, &step, &slicelength)) {
                 throw error_already_set();
             }
 

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -286,18 +286,24 @@ void vector_modifiers(
     cl.def(
         "__delitem__",
         [](Vector &v, const slice &slice) {
-            size_t start = 0, stop = 0, step = 0, slicelength = 0;
+            ssize_t start = 0, stop = 0, step = 0, slicelength = 0;
 
-            if (!slice.compute(v.size(), &start, &stop, &step, &slicelength)) {
+            if (!slice.compute((ssize_t) v.size(), &start, &stop, &step, &slicelength)) {
                 throw error_already_set();
             }
 
-            if (step == 1 && false) {
+            if (step == 1) {
                 v.erase(v.begin() + (DiffType) start, v.begin() + DiffType(start + slicelength));
             } else {
-                for (size_t i = 0; i < slicelength; ++i) {
+                // For a positive step, erasing an element shifts the remaining
+                // (later) elements down by one, so the next index to erase is
+                // ``start + step - 1``. For a negative step the visited indices
+                // are strictly decreasing, so erasing never shifts them and the
+                // next index is simply ``start + step``.
+                ssize_t offset = step > 0 ? step - 1 : step;
+                for (ssize_t i = 0; i < slicelength; ++i) {
                     v.erase(v.begin() + DiffType(start));
-                    start += step - 1;
+                    start += offset;
                 }
             }
         },

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -302,11 +302,12 @@ void vector_modifiers(
                     start += (slicelength - 1) * step;
                     step = -step;
                 }
-                for (ssize_t i = 0; i < slicelength; ++i) {
+                while (true) {
                     v.erase(v.begin() + DiffType(start));
-                    if (i + 1 < slicelength) {
-                        start += step;
+                    if (--slicelength == 0) {
+                        break;
                     }
+                    start += step;
                 }
             }
         },

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -295,16 +295,18 @@ void vector_modifiers(
 
             if (step == 1) {
                 v.erase(v.begin() + (DiffType) start, v.begin() + DiffType(start + slicelength));
-            } else {
-                // For a positive step, erasing an element shifts the remaining
-                // (later) elements down by one, so the next index to erase is
-                // ``start + step - 1``. For a negative step the visited indices
-                // are strictly decreasing, so erasing never shifts them and the
-                // next index is simply ``start + step``.
-                ssize_t offset = step > 0 ? step - 1 : step;
+            } else if (slicelength > 0) {
+                // Erase non-contiguous slices in descending index order so that
+                // erasing an element never shifts an index that remains to be erased.
+                if (step > 0) {
+                    start += (slicelength - 1) * step;
+                    step = -step;
+                }
                 for (ssize_t i = 0; i < slicelength; ++i) {
                     v.erase(v.begin() + DiffType(start));
-                    start += offset;
+                    if (i + 1 < slicelength) {
+                        start += step;
+                    }
                 }
             }
         },

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -67,8 +67,9 @@ def test_vector_int():
     assert len(v_int2) == 0
 
 
-def test_vector_delitem_slice():
-    slice_cases = [
+@pytest.mark.parametrize(
+    "s",
+    [
         slice(1, 4),
         slice(None, None, 2),
         slice(1, None, 2),
@@ -80,14 +81,15 @@ def test_vector_delitem_slice():
         slice(5, 0, -2),
         slice(-3, -1),
         slice(None, None, -3),
-    ]
+    ],
+)
+def test_vector_delitem_slice(s):
     for n in range(8):
-        for s in slice_cases:
-            ref = list(range(n))
-            got = m.VectorInt(range(n))
-            del ref[s]
-            del got[s]
-            assert list(got) == ref, f"n={n} slice={s}"
+        ref = list(range(n))
+        got = m.VectorInt(range(n))
+        del ref[s]
+        del got[s]
+        assert list(got) == ref, f"n={n}"
 
 
 # Older PyPy's failed here, related to the PyPy's buffer protocol.

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -67,6 +67,29 @@ def test_vector_int():
     assert len(v_int2) == 0
 
 
+def test_vector_delitem_slice():
+    slice_cases = [
+        slice(1, 4),
+        slice(None, None, 2),
+        slice(1, None, 2),
+        slice(None, None, -1),
+        slice(None, None, -2),
+        slice(3, 1, -1),
+        slice(2, 2),
+        slice(None),
+        slice(5, 0, -2),
+        slice(-3, -1),
+        slice(None, None, -3),
+    ]
+    for n in range(8):
+        for s in slice_cases:
+            ref = list(range(n))
+            got = m.VectorInt(range(n))
+            del ref[s]
+            del got[s]
+            assert list(got) == ref, f"n={n} slice={s}"
+
+
 # Older PyPy's failed here, related to the PyPy's buffer protocol.
 def test_vector_buffer():
     b = bytearray([1, 2, 3, 4])

--- a/tests/test_stl_binders.py
+++ b/tests/test_stl_binders.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from pybind11_tests import stl_binders as m
@@ -81,6 +83,8 @@ def test_vector_int():
         slice(5, 0, -2),
         slice(-3, -1),
         slice(None, None, -3),
+        slice(3, None, sys.maxsize),
+        slice(-2, -7, -2),
     ],
 )
 def test_vector_delitem_slice(s):
@@ -90,6 +94,13 @@ def test_vector_delitem_slice(s):
         del ref[s]
         del got[s]
         assert list(got) == ref, f"n={n}"
+
+
+def test_vector_delitem_slice_step_zero():
+    v = m.VectorInt(range(8))
+    with pytest.raises(ValueError):
+        del v[::0]
+    assert list(v) == list(range(8))
 
 
 # Older PyPy's failed here, related to the PyPy's buffer protocol.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

`bind_vector`'s `__delitem__(slice)` in `stl_bind.h` advanced the erase
index by `step - 1` for every slice, but that correction is only valid
for **positive** steps (where erasing an element shifts the later
elements down by one). For negative steps the visited indices are
strictly decreasing, so erasing never shifts them and the `- 1` is
wrong:

- `del v[::-2]` on `[0, 1, 2, 3]` produced `[1, 2]` instead of the
  correct `[0, 2]` (silent data corruption).
- `del v[::-1]` ended up calling `v.erase(v.begin() - 1)`, an
  out-of-bounds access (observed SIGBUS).

Separately, the contiguous fast path was guarded by `step == 1 && false`
— a debugging artifact from 2016 (25c03cec) — so a contiguous delete
like `del v[1:1000]` did 999 individual `erase` calls instead of one
range erase.

## Fix

- Use the signed `slice::compute` overload so negative steps stay signed
  instead of arriving as wrapped `size_t` values.
- Original: Advance by `step` for negative steps and `step - 1` for positive
  steps. — Revised: https://github.com/pybind/pybind11/pull/6088#issuecomment-5082537064
- Drop the dead `&& false`, restoring the O(n) contiguous range erase for
  `step == 1`.

Semantics now match CPython `del l[slice]` exactly for forward,
strided, negative, empty, and full slices.

## Tests

Added `test_vector_delitem_slice` in `tests/test_stl_binders.py`,
looping over forward / strided / negative-step / empty / full slices for
vectors of several lengths and comparing against the equivalent Python
`list` `del`.

## Verification

Built a scratch opaque `VectorInt` module against this branch's headers
and compared `del v[...]` to Python `list` semantics across all the slice
cases above (and more) for lengths 0–11 — all match, no out-of-bounds
access.

Part of #6084


## Suggested changelog entry:

* Correct `__delitem__` for negative-step slices and re-enable contiguous erase fast path.

<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6088.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->