### PR TITLE
fix: drop Python 2 coding cookie prepended to evaluated source

### DIFF
--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -52,9 +52,8 @@ object eval(const str &expr, object global = globals(), object local = object())
 
     detail::ensure_builtins_in_globals(global);
 
-    /* PyRun_String does not accept a PyObject / encoding specifier,
-       this seems to be the only alternative */
-    std::string buffer = "# -*- coding: utf-8 -*-\n" + (std::string) expr;
+    // PyRun_String requires a plain C string; Python 3 always assumes UTF-8 source.
+    std::string buffer = (std::string) expr;
 
     int start = 0;
     switch (mode) {


### PR DESCRIPTION
Not only is this a Python 2 holdover, but it makes traceback line numbers be off by one!

:robot: _AI text below_ :robot:

## Summary

- Remove the `# -*- coding: utf-8 -*-` line that was prepended to every string passed to `PyRun_String` in `py::eval` / `py::exec`.
- Python 3's `PyRun_String` already assumes UTF-8 source — the cookie is a Python 2 artifact that serves no purpose.
- **User-visible fix:** the cookie shifted all source line numbers up by one in tracebacks and `SyntaxError`s from evaluated code. Code that `raise`s on line 2 of the evaluated string now correctly appears as line 2 in tracebacks (previously it appeared as line 3).
- Update the adjacent comment to reflect the actual reason for the `std::string` conversion (obtaining a `const char*` for `PyRun_String`).
- `eval_file` reads directly from a `FILE*` via `PyRun_FileEx` and was never affected.

## Verification

Tested on macOS with Python 3.14 by compiling a scratch extension and confirming:
1. `py::eval("1+1")` returns 2.
2. A UTF-8 string literal in evaluated source (`héllo`) round-trips correctly.
3. `py::exec("x = 1\nraise ValueError('line2error')")` now correctly reports the traceback at **line 2** (previously line 3 due to the prepended cookie).

No tests assert on line numbers in evaluated code, so no test updates were needed.

Part of #6084

## Suggested changelog entry:

* Drop Python 2 prepend to evaluated source, causing errors to be off by one. 