### PR TITLE
ci: drop boost from 32-bit mingw32 install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -978,10 +978,12 @@ jobs:
         include:
           - sys: mingw32
             env: i686
+            # Boost is no longer packaged for 32-bit i686 in the MSYS2 repos.
             extra_install: ""
           - sys: mingw64
             env: x86_64
             extra_install: |
+              mingw-w64-x86_64-boost
               mingw-w64-x86_64-python-numpy
               mingw-w64-x86_64-python-scipy
               mingw-w64-x86_64-eigen3
@@ -996,7 +998,6 @@ jobs:
           mingw-w64-${{matrix.env}}-cmake
           mingw-w64-${{matrix.env}}-make
           mingw-w64-${{matrix.env}}-python-pytest
-          mingw-w64-${{matrix.env}}-boost
           mingw-w64-${{matrix.env}}-catch
           ${{ matrix.extra_install }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -978,7 +978,6 @@ jobs:
         include:
           - sys: mingw32
             env: i686
-            # Boost is no longer packaged for 32-bit i686 in the MSYS2 repos.
             extra_install: ""
           - sys: mingw64
             env: x86_64


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

The `🐍 3 • windows-latest • mingw32` CI job started failing at the dependency-install step:

```
pacman ... 'mingw-w64-i686-boost' 'mingw-w64-i686-catch'
error: target not found: mingw-w64-i686-boost
```

MSYS2 has dropped the `mingw-w64-i686-boost` package (32-bit i686 is being phased out), so the install fails before anything is built. This affects `master` and every open PR — the last green `mingw32` run on `master` predates the package removal.

## Fix

Boost is **optional** test coverage: `tests/CMakeLists.txt` does `find_package(Boost 1.56)` and only defines `PYBIND11_TEST_BOOST` (enabling the `boost::optional` / `boost::variant` caster tests) when it's found. Without it, those tests are skipped and the rest of the job builds and runs normally.

This drops `boost` from the shared install list and adds `mingw-w64-x86_64-boost` to the **mingw64** `extra_install`, so:

- **mingw32 (i686)** no longer requests the missing package and goes green again.
- **mingw64 (x86_64)** keeps full boost test coverage.
