### PR TITLE
fix: add life support to handles cast to string_view

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -620,7 +620,7 @@ private:
             }
             value = StringType(bytearray, (size_t) PyByteArray_Size(src.ptr()));
             if (IsView) {
-                loader_life_support::add_patient(utfNbytes);
+                loader_life_support::add_patient(src);
             }
             return true;
         }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -526,6 +526,9 @@ struct string_caster {
                 return false;
             }
             value = StringType(buffer, static_cast<size_t>(size));
+            if (IsView) {
+                loader_life_support::add_patient(src);
+            }
             return true;
         }
 
@@ -603,6 +606,9 @@ private:
                 pybind11_fail("Unexpected PYBIND11_BYTES_AS_STRING() failure.");
             }
             value = StringType(bytes, (size_t) PYBIND11_BYTES_SIZE(src.ptr()));
+            if (IsView) {
+                loader_life_support::add_patient(src);
+            }
             return true;
         }
         if (PyByteArray_Check(src.ptr())) {
@@ -613,6 +619,9 @@ private:
                 pybind11_fail("Unexpected PyByteArray_AsString() failure.");
             }
             value = StringType(bytearray, (size_t) PyByteArray_Size(src.ptr()));
+            if (IsView) {
+                loader_life_support::add_patient(utfNbytes);
+            }
             return true;
         }
 

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -583,14 +583,13 @@ TEST_SUBMODULE(stl, m) {
     m.def("func_with_string_or_vector_string_arg_overload", [](const std::string &) { return 3; });
 
 #ifdef PYBIND11_HAS_STRING_VIEW
-    m.def("func_with_string_views",
-          [](const std::vector<std::string_view> &svs) {
-            py::list l;
-            for (std::string_view sv : svs) {
-                l.append(sv);
-            }
-            return l;
-          });
+    m.def("func_with_string_views", [](const std::vector<std::string_view> &svs) {
+        py::list l;
+        for (std::string_view sv : svs) {
+            l.append(sv);
+        }
+        return l;
+    });
 #endif
 
     class Placeholder {

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -582,6 +582,17 @@ TEST_SUBMODULE(stl, m) {
           [](const std::list<std::string> &) { return 2; });
     m.def("func_with_string_or_vector_string_arg_overload", [](const std::string &) { return 3; });
 
+#ifdef PYBIND11_HAS_STRING_VIEW
+    m.def("func_with_string_views",
+          [](const std::vector<std::string_view> &svs) {
+            py::list l;
+            for (std::string_view sv : svs) {
+                l.append(sv);
+            }
+            return l;
+          });
+#endif
+
     class Placeholder {
     public:
         Placeholder() { print_created(this); }

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -28,6 +28,13 @@ def test_vector(doc):
     # Test regression caused by 936: pointers to stl containers weren't castable
     assert m.cast_ptr_vector() == ["lvalue", "lvalue"]
 
+    if hasattr(m, "func_with_string_views"):
+        def gen():
+            return ('a' + str(x) for x in range(10000, 10010))
+        expected = list(gen())
+        assert m.func_with_string_views(gen()) == expected
+        assert m.func_with_string_views((x.encode() for x in gen())) == expected
+        assert m.func_with_string_views((bytearray(x.encode()) for x in gen())) == expected
 
 def test_deque():
     """std::deque <-> list"""

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -29,12 +29,17 @@ def test_vector(doc):
     assert m.cast_ptr_vector() == ["lvalue", "lvalue"]
 
     if hasattr(m, "func_with_string_views"):
+
         def gen():
-            return ('a' + str(x) for x in range(10000, 10010))
+            return ("a" + str(x) for x in range(10000, 10010))
+
         expected = list(gen())
         assert m.func_with_string_views(gen()) == expected
-        assert m.func_with_string_views((x.encode() for x in gen())) == expected
-        assert m.func_with_string_views((bytearray(x.encode()) for x in gen())) == expected
+        assert m.func_with_string_views(x.encode() for x in gen()) == expected
+        assert (
+            m.func_with_string_views(bytearray(x.encode()) for x in gen()) == expected
+        )
+
 
 def test_deque():
     """std::deque <-> list"""


### PR DESCRIPTION
## Description
std::string_view is a reference type and therefore the handles are required to be put on life-support.

```C++
void my_func(std::vector<std::string_view> arg);
```

```Python
my_func(str(i).encode() for i in range(1000,1010))
```

## Suggested changelog entry:
Add life support to handles cast to string_view.

