### PR TITLE
fix(cmake): respect explicit PYBIND11_USE_CROSSCOMPILING under CMP0190

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,11 @@ option(PYBIND11_SIMPLE_GIL_MANAGEMENT
 set(PYBIND11_INTERNALS_VERSION
     ""
     CACHE STRING "Override the ABI version, may be used to enable the unstable ABI.")
+# Record whether the project set this before option() supplies its OFF default, so
+# pybind11Common.cmake can apply its CMP0190-aware default without clobbering an explicit value.
+if(NOT DEFINED PYBIND11_USE_CROSSCOMPILING)
+  set(_PYBIND11_USE_CROSSCOMPILING_DEFAULTED ON)
+endif()
 option(PYBIND11_USE_CROSSCOMPILING "Respect CMAKE_CROSSCOMPILING" OFF)
 
 if(PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION)

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -43,16 +43,18 @@ set(pybind11_INCLUDE_DIRS
 
 # CMP0190 prohibits calling FindPython with both Interpreter and Development components
 # when cross-compiling, unless the CMAKE_CROSSCOMPILING_EMULATOR variable is defined.
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.1")
+# Default PYBIND11_USE_CROSSCOMPILING to ON in that case, but never override a value the
+# project set explicitly (e.g. Emscripten/Pyodide defines an emulator yet still wants it ON).
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.1"
+   AND NOT DEFINED PYBIND11_USE_CROSSCOMPILING
+   AND NOT DEFINED CMAKE_CROSSCOMPILING_EMULATOR)
   cmake_policy(GET CMP0190 _pybind11_cmp0190)
   if(_pybind11_cmp0190 STREQUAL "NEW")
     set(PYBIND11_USE_CROSSCOMPILING "ON")
   endif()
 endif()
 
-if(CMAKE_CROSSCOMPILING
-   AND PYBIND11_USE_CROSSCOMPILING
-   AND NOT DEFINED CMAKE_CROSSCOMPILING_EMULATOR)
+if(CMAKE_CROSSCOMPILING AND PYBIND11_USE_CROSSCOMPILING)
   set(_PYBIND11_CROSSCOMPILING
       ON
       CACHE INTERNAL "")

--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -45,9 +45,12 @@ set(pybind11_INCLUDE_DIRS
 # when cross-compiling, unless the CMAKE_CROSSCOMPILING_EMULATOR variable is defined.
 # Default PYBIND11_USE_CROSSCOMPILING to ON in that case, but never override a value the
 # project set explicitly (e.g. Emscripten/Pyodide defines an emulator yet still wants it ON).
+# PYBIND11_USE_CROSSCOMPILING is undefined for find_package() consumers, but our own
+# CMakeLists.txt always defines it via option(); _PYBIND11_USE_CROSSCOMPILING_DEFAULTED tells
+# us whether that came from the project or from the option() default.
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.1"
-   AND NOT DEFINED PYBIND11_USE_CROSSCOMPILING
-   AND NOT DEFINED CMAKE_CROSSCOMPILING_EMULATOR)
+   AND NOT DEFINED CMAKE_CROSSCOMPILING_EMULATOR
+   AND (NOT DEFINED PYBIND11_USE_CROSSCOMPILING OR _PYBIND11_USE_CROSSCOMPILING_DEFAULTED))
   cmake_policy(GET CMP0190 _pybind11_cmp0190)
   if(_pybind11_cmp0190 STREQUAL "NEW")
     set(PYBIND11_USE_CROSSCOMPILING "ON")


### PR DESCRIPTION
Implemented with Claude Code Opus 4.8 (see linux kernel style trailer in commit messages)

:robot: _AI text below_ :robot:

## Description

Fixes #6043.

Cross-compiling to Emscripten/Pyodide (and any target that defines `CMAKE_CROSSCOMPILING_EMULATOR`) broke with CMake ≥ 4.1 and pybind11 ≥ 3.0.2, failing with a spurious `Cannot run the interpreter` / pointer-size mismatch.

PR #5829 added `AND NOT DEFINED CMAKE_CROSSCOMPILING_EMULATOR` to the condition that sets the internal `_PYBIND11_CROSSCOMPILING` flag. That check was meant only to gate whether pybind11 *auto-defaults* `PYBIND11_USE_CROSSCOMPILING` to `ON`, but it ended up overriding a value the project had set explicitly. Emscripten defines `CMAKE_CROSSCOMPILING_EMULATOR` (node) while still wanting cross-compiling mode, so the flag was forced `OFF`.

This moves the emulator check up so it only guards the auto-default (which also no longer fires if the project already set the variable), and restores the second condition to `CMAKE_CROSSCOMPILING AND PYBIND11_USE_CROSSCOMPILING`. This is the fix proposed by the original PR author (@mhsmith) in the issue thread.

Behavior preserved across all cases:
- Emscripten/Pyodide — sets `PYBIND11_USE_CROSSCOMPILING=ON` explicitly → respected → `ON`
- Android (CMake ≥ 4.1, CMP0190 `NEW`, no emulator, variable unset) → still auto-defaults to `ON`
- Explicit `OFF` → respected

## Suggested changelog entry:

* Fixed cross-compilation to Emscripten/Pyodide with CMake ≥ 4.1 by no longer overriding an explicitly set `PYBIND11_USE_CROSSCOMPILING` when `CMAKE_CROSSCOMPILING_EMULATOR` is defined.