### PR TITLE
ci: update cibuildwheel to v4.1 and pyodide to 314

### DIFF
--- a/.github/workflows/tests-cibw.yml
+++ b/.github/workflows/tests-cibw.yml
@@ -25,12 +25,12 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - uses: pypa/cibuildwheel@v3.4
+    - uses: pypa/cibuildwheel@v4.1
       env:
         PYODIDE_BUILD_EXPORTS: whole_archive
       with:
         package-dir: tests
-        only: cp312-pyodide_wasm32
+        only: cp314-pyodide_wasm32
 
   build-ios:
     name: iOS wheel ${{ matrix.runs-on }}
@@ -48,10 +48,9 @@ jobs:
     # We have to uninstall first because GH is now using a local tap to build cmake<4, iOS needs cmake>=4
     - run: brew uninstall cmake && brew install cmake
 
-    - uses: pypa/cibuildwheel@v3.4
+    - uses: pypa/cibuildwheel@v4.1
       env:
         CIBW_PLATFORM: ios
-        CIBW_SKIP: cp314-*  # https://github.com/pypa/cibuildwheel/issues/2494
       with:
         package-dir: tests
 
@@ -73,7 +72,7 @@ jobs:
       if: contains(matrix.runs-on, 'macos')
       run: echo "CIBW_TEST_COMMAND=" >> "$GITHUB_ENV"
 
-    - uses: pypa/cibuildwheel@v3.4
+    - uses: pypa/cibuildwheel@v4.1
       env:
         CIBW_PLATFORM: android
       with:

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -9,10 +9,8 @@ from pybind11_tests import numpy_array as m
 
 np = pytest.importorskip("numpy")
 
-# numpy < 2.4 has a resize(refcheck=True) regression on Python 3.14: it fails to
-# notice the reference held by the bound function, so a resize that should raise
-# instead succeeds. Only the iOS test environment is still pinned to such a numpy
-# (no newer iOS wheels exist yet).
+# numpy < 2.4 fails to detect aliasing in ndarray.resize on Python 3.14, so a
+# resize that should raise instead succeeds: numpy/numpy#30265 (fixed in 2.4.0).
 NUMPY_RESIZE_REFCHECK_BROKEN = sys.version_info >= (3, 14) and tuple(
     int(x) for x in np.__version__.split(".")[:2]
 ) < (2, 4)

--- a/tests/test_numpy_array.py
+++ b/tests/test_numpy_array.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 import env  # noqa: F401
 from pybind11_tests import numpy_array as m
 
 np = pytest.importorskip("numpy")
+
+# numpy < 2.4 has a resize(refcheck=True) regression on Python 3.14: it fails to
+# notice the reference held by the bound function, so a resize that should raise
+# instead succeeds. Only the iOS test environment is still pinned to such a numpy
+# (no newer iOS wheels exist yet).
+NUMPY_RESIZE_REFCHECK_BROKEN = sys.version_info >= (3, 14) and tuple(
+    int(x) for x in np.__version__.split(".")[:2]
+) < (2, 4)
 
 
 def test_dtypes():
@@ -485,6 +495,10 @@ def test_initializer_list():
     assert m.array_initializer_list4().shape == (1, 2, 3, 4)
 
 
+@pytest.mark.xfail(
+    NUMPY_RESIZE_REFCHECK_BROKEN,
+    reason="numpy<2.4 resize(refcheck) regression on Python 3.14",
+)
 def test_array_resize():
     a = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype="float64")
     m.array_reshape2(a)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Description

Updates the cibuildwheel test workflow:

- Bumps `pypa/cibuildwheel` from `v3.4` to `v4.1` (latest) across the Pyodide, iOS, and Android jobs.
- Moves the Pyodide build from `cp312-pyodide_wasm32` to `cp314-pyodide_wasm32`, building against pyodide `314.0.0` (Python 3.14).
- Drops the iOS `CIBW_SKIP: cp314-*` workaround now that the [pypa/cibuildwheel#2494](https://github.com/pypa/cibuildwheel/issues/2494) header build issue is resolved, so iOS cp314 wheels are now built and tested.

Enabling cp314 iOS testing surfaced a pre-existing (unrelated) failure in `test_array_resize`: numpy `< 2.4` has a `resize(refcheck=True)` regression on Python 3.14 where the reference held by the bound function isn't detected, so a resize that should raise instead succeeds and the later reshape rejects the non-square size. It's fixed in numpy `>= 2.4` (used everywhere else), but the iOS test environment has no numpy wheel newer than `2.3.5.post1`, so the test is `xfail`ed for that specific `numpy < 2.4` + Python 3.14 combination.

## Suggested changelog entry

Updated the CIBW test workflow to cibuildwheel v4.1 and bumped the Pyodide build to 314.
