### PR TITLE
fix: only add string_view life support for transient sources

### DIFF
--- a/docs/advanced/cast/custom.rst
+++ b/docs/advanced/cast/custom.rst
@@ -120,6 +120,24 @@ type is explicitly allowed.
     For further information on the ``return_value_policy`` argument of ``cast`` refer to :ref:`return_value_policies`.
     To learn about the ``convert`` argument of ``load`` see :ref:`nonconverting_arguments`.
 
+.. note::
+
+    If a custom ``load()`` produces a non-owning view of storage owned by a
+    Python object, and keeping that object alive is sufficient to keep the
+    storage valid, register the owner (often ``src``) with
+    ``pybind11::detail::loader_life_support::try_add_patient(owner)``. During a
+    bound-function call, this keeps the owner alive until the call returns. With
+    no active call frame, it returns ``false`` and the caller remains
+    responsible for the lifetime.
+
+    If ``load()`` instead creates a temporary Python object to own the view's
+    storage, use the strict ``loader_life_support::add_patient(owner)``. Outside
+    a bound-function call, it raises :class:`cast_error` rather than allowing a
+    dangling view. Neither form permits C++ code to retain the view after the
+    call without separate lifetime management. These ``detail`` helpers are
+    intended only for type-caster implementations. See
+    :ref:`string_view_lifetime` for a concrete example.
+
 .. warning::
 
     When using custom type casters, it's important to declare them consistently

--- a/docs/advanced/cast/stl.rst
+++ b/docs/advanced/cast/stl.rst
@@ -17,6 +17,10 @@ converted (i.e. copied) on every Python->C++ and C++->Python transition, which
 can have implications on the program semantics and performance. Please read the
 next sections for more details and alternative approaches that avoid this.
 
+Copying the container does not make non-owning element types own their data.
+In particular, containers of C++ string views have additional
+:ref:`string_view_lifetime` requirements.
+
 .. note::
 
     Arbitrary nesting of any of these types is possible.

--- a/docs/advanced/cast/strings.rst
+++ b/docs/advanced/cast/strings.rst
@@ -280,6 +280,8 @@ expressed as a single Unicode code point
 no way to capture them in a C++ character type.
 
 
+.. _string_view_lifetime:
+
 C++17 string views
 ==================
 
@@ -288,6 +290,30 @@ They follow the same rules for encoding and decoding as the corresponding STL
 string type (for example, a ``std::u16string_view`` argument will be passed
 UTF-16-encoded data, and a returned ``std::string_view`` will be decoded as
 UTF-8).
+
+A string view does not own its character data. When a view is loaded as an
+argument to a pybind11-bound function, pybind11 keeps the Python object that
+provides the data alive until the function returns. This also applies to views
+nested in automatically converted STL containers. The C++ function must not
+retain any such view after it returns unless it separately guarantees that the
+backing storage remains alive and valid.
+
+Lifetime support keeps the Python object alive, but does not prevent its storage
+from being invalidated. For example, if C++ releases the GIL or calls back into
+Python, resizing a backing ``bytearray`` while the view is in use can invalidate
+the view.
+
+A direct Python-to-C++ :func:`py::cast` made when no bound-function call is
+active has no such lifetime support. When a cast to a non-owning view succeeds,
+the caller must keep the backing Python object alive, with its storage
+unchanged, for as long as the view is used. For a container of views, this
+requirement applies to every element: retain the elements directly or through
+an unmodified owning container, and do not cast an iterable that creates
+temporary elements.
+
+Some view conversions require temporary backing storage, for example to encode
+text. Outside a bound-function call, such conversions raise
+:class:`cast_error` instead of returning a dangling view.
 
 References
 ==========

--- a/docs/advanced/pycpp/object.rst
+++ b/docs/advanced/pycpp/object.rst
@@ -76,6 +76,10 @@ The reverse direction uses the following syntax:
 
 When conversion fails, both directions throw the exception :class:`cast_error`.
 
+When casting to a non-owning type such as ``std::string_view``, the Python
+source may need to remain alive after a successful cast. See
+:ref:`string_view_lifetime` for details.
+
 .. _python_libs:
 
 Accessing Python libraries from C++

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -526,7 +526,9 @@ struct string_caster {
             }
             value = StringType(buffer, static_cast<size_t>(size));
             if (IsView) {
-                loader_life_support::add_patient(src);
+                // `src` owns the buffer; keep it alive if inside a bound function,
+                // otherwise the caller is responsible for its lifetime.
+                loader_life_support::try_add_patient(src);
             }
             return true;
         }
@@ -606,7 +608,7 @@ private:
             }
             value = StringType(bytes, (size_t) PYBIND11_BYTES_SIZE(src.ptr()));
             if (IsView) {
-                loader_life_support::add_patient(src);
+                loader_life_support::try_add_patient(src);
             }
             return true;
         }
@@ -619,7 +621,7 @@ private:
             }
             value = StringType(bytearray, (size_t) PyByteArray_Size(src.ptr()));
             if (IsView) {
-                loader_life_support::add_patient(src);
+                loader_life_support::try_add_patient(src);
             }
             return true;
         }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -525,6 +525,9 @@ struct string_caster {
                 return false;
             }
             value = StringType(buffer, static_cast<size_t>(size));
+            if (IsView) {
+                loader_life_support::add_patient(src);
+            }
             return true;
         }
 
@@ -602,6 +605,9 @@ private:
                 pybind11_fail("Unexpected PYBIND11_BYTES_AS_STRING() failure.");
             }
             value = StringType(bytes, (size_t) PYBIND11_BYTES_SIZE(src.ptr()));
+            if (IsView) {
+                loader_life_support::add_patient(src);
+            }
             return true;
         }
         if (PyByteArray_Check(src.ptr())) {
@@ -612,6 +618,9 @@ private:
                 pybind11_fail("Unexpected PyByteArray_AsString() failure.");
             }
             value = StringType(bytearray, (size_t) PyByteArray_Size(src.ptr()));
+            if (IsView) {
+                loader_life_support::add_patient(src);
+            }
             return true;
         }
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -525,10 +525,10 @@ struct string_caster {
                 return false;
             }
             value = StringType(buffer, static_cast<size_t>(size));
-            if (IsView) {
-                // `src` owns the buffer; keep it alive if inside a bound function,
-                // otherwise the caller is responsible for its lifetime.
-                loader_life_support::try_add_patient(src);
+            if (IsView && loading_from_transient_source()) {
+                // The view points into `src`, which is owned by a transient source that
+                // will be released before the view is used, so keep `src` alive.
+                loader_life_support::add_patient(src);
             }
             return true;
         }
@@ -607,8 +607,8 @@ private:
                 pybind11_fail("Unexpected PYBIND11_BYTES_AS_STRING() failure.");
             }
             value = StringType(bytes, (size_t) PYBIND11_BYTES_SIZE(src.ptr()));
-            if (IsView) {
-                loader_life_support::try_add_patient(src);
+            if (IsView && loading_from_transient_source()) {
+                loader_life_support::add_patient(src);
             }
             return true;
         }
@@ -620,8 +620,8 @@ private:
                 pybind11_fail("Unexpected PyByteArray_AsString() failure.");
             }
             value = StringType(bytearray, (size_t) PyByteArray_Size(src.ptr()));
-            if (IsView) {
-                loader_life_support::try_add_patient(src);
+            if (IsView && loading_from_transient_source()) {
+                loader_life_support::add_patient(src);
             }
             return true;
         }

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -525,10 +525,10 @@ struct string_caster {
                 return false;
             }
             value = StringType(buffer, static_cast<size_t>(size));
-            if (IsView && loading_from_transient_source()) {
-                // The view points into `src`, which is owned by a transient source that
-                // will be released before the view is used, so keep `src` alive.
-                loader_life_support::add_patient(src);
+            if (IsView) {
+                // `src` owns the buffer; keep it alive if inside a bound function,
+                // otherwise the caller is responsible for its lifetime.
+                loader_life_support::try_add_patient(src);
             }
             return true;
         }
@@ -607,8 +607,8 @@ private:
                 pybind11_fail("Unexpected PYBIND11_BYTES_AS_STRING() failure.");
             }
             value = StringType(bytes, (size_t) PYBIND11_BYTES_SIZE(src.ptr()));
-            if (IsView && loading_from_transient_source()) {
-                loader_life_support::add_patient(src);
+            if (IsView) {
+                loader_life_support::try_add_patient(src);
             }
             return true;
         }
@@ -620,8 +620,8 @@ private:
                 pybind11_fail("Unexpected PyByteArray_AsString() failure.");
             }
             value = StringType(bytearray, (size_t) PyByteArray_Size(src.ptr()));
-            if (IsView && loading_from_transient_source()) {
-                loader_life_support::add_patient(src);
+            if (IsView) {
+                loader_life_support::try_add_patient(src);
             }
             return true;
         }

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -81,11 +81,26 @@ public:
         }
     }
 
+    /// Keep `h` alive until the current patient frame is destroyed, if there is one.
+    /// Returns false when called outside a bound function (no frame). Use this, rather
+    /// than `add_patient`, when failing to register is acceptable because the caller
+    /// owns the source's lifetime outside the call framework (e.g. a view that points
+    /// into an existing Python object, as opposed to a freshly created temporary).
+    PYBIND11_NOINLINE static bool try_add_patient(handle h) {
+        loader_life_support *frame = tls_current_frame();
+        if (!frame) {
+            return false;
+        }
+        if (frame->keep_alive.insert(h.ptr()).second) {
+            Py_INCREF(h.ptr());
+        }
+        return true;
+    }
+
     /// This can only be used inside a pybind11-bound function, either by `argument_loader`
     /// at argument preparation time or by `py::cast()` at execution time.
     PYBIND11_NOINLINE static void add_patient(handle h) {
-        loader_life_support *frame = tls_current_frame();
-        if (!frame) {
+        if (!try_add_patient(h)) {
             // NOTE: It would be nice to include the stack frames here, as this indicates
             // use of pybind11::cast<> outside the normal call framework, finding such
             // a location is challenging. Developers could consider printing out
@@ -93,10 +108,6 @@ public:
             throw cast_error("When called outside a bound function, py::cast() cannot "
                              "do Python -> C++ conversions which require the creation "
                              "of temporary values");
-        }
-
-        if (frame->keep_alive.insert(h.ptr()).second) {
-            Py_INCREF(h.ptr());
         }
     }
 };

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -81,26 +81,11 @@ public:
         }
     }
 
-    /// Keep `h` alive until the current patient frame is destroyed, if there is one.
-    /// Returns false when called outside a bound function (no frame). Use this, rather
-    /// than `add_patient`, when failing to register is acceptable because the caller
-    /// owns the source's lifetime outside the call framework (e.g. a view that points
-    /// into an existing Python object, as opposed to a freshly created temporary).
-    PYBIND11_NOINLINE static bool try_add_patient(handle h) {
-        loader_life_support *frame = tls_current_frame();
-        if (!frame) {
-            return false;
-        }
-        if (frame->keep_alive.insert(h.ptr()).second) {
-            Py_INCREF(h.ptr());
-        }
-        return true;
-    }
-
     /// This can only be used inside a pybind11-bound function, either by `argument_loader`
     /// at argument preparation time or by `py::cast()` at execution time.
     PYBIND11_NOINLINE static void add_patient(handle h) {
-        if (!try_add_patient(h)) {
+        loader_life_support *frame = tls_current_frame();
+        if (!frame) {
             // NOTE: It would be nice to include the stack frames here, as this indicates
             // use of pybind11::cast<> outside the normal call framework, finding such
             // a location is challenging. Developers could consider printing out
@@ -109,7 +94,39 @@ public:
                              "do Python -> C++ conversions which require the creation "
                              "of temporary values");
         }
+
+        if (frame->keep_alive.insert(h.ptr()).second) {
+            Py_INCREF(h.ptr());
+        }
     }
+};
+
+// While set, a type caster is converting elements borrowed from a *transient* source --
+// a generator/iterator, or a temporary container materialized from one -- whose items are
+// released before the converted C++ value is used. A view caster (e.g. for std::string_view)
+// consults this to decide whether the viewed Python object needs life support: a view into a
+// durable, caller-owned object does not, whereas a view into a transient source does. Outside
+// a bound function (no life support frame) the latter cannot be made safe, so `add_patient`
+// rightly throws rather than producing a dangling view.
+inline bool &loading_from_transient_source() {
+    static thread_local bool flag = false;
+    return flag;
+}
+
+// RAII guard marking the dynamic scope in which elements are loaded from a transient source.
+// Restores (rather than clears) the previous value so that nesting is transitive: a durable
+// container nested inside a transient one is itself transient.
+class transient_source_guard {
+public:
+    transient_source_guard() : prev(loading_from_transient_source()) {
+        loading_from_transient_source() = true;
+    }
+    ~transient_source_guard() { loading_from_transient_source() = prev; }
+    transient_source_guard(const transient_source_guard &) = delete;
+    transient_source_guard &operator=(const transient_source_guard &) = delete;
+
+private:
+    bool prev;
 };
 
 // Gets the cache entry for the given type, creating it if necessary.  The return value is the pair

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -81,11 +81,26 @@ public:
         }
     }
 
+    /// Keep `h` alive until the current patient frame is destroyed, if there is one.
+    /// Returns false when called outside a bound function (no frame). Use this, rather
+    /// than `add_patient`, when failing to register is acceptable because the caller
+    /// owns the source's lifetime outside the call framework (e.g. a view that points
+    /// into an existing Python object, as opposed to a freshly created temporary).
+    PYBIND11_NOINLINE static bool try_add_patient(handle h) {
+        loader_life_support *frame = tls_current_frame();
+        if (!frame) {
+            return false;
+        }
+        if (frame->keep_alive.insert(h.ptr()).second) {
+            Py_INCREF(h.ptr());
+        }
+        return true;
+    }
+
     /// This can only be used inside a pybind11-bound function, either by `argument_loader`
     /// at argument preparation time or by `py::cast()` at execution time.
     PYBIND11_NOINLINE static void add_patient(handle h) {
-        loader_life_support *frame = tls_current_frame();
-        if (!frame) {
+        if (!try_add_patient(h)) {
             // NOTE: It would be nice to include the stack frames here, as this indicates
             // use of pybind11::cast<> outside the normal call framework, finding such
             // a location is challenging. Developers could consider printing out
@@ -94,39 +109,7 @@ public:
                              "do Python -> C++ conversions which require the creation "
                              "of temporary values");
         }
-
-        if (frame->keep_alive.insert(h.ptr()).second) {
-            Py_INCREF(h.ptr());
-        }
     }
-};
-
-// While set, a type caster is converting elements borrowed from a *transient* source --
-// a generator/iterator, or a temporary container materialized from one -- whose items are
-// released before the converted C++ value is used. A view caster (e.g. for std::string_view)
-// consults this to decide whether the viewed Python object needs life support: a view into a
-// durable, caller-owned object does not, whereas a view into a transient source does. Outside
-// a bound function (no life support frame) the latter cannot be made safe, so `add_patient`
-// rightly throws rather than producing a dangling view.
-inline bool &loading_from_transient_source() {
-    static thread_local bool flag = false;
-    return flag;
-}
-
-// RAII guard marking the dynamic scope in which elements are loaded from a transient source.
-// Restores (rather than clears) the previous value so that nesting is transitive: a durable
-// container nested inside a transient one is itself transient.
-class transient_source_guard {
-public:
-    transient_source_guard() : prev(loading_from_transient_source()) {
-        loading_from_transient_source() = true;
-    }
-    ~transient_source_guard() { loading_from_transient_source() = prev; }
-    transient_source_guard(const transient_source_guard &) = delete;
-    transient_source_guard &operator=(const transient_source_guard &) = delete;
-
-private:
-    bool prev;
 };
 
 // Gets the cache entry for the given type, creating it if necessary.  The return value is the pair

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -198,6 +198,9 @@ public:
         }
         assert(isinstance<iterable>(src));
         value.clear();
+        // Elements are borrowed from the iterator and released as it advances, so views
+        // into them need life support.
+        transient_source_guard guard;
         return convert_iterable(reinterpret_borrow<iterable>(src), convert);
     }
 
@@ -264,6 +267,9 @@ public:
             throw error_already_set();
         }
         assert(isinstance<iterable>(items));
+        // The materialized dict is transient (released when load() returns), so views into
+        // its keys/values need life support.
+        transient_source_guard guard;
         return convert_elements(dict(reinterpret_borrow<iterable>(items)), convert);
     }
 
@@ -314,6 +320,9 @@ struct list_caster {
         // the generator is not left in an unpredictable (to the caller) partially-consumed
         // state.
         assert(isinstance<iterable>(src));
+        // The materialized tuple is transient (released when load() returns), so views into
+        // its elements need life support.
+        transient_source_guard guard;
         return convert_elements(tuple(reinterpret_borrow<iterable>(src)), convert);
     }
 
@@ -449,6 +458,9 @@ public:
         // the generator is not left in an unpredictable (to the caller) partially-consumed
         // state.
         assert(isinstance<iterable>(src));
+        // The materialized tuple is transient (released when load() returns), so views into
+        // its elements need life support.
+        transient_source_guard guard;
         return convert_elements(tuple(reinterpret_borrow<iterable>(src)), convert);
     }
 

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -198,9 +198,6 @@ public:
         }
         assert(isinstance<iterable>(src));
         value.clear();
-        // Elements are borrowed from the iterator and released as it advances, so views
-        // into them need life support.
-        transient_source_guard guard;
         return convert_iterable(reinterpret_borrow<iterable>(src), convert);
     }
 
@@ -267,9 +264,6 @@ public:
             throw error_already_set();
         }
         assert(isinstance<iterable>(items));
-        // The materialized dict is transient (released when load() returns), so views into
-        // its keys/values need life support.
-        transient_source_guard guard;
         return convert_elements(dict(reinterpret_borrow<iterable>(items)), convert);
     }
 
@@ -320,9 +314,6 @@ struct list_caster {
         // the generator is not left in an unpredictable (to the caller) partially-consumed
         // state.
         assert(isinstance<iterable>(src));
-        // The materialized tuple is transient (released when load() returns), so views into
-        // its elements need life support.
-        transient_source_guard guard;
         return convert_elements(tuple(reinterpret_borrow<iterable>(src)), convert);
     }
 
@@ -458,9 +449,6 @@ public:
         // the generator is not left in an unpredictable (to the caller) partially-consumed
         // state.
         assert(isinstance<iterable>(src));
-        // The materialized tuple is transient (released when load() returns), so views into
-        // its elements need life support.
-        transient_source_guard guard;
         return convert_elements(tuple(reinterpret_borrow<iterable>(src)), convert);
     }
 

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -582,6 +582,16 @@ TEST_SUBMODULE(stl, m) {
           [](const std::list<std::string> &) { return 2; });
     m.def("func_with_string_or_vector_string_arg_overload", [](const std::string &) { return 3; });
 
+#ifdef PYBIND11_HAS_STRING_VIEW
+    m.def("func_with_string_views", [](const std::vector<std::string_view> &svs) {
+        py::list l;
+        for (std::string_view sv : svs) {
+            l.append(sv);
+        }
+        return l;
+    });
+#endif
+
     class Placeholder {
     public:
         Placeholder() { print_created(this); }

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -590,6 +590,10 @@ TEST_SUBMODULE(stl, m) {
         }
         return l;
     });
+    m.def("string_view_life_support_check",
+          [](const std::vector<std::string_view> &, int, const py::list &destroyed) {
+              return destroyed.size();
+          });
 #endif
 
     class Placeholder {

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -594,6 +594,10 @@ TEST_SUBMODULE(stl, m) {
           [](const std::vector<std::string_view> &, int, const py::list &destroyed) {
               return destroyed.size();
           });
+    m.def("nested_string_view_life_support_check",
+          [](const std::vector<std::vector<std::string_view>> &, int, const py::list &destroyed) {
+              return destroyed.size();
+          });
 #endif
 
     class Placeholder {

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -28,6 +28,18 @@ def test_vector(doc):
     # Test regression caused by 936: pointers to stl containers weren't castable
     assert m.cast_ptr_vector() == ["lvalue", "lvalue"]
 
+    if hasattr(m, "func_with_string_views"):
+
+        def gen():
+            return ("a" + str(x) for x in range(10000, 10010))
+
+        expected = list(gen())
+        assert m.func_with_string_views(gen()) == expected
+        assert m.func_with_string_views(x.encode() for x in gen()) == expected
+        assert (
+            m.func_with_string_views(bytearray(x.encode()) for x in gen()) == expected
+        )
+
 
 def test_deque():
     """std::deque <-> list"""

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -73,6 +73,74 @@ def test_string_view_life_support_during_argument_conversion():
     assert all(ref() is None for ref in weakrefs)
 
 
+@pytest.mark.skipif(
+    not hasattr(m, "string_view_life_support_check"), reason="no <string_view>"
+)
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
+@pytest.mark.parametrize(
+    ("element_type", "values"),
+    [
+        pytest.param(str, ("first", "second"), id="str"),
+        pytest.param(bytes, (b"first", b"second"), id="bytes"),
+        pytest.param(bytearray, (b"first", b"second"), id="bytearray"),
+    ],
+)
+def test_string_view_life_support_for_generator(element_type, values):
+    destroyed = []
+
+    class Tracked(element_type):
+        def __del__(self):
+            destroyed.append(None)
+
+    def source():
+        for value in values:
+            yield Tracked(value)
+
+    class CollectGarbageOnIndex:
+        def __index__(self):
+            pytest.gc_collect()
+            return 0
+
+    assert (
+        m.string_view_life_support_check(source(), CollectGarbageOnIndex(), destroyed)
+        == 0
+    )
+    pytest.gc_collect()
+    assert len(destroyed) == len(values)
+
+
+@pytest.mark.skipif(
+    not hasattr(m, "nested_string_view_life_support_check"),
+    reason="no <string_view>",
+)
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
+def test_string_view_life_support_for_nested_containers():
+    destroyed = []
+
+    class TrackedString(str):
+        def __del__(self):
+            destroyed.append(None)
+
+    source = [
+        [TrackedString("first"), TrackedString("second")],
+        [TrackedString("third"), TrackedString("fourth")],
+    ]
+
+    class ClearSourceOnIndex:
+        def __index__(self):
+            source.clear()
+            pytest.gc_collect()
+            return 0
+
+    assert (
+        m.nested_string_view_life_support_check(source, ClearSourceOnIndex(), destroyed)
+        == 0
+    )
+    assert source == []
+    pytest.gc_collect()
+    assert len(destroyed) == 4
+
+
 def test_deque():
     """std::deque <-> list"""
     lst = m.cast_deque()

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import weakref
+
 import pytest
 
 import env  # noqa: F401
@@ -39,6 +41,36 @@ def test_vector(doc):
         assert (
             m.func_with_string_views(bytearray(x.encode()) for x in gen()) == expected
         )
+
+
+@pytest.mark.skipif(
+    not hasattr(m, "string_view_life_support_check"), reason="no <string_view>"
+)
+@pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
+def test_string_view_life_support_during_argument_conversion():
+    destroyed = []
+
+    class TrackedString(str):
+        pass
+
+    source = [TrackedString("first"), TrackedString("second")]
+    weakrefs = [weakref.ref(item, lambda _: destroyed.append(None)) for item in source]
+
+    # Clear the only Python owners after the views have loaded, but before the
+    # bound function is called.
+    class ClearSourceOnIndex:
+        def __index__(self):
+            source.clear()
+            pytest.gc_collect()
+            return 0
+
+    assert (
+        m.string_view_life_support_check(source, ClearSourceOnIndex(), destroyed) == 0
+    )
+    assert source == []
+    pytest.gc_collect()
+    assert len(destroyed) == 2
+    assert all(ref() is None for ref in weakrefs)
 
 
 def test_deque():

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -48,6 +48,16 @@ def test_vector(doc):
 )
 @pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
 def test_string_view_life_support_during_argument_conversion():
+    # Design background: PR #6096, "Why these lifetime tests are deliberately
+    # implementation-aware".
+    # This test uses conversion of a later argument as a checkpoint between
+    # loading the string views and entering the C++ function. Argument casters
+    # run left-to-right: after the first argument creates the views, the second
+    # argument's __index__ clears the list that owned their Python strings and
+    # forces GC. The C++ probe checks only whether those strings were destroyed,
+    # never the potentially dangling views. Zero during the call proves that
+    # loader life support worked; dead weakrefs afterward prove that it did not
+    # keep the strings alive too long.
     destroyed = []
 
     class TrackedString(str):
@@ -115,6 +125,12 @@ def test_string_view_life_support_for_generator(element_type, values):
 )
 @pytest.mark.skipif("env.GRAALPY", reason="Cannot reliably trigger GC")
 def test_string_view_life_support_for_nested_containers():
+    # Design background: PR #6096, "Why these lifetime tests are deliberately
+    # implementation-aware". This uses the later-argument checkpoint described
+    # in test_string_view_life_support_during_argument_conversion. Here,
+    # clearing the outer list also releases the inner lists, verifying that life
+    # support reaches every Python string backing a view in the recursively
+    # converted std::vector<std::vector<std::string_view>>.
     destroyed = []
 
     class TrackedString(str):

--- a/tests/test_with_catch/test_interpreter.cpp
+++ b/tests/test_with_catch/test_interpreter.cpp
@@ -1,5 +1,6 @@
 #include <pybind11/critical_section.h>
 #include <pybind11/embed.h>
+#include <pybind11/stl.h>
 
 // Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to
 // catch 2.0.1; this should be fixed in the next catch release after 2.0.1).
@@ -11,8 +12,10 @@ PYBIND11_WARNING_DISABLE_MSVC(4996)
 #include <cstdlib>
 #include <fstream>
 #include <functional>
+#include <string_view>
 #include <thread>
 #include <utility>
+#include <vector>
 
 namespace py = pybind11;
 using namespace py::literals;
@@ -511,10 +514,10 @@ TEST_CASE("make_iterator can be called before then after finalizing an interpret
 }
 
 #ifdef PYBIND11_HAS_STRING_VIEW
-TEST_CASE("Casting to a string_view outside a bound function") {
-    // Regression for PR #6092: view casters add the source to loader_life_support, but
-    // outside a bound function there is no frame. The caller owns the source's lifetime
-    // here, so the cast must succeed rather than throw.
+TEST_CASE("Casting to a string_view from a durable source outside a bound function") {
+    // Outside a bound function there is no loader_life_support frame. When the source is a
+    // durable, caller-owned object the view does not need life support, so the cast must
+    // succeed rather than throw (regression from PR #6092).
     py::str unicode("hello");
     py::bytes bytes_obj("world", 5);
     auto bytearray_obj
@@ -523,5 +526,22 @@ TEST_CASE("Casting to a string_view outside a bound function") {
     REQUIRE(py::cast<std::string_view>(unicode) == "hello");
     REQUIRE(py::cast<std::string_view>(bytes_obj) == "world");
     REQUIRE(py::cast<std::string_view>(bytearray_obj) == "bytes");
+
+    // A list is durable too: the views point into elements the list keeps alive.
+    py::list durable;
+    durable.append("a");
+    durable.append("b");
+    auto from_list = py::cast<std::vector<std::string_view>>(durable);
+    REQUIRE(from_list.size() == 2);
+    REQUIRE(from_list[0] == "a");
+    REQUIRE(from_list[1] == "b");
+}
+
+TEST_CASE("Casting to a string_view from a transient source outside a bound function") {
+    // A generator is a transient source: the materialized temporary backing the views is
+    // released when the cast returns, and there is no frame to keep it alive. This cannot
+    // be made safe, so it must throw rather than produce dangling views.
+    auto gen = py::eval("('transient_' + str(x) for x in range(5))");
+    REQUIRE_THROWS_AS(py::cast<std::vector<std::string_view>>(gen), py::cast_error);
 }
 #endif

--- a/tests/test_with_catch/test_interpreter.cpp
+++ b/tests/test_with_catch/test_interpreter.cpp
@@ -509,3 +509,19 @@ TEST_CASE("make_iterator can be called before then after finalizing an interpret
 
     py::initialize_interpreter();
 }
+
+#ifdef PYBIND11_HAS_STRING_VIEW
+TEST_CASE("Casting to a string_view outside a bound function") {
+    // Regression for PR #6092: view casters add the source to loader_life_support, but
+    // outside a bound function there is no frame. The caller owns the source's lifetime
+    // here, so the cast must succeed rather than throw.
+    py::str unicode("hello");
+    py::bytes bytes_obj("world", 5);
+    auto bytearray_obj
+        = py::reinterpret_steal<py::object>(PyByteArray_FromStringAndSize("bytes", 5));
+
+    REQUIRE(py::cast<std::string_view>(unicode) == "hello");
+    REQUIRE(py::cast<std::string_view>(bytes_obj) == "world");
+    REQUIRE(py::cast<std::string_view>(bytearray_obj) == "bytes");
+}
+#endif

--- a/tests/test_with_catch/test_interpreter.cpp
+++ b/tests/test_with_catch/test_interpreter.cpp
@@ -523,5 +523,18 @@ TEST_CASE("Casting to a string_view outside a bound function") {
     REQUIRE(py::cast<std::string_view>(unicode) == "hello");
     REQUIRE(py::cast<std::string_view>(bytes_obj) == "world");
     REQUIRE(py::cast<std::string_view>(bytearray_obj) == "bytes");
+
+    // Wide string views require an encoded temporary. With no loader life-support
+    // frame, returning a view into that temporary must fail.
+    REQUIRE_THROWS_AS(py::cast<std::u16string_view>(unicode), py::cast_error);
+    REQUIRE_THROWS_AS(py::cast<std::u32string_view>(unicode), py::cast_error);
+
+    // Bound-function dispatch provides a frame that keeps both temporaries alive.
+    auto accepts_wide_views
+        = py::cpp_function([](std::u16string_view value16, std::u32string_view value32) {
+              return value16 == std::u16string_view(u"hello")
+                     && value32 == std::u32string_view(U"hello");
+          });
+    REQUIRE(accepts_wide_views(unicode, unicode).cast<bool>());
 }
 #endif

--- a/tests/test_with_catch/test_interpreter.cpp
+++ b/tests/test_with_catch/test_interpreter.cpp
@@ -1,6 +1,5 @@
 #include <pybind11/critical_section.h>
 #include <pybind11/embed.h>
-#include <pybind11/stl.h>
 
 // Silence MSVC C++17 deprecation warning from Catch regarding std::uncaught_exceptions (up to
 // catch 2.0.1; this should be fixed in the next catch release after 2.0.1).
@@ -12,10 +11,8 @@ PYBIND11_WARNING_DISABLE_MSVC(4996)
 #include <cstdlib>
 #include <fstream>
 #include <functional>
-#include <string_view>
 #include <thread>
 #include <utility>
-#include <vector>
 
 namespace py = pybind11;
 using namespace py::literals;
@@ -514,10 +511,10 @@ TEST_CASE("make_iterator can be called before then after finalizing an interpret
 }
 
 #ifdef PYBIND11_HAS_STRING_VIEW
-TEST_CASE("Casting to a string_view from a durable source outside a bound function") {
-    // Outside a bound function there is no loader_life_support frame. When the source is a
-    // durable, caller-owned object the view does not need life support, so the cast must
-    // succeed rather than throw (regression from PR #6092).
+TEST_CASE("Casting to a string_view outside a bound function") {
+    // Regression for PR #6092: view casters add the source to loader_life_support, but
+    // outside a bound function there is no frame. The caller owns the source's lifetime
+    // here, so the cast must succeed rather than throw.
     py::str unicode("hello");
     py::bytes bytes_obj("world", 5);
     auto bytearray_obj
@@ -526,22 +523,5 @@ TEST_CASE("Casting to a string_view from a durable source outside a bound functi
     REQUIRE(py::cast<std::string_view>(unicode) == "hello");
     REQUIRE(py::cast<std::string_view>(bytes_obj) == "world");
     REQUIRE(py::cast<std::string_view>(bytearray_obj) == "bytes");
-
-    // A list is durable too: the views point into elements the list keeps alive.
-    py::list durable;
-    durable.append("a");
-    durable.append("b");
-    auto from_list = py::cast<std::vector<std::string_view>>(durable);
-    REQUIRE(from_list.size() == 2);
-    REQUIRE(from_list[0] == "a");
-    REQUIRE(from_list[1] == "b");
-}
-
-TEST_CASE("Casting to a string_view from a transient source outside a bound function") {
-    // A generator is a transient source: the materialized temporary backing the views is
-    // released when the cast returns, and there is no frame to keep it alive. This cannot
-    // be made safe, so it must throw rather than produce dangling views.
-    auto gen = py::eval("('transient_' + str(x) for x in range(5))");
-    REQUIRE_THROWS_AS(py::cast<std::vector<std::string_view>>(gen), py::cast_error);
 }
 #endif


### PR DESCRIPTION
Note: For a consolidated explanation of the original failure mode, the direct-cast regression, and the rationale for the final lifetime model, see the comment ["String-view lifetime: original issue and final design."](https://github.com/pybind/pybind11/pull/6096#issuecomment-5082136036) below.

___

:robot: _AI text below_ :robot:

## Description

Re-applies #6092 and fixes the regression that caused it to be reverted.

#6092 was reverted on master in #6097 because, while it fixed a real use-after-free, it also introduced a regression (details below). This PR re-introduces #6092 and then corrects it, so it is structured as three commits:

1. **revert the revert** — re-applies #6092 on top of the current (reverted) master.
2. **don't throw from string_view life support outside a bound function**
3. **only add string_view life support for transient sources**

### Background

#6092 added `loader_life_support::add_patient(src)` whenever a string **view** (`std::string_view`) is loaded, to fix a **real use-after-free**: when a container of views is built from a *non-sequence iterable* (e.g. a generator), the container caster materializes a temporary (a `tuple`/`dict`, or the generator's per-iteration items) that owns the strings and releases it *before* the bound function body runs, leaving the views dangling. Confirmed under AddressSanitizer (freed-by: `pybind11::tuple::~tuple()` → `tupledealloc` → `unicode_dealloc`; UAF read in the function body). So the fix is needed — simply reverting #6092 reintroduces the UAF.

However, `add_patient` **throws** when there is no life support frame (i.e. outside a bound function dispatch), so casting a view via a manual `py::cast<std::string_view>(obj)` in helper/embedding code started throwing even though the caller owns `obj` — a regression hit in real codebases. That regression is why #6092 was reverted.

### Approach

The view caster cannot tell a **durable**, caller-owned source from a **transient**, pybind11-managed one (a tuple materialized from a generator, or a generator element the iterator only borrows). That provenance lives in the *container* caster. This PR introduces an ambient `detail::transient_source_guard` that the `list`, `set`, `map`, and `array` casters set around their generator/materialized paths, and the string caster keeps the source alive **only when loading from a transient source**.

Result:

| source | inside bound function | outside (no frame) |
|---|---|---|
| durable (direct arg, list/set/dict, manual cast) | no life support added | **works** (no throw) |
| transient (generator/iterator) | kept alive via life support | **throws** (cannot be made safe) |

This addresses both goals: life support is added only when actually needed, and a generator used outside a frame fails loudly instead of silently dangling. The guard *restores* (rather than clears) the previous value, so a durable container nested in a transient one is correctly treated as transient.

The pre-existing `add_patient(utfNbytes)` for UTF-16/32 views stays unconditional: there the view points into a freshly re-encoded temporary that always needs life support regardless of source.

### Tests
- New Catch2 tests in `test_interpreter.cpp` (no-frame context, which `m.def` lambdas can't reproduce since they always have a frame): casting a view from a durable source (str/bytes/bytearray/list) outside a bound function succeeds; casting `std::vector<std::string_view>` from a generator outside a bound function throws `cast_error`.
- #6092's existing `test_stl` generator test continues to cover the in-frame UAF (CI runs it under ASAN).

Verified locally with a standalone libpython+ASAN harness across the full matrix above: in-frame generator is ASAN-clean, out-of-frame durable cases succeed, out-of-frame generator throws.

## Suggested changelog entry:

* String views (e.g. ``std::string_view``) are now kept alive only when loaded from a transient source (such as a generator), fixing both a use-after-free and a regression where casting a view from a durable object outside a bound function would throw.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6096.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->