### PR TITLE
revert: "add life support to handles cast to string_view (#6092)"

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -525,9 +525,6 @@ struct string_caster {
                 return false;
             }
             value = StringType(buffer, static_cast<size_t>(size));
-            if (IsView) {
-                loader_life_support::add_patient(src);
-            }
             return true;
         }
 
@@ -605,9 +602,6 @@ private:
                 pybind11_fail("Unexpected PYBIND11_BYTES_AS_STRING() failure.");
             }
             value = StringType(bytes, (size_t) PYBIND11_BYTES_SIZE(src.ptr()));
-            if (IsView) {
-                loader_life_support::add_patient(src);
-            }
             return true;
         }
         if (PyByteArray_Check(src.ptr())) {
@@ -618,9 +612,6 @@ private:
                 pybind11_fail("Unexpected PyByteArray_AsString() failure.");
             }
             value = StringType(bytearray, (size_t) PyByteArray_Size(src.ptr()));
-            if (IsView) {
-                loader_life_support::add_patient(src);
-            }
             return true;
         }
 

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -582,16 +582,6 @@ TEST_SUBMODULE(stl, m) {
           [](const std::list<std::string> &) { return 2; });
     m.def("func_with_string_or_vector_string_arg_overload", [](const std::string &) { return 3; });
 
-#ifdef PYBIND11_HAS_STRING_VIEW
-    m.def("func_with_string_views", [](const std::vector<std::string_view> &svs) {
-        py::list l;
-        for (std::string_view sv : svs) {
-            l.append(sv);
-        }
-        return l;
-    });
-#endif
-
     class Placeholder {
     public:
         Placeholder() { print_created(this); }

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -28,18 +28,6 @@ def test_vector(doc):
     # Test regression caused by 936: pointers to stl containers weren't castable
     assert m.cast_ptr_vector() == ["lvalue", "lvalue"]
 
-    if hasattr(m, "func_with_string_views"):
-
-        def gen():
-            return ("a" + str(x) for x in range(10000, 10010))
-
-        expected = list(gen())
-        assert m.func_with_string_views(gen()) == expected
-        assert m.func_with_string_views(x.encode() for x in gen()) == expected
-        assert (
-            m.func_with_string_views(bytearray(x.encode()) for x in gen()) == expected
-        )
-
 
 def test_deque():
     """std::deque <-> list"""


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Reverts #6092.

#6092 ("add life support to handles cast to string_view") introduced regressions that are being addressed in #6096. Reverting it here so `master` is clean while the proper fix is worked out.

This is a clean revert of 59d7cb28 — it removes the `loader_life_support::add_patient(src)` calls added to `string_caster` and the accompanying `func_with_string_views` test.

## Suggested changelog entry

Reverted #6092 (string_view life support), which introduced regressions.
