### PR TITLE
fix(ci): use the intended Python interpreter for CMake discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,10 +241,6 @@ jobs:
       matrix:
         include:
           - container: quay.io/pypa/manylinux_2_28_x86_64:latest
-            python-version: '3.13t'
-          - container: quay.io/pypa/musllinux_1_2_x86_64:latest
-            python-version: '3.13t'
-          - container: quay.io/pypa/manylinux_2_28_x86_64:latest
             python-version: '3.14t'
           - container: quay.io/pypa/musllinux_1_2_x86_64:latest
             python-version: '3.14t'

--- a/.github/workflows/reusable-standard.yml
+++ b/.github/workflows/reusable-standard.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup Python ${{ inputs.python-version }}
+        id: python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
@@ -69,10 +70,6 @@ jobs:
 
       # FindPython's version scan can pick a different interpreter (e.g.
       # Homebrew's 3.14 instead of setup-python's 3.14t), so pin it.
-      - name: Locate Python for CMake
-        shell: bash
-        run: echo "PYTHON_EXE=$(python -c 'import sys, pathlib; print(pathlib.Path(sys.executable).as_posix())')" >> "$GITHUB_ENV"
-
       - name: Configure
         run: >
           cmake -S. -Bbuild -Werror=dev
@@ -80,7 +77,7 @@ jobs:
           -DPYBIND11_PYTEST_ARGS=-v
           -DDOWNLOAD_CATCH=ON
           -DDOWNLOAD_EIGEN=ON
-          -DPYTHON_EXECUTABLE=${{ env.PYTHON_EXE }}
+          -DPYTHON_EXECUTABLE=${{ steps.python.outputs.python-path }}
           ${{ inputs.cmake-args }}
 
       - name: Build

--- a/.github/workflows/reusable-standard.yml
+++ b/.github/workflows/reusable-standard.yml
@@ -67,6 +67,12 @@ jobs:
         if: runner.os != 'Windows'
         run: echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
 
+      # FindPython's version scan can pick a different interpreter (e.g.
+      # Homebrew's 3.14 instead of setup-python's 3.14t), so pin it.
+      - name: Locate Python for CMake
+        shell: bash
+        run: echo "PYTHON_EXE=$(python -c 'import sys, pathlib; print(pathlib.Path(sys.executable).as_posix())')" >> "$GITHUB_ENV"
+
       - name: Configure
         run: >
           cmake -S. -Bbuild -Werror=dev
@@ -74,6 +80,7 @@ jobs:
           -DPYBIND11_PYTEST_ARGS=-v
           -DDOWNLOAD_CATCH=ON
           -DDOWNLOAD_EIGEN=ON
+          -DPYTHON_EXECUTABLE=${{ env.PYTHON_EXE }}
           ${{ inputs.cmake-args }}
 
       - name: Build

--- a/.github/workflows/reusable-standard.yml
+++ b/.github/workflows/reusable-standard.yml
@@ -68,8 +68,9 @@ jobs:
         if: runner.os != 'Windows'
         run: echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
 
-      # FindPython's version scan can pick a different interpreter (e.g.
-      # Homebrew's 3.14 instead of setup-python's 3.14t), so pin it.
+      # Pass setup-python's resolved interpreter path to CMake so FindPython
+      # does not select a different interpreter (e.g. Homebrew's 3.14 instead
+      # of setup-python's 3.14t).
       - name: Configure
         run: >
           cmake -S. -Bbuild -Werror=dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,16 @@ if(PYBIND11_MASTER_PROJECT)
       set(Python_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.venv")
     endif()
   endif()
+
+  # Python_ROOT_DIR is only a hint; a newer Python elsewhere on the system
+  # still wins the version scan, so pin the venv's interpreter directly.
+  if(DEFINED Python_ROOT_DIR AND NOT DEFINED Python_EXECUTABLE)
+    if(WIN32 AND EXISTS "${Python_ROOT_DIR}/Scripts/python.exe")
+      set(Python_EXECUTABLE "${Python_ROOT_DIR}/Scripts/python.exe")
+    elseif(EXISTS "${Python_ROOT_DIR}/bin/python")
+      set(Python_EXECUTABLE "${Python_ROOT_DIR}/bin/python")
+    endif()
+  endif()
 endif()
 
 set(PYBIND11_HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,8 +178,9 @@ if(PYBIND11_MASTER_PROJECT)
     endif()
   endif()
 
-  # Python_ROOT_DIR is only a hint; a newer Python elsewhere on the system
-  # still wins the version scan, so pin the venv's interpreter directly.
+  # Python_ROOT_DIR is only a search hint, so FindPython may select a newer
+  # Python elsewhere. Set Python_EXECUTABLE to the venv's interpreter path
+  # to bypass interpreter discovery.
   if(DEFINED Python_ROOT_DIR AND NOT DEFINED Python_EXECUTABLE)
     if(WIN32 AND EXISTS "${Python_ROOT_DIR}/Scripts/python.exe")
       set(Python_EXECUTABLE "${Python_ROOT_DIR}/Scripts/python.exe")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Description

CI has been red since the manylinux/musllinux images added Python 3.15 and dropped 3.13t, and the same runner refresh broke the free-threaded jobs on macOS and Windows:

- In the manylinux jobs, `uv` creates the requested venv, but `Python_ROOT_DIR` is only a hint: FindPython's version scan tries 3.15 first and finds `/usr/local/bin/python3.15` on PATH before considering the venv's older interpreter. All four jobs then built against 3.15 and failed at the pytest step (`No module named pytest`).
- In the standard macOS/Windows 3.14t jobs, FindPython picked a system GIL 3.14 (e.g. Homebrew's framework build) instead of setup-python's free-threaded interpreter.

Fixes:

- `CMakeLists.txt`: when the venv machinery sets `Python_ROOT_DIR`, also pin `Python_EXECUTABLE` to the venv's interpreter, making discovery exact instead of heuristic.
- `reusable-standard.yml`: pass setup-python's interpreter to CMake as `-DPYTHON_EXECUTABLE` (works in both old and new FindPython modes).
- `ci.yml`: drop the 3.13t manylinux rows; the images no longer ship 3.13t, and 3.14t rows already exist.

## Suggested changelog entry:

<!-- no entry needed -->