### PR TITLE
ci: drop near-duplicate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,30 +81,16 @@ jobs:
             python-version: '3.10'
             cmake-args: -DCMAKE_CXX_STANDARD=20
           - runs-on: ubuntu-latest
-            python-version: '3.11'
-            cmake-args: -DPYBIND11_TEST_SMART_HOLDER=ON -DCMAKE_CXX_STANDARD=17
-          - runs-on: ubuntu-latest
             python-version: '3.12'
             cmake-args: -DPYBIND11_TEST_SMART_HOLDER=ON -DPYBIND11_SIMPLE_GIL_MANAGEMENT=ON
           - runs-on: ubuntu-latest
-            python-version: '3.14t'
-            cmake-args: -DCMAKE_CXX_STANDARD=20 -DPYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION=ON
-          - runs-on: ubuntu-latest
             python-version: '3.14'
             cmake-args: -DCMAKE_CXX_STANDARD=14
-          - runs-on: ubuntu-latest
-            python-version: 'pypy-3.11-v7.3.23'
-            cmake-args: -DCMAKE_CXX_STANDARD=14
-          - runs-on: ubuntu-latest
-            python-version: 'graalpy-25.0'
 
           # No SciPy for macOS ARM
           - runs-on: macos-15-intel
             python-version: '3.8'
             cmake-args: -DCMAKE_CXX_STANDARD=14
-          - runs-on: macos-15-intel
-            python-version: '3.11'
-            cmake-args: -DPYBIND11_TEST_SMART_HOLDER=ON
           - runs-on: macos-15-intel
             python-version: '3.13'
             cmake-args: -DCMAKE_CXX_STANDARD=11
@@ -125,9 +111,6 @@ jobs:
           - runs-on: windows-2022
             python-version: '3.8'
             cmake-args: -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DPYBIND11_NUMPY_1_ONLY=ON
-          - runs-on: windows-2022
-            python-version: '3.9'
-            cmake-args: -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL -DCMAKE_CXX_STANDARD=14
           # This needs a python built with MTd
           # - runs-on: windows-2022
           #   python-version: '3.11'
@@ -278,8 +261,6 @@ jobs:
           - clang: 5
             std: 14
           - clang: 11
-            std: 20
-          - clang: 14
             std: 20
           - clang: 16
             std: 20
@@ -465,7 +446,6 @@ jobs:
         include:
           - { gcc: 9, std: 20 }
           - { gcc: 10, std: 17 }
-          - { gcc: 10, std: 20 }
           - { gcc: 13, std: 20, cxx_flags: "-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls" }
 
     name: "🐍 3 • GCC ${{ matrix.gcc }} • C++${{ matrix.std }} • x64${{ matrix.cxx_flags && ' • cxx_flags' || '' }}"
@@ -509,25 +489,6 @@ jobs:
 
     - name: Visibility test
       run: cmake --build build --target test_cross_module_rtti
-
-    - name: Configure - Exercise cmake -DPYBIND11_TEST_OVERRIDE
-      if: matrix.gcc == '12'
-      shell: bash
-      run: >
-        cmake -S . -B build_partial
-        -DPYBIND11_WERROR=ON
-        -DDOWNLOAD_CATCH=ON
-        -DCMAKE_CXX_STANDARD=${{ matrix.std }}
-        -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
-        "-DPYBIND11_TEST_OVERRIDE=test_call_policies.cpp;test_gil_scoped.cpp;test_thread.cpp"
-
-    - name: Build - Exercise cmake -DPYBIND11_TEST_OVERRIDE
-      if: matrix.gcc == '12'
-      run: cmake --build build_partial -j 2
-
-    - name: Python tests - Exercise cmake -DPYBIND11_TEST_OVERRIDE
-      if: matrix.gcc == '12'
-      run: cmake --build build_partial --target pytest
 
   # Testing on ICC using the oneAPI apt repo
   icc:
@@ -796,8 +757,6 @@ jobs:
         include:
           - python: '3.8'
             args: -DCMAKE_CXX_STANDARD=17
-          - python: '3.10'
-            args: -DCMAKE_CXX_STANDARD=20
           - python: '3.13'
 
 
@@ -851,8 +810,6 @@ jobs:
         include:
           - python: 3.9
             args: -DCMAKE_CXX_STANDARD=20
-          - python: 3.8
-            args: -DCMAKE_CXX_STANDARD=17
 
     name: "🐍 ${{ matrix.python }} • MSVC 2022 (Debug) • x86 ${{ matrix.args }}"
     runs-on: windows-2022


### PR DESCRIPTION
I trimmed some things that were not adding much, to try to speed up the CI just a bit.

:robot: _AI text below_ :robot:

## Description

Trims ~10 jobs from each non-draft PR run (~76 → ~66) by removing near-duplicates; every interpreter × OS pair and every distinct flag keeps at least one job:

- `standard-large` ubuntu pypy-3.11 and graalpy — both still run on ubuntu in `standard-small` (so on drafts too), plus macOS, and pypy on Windows.
- `standard-large` ubuntu 3.11 smart_holder and macos-15-intel 3.11 smart_holder — smart_holder still runs on ubuntu 3.12, ubuntu 3.14t, and Windows 3.9/3.10.
- `standard-large` ubuntu 3.14t — free-threading still runs on ubuntu (small), macOS, Windows, manylinux, and musllinux; `PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION` stays covered by macOS 3.12.
- windows-2022 3.9 `MultiThreadedDLL` — that runtime is the CMake default, so this was a plain 3.9 MSVC job; the non-default runtimes keep their jobs.
- clang 14 (between clang 11 and 16, all C++20) and gcc 10/C++20 (between gcc 9/C++20 and gcc 10/C++17).
- win32 3.10 and win32-debug 3.8 — x86 keeps its endpoints (3.8/C++17, 3.13) plus one Debug job.

Also deletes the `PYBIND11_TEST_OVERRIDE` steps in the gcc job: they were gated on `matrix.gcc == 12`, which is no longer in the matrix, so they have been dead for a while. The windows-2022 job still runs the same exercise.