### PR TITLE
ci: test Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
           - runs-on: ubuntu-latest
             python-version: 'graalpy-25.0'
             cmake-args: -DCMAKE_CXX_STANDARD=20
+          - runs-on: ubuntu-latest
+            python-version: '3.15'
+            cmake-args: -DCMAKE_CXX_STANDARD=20
           - runs-on: macos-latest
             python-version: '3.14'
             cmake-args: -DCMAKE_CXX_STANDARD=14
@@ -86,6 +89,9 @@ jobs:
           - runs-on: ubuntu-latest
             python-version: '3.14'
             cmake-args: -DCMAKE_CXX_STANDARD=14
+          - runs-on: ubuntu-latest
+            python-version: '3.15t'
+            cmake-args: -DCMAKE_CXX_STANDARD=17 -DPYBIND11_TEST_SMART_HOLDER=ON
 
           # No SciPy for macOS ARM
           - runs-on: macos-15-intel
@@ -100,6 +106,9 @@ jobs:
           - runs-on: macos-latest
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=20
+          - runs-on: macos-latest
+            python-version: '3.15'
+            cmake-args: -DCMAKE_CXX_STANDARD=17
           - runs-on: macos-latest
             python-version: 'pypy-3.11-v7.3.23'
           - runs-on: macos-latest
@@ -127,6 +136,9 @@ jobs:
           - runs-on: windows-latest
             python-version: '3.14t'
             cmake-args: -DCMAKE_CXX_STANDARD=23
+          - runs-on: windows-latest
+            python-version: '3.15'
+            cmake-args: -DCMAKE_CXX_STANDARD=20
           - runs-on: windows-latest
             python-version: 'pypy3.11'
             cmake-args: -DCMAKE_CXX_STANDARD=20

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   standard:
-    name: "🐍 3.13 latest • ubuntu-latest • x64"
+    name: "🐍 3.15 latest • ubuntu-latest • x64"
     runs-on: ubuntu-latest
     # Only runs when the  'python dev' label is selected
     if: "contains(github.event.pull_request.labels.*.name, 'python dev')"
@@ -26,10 +26,10 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - name: Setup Python 3.13
+    - name: Setup Python 3.15
       uses: actions/setup-python@v6
       with:
-        python-version: "3.13"
+        python-version: "3.15"
         allow-prereleases: true
 
     - name: Setup Boost

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: C++",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,8 @@
 --extra-index-url=https://www.graalvm.org/python/wheels
 --only-binary=:all:
 build>=1
+# No released numpy has cp315 wheels yet; drop the upper bound once it does.
+numpy>=2.4.0; platform_python_implementation=="CPython" and python_version>="3.14" and python_version<"3.15"
 numpy~=1.23.0; python_version=="3.8" and platform_python_implementation=="PyPy"
 numpy~=1.25.0; python_version=="3.9" and platform_python_implementation=="PyPy"
 numpy~=2.2.0; python_version=="3.10" and platform_python_implementation=="PyPy"
@@ -10,7 +12,6 @@ numpy~=1.22.2; platform_python_implementation=="CPython" and python_version=="3.
 numpy~=1.26.0; platform_python_implementation=="CPython" and python_version>="3.11" and python_version<"3.13" and platform_machine!="ARM64"
 numpy>=2.3.0; platform_python_implementation=="CPython" and python_version>="3.11" and platform_machine=="ARM64"
 numpy~=2.2.0; platform_python_implementation=="CPython" and python_version=="3.13" and platform_machine!="ARM64"
-numpy>=2.4.0; platform_python_implementation=="CPython" and python_version>="3.14"
 pytest>=6
 pytest-timeout
 scipy~=1.5.4; platform_python_implementation=="CPython" and python_version<"3.10"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 
 import pytest
@@ -123,6 +124,8 @@ def test_python_alreadyset_in_destructor(monkeypatch, capsys):
     assert triggered is True
 
     _, captured_stderr = capsys.readouterr()
+    # Python 3.15 colorizes this traceback when FORCE_COLOR is set.
+    captured_stderr = re.sub(r"\x1b\[[0-9;]*m", "", captured_stderr)
     assert captured_stderr.startswith("Exception ignored in: 'already_set demo'")
     assert captured_stderr.rstrip().endswith("KeyError: 'bar'")
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -124,8 +124,8 @@ def test_python_alreadyset_in_destructor(monkeypatch, capsys):
     assert triggered is True
 
     _, captured_stderr = capsys.readouterr()
-    # Python 3.15 colorizes this traceback when FORCE_COLOR is set.
-    captured_stderr = re.sub(r"\x1b\[[0-9;]*m", "", captured_stderr)
+    # Strip ANSI codes that Python 3.15+ adds to this traceback under FORCE_COLOR.
+    captured_stderr = re.sub(r"\x1b\[[0-?]*[ -/]*m", "", captured_stderr)
     assert captured_stderr.startswith("Exception ignored in: 'already_set demo'")
     assert captured_stderr.rstrip().endswith("KeyError: 'bar'")
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Description

Adds Python 3.15 to the CI matrix: Linux, macOS, and Windows, plus 3.15t (free-threaded) on Linux. `reusable-standard.yml` already passes `allow-prereleases: true`, so no change was needed there.

The `upstream.yml` workflow — the one gated behind the `python dev` label, meant for pre-release Pythons — was still pinned to 3.13, so it no longer tested anything upstream. It now uses 3.15.

Turning the jobs on found two real problems, both fixed here:

- No released numpy has cp315 wheels, and the install runs under `--only-binary`, so nothing resolved. `tests/requirements.txt` now bounds numpy to `python_version<"3.15"`; drop that bound when wheels land. Every numpy use in the tests is behind `importorskip`, so the numpy and Eigen modules skip until then.
- `test_python_alreadyset_in_destructor` failed because 3.15 colorizes the traceback the default unraisable hook writes when `FORCE_COLOR` is set, which CI sets. The test now strips ANSI codes before checking the exception line.

Also adds the 3.15 classifier.

Beyond CI, the full suite was run locally against 3.15.0b4: 993 passed, 40 skipped, plus the C++ tests.

## Suggested changelog entry

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Test Python 3.15 in CI.


