### PR TITLE
chore(tools): make_changelog missed and resurrected PRs

### DIFF
--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -28,6 +28,9 @@ MD_ENTRY = re.compile(
     """,
     re.DOTALL | re.VERBOSE | re.MULTILINE,
 )
+# Conventional commit prefix, such as "fix(cmake)!:"
+TITLE_CAT = re.compile(r"(?P<cat>\w+)(?:\((?P<sub>[^)]+)\))?!?:")
+
 print()
 
 
@@ -67,20 +70,15 @@ missing = []
 old = []
 cats_descr = {
     "feat": "New Features",
-    "feat(types)": "",
-    "feat(cmake)": "",
     "fix": "Bug fixes",
-    "fix(types)": "",
-    "fix(cmake)": "",
-    "fix(free-threading)": "",
     "docs": "Documentation",
     "tests": "Tests",
     "ci": "CI",
     "chore": "Other",
-    "chore(cmake)": "",
     "unknown": "Uncategorised",
 }
-cats: dict[str, list[str]] = {c: [] for c in cats_descr}
+# Each main category maps its subcategories ("" if there is none) to entries
+cats: dict[str, dict[str, list[str]]] = {c: {} for c in cats_descr}
 
 for issue in issues:
     if "```rst" in issue.body:
@@ -107,22 +105,26 @@ for issue in issues:
         continue
 
     msg += f"\n  [#{issue.number}]({issue.html_url})"
-    for cat, cat_list in cats.items():
-        if issue.title.lower().startswith(f"{cat}:"):
-            cat_list.append(msg)
-            break
-    else:
-        cats["unknown"].append(msg)
+    title = TITLE_CAT.match(issue.title)
+    cat = title.group("cat").lower() if title else "unknown"
+    sub = (title.group("sub") or "").lower() if title else ""
+    if cat not in cats:
+        cat, sub = "unknown", ""
+    cats[cat].setdefault(sub, []).append(msg)
 
-for cat, msgs in cats.items():
-    if msgs:
-        desc = cats_descr[cat]
-        print(f"[bold]{desc}:" if desc else f"<!-- {cat} -->")
+for cat, subs in cats.items():
+    if subs:
+        print(f"[bold]{cats_descr[cat]}:")
         print()
-        for msg in msgs:
-            print(Syntax(msg, "md", theme="ansi_light", word_wrap=True))
+        # An empty subcategory sorts first, so plain entries lead the section
+        for sub in sorted(subs):
+            if sub:
+                print(f"<!-- {cat}({sub}) -->")
+                print()
+            for msg in subs[sub]:
+                print(Syntax(msg, "md", theme="ansi_light", word_wrap=True))
+                print()
             print()
-        print()
 
 if missing:
     print()

--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env -S uv run
 
 # /// script
-# dependencies = ["ghapi", "rich"]
+# dependencies = ["ghapi>=2", "rich"]
 # ///
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 
 import ghapi.all
 from rich import print
@@ -14,7 +16,7 @@ from rich.syntax import Syntax
 
 MD_ENTRY = re.compile(
     r"""
-    \#\#\ Suggested\ changelog\ entry:     # Match the heading exactly
+    ^\#+\ Suggested\ changelog\ entry:?\s*$ # Match the heading, colon optional
     (?:\s*<!--.*?-->)?                     # Optionally match one comment
     (?P<content>.*?)                       # Lazily capture content until...
     (?=                                    # Lookahead for one of the following:
@@ -29,12 +31,38 @@ MD_ENTRY = re.compile(
 print()
 
 
-api = ghapi.all.GhApi(owner="pybind", repo="pybind11")
+def get_token() -> str | None:
+    """
+    Unauthenticated requests get a shared CDN cache ("Cache-Control: public"),
+    which returns stale bodies and labels. A token makes the cache private.
+    """
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        return token
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"], capture_output=True, text=True, check=True
+        )
+    except (OSError, subprocess.CalledProcessError):
+        print("[yellow]No GitHub token found; results may be stale (cached).")
+        return None
+    return result.stdout.strip()
 
-issues_pages = ghapi.page.paged(
-    api.issues.list_for_repo, labels="needs changelog", state="closed"
+
+LABEL = "needs changelog"
+
+api = ghapi.all.GhApi(owner="pybind", repo="pybind11", token=get_token(), sync=True)
+
+issues_pages = ghapi.page.sync_paged(
+    api.issues.list_for_repo, labels=LABEL, state="closed"
 )
-issues = (issue for page in issues_pages for issue in page)
+# The server-side label filter lags behind label removals, so re-check each issue
+issues = (
+    issue
+    for page in issues_pages
+    for issue in page
+    if any(label.name == LABEL for label in issue.labels)
+)
 missing = []
 old = []
 cats_descr = {

--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -54,7 +54,7 @@ LABEL = "needs changelog"
 api = ghapi.all.GhApi(owner="pybind", repo="pybind11", token=get_token(), sync=True)
 
 issues_pages = ghapi.page.sync_paged(
-    api.issues.list_for_repo, labels=LABEL, state="closed"
+    api.issues.list_for_repo, labels=LABEL, state="closed", per_page=100
 )
 # The server-side label filter lags behind label removals, so re-check each issue
 issues = (


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`nox -s make_changelog` skipped some PRs, showed old descriptions for others, and listed PRs whose label was already removed. There were three separate causes:

1. **Stale PR bodies.** The requests were unauthenticated, so GitHub replied with `Cache-Control: public` and a shared CDN cache supplied old descriptions. The script now sends a token from `GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`. This also raises the rate limit from 60/hr to 5000/hr, which pagination needs.
2. **Skipped entries.** The heading regex required a trailing colon, so `## Suggested changelog entry` without one was reported as missing. The colon is now optional.
3. **Unlabeled PRs coming back.** GitHub's `labels=` list filter is eventually consistent and lagged a label removal by more than 20 minutes, even authenticated and with a cache-busting parameter. Each issue's own `labels` array is now re-checked on the client.

Two more changes on top:

- **Subcategories group automatically.** Only the main categories are listed now. A conventional commit scope such as `fix(cmake):` becomes a group inside its main category, printed under `<!-- fix(cmake) -->` and sorted alphabetically after the entries that have no scope. The main heading also prints when a category holds only scoped entries, which `feat(subinterpreter)` did not get before. A breaking-change `!` in the prefix is accepted.
- **100 issues per page** instead of the default 30.

Also moves to `ghapi>=2` and its sync API.

Checked against the current label set: the false "missing" reports and the resurrected PRs are gone, and the remaining reports are PRs that really have no changelog heading.

## Suggested changelog entry:

<!-- no entry needed -->
