### PR TITLE
fix: include `complex` in std::complex input annotation

### DIFF
--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -86,6 +86,8 @@ public:
         return PyComplex_FromDoubles((double) src.real(), (double) src.imag());
     }
 
+    // `complex` does not satisfy `typing.SupportsComplex` in typeshed for Python <= 3.10.
+    // Keep it explicit so generated stubs targeting those versions accept complex values.
     PYBIND11_TYPE_CASTER(
         std::complex<T>,
         io_name("complex | typing.SupportsComplex | typing.SupportsFloat | typing.SupportsIndex",

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -88,7 +88,7 @@ public:
 
     PYBIND11_TYPE_CASTER(
         std::complex<T>,
-        io_name("typing.SupportsComplex | typing.SupportsFloat | typing.SupportsIndex",
+        io_name("complex | typing.SupportsComplex | typing.SupportsFloat | typing.SupportsIndex",
                 "complex"));
 };
 PYBIND11_NAMESPACE_END(detail)

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -565,7 +565,7 @@ def test_complex_cast(doc):
 
     assert (
         doc(convert)
-        == "complex_convert(arg0: typing.SupportsComplex | typing.SupportsFloat | typing.SupportsIndex) -> complex"
+        == "complex_convert(arg0: complex | typing.SupportsComplex | typing.SupportsFloat | typing.SupportsIndex) -> complex"
     )
     assert doc(noconvert) == "complex_noconvert(arg0: complex) -> complex"
 


### PR DESCRIPTION
See https://github.com/pybind/pybind11/discussions/6112.

:robot: _AI text below_ :robot:

## Description

Fixes #6102

The `std::complex<T>` caster declared its input annotation as
`typing.SupportsComplex | typing.SupportsFloat | typing.SupportsIndex`, which
omits the builtin `complex`. In typeshed, `complex` only gets `__complex__` on
Python 3.11+, so on Python 3.10 a strict type checker rejects passing a plain
complex literal, although the caster accepts it. The input annotation now starts
with `complex |`, and the signature test was updated.

## Suggested changelog entry:

* Include the builtin ``complex`` type in the input annotation of the
  ``std::complex<T>`` type caster.

https://claude.ai/code/session_013JABmnjt9oAh29p1pytAB3
