### PR TITLE
fix(cmake): don't pass -fno-fat-lto-objects on Apple GCC

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -353,7 +353,11 @@ function(_pybind11_generate_lto target prefer_thin_lto)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT APPLE)
       # Clang Gold plugin does not support -Os; append -O3 to MinSizeRel builds to override it
       set(linker_append ";$<$<CONFIG:MinSizeRel>:-O3>")
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND NOT MINGW)
+    elseif(
+      CMAKE_CXX_COMPILER_ID MATCHES "GNU"
+      AND NOT MINGW
+      AND NOT APPLE)
+      # GCC on macOS has no linker plugin, which -fno-fat-lto-objects requires
       set(cxx_append ";-fno-fat-lto-objects")
     endif()
 


### PR DESCRIPTION
See https://github.com/pybind/pybind11/discussions/6112.

:robot: _AI text below_ :robot:

## Description

GCC on macOS has no linker plugin. `-fno-fat-lto-objects` needs one, so `cc1plus` fails with "`-fno-fat-lto-objects` are supported only with linker plugin". Because the LTO probe always adds this flag for non-MinGW GNU compilers, every probe (`-flto=auto`, `-flto`) fails and LTO is silently disabled, although plain `-flto=auto` works.

This change skips the flag when `APPLE` is set.

Verified with Homebrew `g++-16` on macOS: before, `HAS_FLTO_AUTO` and `HAS_FLTO` both fail and `pybind11::lto` is disabled; after, `HAS_FLTO_AUTO` succeeds and `pybind11::lto` is enabled. The Apple Clang path is unchanged.

Fixes #6060

## Suggested changelog entry:

* Do not pass `-fno-fat-lto-objects` to GCC on macOS, which made all LTO probes fail and silently disabled LTO.

https://claude.ai/code/session_013JABmnjt9oAh29p1pytAB3
