### PR TITLE
fix(cmake): keep cross-compiling support with CMake 4.1 / CMP0190

### DIFF
--- a/tools/pybind11Common.cmake
+++ b/tools/pybind11Common.cmake
@@ -43,16 +43,16 @@ set(pybind11_INCLUDE_DIRS
 
 # CMP0190 prohibits calling FindPython with both Interpreter and Development components
 # when cross-compiling, unless the CMAKE_CROSSCOMPILING_EMULATOR variable is defined.
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.1")
+# An emulator can run the target interpreter, so it only suppresses this default; a project
+# that asks for cross-compiling support explicitly always gets it (see #6043).
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.1" AND NOT CMAKE_CROSSCOMPILING_EMULATOR)
   cmake_policy(GET CMP0190 _pybind11_cmp0190)
   if(_pybind11_cmp0190 STREQUAL "NEW")
     set(PYBIND11_USE_CROSSCOMPILING "ON")
   endif()
 endif()
 
-if(CMAKE_CROSSCOMPILING
-   AND PYBIND11_USE_CROSSCOMPILING
-   AND NOT DEFINED CMAKE_CROSSCOMPILING_EMULATOR)
+if(CMAKE_CROSSCOMPILING AND PYBIND11_USE_CROSSCOMPILING)
   set(_PYBIND11_CROSSCOMPILING
       ON
       CACHE INTERNAL "")


### PR DESCRIPTION
See https://github.com/pybind/pybind11/discussions/6112. Duplicate of #6094.

:robot: _AI text below_ :robot:

## Description

Fixes #6043. Fix proposed by @mhsmith in #6043.

CMake 4.1 policy CMP0190 requires `CMAKE_CROSSCOMPILING_EMULATOR` to be defined when `FindPython` is called with both `Interpreter` and `Development` while cross-compiling. The Emscripten toolchain file defines it (to `node`) automatically, so the `NOT DEFINED CMAKE_CROSSCOMPILING_EMULATOR` condition added in #5829 turned `_PYBIND11_CROSSCOMPILING` off in exactly the Emscripten/Pyodide case, even when the project set `PYBIND11_USE_CROSSCOMPILING` itself. The build then failed with a spurious "Cannot run the interpreter".

The emulator check now only suppresses the CMP0190-related *default*; an explicit `PYBIND11_USE_CROSSCOMPILING` is honored again. An emulator set to an empty value counts as no emulator.

Verified by simulation (no Emscripten toolchain available), CMake 4.4, CMP0190 `NEW`, `CMAKE_CROSSCOMPILING=ON`. Value of `_PYBIND11_CROSSCOMPILING`:

| emulator | `PYBIND11_USE_CROSSCOMPILING` | before | after |
| --- | --- | --- | --- |
| unset | unset / ON / OFF | ON | ON |
| empty | unset / ON / OFF | OFF | ON |
| real command | unset | OFF | OFF |
| real command | ON | **OFF** | **ON** |
| real command | OFF | OFF | OFF |

The bold row is the reported bug. With CMP0190 `OLD` (or CMake < 4.1) the result is again `CMAKE_CROSSCOMPILING AND PYBIND11_USE_CROSSCOMPILING`, as in pybind11 3.0.1.

## Suggested changelog entry:

* Cross-compiling support is no longer disabled when `CMAKE_CROSSCOMPILING_EMULATOR` is defined, which CMake 4.1's `CMP0190` and the Emscripten toolchain do. This repairs Emscripten/Pyodide builds.

https://claude.ai/code/session_013JABmnjt9oAh29p1pytAB3
