### PR TITLE
fix: align py::print with Python semantics

### DIFF
--- a/docs/advanced/pycpp/utilities.rst
+++ b/docs/advanced/pycpp/utilities.rst
@@ -21,6 +21,11 @@ expected in Python:
     auto args = py::make_tuple("unpacked", true);
     py::print("->", *args, "end"_a="<-"); // -> unpacked True <-
 
+As in Python, omitting ``file`` or passing ``py::none()`` uses the current
+``sys.stdout``. If ``sys.stdout`` is ``None``, :func:`py::print` returns without
+writing; a missing ``sys.stdout`` or an error from a custom stream is still
+reported normally.
+
 .. _ostream_redirect:
 
 Capturing standard output from ostream

--- a/docs/advanced/pycpp/utilities.rst
+++ b/docs/advanced/pycpp/utilities.rst
@@ -21,10 +21,10 @@ expected in Python:
     auto args = py::make_tuple("unpacked", true);
     py::print("->", *args, "end"_a="<-"); // -> unpacked True <-
 
-As in Python, omitting ``file`` or passing ``py::none()`` uses the current
-``sys.stdout``. If ``sys.stdout`` is ``None``, :func:`py::print` returns without
-writing; a missing ``sys.stdout`` or an error from a custom stream is still
-reported normally.
+As in Python, omitting ``file`` or passing ``"file"_a = py::none()`` uses the
+current ``sys.stdout``. If ``sys.stdout`` is ``None``, :func:`py::print` returns
+without writing. During normal interpreter operation, a missing ``sys.stdout``
+or an error from a custom stream is still reported normally.
 
 .. _ostream_redirect:
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3809,7 +3809,7 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         }
         PyObject *stdout_obj = dict_getitemstringref(sys_dict, "stdout");
         if (stdout_obj == nullptr) {
-            PyErr_SetString(PyExc_RuntimeError, "lost sys.stdout");
+            set_error(PyExc_RuntimeError, "lost sys.stdout");
             throw error_already_set();
         }
         file = reinterpret_steal<object>(stdout_obj);
@@ -3826,7 +3826,7 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
                 // A missing sys module indicates interpreter shutdown.
                 return;
             }
-            PyErr_SetString(PyExc_RuntimeError, "lost sys.stdout");
+            set_error(PyExc_RuntimeError, "lost sys.stdout");
             throw error_already_set();
         }
         file = reinterpret_borrow<object>(stdout_obj);
@@ -3838,50 +3838,41 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         }
     }
 
-    if (sep && !sep.is_none() && !PyUnicode_Check(sep.ptr())) {
-        PyErr_Format(PyExc_TypeError,
-                     "sep must be None or a string, not %.200s",
-                     Py_TYPE(sep.ptr())->tp_name);
-        throw error_already_set();
-    }
-
-    if (end && !end.is_none() && !PyUnicode_Check(end.ptr())) {
-        PyErr_Format(PyExc_TypeError,
-                     "end must be None or a string, not %.200s",
-                     Py_TYPE(end.ptr())->tp_name);
-        throw error_already_set();
-    }
-
-    for (size_t i = 0; i < args.size(); ++i) {
-        if (i > 0) {
-            int result = sep && !sep.is_none()
-                             ? PyFile_WriteObject(sep.ptr(), file.ptr(), Py_PRINT_RAW)
-                             : PyFile_WriteString(" ", file.ptr());
-            if (result != 0) {
-                throw error_already_set();
-            }
-        }
-        if (PyFile_WriteObject(args[i].ptr(), file.ptr(), Py_PRINT_RAW) != 0) {
+    // As with Python's print(), an omitted keyword or None selects the default.
+    auto as_string_or_default = [](object &o, const char *name, const char *default_value) {
+        if (!o || o.is_none()) {
+            o = str(default_value);
+        } else if (!PyUnicode_Check(o.ptr())) {
+            PyErr_Format(PyExc_TypeError,
+                         "%s must be None or a string, not %.200s",
+                         name,
+                         Py_TYPE(o.ptr())->tp_name);
             throw error_already_set();
         }
-    }
+    };
+    as_string_or_default(sep, "sep", " ");
+    as_string_or_default(end, "end", "\n");
 
-    int result = end && !end.is_none() ? PyFile_WriteObject(end.ptr(), file.ptr(), Py_PRINT_RAW)
-                                       : PyFile_WriteString("\n", file.ptr());
-    if (result != 0) {
-        throw error_already_set();
+    auto write = [&file](handle text) {
+        if (PyFile_WriteObject(text.ptr(), file.ptr(), Py_PRINT_RAW) != 0) {
+            throw error_already_set();
+        }
+    };
+
+    bool first = true;
+    for (handle arg : args) {
+        if (!first) {
+            write(sep);
+        }
+        first = false;
+        write(arg);
     }
+    write(end);
 
     // Native interpreters differ in when they convert flush to bool. Evaluating it only
     // after successful output preserves py::print's historical behavior.
-    if (flush) {
-        int should_flush = PyObject_IsTrue(flush.ptr());
-        if (should_flush < 0) {
-            throw error_already_set();
-        }
-        if (should_flush != 0) {
-            file.attr("flush")();
-        }
+    if (flush && bool_(flush)) {
+        file.attr("flush")();
     }
 }
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3775,27 +3775,6 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         }
     }
 
-    object flush;
-    if (kwargs.contains("flush")) {
-        flush = kwargs["flush"].cast<object>();
-    }
-    auto flush_is_true = [&flush]() {
-        int result = PyObject_IsTrue(flush.ptr());
-        if (result < 0) {
-            throw error_already_set();
-        }
-        return result != 0;
-    };
-
-    bool should_flush = false;
-#if PY_VERSION_HEX >= 0x03090000 && !defined(PYPY_VERSION) && !defined(GRAALVM_PYTHON)
-    // CPython 3.9+ converts flush to bool during argument parsing. GraalPy does so
-    // after resolving file and validating sep/end; CPython 3.8 and PyPy do so after writing.
-    if (flush) {
-        should_flush = flush_is_true();
-    }
-#endif
-
     object file;
     if (kwargs.contains("file")) {
         file = kwargs["file"].cast<object>();
@@ -3867,12 +3846,6 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         throw error_already_set();
     }
 
-#ifdef GRAALVM_PYTHON
-    if (flush) {
-        should_flush = flush_is_true();
-    }
-#endif
-
     for (size_t i = 0; i < args.size(); ++i) {
         if (i > 0) {
             int result = sep && !sep.is_none()
@@ -3893,13 +3866,16 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         throw error_already_set();
     }
 
-#if (PY_VERSION_HEX < 0x03090000 && !defined(GRAALVM_PYTHON)) || defined(PYPY_VERSION)
-    if (flush) {
-        should_flush = flush_is_true();
-    }
-#endif
-    if (should_flush) {
-        file.attr("flush")();
+    // Native interpreters differ in when they convert flush to bool. Evaluating it only
+    // after successful output preserves py::print's historical behavior.
+    if (kwargs.contains("flush")) {
+        int should_flush = PyObject_IsTrue(kwargs["flush"].ptr());
+        if (should_flush < 0) {
+            throw error_already_set();
+        }
+        if (should_flush != 0) {
+            file.attr("flush")();
+        }
     }
 }
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3764,27 +3764,32 @@ register_local_exception(handle scope, const char *name, handle base = PyExc_Exc
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
+    object file;
+    if (kwargs.contains("file")) {
+        file = kwargs["file"].cast<object>();
+    }
+
+    // As with Python's print(), an omitted file or file=None means sys.stdout.
+    if (!file || file.is_none()) {
+        PyObject *stdout_obj = PySys_GetObject("stdout");
+        if (stdout_obj == nullptr) {
+            PyErr_SetString(PyExc_RuntimeError, "lost sys.stdout");
+            throw error_already_set();
+        }
+        // sys.stdout may be None when stdout is not connected, for example in
+        // a Windows GUI application. In that case, print() is a no-op.
+        if (stdout_obj == Py_None) {
+            return;
+        }
+        file = reinterpret_borrow<object>(stdout_obj);
+    }
+
     auto strings = tuple(args.size());
     for (size_t i = 0; i < args.size(); ++i) {
         strings[i] = str(args[i]);
     }
     auto sep = kwargs.contains("sep") ? kwargs["sep"] : str(" ");
     auto line = sep.attr("join")(std::move(strings));
-
-    object file;
-    if (kwargs.contains("file")) {
-        file = kwargs["file"].cast<object>();
-    } else {
-        try {
-            file = module_::import("sys").attr("stdout");
-        } catch (const error_already_set &) {
-            /* If print() is called from code that is executed as
-               part of garbage collection during interpreter shutdown,
-               importing 'sys' can fail. Give up rather than crashing the
-               interpreter in this case. */
-            return;
-        }
-    }
 
     auto write = file.attr("write");
     write(std::move(line));

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3775,14 +3775,26 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         }
     }
 
-    bool flush = false;
+    object flush;
     if (kwargs.contains("flush")) {
-        int result = PyObject_IsTrue(kwargs["flush"].ptr());
+        flush = kwargs["flush"].cast<object>();
+    }
+    auto flush_is_true = [&flush]() {
+        int result = PyObject_IsTrue(flush.ptr());
         if (result < 0) {
             throw error_already_set();
         }
-        flush = result != 0;
+        return result != 0;
+    };
+
+    bool should_flush = false;
+#if PY_VERSION_HEX >= 0x03090000 && !defined(PYPY_VERSION) && !defined(GRAALVM_PYTHON)
+    // CPython 3.9+ converts flush to bool during argument parsing. GraalPy does so
+    // after resolving file and validating sep/end; CPython 3.8 and PyPy do so after writing.
+    if (flush) {
+        should_flush = flush_is_true();
     }
+#endif
 
     object file;
     if (kwargs.contains("file")) {
@@ -3855,6 +3867,12 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         throw error_already_set();
     }
 
+#ifdef GRAALVM_PYTHON
+    if (flush) {
+        should_flush = flush_is_true();
+    }
+#endif
+
     for (size_t i = 0; i < args.size(); ++i) {
         if (i > 0) {
             int result = sep && !sep.is_none()
@@ -3875,7 +3893,12 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         throw error_already_set();
     }
 
+#if (PY_VERSION_HEX < 0x03090000 && !defined(GRAALVM_PYTHON)) || defined(PYPY_VERSION)
     if (flush) {
+        should_flush = flush_is_true();
+    }
+#endif
+    if (should_flush) {
         file.attr("flush")();
     }
 }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3764,6 +3764,22 @@ register_local_exception(handle scope, const char *name, handle base = PyExc_Exc
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
+    for (auto item : kwargs) {
+        auto key = item.first.cast<std::string>();
+        if (key != "sep" && key != "end" && key != "file" && key != "flush") {
+            throw type_error("'" + key + "' is an invalid keyword argument for print()");
+        }
+    }
+
+    bool flush = false;
+    if (kwargs.contains("flush")) {
+        int result = PyObject_IsTrue(kwargs["flush"].ptr());
+        if (result < 0) {
+            throw error_already_set();
+        }
+        flush = result != 0;
+    }
+
     object file;
     if (kwargs.contains("file")) {
         file = kwargs["file"].cast<object>();
@@ -3771,31 +3787,65 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
 
     // As with Python's print(), an omitted file or file=None means sys.stdout.
     if (!file || file.is_none()) {
-        PyObject *stdout_obj = PySys_GetObject("stdout");
+        object sys;
+        try {
+            sys = module_::import("sys");
+        } catch (const error_already_set &) {
+            // Importing sys can fail while an interpreter is shutting down.
+            return;
+        }
+        PyObject *sys_dict = PyModule_GetDict(sys.ptr());
+        if (sys_dict == nullptr) {
+            throw error_already_set();
+        }
+        // Keep the stream alive if another thread replaces it in a free-threaded build.
+        PyObject *stdout_obj = dict_getitemstringref(sys_dict, "stdout");
         if (stdout_obj == nullptr) {
             PyErr_SetString(PyExc_RuntimeError, "lost sys.stdout");
             throw error_already_set();
         }
+        file = reinterpret_steal<object>(stdout_obj);
         // sys.stdout may be None when stdout is not connected, for example in
         // a Windows GUI application. In that case, print() is a no-op.
-        if (stdout_obj == Py_None) {
+        if (file.is_none()) {
             return;
         }
-        file = reinterpret_borrow<object>(stdout_obj);
+    }
+
+    object sep = kwargs.contains("sep") ? kwargs["sep"].cast<object>() : str(" ");
+    if (sep.is_none()) {
+        sep = str(" ");
+    } else if (!PyUnicode_Check(sep.ptr())) {
+        PyErr_Format(PyExc_TypeError,
+                     "sep must be None or a string, not %.200s",
+                     Py_TYPE(sep.ptr())->tp_name);
+        throw error_already_set();
+    }
+
+    object end = kwargs.contains("end") ? kwargs["end"].cast<object>() : str("\n");
+    if (end.is_none()) {
+        end = str("\n");
+    } else if (!PyUnicode_Check(end.ptr())) {
+        PyErr_Format(PyExc_TypeError,
+                     "end must be None or a string, not %.200s",
+                     Py_TYPE(end.ptr())->tp_name);
+        throw error_already_set();
     }
 
     auto strings = tuple(args.size());
     for (size_t i = 0; i < args.size(); ++i) {
         strings[i] = str(args[i]);
     }
-    auto sep = kwargs.contains("sep") ? kwargs["sep"] : str(" ");
-    auto line = sep.attr("join")(std::move(strings));
+    auto line = reinterpret_steal<object>(PyUnicode_Join(sep.ptr(), strings.ptr()));
+    if (!line) {
+        throw error_already_set();
+    }
 
     auto write = file.attr("write");
     write(std::move(line));
-    write(kwargs.contains("end") ? kwargs["end"] : str("\n"));
+    write(std::move(end));
 
-    if (kwargs.contains("flush") && kwargs["flush"].cast<bool>()) {
+    if (flush) {
         file.attr("flush")();
     }
 }

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3765,9 +3765,13 @@ register_local_exception(handle scope, const char *name, handle base = PyExc_Exc
 PYBIND11_NAMESPACE_BEGIN(detail)
 PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
     for (auto item : kwargs) {
-        auto key = item.first.cast<std::string>();
-        if (key != "sep" && key != "end" && key != "file" && key != "flush") {
-            throw type_error("'" + key + "' is an invalid keyword argument for print()");
+        PyObject *key = item.first.ptr();
+        if (PyUnicode_CompareWithASCIIString(key, "sep") != 0
+            && PyUnicode_CompareWithASCIIString(key, "end") != 0
+            && PyUnicode_CompareWithASCIIString(key, "file") != 0
+            && PyUnicode_CompareWithASCIIString(key, "flush") != 0) {
+            PyErr_Format(PyExc_TypeError, "'%U' is an invalid keyword argument for print()", key);
+            throw error_already_set();
         }
     }
 
@@ -3787,6 +3791,10 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
 
     // As with Python's print(), an omitted file or file=None means sys.stdout.
     if (!file || file.is_none()) {
+#ifdef Py_GIL_DISABLED
+        // PySys_GetObject() returns a borrowed reference. Use a strong reference
+        // because sys.stdout can be replaced concurrently in a free-threaded build;
+        // importing sys is the only public API that provides one.
         object sys;
         try {
             sys = module_::import("sys");
@@ -3798,13 +3806,26 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         if (sys_dict == nullptr) {
             throw error_already_set();
         }
-        // Keep the stream alive if another thread replaces it in a free-threaded build.
         PyObject *stdout_obj = dict_getitemstringref(sys_dict, "stdout");
         if (stdout_obj == nullptr) {
             PyErr_SetString(PyExc_RuntimeError, "lost sys.stdout");
             throw error_already_set();
         }
         file = reinterpret_steal<object>(stdout_obj);
+#else
+        PyObject *stdout_obj = PySys_GetObject("stdout");
+        if (stdout_obj == nullptr) {
+            try {
+                module_::import("sys");
+            } catch (const error_already_set &) {
+                // A missing sys module indicates interpreter shutdown.
+                return;
+            }
+            PyErr_SetString(PyExc_RuntimeError, "lost sys.stdout");
+            throw error_already_set();
+        }
+        file = reinterpret_borrow<object>(stdout_obj);
+#endif
         // sys.stdout may be None when stdout is not connected, for example in
         // a Windows GUI application. In that case, print() is a no-op.
         if (file.is_none()) {
@@ -3812,38 +3833,47 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         }
     }
 
-    object sep = kwargs.contains("sep") ? kwargs["sep"].cast<object>() : str(" ");
-    if (sep.is_none()) {
-        sep = str(" ");
-    } else if (!PyUnicode_Check(sep.ptr())) {
+    object sep;
+    if (kwargs.contains("sep")) {
+        sep = kwargs["sep"].cast<object>();
+    }
+    if (sep && !sep.is_none() && !PyUnicode_Check(sep.ptr())) {
         PyErr_Format(PyExc_TypeError,
                      "sep must be None or a string, not %.200s",
                      Py_TYPE(sep.ptr())->tp_name);
         throw error_already_set();
     }
 
-    object end = kwargs.contains("end") ? kwargs["end"].cast<object>() : str("\n");
-    if (end.is_none()) {
-        end = str("\n");
-    } else if (!PyUnicode_Check(end.ptr())) {
+    object end;
+    if (kwargs.contains("end")) {
+        end = kwargs["end"].cast<object>();
+    }
+    if (end && !end.is_none() && !PyUnicode_Check(end.ptr())) {
         PyErr_Format(PyExc_TypeError,
                      "end must be None or a string, not %.200s",
                      Py_TYPE(end.ptr())->tp_name);
         throw error_already_set();
     }
 
-    auto strings = tuple(args.size());
     for (size_t i = 0; i < args.size(); ++i) {
-        strings[i] = str(args[i]);
-    }
-    auto line = reinterpret_steal<object>(PyUnicode_Join(sep.ptr(), strings.ptr()));
-    if (!line) {
-        throw error_already_set();
+        if (i > 0) {
+            int result = sep && !sep.is_none()
+                             ? PyFile_WriteObject(sep.ptr(), file.ptr(), Py_PRINT_RAW)
+                             : PyFile_WriteString(" ", file.ptr());
+            if (result != 0) {
+                throw error_already_set();
+            }
+        }
+        if (PyFile_WriteObject(args[i].ptr(), file.ptr(), Py_PRINT_RAW) != 0) {
+            throw error_already_set();
+        }
     }
 
-    auto write = file.attr("write");
-    write(std::move(line));
-    write(std::move(end));
+    int result = end && !end.is_none() ? PyFile_WriteObject(end.ptr(), file.ptr(), Py_PRINT_RAW)
+                                       : PyFile_WriteString("\n", file.ptr());
+    if (result != 0) {
+        throw error_already_set();
+    }
 
     if (flush) {
         file.attr("flush")();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3791,9 +3791,11 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
     // As with Python's print(), an omitted file or file=None means sys.stdout.
     if (!file || file.is_none()) {
 #ifdef Py_GIL_DISABLED
-        // PySys_GetObject() returns a borrowed reference. Use a strong reference
-        // because sys.stdout can be replaced concurrently in a free-threaded build;
-        // importing sys is the only public API that provides one.
+        // CPython's built-in print() gets a strong reference to the current interpreter's
+        // sys.stdout with the private _PySys_GetRequiredAttr(), which is unavailable to
+        // extension modules. The public PySys_GetObject() returns only a borrowed reference
+        // that another thread could invalidate, so import sys and use a strong-reference
+        // dictionary lookup instead.
         object sys;
         try {
             sys = module_::import("sys");
@@ -3812,6 +3814,10 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         }
         file = reinterpret_steal<object>(stdout_obj);
 #else
+        // With the GIL held, no other thread can replace sys.stdout between the borrowed
+        // lookup and incrementing its reference count. PySys_GetObject() also reads the
+        // current interpreter's sys dictionary directly, matching CPython's built-in print()
+        // without consulting sys.modules.
         PyObject *stdout_obj = PySys_GetObject("stdout");
         if (stdout_obj == nullptr) {
             try {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3764,20 +3764,28 @@ register_local_exception(handle scope, const char *name, handle base = PyExc_Exc
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
+    object sep;
+    object end;
+    object file;
+    object flush;
+
     for (auto item : kwargs) {
         PyObject *key = item.first.ptr();
-        if (PyUnicode_CompareWithASCIIString(key, "sep") != 0
-            && PyUnicode_CompareWithASCIIString(key, "end") != 0
-            && PyUnicode_CompareWithASCIIString(key, "file") != 0
-            && PyUnicode_CompareWithASCIIString(key, "flush") != 0) {
+        auto key_is
+            = [key](const char *name) { return PyUnicode_CompareWithASCIIString(key, name) == 0; };
+
+        if (key_is("sep")) {
+            sep = reinterpret_borrow<object>(item.second);
+        } else if (key_is("end")) {
+            end = reinterpret_borrow<object>(item.second);
+        } else if (key_is("file")) {
+            file = reinterpret_borrow<object>(item.second);
+        } else if (key_is("flush")) {
+            flush = reinterpret_borrow<object>(item.second);
+        } else {
             PyErr_Format(PyExc_TypeError, "'%U' is an invalid keyword argument for print()", key);
             throw error_already_set();
         }
-    }
-
-    object file;
-    if (kwargs.contains("file")) {
-        file = kwargs["file"].cast<object>();
     }
 
     // As with Python's print(), an omitted file or file=None means sys.stdout.
@@ -3824,10 +3832,6 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         }
     }
 
-    object sep;
-    if (kwargs.contains("sep")) {
-        sep = kwargs["sep"].cast<object>();
-    }
     if (sep && !sep.is_none() && !PyUnicode_Check(sep.ptr())) {
         PyErr_Format(PyExc_TypeError,
                      "sep must be None or a string, not %.200s",
@@ -3835,10 +3839,6 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
         throw error_already_set();
     }
 
-    object end;
-    if (kwargs.contains("end")) {
-        end = kwargs["end"].cast<object>();
-    }
     if (end && !end.is_none() && !PyUnicode_Check(end.ptr())) {
         PyErr_Format(PyExc_TypeError,
                      "end must be None or a string, not %.200s",
@@ -3868,8 +3868,8 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
 
     // Native interpreters differ in when they convert flush to bool. Evaluating it only
     // after successful output preserves py::print's historical behavior.
-    if (kwargs.contains("flush")) {
-        int should_flush = PyObject_IsTrue(kwargs["flush"].ptr());
+    if (flush) {
+        int should_flush = PyObject_IsTrue(flush.ptr());
         if (should_flush < 0) {
             throw error_already_set();
         }

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -643,6 +643,9 @@ TEST_SUBMODULE(pytypes, m) {
             "{a} + {b} = {c}"_s.format("a"_a = "py::print", "b"_a = "str.format", "c"_a = "this"));
     });
 
+    m.def("print_args",
+          [](const py::args &args, const py::kwargs &kwargs) { py::print(*args, **kwargs); });
+
     m.def("print_failure", []() { py::print(42, UnregisteredType()); });
 
     m.def("hash_function", [](py::object obj) { return py::hash(std::move(obj)); });

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -660,43 +660,37 @@ def test_print_flush_uses_python_truthiness():
     assert output.flush_count == 1
 
 
-def test_print_flush_truthiness_error_after_output():
-    class MarkerError(Exception):
-        pass
+class PrintMarkerError(Exception):
+    pass
 
+
+def test_print_flush_truthiness_error_after_output():
     class BadFlush:
         def __bool__(self):
-            raise MarkerError
+            raise PrintMarkerError
 
     output = StringIO()
-    with pytest.raises(MarkerError):
+    with pytest.raises(PrintMarkerError):
         m.print_args("text", file=output, flush=BadFlush())
     assert output.getvalue() == "text\n"
 
 
 def test_print_propagates_stream_errors():
-    class MarkerError(Exception):
-        pass
-
     class BadWrite:
         def write(self, value):
-            raise MarkerError(value)
+            raise PrintMarkerError(value)
 
-    with pytest.raises(MarkerError, match="text"):
+    with pytest.raises(PrintMarkerError, match="text"):
         m.print_args("text", file=BadWrite())
 
     class BadFlush(StringIO):
         def flush(self):
-            raise MarkerError("flush")
+            raise PrintMarkerError("flush")
 
     output = BadFlush()
-    with pytest.raises(MarkerError, match="flush"):
+    with pytest.raises(PrintMarkerError, match="flush"):
         m.print_args("text", file=output, flush=True)
     assert output.getvalue() == "text\n"
-
-
-class PrintMarkerError(Exception):
-    pass
 
 
 def pybind_print_trace(failure):

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -584,7 +584,11 @@ def test_print_file_none_and_stdout(monkeypatch, capture):
     m.print_args(BadStr())
     m.print_args(BadStr(), file=None)
 
-    output = StringIO()
+    class FalseyStream(StringIO):
+        def __bool__(self):
+            return False
+
+    output = FalseyStream()
     m.print_args("explicit stream", file=output)
     assert output.getvalue() == "explicit stream\n"
 
@@ -593,6 +597,78 @@ def test_print_missing_stdout(monkeypatch):
     monkeypatch.delattr(sys, "stdout")
     with pytest.raises(RuntimeError, match="^lost sys.stdout$"):
         m.print_args("no stream")
+
+
+def test_print_none_separator_and_end():
+    output = StringIO()
+    m.print_args("one", "two", sep=None, end=None, file=output)
+    assert output.getvalue() == "one two\n"
+
+
+@pytest.mark.parametrize("keyword", ["sep", "end"])
+def test_print_rejects_non_string_separator_and_end(keyword):
+    output = StringIO()
+    with pytest.raises(TypeError, match=f"^{keyword} must be None or a string"):
+        m.print_args("text", file=output, **{keyword: object()})
+    assert output.getvalue() == ""
+
+
+def test_print_rejects_unknown_keyword():
+    with pytest.raises(
+        TypeError, match="^'unknown' is an invalid keyword argument for print\\(\\)$"
+    ):
+        m.print_args("text", unknown=True)
+
+
+def test_print_flush_uses_python_truthiness():
+    class Stream(StringIO):
+        def __init__(self):
+            super().__init__()
+            self.flush_count = 0
+
+        def flush(self):
+            self.flush_count += 1
+
+    output = Stream()
+    m.print_args("not flushed", file=output, flush=[])
+    m.print_args("flushed", file=output, flush=[1])
+    assert output.getvalue() == "not flushed\nflushed\n"
+    assert output.flush_count == 1
+
+
+def test_print_flush_truthiness_error_precedes_output():
+    class MarkerError(Exception):
+        pass
+
+    class BadFlush:
+        def __bool__(self):
+            raise MarkerError
+
+    output = StringIO()
+    with pytest.raises(MarkerError):
+        m.print_args("text", file=output, flush=BadFlush())
+    assert output.getvalue() == ""
+
+
+def test_print_propagates_stream_errors():
+    class MarkerError(Exception):
+        pass
+
+    class BadWrite:
+        def write(self, value):
+            raise MarkerError(value)
+
+    with pytest.raises(MarkerError, match="text"):
+        m.print_args("text", file=BadWrite())
+
+    class BadFlush(StringIO):
+        def flush(self):
+            raise MarkerError("flush")
+
+    output = BadFlush()
+    with pytest.raises(MarkerError, match="flush"):
+        m.print_args("text", file=output, flush=True)
+    assert output.getvalue() == "text\n"
 
 
 def test_hash():

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -658,7 +658,7 @@ def test_print_flush_uses_python_truthiness():
     assert output.flush_count == 1
 
 
-def test_print_flush_truthiness_error_precedes_output():
+def test_print_flush_truthiness_error_matches_python():
     class MarkerError(Exception):
         pass
 
@@ -666,10 +666,45 @@ def test_print_flush_truthiness_error_precedes_output():
         def __bool__(self):
             raise MarkerError
 
+    expected = StringIO()
+    with pytest.raises(MarkerError):
+        print("text", file=expected, flush=BadFlush())
+
     output = StringIO()
     with pytest.raises(MarkerError):
         m.print_args("text", file=output, flush=BadFlush())
-    assert output.getvalue() == ""
+    assert output.getvalue() == expected.getvalue()
+
+
+def print_flush_evaluation_trace(print_function, **kwargs):
+    events = []
+
+    class Flush:
+        def __bool__(self):
+            events.append("bool:flush")
+            return True
+
+    try:
+        result = print_function("text", flush=Flush(), **kwargs)
+    except Exception as exc:
+        outcome = type(exc)
+    else:
+        outcome = ("return", result)
+    return events, outcome
+
+
+@pytest.mark.parametrize("keyword", ["sep", "end"])
+def test_print_flush_evaluation_order_with_invalid_sep_and_end(keyword):
+    assert print_flush_evaluation_trace(
+        m.print_args, file=StringIO(), **{keyword: object()}
+    ) == print_flush_evaluation_trace(print, file=StringIO(), **{keyword: object()})
+
+
+def test_print_flush_evaluation_order_with_stdout_none(monkeypatch):
+    monkeypatch.setattr(sys, "stdout", None)
+    assert print_flush_evaluation_trace(m.print_args) == print_flush_evaluation_trace(
+        print
+    )
 
 
 def test_print_propagates_stream_errors():

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -599,6 +599,19 @@ def test_print_missing_stdout(monkeypatch):
         m.print_args("no stream")
 
 
+@pytest.mark.skipif(
+    "env.PY_GIL_DISABLED",
+    reason="PySys_GetObject does not provide a thread-safe strong-reference API",
+)
+def test_print_uses_interpreter_stdout_if_sys_module_is_unavailable(monkeypatch):
+    output = StringIO()
+    with monkeypatch.context() as context:
+        context.setattr(sys, "stdout", output)
+        context.setitem(sys.modules, "sys", None)
+        m.print_args("interpreter stdout")
+    assert output.getvalue() == "interpreter stdout\n"
+
+
 def test_print_none_separator_and_end():
     output = StringIO()
     m.print_args("one", "two", sep=None, end=None, file=output)
@@ -618,6 +631,15 @@ def test_print_rejects_unknown_keyword():
         TypeError, match="^'unknown' is an invalid keyword argument for print\\(\\)$"
     ):
         m.print_args("text", unknown=True)
+
+
+@pytest.mark.parametrize("keyword", ["embedded\0null", "\ud800"])
+def test_print_rejects_unusual_unknown_keyword(keyword):
+    with pytest.raises(TypeError) as exc_info:
+        m.print_args("text", **{keyword: True})
+    assert exc_info.value.args == (
+        f"'{keyword}' is an invalid keyword argument for print()",
+    )
 
 
 def test_print_flush_uses_python_truthiness():
@@ -669,6 +691,66 @@ def test_print_propagates_stream_errors():
     with pytest.raises(MarkerError, match="flush"):
         m.print_args("text", file=output, flush=True)
     assert output.getvalue() == "text\n"
+
+
+class PrintMarkerError(Exception):
+    pass
+
+
+def print_trace(print_function, failure):
+    events = []
+
+    class Value:
+        def __init__(self, text):
+            self.text = text
+
+        def __str__(self):
+            events.append(("str", self.text))
+            if failure == f"str:{self.text}":
+                raise PrintMarkerError
+            return self.text
+
+    class Flush:
+        def __bool__(self):
+            events.append(("bool", "flush"))
+            if failure == "flush-bool":
+                raise PrintMarkerError
+            return True
+
+    class Stream:
+        def __init__(self):
+            self.write_count = 0
+
+        def write(self, value):
+            self.write_count += 1
+            events.append(("write", value))
+            if failure == f"write:{self.write_count}":
+                raise PrintMarkerError
+
+        def flush(self):
+            events.append(("flush",))
+            if failure == "flush":
+                raise PrintMarkerError
+
+    try:
+        result = print_function(
+            Value("one"),
+            Value("two"),
+            sep="|",
+            end="!",
+            file=Stream(),
+            flush=Flush(),
+        )
+    except Exception as exc:
+        outcome = type(exc)
+    else:
+        outcome = ("return", result)
+    return events, outcome
+
+
+@pytest.mark.parametrize("failure", [None, "str:two", "write:2", "flush-bool", "flush"])
+def test_print_matches_python_stream_protocol(failure):
+    assert print_trace(m.print_args, failure) == print_trace(print, failure)
 
 
 def test_hash():

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -658,7 +658,7 @@ def test_print_flush_uses_python_truthiness():
     assert output.flush_count == 1
 
 
-def test_print_flush_truthiness_error_matches_python():
+def test_print_flush_truthiness_error_after_output():
     class MarkerError(Exception):
         pass
 
@@ -666,45 +666,10 @@ def test_print_flush_truthiness_error_matches_python():
         def __bool__(self):
             raise MarkerError
 
-    expected = StringIO()
-    with pytest.raises(MarkerError):
-        print("text", file=expected, flush=BadFlush())
-
     output = StringIO()
     with pytest.raises(MarkerError):
         m.print_args("text", file=output, flush=BadFlush())
-    assert output.getvalue() == expected.getvalue()
-
-
-def print_flush_evaluation_trace(print_function, **kwargs):
-    events = []
-
-    class Flush:
-        def __bool__(self):
-            events.append("bool:flush")
-            return True
-
-    try:
-        result = print_function("text", flush=Flush(), **kwargs)
-    except Exception as exc:
-        outcome = type(exc)
-    else:
-        outcome = ("return", result)
-    return events, outcome
-
-
-@pytest.mark.parametrize("keyword", ["sep", "end"])
-def test_print_flush_evaluation_order_with_invalid_sep_and_end(keyword):
-    assert print_flush_evaluation_trace(
-        m.print_args, file=StringIO(), **{keyword: object()}
-    ) == print_flush_evaluation_trace(print, file=StringIO(), **{keyword: object()})
-
-
-def test_print_flush_evaluation_order_with_stdout_none(monkeypatch):
-    monkeypatch.setattr(sys, "stdout", None)
-    assert print_flush_evaluation_trace(m.print_args) == print_flush_evaluation_trace(
-        print
-    )
+    assert output.getvalue() == "text\n"
 
 
 def test_print_propagates_stream_errors():
@@ -732,7 +697,7 @@ class PrintMarkerError(Exception):
     pass
 
 
-def print_trace(print_function, failure):
+def pybind_print_trace(failure):
     events = []
 
     class Value:
@@ -744,13 +709,6 @@ def print_trace(print_function, failure):
             if failure == f"str:{self.text}":
                 raise PrintMarkerError
             return self.text
-
-    class Flush:
-        def __bool__(self):
-            events.append(("bool", "flush"))
-            if failure == "flush-bool":
-                raise PrintMarkerError
-            return True
 
     class Stream:
         def __init__(self):
@@ -768,13 +726,13 @@ def print_trace(print_function, failure):
                 raise PrintMarkerError
 
     try:
-        result = print_function(
+        result = m.print_args(
             Value("one"),
             Value("two"),
             sep="|",
             end="!",
             file=Stream(),
-            flush=Flush(),
+            flush=True,
         )
     except Exception as exc:
         outcome = type(exc)
@@ -783,9 +741,20 @@ def print_trace(print_function, failure):
     return events, outcome
 
 
-@pytest.mark.parametrize("failure", [None, "str:two", "write:2", "flush-bool", "flush"])
-def test_print_matches_python_stream_protocol(failure):
-    assert print_trace(m.print_args, failure) == print_trace(print, failure)
+def test_print_stream_protocol():
+    complete_events = [
+        ("str", "one"),
+        ("write", "one"),
+        ("write", "|"),
+        ("str", "two"),
+        ("write", "two"),
+        ("write", "!"),
+        ("flush",),
+    ]
+    assert pybind_print_trace(None) == (complete_events, ("return", None))
+    assert pybind_print_trace("str:two") == (complete_events[:4], PrintMarkerError)
+    assert pybind_print_trace("write:2") == (complete_events[:3], PrintMarkerError)
+    assert pybind_print_trace("flush") == (complete_events, PrintMarkerError)
 
 
 def test_hash():

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import sys
 import types
+from io import StringIO
 
 import pytest
 
@@ -568,6 +569,30 @@ def test_print(capture):
         if detailed_error_messages_enabled
         else "'1' to Python object (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)"
     )
+
+
+def test_print_file_none_and_stdout(monkeypatch, capture):
+    with capture:
+        m.print_args("explicit file=None", file=None)
+    assert capture == "explicit file=None\n"
+
+    class BadStr:
+        def __str__(self):
+            raise AssertionError("__str__ should not be called")
+
+    monkeypatch.setattr(sys, "stdout", None)
+    m.print_args(BadStr())
+    m.print_args(BadStr(), file=None)
+
+    output = StringIO()
+    m.print_args("explicit stream", file=output)
+    assert output.getvalue() == "explicit stream\n"
+
+
+def test_print_missing_stdout(monkeypatch):
+    monkeypatch.delattr(sys, "stdout")
+    with pytest.raises(RuntimeError, match="^lost sys.stdout$"):
+        m.print_args("no stream")
 
 
 def test_hash():

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -633,13 +633,15 @@ def test_print_rejects_unknown_keyword():
         m.print_args("text", unknown=True)
 
 
-@pytest.mark.parametrize("keyword", ["embedded\0null", "\ud800"])
+@pytest.mark.parametrize("keyword", ["file\0suffix", "\ud800"])
 def test_print_rejects_unusual_unknown_keyword(keyword):
     with pytest.raises(TypeError) as exc_info:
         m.print_args("text", **{keyword: True})
-    assert exc_info.value.args == (
-        f"'{keyword}' is an invalid keyword argument for print()",
-    )
+    (message,) = exc_info.value.args
+    # On Windows, PyPy's PyErr_Format() does not preserve an unpaired surrogate
+    # passed through %U. The ordinary-key test above checks the complete message;
+    # here the TypeError and intact suffix are the portable safety properties.
+    assert message.endswith(" is an invalid keyword argument for print()")
 
 
 def test_print_flush_uses_python_truthiness():

--- a/tests/test_with_catch/print_shutdown_probe.h
+++ b/tests/test_with_catch/print_shutdown_probe.h
@@ -1,0 +1,29 @@
+// Shared harness for the py::print-during-shutdown regression tests in
+// test_interpreter.cpp and test_subinterpreter.cpp.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+struct print_shutdown_state {
+    bool callback_ran = false;
+    bool stdout_was_none = false;
+    bool print_threw = false;
+};
+
+// Attach a capsule to sys whose destructor calls py::print during interpreter
+// shutdown, recording what happened in `state`.
+inline void install_print_shutdown_probe(print_shutdown_state &state) {
+    namespace py = pybind11;
+    py::module_::import("sys").attr("pybind11_print_on_shutdown")
+        = py::capsule(&state, [](void *payload) noexcept {
+              auto *state = static_cast<print_shutdown_state *>(payload);
+              state->callback_ran = true;
+              state->stdout_was_none = PySys_GetObject("stdout") == Py_None;
+              try {
+                  py::print("print during interpreter shutdown");
+              } catch (...) {
+                  state->print_threw = true;
+              }
+          });
+}

--- a/tests/test_with_catch/test_interpreter.cpp
+++ b/tests/test_with_catch/test_interpreter.cpp
@@ -356,6 +356,22 @@ TEST_CASE("Restart the interpreter") {
     REQUIRE(py_widget.attr("the_message").cast<std::string>() == "Hello after restart");
 }
 
+TEST_CASE("py::print is safe during interpreter shutdown") {
+    bool print_returned = false;
+    {
+        auto sys = py::module_::import("sys");
+        sys.attr("pybind11_print_on_shutdown") = py::capsule(&print_returned, [](void *payload) {
+            py::print("print during interpreter shutdown");
+            *static_cast<bool *>(payload) = true;
+        });
+    }
+
+    py::finalize_interpreter();
+    py::initialize_interpreter();
+
+    REQUIRE(print_returned);
+}
+
 TEST_CASE("Enum module survives restart") { // Added in PR #6015
     // Regression test for gh-5976: py::enum_ uses def_property_static, which
     // calls process_attributes::init after initialize_generic's strdup loop,

--- a/tests/test_with_catch/test_interpreter.cpp
+++ b/tests/test_with_catch/test_interpreter.cpp
@@ -7,6 +7,7 @@
 PYBIND11_WARNING_DISABLE_MSVC(4996)
 
 #include "catch_skip.h"
+#include "print_shutdown_probe.h"
 
 #include <catch.hpp>
 #include <cstdlib>
@@ -353,24 +354,8 @@ TEST_CASE("Restart the interpreter") {
 }
 
 TEST_CASE("py::print is safe during interpreter shutdown") {
-    struct shutdown_state {
-        bool callback_ran = false;
-        bool stdout_was_none = false;
-        bool print_threw = false;
-    } state;
-    {
-        auto sys = py::module_::import("sys");
-        sys.attr("pybind11_print_on_shutdown") = py::capsule(&state, [](void *payload) noexcept {
-            auto *state = static_cast<shutdown_state *>(payload);
-            state->callback_ran = true;
-            state->stdout_was_none = PySys_GetObject("stdout") == Py_None;
-            try {
-                py::print("print during interpreter shutdown");
-            } catch (...) {
-                state->print_threw = true;
-            }
-        });
-    }
+    print_shutdown_state state;
+    install_print_shutdown_probe(state);
 
     py::finalize_interpreter();
     py::initialize_interpreter();

--- a/tests/test_with_catch/test_interpreter.cpp
+++ b/tests/test_with_catch/test_interpreter.cpp
@@ -357,19 +357,32 @@ TEST_CASE("Restart the interpreter") {
 }
 
 TEST_CASE("py::print is safe during interpreter shutdown") {
-    bool print_returned = false;
+    struct shutdown_state {
+        bool callback_ran = false;
+        bool stdout_was_none = false;
+        bool print_returned = false;
+    } state;
     {
         auto sys = py::module_::import("sys");
-        sys.attr("pybind11_print_on_shutdown") = py::capsule(&print_returned, [](void *payload) {
-            py::print("print during interpreter shutdown");
-            *static_cast<bool *>(payload) = true;
+        sys.attr("pybind11_print_on_shutdown") = py::capsule(&state, [](void *payload) {
+            auto *state = static_cast<shutdown_state *>(payload);
+            state->callback_ran = true;
+            state->stdout_was_none = PySys_GetObject("stdout") == Py_None;
+            try {
+                py::print("print during interpreter shutdown");
+                state->print_returned = true;
+            } catch (...) {
+                // Reported by print_returned after the interpreter is reinitialized.
+            }
         });
     }
 
     py::finalize_interpreter();
     py::initialize_interpreter();
 
-    REQUIRE(print_returned);
+    REQUIRE(state.callback_ran);
+    REQUIRE(state.stdout_was_none);
+    REQUIRE(state.print_returned);
 }
 
 TEST_CASE("Enum module survives restart") { // Added in PR #6015

--- a/tests/test_with_catch/test_interpreter.cpp
+++ b/tests/test_with_catch/test_interpreter.cpp
@@ -360,19 +360,18 @@ TEST_CASE("py::print is safe during interpreter shutdown") {
     struct shutdown_state {
         bool callback_ran = false;
         bool stdout_was_none = false;
-        bool print_returned = false;
+        bool print_threw = false;
     } state;
     {
         auto sys = py::module_::import("sys");
-        sys.attr("pybind11_print_on_shutdown") = py::capsule(&state, [](void *payload) {
+        sys.attr("pybind11_print_on_shutdown") = py::capsule(&state, [](void *payload) noexcept {
             auto *state = static_cast<shutdown_state *>(payload);
             state->callback_ran = true;
             state->stdout_was_none = PySys_GetObject("stdout") == Py_None;
             try {
                 py::print("print during interpreter shutdown");
-                state->print_returned = true;
             } catch (...) {
-                // Reported by print_returned after the interpreter is reinitialized.
+                state->print_threw = true;
             }
         });
     }
@@ -382,7 +381,7 @@ TEST_CASE("py::print is safe during interpreter shutdown") {
 
     REQUIRE(state.callback_ran);
     REQUIRE(state.stdout_was_none);
-    REQUIRE(state.print_returned);
+    REQUIRE_FALSE(state.print_threw);
 }
 
 TEST_CASE("Enum module survives restart") { // Added in PR #6015

--- a/tests/test_with_catch/test_subinterpreter.cpp
+++ b/tests/test_with_catch/test_subinterpreter.cpp
@@ -117,6 +117,20 @@ TEST_CASE("Single Subinterpreter") {
     unsafe_reset_internals_for_single_interpreter();
 }
 
+TEST_CASE("py::print is safe during subinterpreter shutdown") {
+    bool print_returned = false;
+    {
+        py::scoped_subinterpreter subinterpreter;
+        py::module_::import("sys").attr("pybind11_print_on_shutdown")
+            = py::capsule(&print_returned, [](void *payload) {
+                  py::print("print during subinterpreter shutdown");
+                  *static_cast<bool *>(payload) = true;
+              });
+    }
+
+    REQUIRE(print_returned);
+}
+
 #    if PY_VERSION_HEX >= 0x030D0000
 TEST_CASE("Move Subinterpreter") {
     std::unique_ptr<py::subinterpreter> sub(new py::subinterpreter(py::subinterpreter::create()));

--- a/tests/test_with_catch/test_subinterpreter.cpp
+++ b/tests/test_with_catch/test_subinterpreter.cpp
@@ -118,17 +118,30 @@ TEST_CASE("Single Subinterpreter") {
 }
 
 TEST_CASE("py::print is safe during subinterpreter shutdown") {
-    bool print_returned = false;
+    struct shutdown_state {
+        bool callback_ran = false;
+        bool stdout_was_none = false;
+        bool print_returned = false;
+    } state;
     {
         py::scoped_subinterpreter subinterpreter;
         py::module_::import("sys").attr("pybind11_print_on_shutdown")
-            = py::capsule(&print_returned, [](void *payload) {
-                  py::print("print during subinterpreter shutdown");
-                  *static_cast<bool *>(payload) = true;
+            = py::capsule(&state, [](void *payload) {
+                  auto *state = static_cast<shutdown_state *>(payload);
+                  state->callback_ran = true;
+                  state->stdout_was_none = PySys_GetObject("stdout") == Py_None;
+                  try {
+                      py::print("print during subinterpreter shutdown");
+                      state->print_returned = true;
+                  } catch (...) {
+                      // Reported by print_returned after returning to the main interpreter.
+                  }
               });
     }
 
-    REQUIRE(print_returned);
+    REQUIRE(state.callback_ran);
+    REQUIRE(state.stdout_was_none);
+    REQUIRE(state.print_returned);
 }
 
 #    if PY_VERSION_HEX >= 0x030D0000

--- a/tests/test_with_catch/test_subinterpreter.cpp
+++ b/tests/test_with_catch/test_subinterpreter.cpp
@@ -8,6 +8,7 @@
 PYBIND11_WARNING_DISABLE_MSVC(4996)
 
 #    include "catch_skip.h"
+#    include "print_shutdown_probe.h"
 
 #    include <catch.hpp>
 #    include <cstdlib>
@@ -118,24 +119,10 @@ TEST_CASE("Single Subinterpreter") {
 }
 
 TEST_CASE("py::print is safe during subinterpreter shutdown") {
-    struct shutdown_state {
-        bool callback_ran = false;
-        bool stdout_was_none = false;
-        bool print_threw = false;
-    } state;
+    print_shutdown_state state;
     {
         py::scoped_subinterpreter subinterpreter;
-        py::module_::import("sys").attr("pybind11_print_on_shutdown")
-            = py::capsule(&state, [](void *payload) noexcept {
-                  auto *state = static_cast<shutdown_state *>(payload);
-                  state->callback_ran = true;
-                  state->stdout_was_none = PySys_GetObject("stdout") == Py_None;
-                  try {
-                      py::print("print during subinterpreter shutdown");
-                  } catch (...) {
-                      state->print_threw = true;
-                  }
-              });
+        install_print_shutdown_probe(state);
     }
 
     REQUIRE(state.callback_ran);

--- a/tests/test_with_catch/test_subinterpreter.cpp
+++ b/tests/test_with_catch/test_subinterpreter.cpp
@@ -121,27 +121,26 @@ TEST_CASE("py::print is safe during subinterpreter shutdown") {
     struct shutdown_state {
         bool callback_ran = false;
         bool stdout_was_none = false;
-        bool print_returned = false;
+        bool print_threw = false;
     } state;
     {
         py::scoped_subinterpreter subinterpreter;
         py::module_::import("sys").attr("pybind11_print_on_shutdown")
-            = py::capsule(&state, [](void *payload) {
+            = py::capsule(&state, [](void *payload) noexcept {
                   auto *state = static_cast<shutdown_state *>(payload);
                   state->callback_ran = true;
                   state->stdout_was_none = PySys_GetObject("stdout") == Py_None;
                   try {
                       py::print("print during subinterpreter shutdown");
-                      state->print_returned = true;
                   } catch (...) {
-                      // Reported by print_returned after returning to the main interpreter.
+                      state->print_threw = true;
                   }
               });
     }
 
     REQUIRE(state.callback_ran);
     REQUIRE(state.stdout_was_none);
-    REQUIRE(state.print_returned);
+    REQUIRE_FALSE(state.print_threw);
 }
 
 #    if PY_VERSION_HEX >= 0x030D0000


### PR DESCRIPTION
## Description

This is a comprehensive cleanup of `py::print`, prompted by the issue reported in #6012.

### Original problem

Windows GUI applications built with `/SUBSYSTEM:WINDOWS` may have `sys.stdout` set to `None`. `py::print` selected that object as its default stream and then attempted to access its `write` attribute, so printing could fail in this otherwise valid interpreter state.

A narrowly placed `None` check addresses that immediate failure, but the surrounding implementation had several related differences from Python's `print` behavior. In particular, an explicit `file=None` was not treated like an omitted `file`, stream selection happened after argument formatting, unknown keyword arguments were silently ignored, and output was assembled and sent through a cached `write` method instead of following Python's incremental file protocol.

### Resulting behavior

This change makes `py::print` follow Python's relevant semantics more closely:

- Omitting `file`, or passing `file=None`, resolves the current `sys.stdout`.
- If the resolved `sys.stdout` is `None`, printing is a no-op. This decision is made before converting values with `str`, matching Python and avoiding side effects during shutdown or in GUI applications without a console stream.
- If `sys.stdout` is missing during normal interpreter operation, `py::print` raises `RuntimeError("lost sys.stdout")` instead of silently discarding output.
- Explicit custom streams remain valid even when they are falsey.
- `sep=None` and `end=None` select their defaults, while invalid `sep` and `end` values are rejected before any output is written.
- Only `sep`, `end`, `file`, and `flush` are accepted as keyword arguments. Unknown keywords, including names containing embedded NULs or unpaired surrogates, produce a safe and informative error.
- `flush` is truth-tested after successful output. This deliberately preserves `py::print`'s historical portable ordering rather than interpreter-specific argument-parsing details; truth-testing and flushing errors propagate normally.
- Output is written incrementally through the public `PyFile_WriteObject` and `PyFile_WriteString` APIs. This preserves consequential incremental stream behavior, including repeated `write` lookup, partial output when a later conversion or write fails, and correct zero-argument behavior.
- Exceptions from value conversion, stream writes, truth testing, and flushing propagate without being replaced.

The implementation deliberately does not delegate to `builtins.print`: doing so would make `py::print` sensitive to monkey-patching (and possible recursion) and would complicate its shutdown behavior.

### Interpreter lifetime and free-threading

The default-stream lookup distinguishes ordinary execution from interpreter teardown. During normal execution a missing `sys.stdout` remains an error; during finalization, printing safely becomes a no-op when the interpreter's `sys` state is no longer available.

CPython's built-in `print` obtains a strong reference directly from the current interpreter's `sys` dictionary through the private `_PySys_GetRequiredAttr()`, which is unavailable to extension modules. On conventional GIL builds, pybind11 can safely promote the borrowed result of `PySys_GetObject()` while retaining the canonical lookup. On free-threaded builds, concurrent replacement makes that unsafe, so pybind11 obtains a strong reference through the imported `sys` module instead.

Because the free-threaded fallback necessarily consults `sys.modules`, the regression that replaces `sys.modules["sys"]` is skipped on those builds; this records the narrow limitation without complicating production code.

Regression coverage exercises shutdown callbacks in both the main interpreter and subinterpreters. A separate `sys.stdout is None` regression verifies that values are not converted with `str` once no output is possible.

### Test coverage

The expanded tests exercise `py::print`'s portable contract across normal output and failure paths, including:

- omitted, `None`, missing, falsey, and custom streams;
- `sep` and `end` defaults and validation, plus `file` and `flush` handling;
- unknown keyword names, including embedded-NUL and unpaired-surrogate names;
- one and multiple positional arguments;
- failures in `__str__`, `write`, `flush` truth testing, and `flush` itself;
- partial-output behavior and operation ordering;
- main-interpreter and subinterpreter shutdown.

No ABI-visible data structures or layouts are changed.

Validation completed locally:

- GCC / CPython 3.14 GIL build: the full Catch2 and pytest suites passed.
- GCC / CPython 3.14 free-threaded build: the full Catch2 and pytest suites passed.
- `pre-commit run --all-files` passed.

This supersedes the implementation proposed in #6012 while preserving its intended behavior when `sys.stdout is None`.


## Suggested changelog entry:

* Fix `py::print` to more closely follow Python's stream and keyword semantics, propagate stream errors, and safely handle `sys.stdout is None`, including during interpreter shutdown.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6120.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6120.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->