### PR TITLE
fix: delegate py::print to Python's native print

### DIFF
--- a/docs/advanced/pycpp/utilities.rst
+++ b/docs/advanced/pycpp/utilities.rst
@@ -7,11 +7,11 @@ Using Python's print function in C++
 The usual way to write output in C++ is using ``std::cout`` while in Python one
 would use ``print``. Since these methods use different buffers, mixing them can
 lead to output order issues. To resolve this, pybind11 modules can use the
-:func:`py::print` function which writes to Python's ``sys.stdout`` for consistency.
+:func:`py::print` function, which writes through Python's printing machinery.
 
-Python's ``print`` function is replicated in the C++ API including optional
-keyword arguments ``sep``, ``end``, ``file``, ``flush``. Everything works as
-expected in Python:
+:func:`py::print` delegates each call to the current ``print`` callable in
+Python's built-ins. With the standard built-in, optional keyword arguments
+``sep``, ``end``, ``file``, and ``flush`` work as they do in Python:
 
 .. code-block:: cpp
 
@@ -20,6 +20,10 @@ expected in Python:
 
     auto args = py::make_tuple("unpacked", true);
     py::print("->", *args, "end"_a="<-"); // -> unpacked True <-
+
+With the standard built-in, omitting ``file`` or passing
+``"file"_a = py::none()`` uses the current ``sys.stdout``. Other output and
+error behavior is likewise supplied by the active Python runtime.
 
 .. _ostream_redirect:
 

--- a/docs/advanced/pycpp/utilities.rst
+++ b/docs/advanced/pycpp/utilities.rst
@@ -9,9 +9,11 @@ would use ``print``. Since these methods use different buffers, mixing them can
 lead to output order issues. To resolve this, pybind11 modules can use the
 :func:`py::print` function, which writes through Python's printing machinery.
 
-:func:`py::print` delegates each call to the current ``print`` callable in
-Python's built-ins. With the standard built-in, optional keyword arguments
-``sep``, ``end``, ``file``, and ``flush`` work as they do in Python:
+:func:`py::print` delegates each call to the ``print`` entry in the current
+execution frame's built-ins (normally ``builtins.print``). When no Python frame
+is executing, it uses the active interpreter's built-ins. With the standard
+built-in, optional keyword arguments ``sep``, ``end``, ``file``, and ``flush``
+work as they do in Python:
 
 .. code-block:: cpp
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3770,7 +3770,7 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
     auto builtins = reinterpret_borrow<dict>(PyEval_GetBuiltins());
 #endif
     object native_print = builtins["print"];
-    object result
+    auto result
         = reinterpret_steal<object>(PyObject_Call(native_print.ptr(), args.ptr(), kwargs.ptr()));
     if (!result) {
         throw error_already_set();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3764,34 +3764,16 @@ register_local_exception(handle scope, const char *name, handle base = PyExc_Exc
 
 PYBIND11_NAMESPACE_BEGIN(detail)
 PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
-    auto strings = tuple(args.size());
-    for (size_t i = 0; i < args.size(); ++i) {
-        strings[i] = str(args[i]);
-    }
-    auto sep = kwargs.contains("sep") ? kwargs["sep"] : str(" ");
-    auto line = sep.attr("join")(std::move(strings));
-
-    object file;
-    if (kwargs.contains("file")) {
-        file = kwargs["file"].cast<object>();
-    } else {
-        try {
-            file = module_::import("sys").attr("stdout");
-        } catch (const error_already_set &) {
-            /* If print() is called from code that is executed as
-               part of garbage collection during interpreter shutdown,
-               importing 'sys' can fail. Give up rather than crashing the
-               interpreter in this case. */
-            return;
-        }
-    }
-
-    auto write = file.attr("write");
-    write(std::move(line));
-    write(kwargs.contains("end") ? kwargs["end"] : str("\n"));
-
-    if (kwargs.contains("flush") && kwargs["flush"].cast<bool>()) {
-        file.attr("flush")();
+#if PY_VERSION_HEX >= 0x030D0000
+    auto builtins = reinterpret_steal<dict>(PyEval_GetFrameBuiltins());
+#else
+    auto builtins = reinterpret_borrow<dict>(PyEval_GetBuiltins());
+#endif
+    object native_print = builtins["print"];
+    object result
+        = reinterpret_steal<object>(PyObject_Call(native_print.ptr(), args.ptr(), kwargs.ptr()));
+    if (!result) {
+        throw error_already_set();
     }
 }
 PYBIND11_NAMESPACE_END(detail)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3769,7 +3769,11 @@ PYBIND11_NOINLINE void print(const tuple &args, const dict &kwargs) {
 #else
     auto builtins = reinterpret_borrow<dict>(PyEval_GetBuiltins());
 #endif
-    object native_print = builtins["print"];
+    // The builtins dictionary may already be partially cleared during interpreter shutdown.
+    auto native_print = reinterpret_steal<object>(dict_getitemstringref(builtins.ptr(), "print"));
+    if (!native_print) {
+        return;
+    }
     auto result
         = reinterpret_steal<object>(PyObject_Call(native_print.ptr(), args.ptr(), kwargs.ptr()));
     if (!result) {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -625,25 +625,8 @@ TEST_SUBMODULE(pytypes, m) {
         return py::dict("d"_a = d, "l"_a = l);
     });
 
-    // test_print
-    m.def("print_function", []() {
-        py::print("Hello, World!");
-        py::print(1, 2.0, "three", true, std::string("-- multiple args"));
-        auto args = py::make_tuple("and", "a", "custom", "separator");
-        py::print("*args", *args, "sep"_a = "-");
-        py::print("no new line here", "end"_a = " -- ");
-        py::print("next print");
-
-        auto py_stderr = py::module_::import("sys").attr("stderr");
-        py::print("this goes to stderr", "file"_a = py_stderr);
-
-        py::print("flush", "flush"_a = true);
-
-        py::print(
-            "{a} + {b} = {c}"_s.format("a"_a = "py::print", "b"_a = "str.format", "c"_a = "this"));
-    });
-
-    m.def("print_failure", []() { py::print(42, UnregisteredType()); });
+    m.def("print_args",
+          [](const py::args &args, const py::kwargs &kwargs) { py::print(*args, **kwargs); });
 
     m.def("hash_function", [](py::object obj) { return py::hash(std::move(obj)); });
 

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -582,6 +582,23 @@ def test_print_missing_from_current_builtins_is_silent(monkeypatch):
     assert result is None
 
 
+def test_print_stdout_none_matches_current_builtin(monkeypatch):
+    def exception_type(func):
+        try:
+            func("text")
+        except Exception as exc:
+            return type(exc)
+        return None
+
+    # Python runtimes differ here; py::print should follow the active runtime.
+    with monkeypatch.context() as context:
+        context.setattr(sys, "stdout", None)
+        native_exception_type = exception_type(builtins.print)
+        pybind_exception_type = exception_type(m.print_args)
+
+    assert pybind_exception_type is native_exception_type
+
+
 def test_print_propagates_current_builtin_exception(monkeypatch):
     class MarkerError(Exception):
         pass

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import contextlib
 import sys
 import types
@@ -7,7 +8,6 @@ import types
 import pytest
 
 import env
-from pybind11_tests import detailed_error_messages_enabled
 from pybind11_tests import pytypes as m
 
 
@@ -545,29 +545,47 @@ def test_implicit_casting():
     assert z["l"] == [3, 6, 9, 12, 15]
 
 
-def test_print(capture):
-    with capture:
-        m.print_function()
-    assert (
-        capture
-        == """
-        Hello, World!
-        1 2.0 three True -- multiple args
-        *args-and-a-custom-separator
-        no new line here -- next print
-        flush
-        py::print + str.format = this
-    """
-    )
-    assert capture.stderr == "this goes to stderr"
+def test_print_delegates_to_current_builtin(monkeypatch):
+    calls = []
 
-    with pytest.raises(RuntimeError) as excinfo:
-        m.print_failure()
-    assert str(excinfo.value) == "Unable to convert call argument " + (
-        "'1' of type 'UnregisteredType' to Python object"
-        if detailed_error_messages_enabled
-        else "'1' to Python object (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)"
-    )
+    def first_print(*args, **kwargs):
+        calls.append(("first", args, kwargs))
+        return object()
+
+    def second_print(*args, **kwargs):
+        calls.append(("second", args, kwargs))
+        return object()
+
+    positional = [object(), object()]
+    keywords = {"first": object(), "second": object()}
+
+    monkeypatch.setattr(builtins, "print", first_print)
+    assert m.print_args(*positional, **keywords) is None
+
+    monkeypatch.setattr(builtins, "print", second_print)
+    assert m.print_args() is None
+
+    assert calls[0][0] == "first"
+    assert len(calls[0][1]) == len(positional)
+    assert all(actual is expected for actual, expected in zip(calls[0][1], positional))
+    assert list(calls[0][2]) == list(keywords)
+    assert all(calls[0][2][key] is value for key, value in keywords.items())
+    assert calls[1] == ("second", (), {})
+
+
+def test_print_propagates_current_builtin_exception(monkeypatch):
+    class MarkerError(Exception):
+        pass
+
+    error = MarkerError()
+
+    def failing_print():
+        raise error
+
+    monkeypatch.setattr(builtins, "print", failing_print)
+    with pytest.raises(MarkerError) as exc_info:
+        m.print_args()
+    assert exc_info.value is error
 
 
 def test_hash():

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -573,6 +573,15 @@ def test_print_delegates_to_current_builtin(monkeypatch):
     assert calls[1] == ("second", (), {})
 
 
+def test_print_missing_from_current_builtins_is_silent(monkeypatch):
+    # The builtins dictionary may have lost its print entry before C++ destructors
+    # run during interpreter shutdown.
+    with monkeypatch.context() as context:
+        context.delattr(builtins, "print")
+        result = m.print_args("ignored")
+    assert result is None
+
+
 def test_print_propagates_current_builtin_exception(monkeypatch):
     class MarkerError(Exception):
         pass


### PR DESCRIPTION
## Description

This replaces pybind11's independent `py::print` implementation with delegation to the
`print` entry in the current execution frame's built-ins, or the active interpreter's
built-ins when no Python frame is executing.

It is a smaller alternative to #6120, prompted by the failure reported in #6012 and first
proposed in [this discussion](https://github.com/pybind/pybind11/pull/6120#issuecomment-5151962954).

### Original problem

In Windows GUI applications built with `/SUBSYSTEM:WINDOWS`, `sys.stdout` can legitimately
be `None`. The previous `py::print` implementation selected that object as its default
stream and then tried to access its `write` attribute, causing the failure reported in
#6012.

A local `None` check fixes that immediate case, but investigation in #6120 exposed a more
general maintenance problem: pybind11 was replicating Python's `print` behavior. Keeping
that replica aligned requires pybind11 to implement and test stream selection, `sep`,
`end`, `file`, and `flush`, keyword validation and diagnostics, partial-output and error
ordering, interpreter shutdown, and free-thread-safe access to `sys.stdout`. Several
details already differed between CPython, PyPy, and pybind11, and future runtime changes
could introduce more drift.

### Design

`py::print` already collects its converted positional and keyword arguments into a tuple
and dictionary. Python does not expose a public C API that directly implements `print`, so
the new implementation obtains the current frame/interpreter built-ins, retrieves its
`print` entry, and invokes that selected callable with the collected tuple and dictionary
through `PyObject_Call`.

The built-ins lookup uses the appropriate public C API and reference ownership for each
supported Python version:

- Python 3.13 and newer use `PyEval_GetFrameBuiltins()`, which returns a new strong
  reference.
- Earlier versions use `PyEval_GetBuiltins()`, which returns a borrowed reference.

Both APIs fall back to the interpreter's built-ins when no Python frame is executing. All
supported free-threaded CPython versions take the Python 3.13+ strong-reference path. The
frame lookup is deliberate: it respects the frame's configured built-ins and avoids
importing or caching the `builtins` module across calls, interpreters, or interpreter
restarts.

The `print` entry is obtained through pybind11's cross-version
`dict_getitemstringref()` helper, which returns a strong reference on every supported
Python version. If the entry is absent, `py::print` returns silently because the built-ins
dictionary may already be partially cleared when C++ destructors run during interpreter
shutdown. Genuine lookup failures still propagate, as do exceptions from any entry that
was found and called. This preserves the historical best-effort teardown behavior without
swallowing call-time errors.

The implementation itself does not access `sys.stdout`; stream selection is left to the
invoked callable. This removes pybind11's separate formatting, keyword parsing, stream
lookup, writing, and flushing implementation. The public C++ API remains `void`, so the
Python callable's return value is discarded, while Python exceptions propagate through
`error_already_set` as usual.

A [benchmark reported during the #6120 discussion](https://github.com/pybind/pybind11/pull/6120#issuecomment-5152050617)
found direct lookup through the `PyEval_Get*Builtins()` APIs to be at parity with the
custom implementation. Retaining the emulation therefore provides no meaningful
performance advantage.

### Resulting behavior and deliberate tradeoff

With the standard built-in `print`, this fixes the `sys.stdout is None` case and makes
`py::print` follow the active runtime's behavior for:

- `sep`, `end`, `file`, and `flush`;
- default and custom output streams;
- keyword validation and diagnostics;
- conversion, writing, flushing, and partial-output errors;
- operation ordering and interpreter-specific differences.

The current frame's built-ins `print` entry—normally `builtins.print`—is mutable.
Replacing it therefore affects subsequent `py::print` calls. This is intentional:
delegation means using the current entry rather than caching an "original" function. A
replacement that calls back into `py::print` can recurse, just as any replacement that
calls itself can recurse. Removing the entry entirely makes `py::print` a no-op, providing
the narrow teardown safeguard described above; an entry that exists but is non-callable
still raises normally when called.

The corresponding benefit is that pybind11 no longer has to predict or reproduce native
behavior. Differences such as CPython and PyPy choosing different exception types for a
missing `sys.stdout` remain the responsibility of those runtimes instead of becoming
pybind11 compatibility code.

### Test strategy

The previous direct test primarily asserted formatted output and behavior supplied by
Python's standard `print`. It is replaced with controlled tests of the delegation layer
itself.

A small test binding accepts arbitrary `py::args` and `py::kwargs` and adapts them to the
public C++ call `py::print(*args, **kwargs)`. The lambda is intentional: `py::print` is a
variadic function template rather than a single function that `m.def` can bind directly,
and a specialization taking `py::args` and `py::kwargs` would pass those containers as
ordinary arguments instead of unpacking them. Python-side tests verify that pybind11:

- resolves the current callable for each invocation rather than caching it;
- forwards positional arguments in order and preserves object identity;
- forwards keyword names, order, and value identity without interpreting them;
- preserves the `void` return contract even when the callable returns a value;
- propagates the exact Python exception raised by the callable;
- returns silently when the current built-ins dictionary has no `print` entry.

A runtime-differential regression test sets `sys.stdout = None` and compares native
`print` with `py::print`, asserting only whether each succeeds or which exception type it
raises. This directly covers the original bug and invokes the real built-in without
freezing CPython's behavior as pybind11 policy; for example, PyPy currently makes a
different choice here.

The tests deliberately do not freeze formatting, stream protocol, flush ordering,
diagnostic wording, or teardown-time behavior of the invoked runtime callable. The
missing-entry test covers only pybind11's owned lookup fallback. Broader no-frame and
shutdown validation remains recorded in #6122.

### Comprehensive validation experiment

Before reducing the tests to that focused contract, #6122 combined this production
implementation with the comprehensive behavioral coverage developed for #6120 and ran it
through the full CI matrix.

The [final CI report](https://github.com/pybind/pybind11/pull/6122#issuecomment-5155970852)
records 73 passing checks, two skipped CI checks, and three PyPy 3.11 failures. All three
failures were the same over-specific test assertion: after removing `sys.stdout`, the test
required CPython's native `RuntimeError`, while PyPy's native `print` raises
`AttributeError`. The assertion failed before comparing `py::print` with native `print`;
all other print coverage, including direct delegation, passed in those PyPy jobs.

Across the supported platform and compiler matrix, the experiment exercised stream and
keyword behavior, failures and operation ordering, unusual keyword names, regular and
free-threaded builds, GraalPy, PyPy, and main/subinterpreter shutdown. It provides broad
evidence for the delegation design while also demonstrating why runtime-owned details
should not remain in pybind11's permanent unit tests.

Local validation of the final focused change also passed:

- GCC / CPython 3.14.4 GIL build: 26 Catch2 tests and 1,347 pytest tests passed
  (2 skipped).
- GCC / free-threaded CPython 3.14.4 build: 26 Catch2 tests and 1,326 pytest tests passed
  (23 skipped).
- `pre-commit run --all-files` passed.

### Documentation and compatibility

The utilities documentation now states that `py::print` uses the current execution
frame's built-ins `print` entry, falling back to the active interpreter's built-ins when
no frame is executing. It retains the useful guidance that, with the standard built-in,
omitting `file` or passing `file=None` uses the current `sys.stdout`.

No ABI-visible data structures or layouts are changed.

This supersedes the narrowly scoped implementation in #6012 and provides the final,
smaller alternative to #6120.

## Suggested changelog entry:

* Make `py::print` delegate to the current frame/interpreter built-ins `print` entry,
  fixing handling of `sys.stdout = None`, following the active runtime's stream, keyword,
  and error semantics, and remaining a no-op if the entry is unavailable during teardown.

<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6121.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->

Close #6120
Close #6021
