### PR TITLE
chore: add an include-what-you-use preset and apply its findings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -280,11 +280,30 @@ To run include what you use, install (`brew install include-what-you-use` on
 macOS), then run:
 
 ```bash
-cmake -S . -B build-iwyu -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=$(which include-what-you-use)
-cmake --build build-iwyu
+cmake --preset iwyu
+cmake --build --preset iwyu
 ```
 
-The report is sent to stderr; you can pipe it into a file if you wish.
+The build always succeeds and IWYU writes its advice to stderr; pipe the build
+output into a file if you wish. Nothing enforces the result, so read the
+report and apply what is correct, with these cautions:
+
+- The same header is reported once per translation unit that includes it, so
+  deduplicate before acting.
+- Only act on a removal that both standard libraries (macOS and Linux) agree
+  on; take an addition from either.
+- `<Python.h>` must stay the first include (via `detail/common.h`); do not let
+  a reorder suggestion move it.
+- Ignore "should add" lines for `<math>` and other headers that are not real
+  public headers; a mapping for `<math>` makes IWYU abort.
+
+Two support files drive the analysis. `tools/iwyu.sh` wraps
+`include-what-you-use` and asks it to also check every pybind11 header, except
+`pybind11.h` and `cast.h`, which crash IWYU 0.26. `tools/iwyu.imp` maps the
+headers a suggestion must not name to the one pybind11 should use: CPython
+internals to `<Python.h>`, libc++ detail headers and the C headers of
+libstdc++ to the standard C++ header. Read the comment at its top before you
+add an entry.
 
 ### Build recipes
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,6 +38,18 @@
         "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--use-color;--warnings-as-errors=*",
         "CMAKE_CXX_STANDARD": "17"
       }
+    },
+    {
+      "name": "iwyu",
+      "displayName": "Include-what-you-use",
+      "inherits": "venv",
+      "binaryDir": "build-iwyu",
+      "cacheVariables": {
+        "CMAKE_CXX_INCLUDE_WHAT_YOU_USE": "${sourceDir}/tools/iwyu.sh",
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_OSX_SYSROOT": "macosx",
+        "PYBIND11_WERROR": false
+      }
     }
   ],
   "buildPresets": [
@@ -56,6 +68,11 @@
       "displayName": "Clang-tidy Build",
       "configurePreset": "tidy",
       "nativeToolOptions": ["-k0"]
+    },
+    {
+      "name": "iwyu",
+      "displayName": "Include-what-you-use Build",
+      "configurePreset": "iwyu"
     },
     {
       "name": "tests",

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -11,10 +11,21 @@
 #pragma once
 
 #include "detail/common.h"
+#include "detail/internals.h"
+#include "detail/type_caster_base.h"
+#include "detail/typeid.h"
+#include "detail/value_and_holder.h"
 #include "cast.h"
+#include "pytypes.h"
 #include "trampoline_self_life_support.h"
 
+#include <cstdint>
 #include <functional>
+#include <string>
+#include <type_traits>
+#include <typeinfo>
+#include <utility>
+#include <vector>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 

--- a/include/pybind11/buffer_info.h
+++ b/include/pybind11/buffer_info.h
@@ -11,6 +11,11 @@
 
 #include "detail/common.h"
 
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -11,12 +11,18 @@
 #pragma once
 
 #include "pybind11.h"
+#include "detail/common.h"
+#include "detail/descr.h"
+#include "cast.h"
+#include "pytypes.h"
 
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <ctime>
 #include <datetime.h>
 #include <mutex>
+#include <ratio>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/chrono.h
+++ b/include/pybind11/chrono.h
@@ -17,7 +17,6 @@
 #include "pytypes.h"
 
 #include <chrono>
-#include <cmath>
 #include <cstdint>
 #include <ctime>
 #include <datetime.h>

--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -10,8 +10,14 @@
 #pragma once
 
 #include "pybind11.h"
+#include "detail/common.h"
+#include "detail/descr.h"
+#include "cast.h"
+#include "pytypes.h"
 
 #include <complex>
+#include <string>
+#include <type_traits>
 
 /// glibc defines I as a macro which breaks things, e.g., boost template names
 #ifdef I

--- a/include/pybind11/conduit/wrap_include_python_h.h
+++ b/include/pybind11/conduit/wrap_include_python_h.h
@@ -41,9 +41,9 @@
 // C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed
 #endif
 
-#include <Python.h>
-#include <frameobject.h>
-#include <pythread.h>
+#include <Python.h>      // IWYU pragma: export
+#include <frameobject.h> // IWYU pragma: export
+#include <pythread.h>    // IWYU pragma: export
 
 #if defined(_MSC_VER)
 #    pragma warning(pop)

--- a/include/pybind11/critical_section.h
+++ b/include/pybind11/critical_section.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "detail/pybind11_namespace_macros.h"
 #include "pytypes.h"
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)

--- a/include/pybind11/detail/argument_vector.h
+++ b/include/pybind11/detail/argument_vector.h
@@ -16,10 +16,12 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <iterator>
+#include <new>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -12,7 +12,29 @@
 #include <pybind11/attr.h>
 #include <pybind11/options.h>
 
+#include "../buffer_info.h"
+#include "../cast.h"
+#include "../pytypes.h"
+#include "../trampoline_self_life_support.h"
+#include "common.h"
+#include "cpp_conduit.h"
 #include "exception_translation.h"
+#include "internals.h"
+#include "type_caster_base.h"
+#include "value_and_holder.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+#include <forward_list>
+#include <memory>
+#include <string>
+#include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -235,14 +235,10 @@
 #include <cstddef>
 #include <cstring>
 #include <exception>
-#include <forward_list>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
-#include <typeindex>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 #if defined(__has_include)
 #    if __has_include(<version>)

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -10,6 +10,12 @@
 #pragma once
 
 #include <pybind11/conduit/wrap_include_python_h.h> // IWYU pragma: export
+
+#include <cassert>
+#include <cstdint>
+#include <initializer_list>
+#include <new>
+#include <utility>
 #if PY_VERSION_HEX < 0x03090000
 #    error "PYTHON < 3.9 IS UNSUPPORTED. pybind11 v3.0 was the last to support Python 3.8."
 #endif

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <pybind11/conduit/wrap_include_python_h.h>
+#include <pybind11/conduit/wrap_include_python_h.h> // IWYU pragma: export
 #if PY_VERSION_HEX < 0x03090000
 #    error "PYTHON < 3.9 IS UNSUPPORTED. pybind11 v3.0 was the last to support Python 3.8."
 #endif
@@ -44,7 +44,7 @@
                          PYBIND11_VERSION_RELEASE_LEVEL,                                          \
                          PYBIND11_VERSION_RELEASE_SERIAL)
 
-#include "pybind11_namespace_macros.h"
+#include "pybind11_namespace_macros.h" // IWYU pragma: export
 
 #if !(defined(_MSC_VER) && __cplusplus == 199711L)
 #    if __cplusplus >= 201402L

--- a/include/pybind11/detail/cpp_conduit.h
+++ b/include/pybind11/detail/cpp_conduit.h
@@ -4,6 +4,7 @@
 
 #include <pybind11/pytypes.h>
 
+#include "../conduit/pybind11_platform_abi_id.h"
 #include "common.h"
 #include "internals.h"
 

--- a/include/pybind11/detail/descr.h
+++ b/include/pybind11/detail/descr.h
@@ -11,6 +11,11 @@
 
 #include "common.h"
 
+#include <array>
+#include <type_traits>
+#include <typeinfo>
+#include <utility>
+
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 

--- a/include/pybind11/detail/exception_translation.h
+++ b/include/pybind11/detail/exception_translation.h
@@ -9,8 +9,12 @@
 
 #pragma once
 
+#include "../pytypes.h"
 #include "common.h"
 #include "internals.h"
+
+#include <exception>
+#include <forward_list>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -10,7 +10,9 @@
 #include <pybind11/conduit/pybind11_platform_abi_id.h>
 #include <pybind11/pytypes.h>
 
+#include "../cast.h"
 #include "common.h"
+#include "internals.h"
 
 #include <cstring>
 #include <utility>

--- a/include/pybind11/detail/function_ref.h
+++ b/include/pybind11/detail/function_ref.h
@@ -41,6 +41,7 @@
 
 #include <pybind11/detail/common.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <type_traits>
 #include <utility>

--- a/include/pybind11/detail/holder_caster_foreign_helpers.h
+++ b/include/pybind11/detail/holder_caster_foreign_helpers.h
@@ -12,7 +12,11 @@
 
 #include <pybind11/gil.h>
 
+#include "../pytypes.h"
 #include "common.h"
+
+#include <memory>
+#include <utility>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -9,8 +9,20 @@
 
 #pragma once
 
-#include "class.h"
+#include "../attr.h"
+#include "../cast.h"
+#include "../pytypes.h"
+#include "common.h"
+#include "descr.h"
+#include "internals.h"
+#include "struct_smart_holder.h"
+#include "type_caster_base.h"
 #include "using_smart_holder.h"
+#include "value_and_holder.h"
+
+#include <memory>
+#include <type_traits>
+#include <utility>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -14,15 +14,31 @@
 #include <pybind11/pytypes.h>
 #include <pybind11/trampoline_self_life_support.h>
 
+#include "../buffer_info.h"
 #include "common.h"
 #include "struct_smart_holder.h"
+#include "value_and_holder.h"
 
 #include <atomic>
 #include <cstdint>
+#include <cstring>
 #include <exception>
+#include <forward_list>
+#include <functional>
 #include <limits>
+#include <memory>
 #include <mutex>
+#include <new>
+#include <stdexcept>
+#include <string>
 #include <thread>
+#include <type_traits>
+#include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 /// Tracks the `internals` and `type_info` ABI version independent of the main library version.
 ///

--- a/include/pybind11/detail/native_enum_data.h
+++ b/include/pybind11/detail/native_enum_data.h
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <string>
 #include <typeindex>
+#include <unordered_map>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -11,13 +11,11 @@
 
 #include <pybind11/gil.h>
 #include <pybind11/pytypes.h>
-#include <pybind11/trampoline_self_life_support.h>
 
 #include "../conduit/pybind11_platform_abi_id.h"
 #include "common.h"
 #include "cpp_conduit.h"
 #include "descr.h"
-#include "dynamic_raw_ptr_cast_if_possible.h"
 #include "internals.h"
 #include "struct_smart_holder.h"
 #include "typeid.h"

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -13,25 +13,32 @@
 #include <pybind11/pytypes.h>
 #include <pybind11/trampoline_self_life_support.h>
 
+#include "../conduit/pybind11_platform_abi_id.h"
 #include "common.h"
 #include "cpp_conduit.h"
 #include "descr.h"
 #include "dynamic_raw_ptr_cast_if_possible.h"
 #include "internals.h"
+#include "struct_smart_holder.h"
 #include "typeid.h"
 #include "using_smart_holder.h"
 #include "value_and_holder.h"
 
+#include <cassert>
 #include <cstdint>
 #include <cstring>
+#include <forward_list>
 #include <iterator>
+#include <memory>
 #include <new>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/include/pybind11/detail/typeid.h
+++ b/include/pybind11/detail/typeid.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <cstdio>
 #include <cstdlib>
 #include <memory>
 #include <string>

--- a/include/pybind11/detail/typeid.h
+++ b/include/pybind11/detail/typeid.h
@@ -11,6 +11,9 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
+#include <string>
+#include <typeinfo>
 
 #if defined(__GNUG__)
 #    include <cxxabi.h>

--- a/include/pybind11/detail/value_and_holder.h
+++ b/include/pybind11/detail/value_and_holder.h
@@ -6,9 +6,7 @@
 
 #include "common.h"
 
-#include <cstddef>
 #include <cstdint>
-#include <typeinfo>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/eigen/matrix.h
+++ b/include/pybind11/eigen/matrix.h
@@ -11,7 +11,17 @@
 
 #include <pybind11/numpy.h>
 
+#include "../pybind11.h"
+#include "../detail/common.h"
+#include "../detail/descr.h"
+#include "../detail/type_caster_base.h"
+#include "../cast.h"
+#include "../pytypes.h"
 #include "common.h"
+
+#include <memory>
+#include <type_traits>
+#include <utility>
 
 /* HINT: To suppress warnings originating from the Eigen headers, use -isystem.
    See also:

--- a/include/pybind11/eigen/tensor.h
+++ b/include/pybind11/eigen/tensor.h
@@ -9,7 +9,20 @@
 
 #include <pybind11/numpy.h>
 
+#include "../detail/common.h"
+#include "../detail/descr.h"
+#include "../detail/type_caster_base.h"
+#include "../cast.h"
+#include "../pytypes.h"
 #include "common.h"
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Core>
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 static_assert(__GNUC__ > 5, "Eigen Tensor support in pybind11 requires GCC > 5.0");

--- a/include/pybind11/embed.h
+++ b/include/pybind11/embed.h
@@ -10,7 +10,11 @@
 #pragma once
 
 #include "pybind11.h"
+#include "detail/common.h"
+#include "detail/internals.h"
 #include "eval.h"
+
+#include <stdexcept>
 
 #if defined(PYPY_VERSION)
 #    error Embedding the interpreter is not supported with PyPy

--- a/include/pybind11/eval.h
+++ b/include/pybind11/eval.h
@@ -12,7 +12,12 @@
 #pragma once
 
 #include "pybind11.h"
+#include "detail/common.h"
+#include "cast.h"
+#include "pytypes.h"
 
+#include <cstdio>
+#include <string>
 #include <utility>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)

--- a/include/pybind11/functional.h
+++ b/include/pybind11/functional.h
@@ -10,8 +10,19 @@
 #pragma once
 
 #include "pybind11.h"
+#include "detail/common.h"
+#include "detail/descr.h"
+#include "detail/function_record_pyobject.h"
+#include "detail/internals.h"
+#include "attr.h"
+#include "cast.h"
+#include "gil.h"
+#include "pytypes.h"
 
 #include <functional>
+#include <type_traits>
+#include <typeinfo>
+#include <utility>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/gil_safe_call_once.h
+++ b/include/pybind11/gil_safe_call_once.h
@@ -14,7 +14,6 @@
 #endif
 #ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 #    include <cstdint>
-#    include <memory>
 #    include <string>
 #endif
 

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -20,6 +20,13 @@
 #pragma once
 
 #include "pybind11.h"
+#include "detail/common.h"
+#include "detail/descr.h"
+#include "detail/internals.h"
+#include "attr.h"
+#include "cast.h"
+#include "gil.h"
+#include "pytypes.h"
 
 #include <algorithm>
 #include <cstring>

--- a/include/pybind11/iostream.h
+++ b/include/pybind11/iostream.h
@@ -33,8 +33,6 @@
 #include <iostream>
 #include <iterator>
 #include <memory>
-#include <ostream>
-#include <streambuf>
 #include <string>
 #include <utility>
 

--- a/include/pybind11/native_enum.h
+++ b/include/pybind11/native_enum.h
@@ -12,9 +12,7 @@
 #include "pytypes.h"
 
 #include <cassert>
-#include <limits>
 #include <type_traits>
-#include <typeindex>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 

--- a/include/pybind11/native_enum.h
+++ b/include/pybind11/native_enum.h
@@ -5,9 +5,11 @@
 #pragma once
 
 #include "detail/common.h"
+#include "detail/internals.h"
 #include "detail/native_enum_data.h"
 #include "detail/type_caster_base.h"
 #include "cast.h"
+#include "pytypes.h"
 
 #include <cassert>
 #include <limits>

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -11,21 +11,31 @@
 
 #include "pybind11.h"
 #include "detail/common.h"
+#include "detail/descr.h"
+#include "detail/internals.h"
+#include "buffer_info.h"
+#include "cast.h"
 #include "complex.h"
 #include "gil_safe_call_once.h"
 #include "pytypes.h"
 
 #include <algorithm>
 #include <array>
+#include <complex>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <numeric>
 #include <sstream>
+#include <stdexcept>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -24,8 +24,6 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
-#include <cstring>
 #include <functional>
 #include <numeric>
 #include <sstream>

--- a/include/pybind11/operators.h
+++ b/include/pybind11/operators.h
@@ -10,6 +10,12 @@
 #pragma once
 
 #include "pybind11.h"
+#include "detail/pybind11_namespace_macros.h"
+#include "attr.h"
+
+#include <cmath>
+#include <functional>
+#include <type_traits>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -14,14 +14,17 @@
 
 #include <assert.h>
 #include <cstddef>
+#include <cstdio>
 #include <exception>
 #include <frameobject.h>
 #include <iterator>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
+#include <vector>
 
 #if defined(PYBIND11_HAS_OPTIONAL)
 #    include <optional>

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -16,7 +16,6 @@
 #include <cstddef>
 #include <cstdio>
 #include <exception>
-#include <frameobject.h>
 #include <iterator>
 #include <memory>
 #include <stdexcept>

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -13,7 +13,12 @@
 #include "detail/common.h"
 #include "detail/descr.h"
 #include "detail/type_caster_base.h"
+#include "cast.h"
+#include "pytypes.h"
 
+#include <array>
+#include <cassert>
+#include <cstring>
 #include <deque>
 #include <initializer_list>
 #include <list>
@@ -21,9 +26,13 @@
 #include <memory>
 #include <ostream>
 #include <set>
+#include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <valarray>
+#include <vector>
 
 // See `detail/common.h` for implementation of these guards.
 #if defined(PYBIND11_HAS_OPTIONAL)

--- a/include/pybind11/stl/filesystem.h
+++ b/include/pybind11/stl/filesystem.h
@@ -11,6 +11,7 @@
 #include <pybind11/pytypes.h>
 
 #include <string>
+#include <type_traits>
 
 #if defined(PYBIND11_HAS_FILESYSTEM)
 #    include <filesystem>

--- a/include/pybind11/stl_bind.h
+++ b/include/pybind11/stl_bind.h
@@ -9,14 +9,28 @@
 
 #pragma once
 
+#include "pybind11.h"
 #include "detail/common.h"
+#include "detail/descr.h"
+#include "detail/internals.h"
 #include "detail/type_caster_base.h"
+#include "attr.h"
+#include "buffer_info.h"
 #include "cast.h"
 #include "operators.h"
+#include "pytypes.h"
 
 #include <algorithm>
+#include <exception>
+#include <iterator>
+#include <memory>
+#include <optional>
 #include <sstream>
+#include <stdexcept>
+#include <string>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)

--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -12,8 +12,12 @@
 #include "detail/common.h"
 #include "detail/internals.h"
 #include "gil.h"
+#include "pytypes.h"
 
+#include <cstdint>
+#include <cstring>
 #include <stdexcept>
+#include <utility>
 
 #ifndef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 #    error "This platform does not support subinterpreters, do not include this file."

--- a/include/pybind11/trampoline_self_life_support.h
+++ b/include/pybind11/trampoline_self_life_support.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "detail/common.h"
+#include "detail/struct_smart_holder.h"
 #include "detail/using_smart_holder.h"
 #include "detail/value_and_holder.h"
 

--- a/include/pybind11/type_caster_pyobject_ptr.h
+++ b/include/pybind11/type_caster_pyobject_ptr.h
@@ -7,6 +7,9 @@
 #include "cast.h"
 #include "pytypes.h"
 
+#include <string>
+#include <type_traits>
+
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 

--- a/include/pybind11/typing.h
+++ b/include/pybind11/typing.h
@@ -11,10 +11,12 @@
 #pragma once
 
 #include "detail/common.h"
+#include "detail/descr.h"
 #include "cast.h"
 #include "pytypes.h"
 
 #include <algorithm>
+#include <type_traits>
 
 #if defined(__cpp_nontype_template_args) && __cpp_nontype_template_args >= 201911L
 #    define PYBIND11_TYPING_H_HAS_STRING_LITERAL

--- a/include/pybind11/warnings.h
+++ b/include/pybind11/warnings.h
@@ -11,6 +11,10 @@
 
 #include "pybind11.h"
 #include "detail/common.h"
+#include "cast.h"
+#include "pytypes.h"
+
+#include <string>
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 

--- a/tools/iwyu.imp
+++ b/tools/iwyu.imp
@@ -1,0 +1,111 @@
+# include-what-you-use mapping file for pybind11.
+#
+# CPython and both C++ standard libraries make IWYU ask for a header that
+# pybind11 must not include directly: CPython symbols come from headers that
+# only <Python.h> may include, libc++ (macOS) exposes private detail headers,
+# and libstdc++ (Linux) exposes the C headers behind <cXXX>.
+#
+# Prefer a symbol entry. An include entry only takes effect when the left side
+# is private, and declaring a real C header private makes IWYU abort with a
+# "same file seen with two different visibilities" assertion.
+[
+  # CPython headers that <Python.h> includes, generated from the CPython 3.14
+  # include directory (one entry per header named in Python.h itself; headers
+  # such as <datetime.h> that Python.h does not include are kept direct).
+  { include: ["@[\"<]cpython/.*[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]internal/.*[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]abstract\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]audit\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]bltinmodule\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]boolobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]bytearrayobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]bytesobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]ceval\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]codecs\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]compile\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]complexobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]critical_section\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]descrobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]dictobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]enumobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]fileobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]fileutils\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]floatobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]genericaliasobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]import\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]intrcheck\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]iterobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]listobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]lock\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]longobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]memoryobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]methodobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]modsupport\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]moduleobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]monitoring\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]object\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]objimpl\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]osmodule\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]patchlevel\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pyatomic\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pybuffer\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pycapsule\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pyconfig\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pyerrors\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pyframe\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pyhash\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pylifecycle\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pymacconfig\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pymacro\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pymath\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pymem\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pyport\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pystate\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pystats\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pystrcmp\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pystrtod\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pythonrun\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pythread\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]pytypedefs\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]rangeobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]refcount\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]setobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]sliceobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]structseq\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]sysmodule\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]traceback\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]tupleobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]typeslots\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]unicodeobject\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]warnings\\.h[\">]", private, "<Python.h>", public] },
+  { include: ["@[\"<]weakrefobject\\.h[\">]", private, "<Python.h>", public] },
+
+  # libstdc++ reports the C header for these C library symbols.
+  { symbol: ["abs", private, "<cstdlib>", public] },
+  { symbol: ["free", private, "<cstdlib>", public] },
+  { symbol: ["malloc", private, "<cstdlib>", public] },
+  { symbol: ["memcpy", private, "<cstring>", public] },
+  { symbol: ["memset", private, "<cstring>", public] },
+  { symbol: ["size_t", private, "<cstddef>", public] },
+  { symbol: ["strcmp", private, "<cstring>", public] },
+  { symbol: ["strlen", private, "<cstring>", public] },
+
+  # libc++ detail headers. These are private, so an include entry works and
+  # covers every symbol at once.
+  { include: ["<_ctype.h>", private, "<cctype>", public] },
+  { include: ["<_stdio.h>", private, "<cstdio>", public] },
+  { include: ["<_stdlib.h>", private, "<cstdlib>", public] },
+  { include: ["<_string.h>", private, "<cstring>", public] },
+  { include: ["<_time.h>", private, "<ctime>", public] },
+  { include: ["<_wchar.h>", private, "<cwchar>", public] },
+  { include: ["<__config>", private, "<version>", public] },
+  { include: ["<__config_site>", private, "<version>", public] },
+  { include: ["<__hash_table>", private, "<unordered_map>", public] },
+  { include: ["<__hash_table>", private, "<unordered_set>", public] },
+  { include: ["<__locale>", private, "<locale>", public] },
+
+  # Eigen detail headers; name the top-level module header instead.
+  { include: ["@[\"<]Eigen/src/SparseCore/.*[\">]", private, "<Eigen/SparseCore>", public] },
+  { include: ["@[\"<]Eigen/src/.*[\">]", private, "<Eigen/Core>", public] },
+  { include: ["@[\"<]unsupported/Eigen/CXX11/src/.*[\">]", private, "<unsupported/Eigen/CXX11/Tensor>", public] },
+]

--- a/tools/iwyu.sh
+++ b/tools/iwyu.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# include-what-you-use wrapper for the "iwyu" CMake preset.
+#
+# Builds the --check_also list from the headers on disk, so a new header is
+# covered without an edit here. Two headers make IWYU 0.26 crash while it
+# analyzes them, so they are skipped:
+#   include/pybind11/pybind11.h  (assertion: "There should be a redecl
+#                                 specifying the default arg")
+#   include/pybind11/cast.h      (segmentation fault)
+set -eu
+root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+
+set -- -Xiwyu --no_fwd_decls "$@"
+set -- -Xiwyu "--mapping_file=$root/tools/iwyu.imp" "$@"
+for h in "$root"/include/pybind11/*.h "$root"/include/pybind11/*/*.h; do
+    case $h in
+    */pybind11/pybind11.h | */pybind11/cast.h) continue ;;
+    esac
+    set -- -Xiwyu "--check_also=$h" "$@"
+done
+
+exec include-what-you-use "$@"


### PR DESCRIPTION
This is a pretty straightforward Claupy of CLIUtils/CLI11#1418. CI will have to test Windows and other variations of compilers and platforms, I did a linux and macOS locally.

iwyu crashes on one of our headers, and segfaults on another, by the way.

:robot: _AI text below_ :robot:

## Description

Adds an `iwyu` preset and applies what it found, following CLIUtils/CLI11#1418.

The preset runs include-what-you-use over the test build through
`tools/iwyu.sh`, which asks IWYU to also check each pybind11 header. Two
headers crash IWYU 0.26 while it analyzes them and are skipped: `pybind11.h`
(assertion: "There should be a redecl specifying the default arg") and
`cast.h` (segmentation fault). Nothing enforces the result: the build always
succeeds and IWYU writes to stderr.

`tools/iwyu.imp` keeps the report readable. It maps each CPython header that
`Python.h` includes back to `<Python.h>` (headers such as `<datetime.h>` that
`Python.h` does not include stay direct), libc++ detail headers and the C
headers libstdc++ reports to the standard C++ header, and Eigen `src/`
internals to the module headers. `IWYU pragma: export` comments on
`detail/common.h` and `conduit/wrap_include_python_h.h` teach IWYU the
convention that `detail/common.h` is how a header gets `<Python.h>`.

The second commit applies the additions, so each header names the pybind11
and standard headers it uses instead of taking them transitively. The third
applies the removals that macOS (libc++) and Debian (libstdc++) runs both
report, after checking the preprocessor branches IWYU did not compile; the
commit message records the rejected findings and why (`Py_GIL_DISABLED` and
`PYPY_VERSION` branches, C++20 branches, forward declarations that carry
default template arguments, and the one-include contract of the feature
headers).

Beyond CI, verified with the full test suite on macOS, a free-threaded 3.14t
build for the `Py_GIL_DISABLED` branches, and a g++ `-Werror` build on Debian
trixie.

## Suggested changelog entry:

* Headers now include what they use, and an `iwyu` CMake preset is available to keep them that way.
