### PR TITLE
fix(subinterpreter): don't touch the thread state before create() attaches one

### DIFF
--- a/include/pybind11/subinterpreter.h
+++ b/include/pybind11/subinterpreter.h
@@ -86,11 +86,14 @@ public:
     /// interpreter and its GIL are not required to be held prior to calling this function.
     static subinterpreter create(PyInterpreterConfig const &cfg) {
 
-        error_scope err_scope;
         subinterpreter result;
         {
             // we must hold the main GIL in order to create a subinterpreter
             subinterpreter_scoped_activate main_guard(main());
+
+            // error_scope reads and writes the *current* thread state, so it must be constructed
+            // only after main_guard has attached one (see PR #6127 for details).
+            error_scope err_scope;
 
             auto *prev_tstate = PyThreadState_Get();
 

--- a/tests/test_with_catch/test_subinterpreter.cpp
+++ b/tests/test_with_catch/test_subinterpreter.cpp
@@ -262,6 +262,54 @@ TEST_CASE("Reused Subinterpreter thread state (multiple interpreters)") {
     unsafe_reset_internals_for_single_interpreter();
 }
 
+TEST_CASE("Create Subinterpreter without a thread state") {
+    // subinterpreter::create() documents that "the main interpreter and its GIL are not required
+    // to be held prior to calling this function".  Embedders routinely end their initialization
+    // with PyEval_SaveThread(), which leaves the calling thread with no PyThreadState at all, and
+    // worker threads that have never touched Python have none either.  So create() must not touch
+    // the current thread state before main_guard attaches one.
+
+    PyInterpreterState *main_interp = PyInterpreterState_Get();
+
+    {
+        py::gil_scoped_release nogil;
+        REQUIRE(py::detail::get_thread_state_unchecked() == nullptr);
+
+        // (a) on a thread that dropped its thread state
+        {
+            auto sub = py::subinterpreter::create();
+            REQUIRE(sub.id() >= 0);
+
+            {
+                py::subinterpreter_scoped_activate activate(sub);
+                REQUIRE(PyInterpreterState_Get() != main_interp);
+            }
+
+            REQUIRE(py::detail::get_thread_state_unchecked() == nullptr);
+        }
+
+        // (b) on a thread that never had one.
+        // REQUIRE throws on failure, so we can't use it within the thread: record what we see
+        // and check it on the main test thread after the join.
+        bool thread_started_without_tstate = false;
+        bool thread_result = false;
+        std::thread([&]() {
+            thread_started_without_tstate = (py::detail::get_thread_state_unchecked() == nullptr);
+
+            auto sub = py::subinterpreter::create();
+            py::subinterpreter_scoped_activate activate(sub);
+            thread_result = (PyInterpreterState_Get() != main_interp);
+        }).join();
+        REQUIRE(thread_started_without_tstate);
+        REQUIRE(thread_result);
+
+        REQUIRE(py::detail::get_thread_state_unchecked() == nullptr);
+    }
+
+    REQUIRE(PyInterpreterState_Get() == main_interp);
+    unsafe_reset_internals_for_single_interpreter();
+}
+
 TEST_CASE("GIL Subinterpreter") {
 
     PyInterpreterState *main_interp = PyInterpreterState_Get();


### PR DESCRIPTION
## Description

### The problem

`subinterpreter::create()` documents that no GIL is required up front:

> `@note` This function acquires (and then releases) the main interpreter GIL, but the main interpreter and its GIL are not required to be held prior to calling this function.

But its very first statement is `error_scope err_scope;` — i.e. `PyErr_Fetch()` — **before** `main_guard` attaches a thread state:

```cpp
static subinterpreter create(PyInterpreterConfig const &cfg) {

    error_scope err_scope;           // <-- PyErr_Fetch() with no tstate
    subinterpreter result;
    {
        // we must hold the main GIL in order to create a subinterpreter
        subinterpreter_scoped_activate main_guard(main());
```

With no current `PyThreadState`, `PyErr_Fetch()` reaches `_PyErr_GetRaisedException(NULL)`, which reads `tstate->current_exception` off a null pointer, and the process dies (SIGSEGV; `0xC0000005` on Windows). `~error_scope` is the mirror image: it calls `PyErr_Restore()` after `main_guard` has already swapped the thread state back away.

Two entirely ordinary situations reach `create()` with no thread state:

- **an embedder that ends its initialization with `PyEval_SaveThread()`** — the documented way to hand the GIL back after `Py_InitializeFromConfig()`;
- **any worker thread that has never touched Python.**

That is how I ran into it. An embedding project calls `PyEval_SaveThread()` at the end of its setup, and every subsequent `py::subinterpreter::create()` from that thread crashed immediately. Instrumenting the call site:

```
tstate=0000000000000000        # right after PyEval_SaveThread()
tstate=00007FFC0E5EADA0        # after an explicit gil_scoped_acquire
```

Wrapping the call in `py::gil_scoped_acquire` works around it, but that contradicts the documented contract.

The existing tests never hit this: they all run under the `py::scoped_interpreter guard{}` in `catch.cpp`, which keeps the GIL held on the main thread for the whole run, so `create()` is only ever reached with a thread state already attached.

### The fix

Move `error_scope` inside the `main_guard` scope, so it is constructed only once a thread state is attached.

The case `error_scope` exists for is unaffected. A caller that **already holds the main GIL** takes `subinterpreter_scoped_activate`'s `simple_gil_` fast path, which keeps the *same* thread state, so its pending error is still saved across `Py_NewInterpreterFromConfig()` and restored afterwards — exactly as before.

A caller sitting on some *other* interpreter never had its error indicator touched in the first place: everything inside the block runs on the main interpreter's thread state, and `PyThreadState_Swap()` does not move error indicators. Leaving that caller's exception pending across the call is therefore correct as well.

As a side benefit, the `pybind11_fail("failed to create new sub-interpreter")` path now unwinds in a safer order: `~error_scope` runs while `main_guard` is still alive, rather than after the thread state has been swapped away (or, previously, when there may have been none at all).

### The test

`Create Subinterpreter without a thread state` covers both entry points — a thread that dropped its thread state via `gil_scoped_release`, and a thread that never had one:

| | before | after |
|---|---|---|
| new test alone | `EXIT=139` (SIGSEGV) | `[ OK ]` |
| whole `test_with_catch` | 33 cases, exit 0 | 34 cases, exit 0 |

Verified on Windows / MSVC 14.51 / CPython 3.13.14. `clang-format --style=file` is clean on both files.

## Suggested changelog entry:

* Fixed a crash in ``py::subinterpreter::create()`` when called without a current ``PyThreadState``, which its documentation explicitly allows — for example from an embedder that ended initialization with ``PyEval_SaveThread()``, or from a worker thread that has never touched Python. ``error_scope`` is now constructed after a thread state has been attached instead of before.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6127.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->