### PR TITLE
fix: bump PYBIND11_INTERNALS_VERSION to 13

### DIFF
--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -39,11 +39,11 @@
 /// further ABI-incompatible changes may be made before the ABI is officially
 /// changed to the new version.
 #ifndef PYBIND11_INTERNALS_VERSION
-#    define PYBIND11_INTERNALS_VERSION 12
+#    define PYBIND11_INTERNALS_VERSION 13
 #endif
 
-#if PYBIND11_INTERNALS_VERSION < 12
-#    error "PYBIND11_INTERNALS_VERSION 12 is the minimum for all platforms for pybind11 v3.1.0"
+#if PYBIND11_INTERNALS_VERSION < 13
+#    error "PYBIND11_INTERNALS_VERSION 13 is the minimum for all platforms for pybind11 v3.1.0"
 #endif
 
 PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
@@ -216,6 +216,9 @@ template <typename value_type>
 using type_map = std::unordered_map<std::type_index, value_type, type_hash, type_equal_to>;
 
 struct override_hash {
+    // With libstdc++, the hasher's noexcept determines whether unordered
+    // containers cache the hash in each node, changing the node layout, so
+    // adding/removing it requires a PYBIND11_INTERNALS_VERSION bump (#6090).
     size_t operator()(const std::pair<const PyObject *, const char *> &v) const noexcept {
         size_t value = std::hash<const void *>()(v.first);
         value ^= std::hash<const void *>()(v.second) + 0x9e3779b9 + (value << 6) + (value >> 2);


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Description

Closes #6090.

Bumps `PYBIND11_INTERNALS_VERSION` to 13 before the v3.1.0 release. #5960 added `noexcept` to the hash functors in `internals.h`. With libstdc++, a `noexcept` hasher disables per-node hash caching in unordered containers, which changes the node layout of `inactive_override_cache`. Modules built from master before and after #5960 both claim internals v12 but disagree on that layout, so v12 is not safe to ship as-is. A comment now marks the `noexcept` as ABI-relevant to prevent an accidental change later.

Investigation of #6090 (partially revert the `noexcept` additions) shows the revert itself is not necessary:

- The custom string-based `type_hash` / `type_equal_to` only compile under libc++ (`_LIBCPP_VERSION`); libstdc++ and MSVC use `std::hash<std::type_index>`. libc++ stores the hash in every node unconditionally, so `noexcept` has no effect there — a benchmark of both variants under libc++ shows identical node size (32 bytes) and identical insert/find/rehash times.
- `override_hash` is the one functor where `noexcept` changes libstdc++ behavior (24- vs 32-byte nodes). It hashes two pointers, so recomputation is nearly free; the smaller uncached node is the better trade. Keep the `noexcept`.

For reference, a benchmark of the general caching trade-off under libstdc++ (GCC 16, djb2 string hash, 2000 keys, 4M lookups) shows caching only matters for expensive string hashes: hits 148 ms vs 115 ms, misses 257 ms vs 147 ms, 200 rehashes 9.9 ms vs 0.8 ms (noexcept/uncached vs cached). That configuration does not occur in pybind11, which is why no revert is needed.

## Suggested changelog entry:

* Bump `PYBIND11_INTERNALS_VERSION` to 13, because #5960 changed the internal override-cache node layout with libstdc++.