### PR TITLE
fix(cmake): carry option-driven defines on pybind11_headers INTERFACE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,13 +109,6 @@ if(NOT DEFINED PYBIND11_USE_CROSSCOMPILING)
 endif()
 option(PYBIND11_USE_CROSSCOMPILING "Respect CMAKE_CROSSCOMPILING" OFF)
 
-if(PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION)
-  add_compile_definitions(PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION)
-endif()
-if(PYBIND11_SIMPLE_GIL_MANAGEMENT)
-  add_compile_definitions(PYBIND11_SIMPLE_GIL_MANAGEMENT)
-endif()
-
 cmake_dependent_option(
   USE_PYTHON_INCLUDE_DIR
   "Install pybind11 headers in Python include directory instead of default installation prefix"
@@ -306,6 +299,13 @@ if(NOT TARGET pybind11_headers)
   if(NOT "${PYBIND11_INTERNALS_VERSION}" STREQUAL "")
     target_compile_definitions(
       pybind11_headers INTERFACE "PYBIND11_INTERNALS_VERSION=${PYBIND11_INTERNALS_VERSION}")
+  endif()
+  if(PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION)
+    target_compile_definitions(pybind11_headers
+                               INTERFACE PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION)
+  endif()
+  if(PYBIND11_SIMPLE_GIL_MANAGEMENT)
+    target_compile_definitions(pybind11_headers INTERFACE PYBIND11_SIMPLE_GIL_MANAGEMENT)
   endif()
 else()
   # It is invalid to install a target twice, too.

--- a/tests/test_cmake_build/CMakeLists.txt
+++ b/tests/test_cmake_build/CMakeLists.txt
@@ -20,6 +20,15 @@ function(pybind11_add_build_test name)
     list(APPEND build_options "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
   endif()
 
+  # Forward option-driven defines so the nested projects can verify they propagate
+  # through the pybind11_headers usage requirements.
+  foreach(opt IN ITEMS PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION
+                       PYBIND11_SIMPLE_GIL_MANAGEMENT)
+    if(${opt})
+      list(APPEND build_options "-D${opt}=ON")
+    endif()
+  endforeach()
+
   if(NOT ARG_INSTALL)
     list(APPEND build_options "-Dpybind11_SOURCE_DIR=${pybind11_SOURCE_DIR}")
   else()

--- a/tests/test_cmake_build/installed_target/CMakeLists.txt
+++ b/tests/test_cmake_build/installed_target/CMakeLists.txt
@@ -8,6 +8,15 @@ message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
 add_library(test_installed_target MODULE ../main.cpp)
 
 target_link_libraries(test_installed_target PRIVATE pybind11::module)
+
+# If a pybind11 option is on, main.cpp checks that the matching macro reached this
+# consumer target via the installed pybind11_headers usage requirements.
+foreach(opt IN ITEMS PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION
+                     PYBIND11_SIMPLE_GIL_MANAGEMENT)
+  if(${opt})
+    target_compile_definitions(test_installed_target PRIVATE "EXPECT_${opt}")
+  endif()
+endforeach()
 set_target_properties(test_installed_target PROPERTIES OUTPUT_NAME test_cmake_build)
 
 # Make sure result is, for example, test_installed_target.so, not libtest_installed_target.dylib

--- a/tests/test_cmake_build/main.cpp
+++ b/tests/test_cmake_build/main.cpp
@@ -1,4 +1,16 @@
 #include <pybind11/pybind11.h>
+
+#ifdef EXPECT_PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION
+#    ifndef PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION
+#        error "PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION did not propagate"
+#    endif
+#endif
+#ifdef EXPECT_PYBIND11_SIMPLE_GIL_MANAGEMENT
+#    ifndef PYBIND11_SIMPLE_GIL_MANAGEMENT
+#        error "PYBIND11_SIMPLE_GIL_MANAGEMENT did not propagate"
+#    endif
+#endif
+
 namespace py = pybind11;
 
 PYBIND11_MODULE(test_cmake_build, m, py::mod_gil_not_used()) {

--- a/tests/test_cmake_build/subdirectory_target/CMakeLists.txt
+++ b/tests/test_cmake_build/subdirectory_target/CMakeLists.txt
@@ -15,6 +15,15 @@ set_target_properties(test_subdirectory_target PROPERTIES OUTPUT_NAME test_cmake
 
 target_link_libraries(test_subdirectory_target PRIVATE pybind11::module)
 
+# If a pybind11 option is on, main.cpp checks that the matching macro reached this
+# consumer target via the pybind11_headers usage requirements.
+foreach(opt IN ITEMS PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION
+                     PYBIND11_SIMPLE_GIL_MANAGEMENT)
+  if(${opt})
+    target_compile_definitions(test_subdirectory_target PRIVATE "EXPECT_${opt}")
+  endif()
+endforeach()
+
 # Make sure result is, for example, test_installed_target.so, not libtest_installed_target.dylib
 pybind11_extension(test_subdirectory_target)
 


### PR DESCRIPTION
This is a general fix anyway, can stand on its own.

:robot: _AI text below_ :robot:

## Description

`PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION` and `PYBIND11_SIMPLE_GIL_MANAGEMENT` were applied with a directory-scoped `add_compile_definitions`, so they only took effect in the master-project (test) build. Move them onto the `pybind11_headers` INTERFACE, the same pattern as `PYBIND11_INTERNALS_VERSION`. The options now also work in `add_subdirectory` mode and ride the exported/installed targets.

This is step 0 of the optional pre-compilation work: must-match configuration macros have to propagate through `pybind11::headers` so a future precompiled static library and consumer modules always agree.

## Suggested changelog entry:

* The CMake options ``PYBIND11_DISABLE_HANDLE_TYPE_NAME_DEFAULT_IMPLEMENTATION`` and ``PYBIND11_SIMPLE_GIL_MANAGEMENT`` now apply in ``add_subdirectory`` mode and to installed/exported targets