### PR TITLE
[chore/headers-interface-defines] feat: add PYBIND11_NOINLINE_ATTR and PYBIND11_INLINE macros

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -160,11 +160,22 @@
 // In contrast, FORWARD DECLARATIONS should never use this macro:
 // https://stackoverflow.com/questions/9317473/forward-declaration-of-inline-functions
 #if defined(PYBIND11_NOINLINE_DISABLED) // Option for maximum portability and experimentation.
-#    define PYBIND11_NOINLINE inline
+#    define PYBIND11_NOINLINE_ATTR
 #elif defined(_MSC_VER)
-#    define PYBIND11_NOINLINE __declspec(noinline) inline
+#    define PYBIND11_NOINLINE_ATTR __declspec(noinline)
 #else
-#    define PYBIND11_NOINLINE __attribute__((noinline)) inline
+#    define PYBIND11_NOINLINE_ATTR __attribute__((noinline))
+#endif
+#define PYBIND11_NOINLINE PYBIND11_NOINLINE_ATTR inline
+
+// PYBIND11_INLINE marks function definitions that live in a `-inl.h` file. It is `inline` in
+// the default header-only mode. Defining PYBIND11_PRECOMPILED makes it empty: the definitions
+// are then compiled once (into a static library linked into each extension module) and the
+// headers only provide declarations.
+#if defined(PYBIND11_PRECOMPILED)
+#    define PYBIND11_INLINE
+#else
+#    define PYBIND11_INLINE inline
 #endif
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Description

Stacked on #6130.

Decompose `PYBIND11_NOINLINE` into `PYBIND11_NOINLINE_ATTR` + `inline` (all three current expansions are reproduced exactly), and add `PYBIND11_INLINE`: `inline` by default, empty when `PYBIND11_PRECOMPILED` is defined. This is the macro groundwork for optional pre-compilation (CLI11 and fmt use the same pattern; see also #2445 and #4001). `PYBIND11_INLINE` has no uses yet, so this PR is a no-op refactor.

## Suggested changelog entry:

* Placeholder.