### PR TITLE
fix(cmake): don't link SHARED modules against libpython in FindPython mode

### DIFF
--- a/tools/pybind11NewTools.cmake
+++ b/tools/pybind11NewTools.cmake
@@ -266,7 +266,13 @@ function(pybind11_add_module target_name)
     set(lib_type MODULE)
   endif()
 
-  if("${_Python}" STREQUAL "Python")
+  if(lib_type STREQUAL "SHARED")
+    # Bypass python_add_library, which links SHARED libraries against libpython.
+    # An extension module must not link libpython on macOS; with a statically
+    # linked interpreter (e.g. python-build-standalone) that loads a second
+    # Python runtime and aborts on import. Matches classic pybind11Tools.cmake.
+    add_library(${target_name} SHARED ${ARG_UNPARSED_ARGUMENTS})
+  elseif("${_Python}" STREQUAL "Python")
     python_add_library(${target_name} ${lib_type} ${ARG_UNPARSED_ARGUMENTS})
   elseif("${_Python}" STREQUAL "Python3")
     python3_add_library(${target_name} ${lib_type} ${ARG_UNPARSED_ARGUMENTS})
@@ -276,10 +282,10 @@ function(pybind11_add_module target_name)
 
   target_link_libraries(${target_name} PRIVATE pybind11::headers)
 
-  if(lib_type STREQUAL "MODULE")
-    target_link_libraries(${target_name} PRIVATE pybind11::module)
-  else()
+  if(lib_type STREQUAL "STATIC")
     target_link_libraries(${target_name} PRIVATE pybind11::embed)
+  else()
+    target_link_libraries(${target_name} PRIVATE pybind11::module)
   endif()
 
   # -fvisibility=hidden is required to allow multiple modules compiled against


### PR DESCRIPTION
Our own test suite fails if using python-build-standalone (or any other statically linked Python). This is one option for a fix.

:robot: _AI text below_ :robot:

## Description

In FindPython mode, `pybind11_add_module(... SHARED ...)` routes through CMake's `Python_add_library`, which hard-links every non-`MODULE` library against `Python::Python`. An extension module must not link `libpython` on macOS: with a statically linked interpreter (uv / python-build-standalone), the linked `libpython3.x.dylib` loads as a second, uninitialized copy of the Python runtime, two-level namespace binds the module's C-API calls to it, and the import aborts with:

```
Fatal Python error: PyInterpreterState_Get: the function must be called with the GIL
held, ... but the GIL is released (the current Python thread state is NULL)
```

This is exactly what the `installed_function` case of `test_cmake_build` (the only case that uses `SHARED`) hits when the repo's documented `cmake --workflow venv` flow (uv-created venv) runs on macOS. Linux hides the same duplicate-runtime setup through ELF symbol interposition, and macOS CI uses dynamically linked python.org builds, so CI never sees it.

Fix, in `pybind11NewTools.cmake`:

- `SHARED` now calls plain `add_library` instead of `Python_add_library`, and
- links `pybind11::module` instead of `pybind11::embed` (only `STATIC` keeps `pybind11::embed`).

This matches what classic mode (`pybind11Tools.cmake`) has always done for `SHARED`, so it aligns the two code paths rather than inventing new semantics. Verified locally on macOS arm64 with a uv-managed CPython 3.13: the built module no longer links `libpython`, the previously-failing `installed_function` case passes, and all other `test_cmake_build` cases (including both embed cases) still pass.

Behavior notes:

- `SHARED` no longer requires the `Development.Embed` component and no longer records a `libpython` dependency. An application that links a `SHARED` pybind11 library into an embedding executable must link `libpython` itself — already the case in classic mode.
- `SHARED` + `WITH_SOABI` previously produced an author warning from FindPython ("MODULE only") and was a no-op; it now fails at configure because `WITH_SOABI` is no longer parsed out. Left unhandled to keep the change minimal.

## Suggested changelog entry:

* ``pybind11_add_module`` in FindPython mode no longer links ``SHARED`` extension modules against ``libpython``, matching classic mode; this fixes import crashes with statically linked interpreters (e.g. uv / python-build-standalone) on macOS.
