### PR TITLE
fix: returning a copyable type with a deleted move constructor

### DIFF
--- a/include/pybind11/detail/function_ref.h
+++ b/include/pybind11/detail/function_ref.h
@@ -31,6 +31,8 @@
 // - renamed back to function_ref
 // - use pybind11 enable_if_t, remove_cvref_t, and remove_reference_t
 // - lint suppressions
+// - accept same-type non-movable returns under C++17 guaranteed copy elision
+//   (issue #6142)
 
 // torch::executor: modified from llvm::function_ref
 // - renamed to FunctionRef
@@ -54,6 +56,17 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 
 template <typename Fn>
 class function_ref;
+
+// pybind11: is_convertible<Ret, Ret> is false for a copyable but non-movable
+// type (it tests conversion from an xvalue, which selects the deleted move
+// constructor), but in C++17 a same-type prvalue is returnable via guaranteed
+// copy elision. Accept that case explicitly. See issue #6142.
+template <typename From, typename To>
+using is_returnable_as = bool_constant<
+#if defined(PYBIND11_CPP17)
+    std::is_same<From, To>::value ||
+#endif
+    std::is_convertible<From, To>::value>;
 
 template <typename Ret, typename... Params>
 class function_ref<Ret(Params...)> {
@@ -81,8 +94,8 @@ public:
         // Functor must be callable and return a suitable type.
         enable_if_t<
             std::is_void<Ret>::value
-            || std::is_convertible<decltype(std::declval<Callable>()(std::declval<Params>()...)),
-                                   Ret>::value> * = nullptr)
+            || is_returnable_as<decltype(std::declval<Callable>()(std::declval<Params>()...)),
+                                Ret>::value> * = nullptr)
         : callback(callback_fn<remove_reference_t<Callable>>),
           callable(reinterpret_cast<intptr_t>(&callable)) {}
 

--- a/include/pybind11/detail/function_ref.h
+++ b/include/pybind11/detail/function_ref.h
@@ -31,7 +31,7 @@
 // - renamed back to function_ref
 // - use pybind11 enable_if_t, remove_cvref_t, and remove_reference_t
 // - lint suppressions
-// - accept same-type non-movable returns under C++17 guaranteed copy elision
+// - accept same-type non-movable returns under guaranteed copy elision
 //   (issue #6142)
 
 // torch::executor: modified from llvm::function_ref
@@ -59,11 +59,11 @@ class function_ref;
 
 // pybind11: is_convertible<Ret, Ret> is false for a copyable but non-movable
 // type (it tests conversion from an xvalue, which selects the deleted move
-// constructor), but in C++17 a same-type prvalue is returnable via guaranteed
-// copy elision. Accept that case explicitly. See issue #6142.
+// constructor), but with guaranteed copy elision a same-type prvalue is still
+// returnable. Accept that case explicitly. See issue #6142.
 template <typename From, typename To>
 using is_returnable_as = bool_constant<
-#if defined(PYBIND11_CPP17)
+#if defined(__cpp_guaranteed_copy_elision) && __cpp_guaranteed_copy_elision >= 201606L
     std::is_same<From, To>::value ||
 #endif
     std::is_convertible<From, To>::value>;

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -107,6 +107,22 @@ public:
 
     int value;
 };
+// #6142: returning a copy-constructible type with an explicitly deleted move
+// constructor failed to compile inside detail::function_ref (3.1.0 regression).
+// Returning such a type by value requires C++17 guaranteed copy elision.
+#if defined(PYBIND11_CPP17)
+class CopyOnlyDeletedMove {
+public:
+    explicit CopyOnlyDeletedMove(int v) : value{v} {}
+    CopyOnlyDeletedMove(const CopyOnlyDeletedMove &) = default;
+    CopyOnlyDeletedMove &operator=(const CopyOnlyDeletedMove &) = delete;
+    CopyOnlyDeletedMove(CopyOnlyDeletedMove &&) = delete;
+    CopyOnlyDeletedMove &operator=(CopyOnlyDeletedMove &&) = delete;
+
+    int value;
+};
+#endif
+
 PYBIND11_NAMESPACE_BEGIN(pybind11)
 PYBIND11_NAMESPACE_BEGIN(detail)
 template <>
@@ -175,6 +191,13 @@ TEST_SUBMODULE(copy_move_policies, m) {
     // test_lacking_move_ctor
     py::class_<lacking_move_ctor>(m, "lacking_move_ctor")
         .def_static("get_one", &lacking_move_ctor::get_one, py::return_value_policy::move);
+
+    // test_copy_only_deleted_move (#6142)
+#if defined(PYBIND11_CPP17)
+    py::class_<CopyOnlyDeletedMove>(m, "CopyOnlyDeletedMove")
+        .def_readonly("value", &CopyOnlyDeletedMove::value);
+    m.def("get_copy_only_deleted_move", []() { return CopyOnlyDeletedMove(42); });
+#endif
 
     // test_move_and_copy_casts
     // NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/tests/test_copy_move.cpp
+++ b/tests/test_copy_move.cpp
@@ -109,8 +109,8 @@ public:
 };
 // #6142: returning a copy-constructible type with an explicitly deleted move
 // constructor failed to compile inside detail::function_ref (3.1.0 regression).
-// Returning such a type by value requires C++17 guaranteed copy elision.
-#if defined(PYBIND11_CPP17)
+// Returning such a type by value requires guaranteed copy elision.
+#if defined(__cpp_guaranteed_copy_elision) && __cpp_guaranteed_copy_elision >= 201606L
 class CopyOnlyDeletedMove {
 public:
     explicit CopyOnlyDeletedMove(int v) : value{v} {}
@@ -193,7 +193,7 @@ TEST_SUBMODULE(copy_move_policies, m) {
         .def_static("get_one", &lacking_move_ctor::get_one, py::return_value_policy::move);
 
     // test_copy_only_deleted_move (#6142)
-#if defined(PYBIND11_CPP17)
+#if defined(__cpp_guaranteed_copy_elision) && __cpp_guaranteed_copy_elision >= 201606L
     py::class_<CopyOnlyDeletedMove>(m, "CopyOnlyDeletedMove")
         .def_readonly("value", &CopyOnlyDeletedMove::value);
     m.def("get_copy_only_deleted_move", []() { return CopyOnlyDeletedMove(42); });

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -145,7 +145,8 @@ def test_unusual_op_ref():
 
 
 @pytest.mark.skipif(
-    not hasattr(m, "get_copy_only_deleted_move"), reason="requires C++17 copy elision"
+    not hasattr(m, "get_copy_only_deleted_move"),
+    reason="requires guaranteed copy elision",
 )
 def test_copy_only_deleted_move():
     """#6142: a copyable type with a deleted move constructor can be returned by value

--- a/tests/test_copy_move.py
+++ b/tests/test_copy_move.py
@@ -142,3 +142,14 @@ def test_unusual_op_ref():
     # Merely to test that this still exists and built successfully.
     assert m.CallCastUnusualOpRefConstRef().__class__.__name__ == "UnusualOpRef"
     assert m.CallCastUnusualOpRefMovable().__class__.__name__ == "UnusualOpRef"
+
+
+@pytest.mark.skipif(
+    not hasattr(m, "get_copy_only_deleted_move"), reason="requires C++17 copy elision"
+)
+def test_copy_only_deleted_move():
+    """#6142: a copyable type with a deleted move constructor can be returned by value
+
+    This is primarily a compile-time regression test.
+    """
+    assert m.get_copy_only_deleted_move().value == 42


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Description

Fixes #6142, a 3.1.0 regression from the `call_impl` outlining in #5887.

`detail::function_ref`'s constructor SFINAE requires `is_convertible<decltype(f(args...)), Ret>`. For a copyable type whose move constructor is explicitly deleted, `is_convertible<Ret, Ret>` is false, because the trait tests conversion from an xvalue, which selects the deleted move constructor. In C++17 such a prvalue return is legal via guaranteed copy elision, so the constraint rejected code the function body compiles fine. The fix also accepts an exact type match (C++17 and later only; in C++14 such a type cannot be returned by value at all).

The regression test fails to compile without the fix and is guarded for C++17, since the C++14 CI builds cannot express the case.

## Suggested changelog entry:

* Fixed a 3.1.0 regression: functions returning a copyable type with an explicitly deleted move constructor failed to compile.
