### PR TITLE
docs: document Sphinx autodoc handler for signature * (#4537)

### DIFF
--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -499,7 +499,7 @@ strings in pybind11-based extension modules to automatically generate beautiful
 documentation in a variety formats. The python_example repository [#f5]_ contains a
 simple example repository which uses this approach.
 
-There are two potential gotchas when using this approach: first, make sure that
+There are a few potential gotchas when using this approach: first, make sure that
 the resulting strings do not contain any :kbd:`TAB` characters, which break the
 docstring parsing routines. You may want to use C++11 raw string literals,
 which are convenient for multi-line comments. Conveniently, any excess
@@ -522,6 +522,27 @@ work, it is important that all lines are indented consistently, i.e.:
         Parameters
         ----------
     )mydelimiter");
+
+Second, auto-generated signatures intentionally contain a literal ``*`` (for
+``*args``, ``py::args``, ``py::kw_only``, and similar). That matches normal
+Python / ``help()`` / stubgen conventions, and Sphinx's own
+``autodoc_docstring_signature`` expects it. Sphinx reStructuredText, however,
+treats unpaired ``*`` as emphasis and may warn with
+``Inline emphasis start-string without end-string``.
+
+Do **not** escape ``*`` inside the generated docstring itself. Instead, escape
+it when Sphinx processes the docstring by connecting an
+``autodoc-process-docstring`` handler in your project's ``conf.py`` (with
+``sphinx.ext.autodoc`` enabled):
+
+.. code-block:: python
+
+    def process_docstring(app, what, name, obj, options, lines):
+        for i, line in enumerate(lines):
+            lines[i] = line.replace("*", r"\*")
+
+    def setup(app):
+        app.connect("autodoc-process-docstring", process_docstring)
 
 By default, pybind11 automatically generates and prepends a signature to the docstring of a function
 registered with ``module_::def()`` and ``class_::def()``. Sometimes this

--- a/docs/advanced/misc.rst
+++ b/docs/advanced/misc.rst
@@ -541,6 +541,7 @@ it when Sphinx processes the docstring by connecting an
         for i, line in enumerate(lines):
             lines[i] = line.replace("*", r"\*")
 
+
     def setup(app):
         app.connect("autodoc-process-docstring", process_docstring)
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -855,6 +855,14 @@ protected:
 
         std::string signatures;
         int index = 0;
+        auto append_doc_signature = [&signatures](const char *sig) {
+            for (const char *p = sig; *p != '\0'; ++p) {
+                if (*p == '*') {
+                    signatures += '\\';
+                }
+                signatures += *p;
+            }
+        };
         /* Create a nice pydoc rec including all signatures and
            docstrings of the functions in the overload chain */
         if (chain && options::show_function_signatures()
@@ -876,7 +884,7 @@ protected:
                     signatures += std::to_string(++index) + ". ";
                 }
                 signatures += rec->name;
-                signatures += it->signature;
+                append_doc_signature(it->signature);
                 signatures += '\n';
             }
             if (it->doc && it->doc[0] != '\0' && options::show_user_defined_docstrings()) {

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -855,14 +855,6 @@ protected:
 
         std::string signatures;
         int index = 0;
-        auto append_doc_signature = [&signatures](const char *sig) {
-            for (const char *p = sig; *p != '\0'; ++p) {
-                if (*p == '*') {
-                    signatures += '\\';
-                }
-                signatures += *p;
-            }
-        };
         /* Create a nice pydoc rec including all signatures and
            docstrings of the functions in the overload chain */
         if (chain && options::show_function_signatures()
@@ -884,7 +876,7 @@ protected:
                     signatures += std::to_string(++index) + ". ";
                 }
                 signatures += rec->name;
-                append_doc_signature(it->signature);
+                signatures += it->signature;
                 signatures += '\n';
             }
             if (it->doc && it->doc[0] != '\0' && options::show_user_defined_docstrings()) {


### PR DESCRIPTION
Fixes #4537

## Summary

- Keep literal `*` in generated function signatures (needed by `help()`, stubgen, and `autodoc_docstring_signature`).
- Document an `autodoc-process-docstring` handler in `docs/advanced/misc.rst` so Sphinx escapes `*` at doc-build time instead of changing the runtime docstring.

## Test plan

- [ ] Confirm generated signatures still contain literal `*`.
- [ ] With the documented `conf.py` handler, Sphinx no longer warns on `py::args` / `py::kw_only` signatures.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6144.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->