### PR TITLE
fix: guard cxxabi.h include with __has_include for clang-cl

### DIFF
--- a/include/pybind11/detail/typeid.h
+++ b/include/pybind11/detail/typeid.h
@@ -14,6 +14,9 @@
 
 #if defined(__GNUG__)
 #    if !defined(__has_include)
+// All supported Clang versions provide __has_include, but GCC versions before 5 do not.
+// Preserve the previous unconditional __GNUG__ behavior for those older, still-supported
+// GCC versions (see PR #6145).
 #        define PYBIND11_HAS_CXXABI_H
 #    elif __has_include(<cxxabi.h>)
 #        define PYBIND11_HAS_CXXABI_H

--- a/include/pybind11/detail/typeid.h
+++ b/include/pybind11/detail/typeid.h
@@ -13,6 +13,13 @@
 #include <cstdlib>
 
 #if defined(__GNUG__)
+#    if !defined(__has_include)
+#        define PYBIND11_HAS_CXXABI_H
+#    elif __has_include(<cxxabi.h>)
+#        define PYBIND11_HAS_CXXABI_H
+#    endif
+#endif
+#if defined(PYBIND11_HAS_CXXABI_H)
 #    include <cxxabi.h>
 #endif
 
@@ -33,7 +40,7 @@ inline void erase_all(std::string &string, const std::string &search) {
 }
 
 PYBIND11_NOINLINE void clean_type_id(std::string &name) {
-#if defined(__GNUG__)
+#if defined(PYBIND11_HAS_CXXABI_H)
     int status = 0;
     std::unique_ptr<char, void (*)(void *)> res{
         abi::__cxa_demangle(name.c_str(), nullptr, nullptr, &status), std::free};


### PR DESCRIPTION
## Description

clang-cl on Windows defines `__GNUG__` but does not ship `<cxxabi.h>`, so `detail/typeid.h` fails with `fatal error: 'cxxabi.h' file not found`.

This introduces `PYBIND11_HAS_CXXABI_H` as suggested by @henryiii in #6129: defined only when `<cxxabi.h>` is actually available, using `__has_include` with a fallback for toolchains without it (pybind11 still supports C++11, where `__has_include` is not guaranteed). The macro guards both the `#include <cxxabi.h>` and the `abi::__cxa_demangle` call site in `clean_type_id` — guarding the include alone would leave the call undeclared.

Fixes #6129

## Verification

- Local (AppleClang, C++11): `clean_type_id` still demangles (`N4demo3FooE` -> `demo::Foo`) when the header is available.
- Forced-fallback build (macro path disabled): compiles and takes the `erase_all` branch without referencing `cxxabi.h` or `__cxa_demangle`.
- Full test suite green: cpptest 25 cases / 11285 assertions passed; pytest 1296 passed / 51 skipped (platform features) / 2 xfailed (pre-existing, #4319).

## Suggested changelog entry

Guard the `<cxxabi.h>` include with `__has_include` so that toolchains defining `__GNUG__` without the header (e.g. clang-cl) can compile `detail/typeid.h`.