### PR TITLE
fix(numpy): accept PYBIND11_TYPE-wrapped types in the dtype macros

### DIFF
--- a/docs/advanced/pycpp/numpy.rst
+++ b/docs/advanced/pycpp/numpy.rst
@@ -232,6 +232,10 @@ prevent many types of unsupported structures, it is still the user's
 responsibility to use only "plain" structures that can be safely manipulated as
 raw memory without violating invariants.
 
+Types whose spelling contains a comma must be wrapped in ``PYBIND11_TYPE``:
+``PYBIND11_NUMPY_DTYPE(PYBIND11_TYPE(C<int, double>), x, y)``.
+See :ref:`macro_notes`.
+
 Scalar types
 ============
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1799,10 +1799,11 @@ private:
 #    define PYBIND11_NUMPY_DTYPE_EX(Type, ...) ((void) 0)
 #else
 
-// T arrives parenthesized: the PYBIND11_MAP_LIST expansion below re-splits on commas (see #4018).
+// The _IMPL variants take T parenthesized to survive the comma re-splitting in the
+// PYBIND11_MAP_LIST expansions below; the plain variants keep accepting a bare type (see #4018).
 #    define PYBIND11_UNPAREN_TYPE(T) PYBIND11_TYPE T
 
-#    define PYBIND11_FIELD_DESCRIPTOR_EX(T, Field, Name)                                          \
+#    define PYBIND11_FIELD_DESCRIPTOR_EX_IMPL(T, Field, Name)                                     \
         ::pybind11::detail::field_descriptor {                                                    \
             Name, offsetof(PYBIND11_UNPAREN_TYPE(T), Field),                                      \
                 sizeof(decltype(std::declval<PYBIND11_UNPAREN_TYPE(T)>().Field)),                 \
@@ -1812,8 +1813,15 @@ private:
                     decltype(std::declval<PYBIND11_UNPAREN_TYPE(T)>().Field)>::dtype()            \
         }
 
+#    define PYBIND11_FIELD_DESCRIPTOR_IMPL(T, Field)                                              \
+        PYBIND11_FIELD_DESCRIPTOR_EX_IMPL(T, Field, #Field)
+
+#    define PYBIND11_FIELD_DESCRIPTOR_EX(T, Field, Name)                                          \
+        PYBIND11_FIELD_DESCRIPTOR_EX_IMPL((T), Field, Name)
+
 // Extract name, offset and format descriptor for a struct field
-#    define PYBIND11_FIELD_DESCRIPTOR(T, Field) PYBIND11_FIELD_DESCRIPTOR_EX(T, Field, #Field)
+#    define PYBIND11_FIELD_DESCRIPTOR(T, Field)                                                   \
+        PYBIND11_FIELD_DESCRIPTOR_EX_IMPL((T), Field, #Field)
 
 // The main idea of this macro is borrowed from https://github.com/swansontec/map-macro
 // (C) William Swanson, Paul Fultz
@@ -1851,7 +1859,7 @@ private:
 #    define PYBIND11_NUMPY_DTYPE(Type, ...)                                                       \
         ::pybind11::detail::npy_format_descriptor<Type>::register_dtype(                          \
             ::std::vector<::pybind11::detail::field_descriptor>{                                  \
-                PYBIND11_MAP_LIST(PYBIND11_FIELD_DESCRIPTOR, (Type), __VA_ARGS__)})
+                PYBIND11_MAP_LIST(PYBIND11_FIELD_DESCRIPTOR_IMPL, (Type), __VA_ARGS__)})
 
 #    if defined(_MSC_VER) && !defined(__clang__)
 #        define PYBIND11_MAP2_LIST_NEXT1(test, next)                                              \
@@ -1873,7 +1881,7 @@ private:
 #    define PYBIND11_NUMPY_DTYPE_EX(Type, ...)                                                    \
         ::pybind11::detail::npy_format_descriptor<Type>::register_dtype(                          \
             ::std::vector<::pybind11::detail::field_descriptor>{                                  \
-                PYBIND11_MAP2_LIST(PYBIND11_FIELD_DESCRIPTOR_EX, (Type), __VA_ARGS__)})
+                PYBIND11_MAP2_LIST(PYBIND11_FIELD_DESCRIPTOR_EX_IMPL, (Type), __VA_ARGS__)})
 
 #endif // __CLION_IDE__
 

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1799,12 +1799,17 @@ private:
 #    define PYBIND11_NUMPY_DTYPE_EX(Type, ...) ((void) 0)
 #else
 
+// T arrives parenthesized: the PYBIND11_MAP_LIST expansion below re-splits on commas (see #4018).
+#    define PYBIND11_UNPAREN_TYPE(T) PYBIND11_TYPE T
+
 #    define PYBIND11_FIELD_DESCRIPTOR_EX(T, Field, Name)                                          \
         ::pybind11::detail::field_descriptor {                                                    \
-            Name, offsetof(T, Field), sizeof(decltype(std::declval<T>().Field)),                  \
-                ::pybind11::format_descriptor<decltype(std::declval<T>().Field)>::format(),       \
+            Name, offsetof(PYBIND11_UNPAREN_TYPE(T), Field),                                      \
+                sizeof(decltype(std::declval<PYBIND11_UNPAREN_TYPE(T)>().Field)),                 \
+                ::pybind11::format_descriptor<                                                    \
+                    decltype(std::declval<PYBIND11_UNPAREN_TYPE(T)>().Field)>::format(),          \
                 ::pybind11::detail::npy_format_descriptor<                                        \
-                    decltype(std::declval<T>().Field)>::dtype()                                   \
+                    decltype(std::declval<PYBIND11_UNPAREN_TYPE(T)>().Field)>::dtype()            \
         }
 
 // Extract name, offset and format descriptor for a struct field
@@ -1846,7 +1851,7 @@ private:
 #    define PYBIND11_NUMPY_DTYPE(Type, ...)                                                       \
         ::pybind11::detail::npy_format_descriptor<Type>::register_dtype(                          \
             ::std::vector<::pybind11::detail::field_descriptor>{                                  \
-                PYBIND11_MAP_LIST(PYBIND11_FIELD_DESCRIPTOR, Type, __VA_ARGS__)})
+                PYBIND11_MAP_LIST(PYBIND11_FIELD_DESCRIPTOR, (Type), __VA_ARGS__)})
 
 #    if defined(_MSC_VER) && !defined(__clang__)
 #        define PYBIND11_MAP2_LIST_NEXT1(test, next)                                              \
@@ -1868,7 +1873,7 @@ private:
 #    define PYBIND11_NUMPY_DTYPE_EX(Type, ...)                                                    \
         ::pybind11::detail::npy_format_descriptor<Type>::register_dtype(                          \
             ::std::vector<::pybind11::detail::field_descriptor>{                                  \
-                PYBIND11_MAP2_LIST(PYBIND11_FIELD_DESCRIPTOR_EX, Type, __VA_ARGS__)})
+                PYBIND11_MAP2_LIST(PYBIND11_FIELD_DESCRIPTOR_EX, (Type), __VA_ARGS__)})
 
 #endif // __CLION_IDE__
 

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -102,6 +102,12 @@ PYBIND11_PACKED(struct StructWithUglyNames {
     uint64_t __y__;
 });
 
+template <typename T1, typename T2>
+struct TemplatedStruct {
+    T1 a;
+    T2 b;
+};
+
 enum class E1 : int64_t { A = -1, B = 1 };
 enum E2 : uint8_t { X = 1, Y = 2 };
 
@@ -351,6 +357,14 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     PYBIND11_NUMPY_DTYPE(ArrayStruct, a, b, c, d);
     PYBIND11_NUMPY_DTYPE(EnumStruct, e1, e2);
     PYBIND11_NUMPY_DTYPE(ComplexStruct, cflt, cdbl);
+
+    // test_templated_dtype
+    PYBIND11_NUMPY_DTYPE(PYBIND11_TYPE(TemplatedStruct<int32_t, float>), a, b);
+    PYBIND11_NUMPY_DTYPE_EX(PYBIND11_TYPE(TemplatedStruct<int16_t, int16_t>), a, "x", b, "y");
+    m.def("templated_dtypes", []() {
+        return py::make_tuple(py::dtype::of<TemplatedStruct<int32_t, float>>(),
+                              py::dtype::of<TemplatedStruct<int16_t, int16_t>>());
+    });
 
     // ... or after
     py::class_<PackedStruct>(m, "PackedStruct");

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -360,10 +360,23 @@ TEST_SUBMODULE(numpy_dtypes, m) {
 
     // test_templated_dtype
     PYBIND11_NUMPY_DTYPE(PYBIND11_TYPE(TemplatedStruct<int32_t, float>), a, b);
-    PYBIND11_NUMPY_DTYPE_EX(PYBIND11_TYPE(TemplatedStruct<int16_t, int16_t>), a, "x", b, "y");
+    PYBIND11_NUMPY_DTYPE_EX(PYBIND11_TYPE(TemplatedStruct<int16_t, uint16_t>), a, "x", b, "y");
     m.def("templated_dtypes", []() {
         return py::make_tuple(py::dtype::of<TemplatedStruct<int32_t, float>>(),
-                              py::dtype::of<TemplatedStruct<int16_t, int16_t>>());
+                              py::dtype::of<TemplatedStruct<int16_t, uint16_t>>());
+    });
+
+    // test_direct_field_descriptor
+    m.def("direct_field_descriptors", []() {
+        py::detail::field_descriptor direct[]
+            = {PYBIND11_FIELD_DESCRIPTOR(SimpleStruct, uint_),
+               PYBIND11_FIELD_DESCRIPTOR_EX(SimpleStruct, float_, "flt"),
+               PYBIND11_FIELD_DESCRIPTOR(PYBIND11_TYPE(TemplatedStruct<int32_t, float>), b)};
+        py::list names;
+        for (const auto &fd : direct) {
+            names.append(fd.name);
+        }
+        return names;
     });
 
     // ... or after

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -209,7 +209,11 @@ def test_templated_dtype():
     """A type spelled with a comma needs PYBIND11_TYPE here."""
     plain, renamed = m.templated_dtypes()
     assert plain == np.dtype([("a", "i4"), ("b", "f4")])
-    assert renamed == np.dtype([("x", "i2"), ("y", "i2")])
+    assert renamed == np.dtype([("x", "i2"), ("y", "u2")])
+
+
+def test_direct_field_descriptor():
+    assert m.direct_field_descriptors() == ["uint_", "flt", "b"]
 
 
 def test_recarray(simple_dtype, packed_dtype):

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -205,6 +205,13 @@ def test_dtype(simple_dtype):
     assert (m.test_dtype_switch(arr.astype("longdouble")) == arr + 1).all()
 
 
+def test_templated_dtype():
+    """A type spelled with a comma needs PYBIND11_TYPE here."""
+    plain, renamed = m.templated_dtypes()
+    assert plain == np.dtype([("a", "i4"), ("b", "f4")])
+    assert renamed == np.dtype([("x", "i2"), ("y", "i2")])
+
+
 def test_recarray(simple_dtype, packed_dtype):
     elements = [(False, 0, 0.0, -0.0), (True, 1, 1.5, -2.5), (False, 2, 3.0, -5.0)]
 


### PR DESCRIPTION
## Description

Fixes #4018.

`PYBIND11_TYPE` is the documented way to pass a type with a comma in its spelling to a macro,
but it doesn't work with the dtype macros:

```cpp
template <typename T1, typename T2>
struct TestStruct {
    T1 a;
    T2 b;
};

PYBIND11_MODULE(repro, m) {
    PYBIND11_NUMPY_DTYPE(PYBIND11_TYPE(TestStruct<float, double>), a, b);  // error: expected ','
}
```

The only workaround was a `using` alias.

This happens because `PYBIND11_TYPE` is itself a macro. `PYBIND11_NUMPY_DTYPE` builds its field
list through `PYBIND11_MAP_LIST`, which rescans its output repeatedly, and the first rescan
expands the wrapper away. After that the bare comma splits the type in two at the next argument
collection. Re-wrapping at every step, the way `PYBIND11_OVERRIDE` does, gives one correct field
and then a field named `"double>"`.

Plain parentheses survive rescanning, so the dtype macros now pass `(Type)` through the map
machinery, and a new `PYBIND11_FIELD_DESCRIPTOR_EX_IMPL` removes the parentheses where the type
is actually used (`#define PYBIND11_UNPAREN_TYPE(T) PYBIND11_TYPE T`). The public
`PYBIND11_FIELD_DESCRIPTOR` and `PYBIND11_FIELD_DESCRIPTOR_EX` still take a bare type and add
the parentheses themselves before forwarding to the `_IMPL` macro, so projects that call them
directly are unaffected, and they now accept a `PYBIND11_TYPE`-wrapped type as well. Existing
call sites preprocess to the same tokens as before.

The tests register a two-parameter struct through both dtype macros and check the resulting
dtypes, with two different field types in the `_EX` case so each renamed field is checked
against its own type. A second test calls the field descriptor macros directly, with bare and
wrapped types.

## Suggested changelog entry:

* `PYBIND11_NUMPY_DTYPE` and `PYBIND11_NUMPY_DTYPE_EX` now accept a type whose spelling contains
  a comma, when it is wrapped in `PYBIND11_TYPE`. Previously the wrapper was silently dropped
  during expansion and only a `using` alias worked.


<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6148.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->
