### PR TITLE
chore: use much more specific CPP feature flags

### DIFF
--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -27,7 +27,7 @@ struct format_descriptor<std::complex<T>, detail::enable_if_t<std::is_floating_p
     static std::string format() { return std::string(value); }
 };
 
-#ifndef PYBIND11_CPP17
+#if !defined(__cpp_inline_variables) || __cpp_inline_variables < 201606L
 
 template <typename T>
 constexpr const char

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -1202,7 +1202,7 @@ struct format_descriptor<T, detail::enable_if_t<std::is_arithmetic<T>::value>> {
     static std::string format() { return std::string(1, c); }
 };
 
-#if !defined(PYBIND11_CPP17)
+#if !defined(__cpp_inline_variables) || __cpp_inline_variables < 201606L
 
 template <typename T>
 constexpr const char
@@ -1278,7 +1278,7 @@ struct overload_cast_impl {
 PYBIND11_NAMESPACE_END(detail)
 
 // overload_cast requires variable templates: C++14
-#if defined(PYBIND11_CPP14)
+#if defined(__cpp_variable_templates) && __cpp_variable_templates >= 201304L
 #    define PYBIND11_OVERLOAD_CAST 1
 /// Syntax sugar for resolving overloaded function pointers:
 ///  - regular: static_cast<Return (Class::*)(Arg0, Arg1, Arg2)>(&Class::func)
@@ -1292,7 +1292,8 @@ static constexpr detail::overload_cast_impl<Args...> overload_cast{};
 ///  - sweet:   overload_cast<Arg>(&Class::func, const_)
 static constexpr auto const_ = std::true_type{};
 
-#if !defined(PYBIND11_CPP14) // no overload_cast: providing something that static_assert-fails:
+#if !defined(__cpp_variable_templates) || __cpp_variable_templates < 201304L
+// No overload_cast: providing something that static_assert-fails.
 template <typename... Args>
 struct overload_cast {
     static_assert(detail::deferred_t<std::false_type, Args...>::value,

--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -388,7 +388,7 @@ struct factory<Func, void_type (*)(), Return(Args...), void_type()> {
     // instance, or the alias needs to be constructible from a `Class &&` argument.
     template <typename Class, typename... Extra>
     void execute(Class &cl, const Extra &...extra) && {
-#if defined(PYBIND11_CPP14)
+#if defined(__cpp_init_captures) && __cpp_init_captures >= 201304L
         cl.def(
             "__init__",
             [func = std::move(class_factory)]
@@ -435,7 +435,7 @@ struct factory<CFunc, AFunc, CReturn(CArgs...), AReturn(AArgs...)> {
         static_assert(Class::has_alias,
                       "The two-argument version of `py::init()` can "
                       "only be used if the class has an alias");
-#if defined(PYBIND11_CPP14)
+#if defined(__cpp_init_captures) && __cpp_init_captures >= 201304L
         cl.def(
             "__init__",
             [class_func = std::move(class_factory), alias_func = std::move(alias_factory)]
@@ -524,7 +524,7 @@ struct pickle_factory<Get, Set, RetState(Self), NewInstance(ArgState)> {
     void execute(Class &cl, const Extra &...extra) && {
         cl.def("__getstate__", std::move(get), pos_only());
 
-#if defined(PYBIND11_CPP14)
+#if defined(__cpp_init_captures) && __cpp_init_captures >= 201304L
         cl.def(
             "__setstate__",
             [func = std::move(set)]

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -294,7 +294,7 @@ public:
 
 // Prior to C++17, we don't have inline variables, so we have to
 // provide an out-of-line definition of the class member.
-#if !defined(PYBIND11_CPP17)
+#if !defined(__cpp_inline_variables) || __cpp_inline_variables < 201606L
 template <typename cast_in, typename cast_out>
 constexpr typename ReadableFunctionSignature<cast_in, cast_out>::sig_type
     ReadableFunctionSignature<cast_in, cast_out>::kSig;

--- a/tests/test_class.cpp
+++ b/tests/test_class.cpp
@@ -516,7 +516,8 @@ TEST_SUBMODULE(class_, m) {
     py::class_<StringWrapper>(m, "StringWrapper").def(py::init<std::string>());
     py::implicitly_convertible<std::string, StringWrapper>();
 
-#if defined(PYBIND11_CPP17)
+#if (defined(__cpp_aligned_new) && __cpp_aligned_new >= 201606L)                                  \
+    || (defined(__INTEL_COMPILER) && __cplusplus >= 201703L)
     struct alignas(1024) Aligned {
         std::uintptr_t ptr() const { return (uintptr_t) this; }
     };


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
* Narrows a bunch of previously broad CPP version guards to just the feature macros they need to compile.
<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the block below with the expected entry. Delete if no entry needed;
     but do not delete the header if an entry is needed! Will be collected via a script. -->

* Narrow CPP version guards to minimum require CPP feature macros
