### PR TITLE
feat(numpy): add NPY_HALF_ to npy_api::constants

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -235,8 +235,7 @@ struct npy_api {
         NPY_STRING_,
         NPY_UNICODE_,
         NPY_VOID_,
-        // NumPy's NPY_DATETIME (21) and NPY_TIMEDELTA (22) are not mirrored here.
-        NPY_HALF_ = 23,
+        NPY_HALF_ = 23, // NPY_DATETIME (21) and NPY_TIMEDELTA (22) are not mirrored
         // Platform-dependent normalization
         NPY_INT8_ = NPY_BYTE_,
         NPY_UINT8_ = NPY_UBYTE_,

--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -235,6 +235,8 @@ struct npy_api {
         NPY_STRING_,
         NPY_UNICODE_,
         NPY_VOID_,
+        // NumPy's NPY_DATETIME (21) and NPY_TIMEDELTA (22) are not mirrored here.
+        NPY_HALF_ = 23,
         // Platform-dependent normalization
         NPY_INT8_ = NPY_BYTE_,
         NPY_UINT8_ = NPY_UBYTE_,

--- a/tests/test_numpy_dtypes.cpp
+++ b/tests/test_numpy_dtypes.cpp
@@ -318,6 +318,21 @@ py::array_t<T> dispatch_array_increment(const py::array_t<T> &arr) {
 struct A {};
 struct B {};
 
+struct UserHalf {
+    uint16_t bits;
+};
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+PYBIND11_NAMESPACE_BEGIN(detail)
+template <>
+struct npy_format_descriptor<UserHalf> {
+    static constexpr auto name = const_name("numpy.float16");
+    static constexpr int value = npy_api::NPY_HALF_;
+    static pybind11::dtype dtype() { return pybind11::dtype(/*typenum*/ value); }
+};
+PYBIND11_NAMESPACE_END(detail)
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)
+
 TEST_SUBMODULE(numpy_dtypes, m) {
     try {
         py::module_::import("numpy");
@@ -645,6 +660,10 @@ TEST_SUBMODULE(numpy_dtypes, m) {
     };
     PYBIND11_NUMPY_DTYPE(TrailingPaddingStruct, a, b);
     m.def("trailing_padding_dtype", []() { return py::dtype::of<TrailingPaddingStruct>(); });
+
+    // test_half_dtype (issue #4061)
+    m.def("half_dtype_num", []() { return py::dtype::num_of<UserHalf>(); });
+    m.def("half_roundtrip", [](const py::array_t<UserHalf> &arr) { return arr; });
 
     // test_string_array
     m.def("create_string_array", [](bool non_empty) {

--- a/tests/test_numpy_dtypes.py
+++ b/tests/test_numpy_dtypes.py
@@ -205,6 +205,13 @@ def test_dtype(simple_dtype):
     assert (m.test_dtype_switch(arr.astype("longdouble")) == arr + 1).all()
 
 
+def test_half_dtype():
+    assert m.half_dtype_num() == np.dtype("float16").num
+
+    result = m.half_roundtrip(np.array([1.5, 2.25, -3.0], dtype=np.float16))
+    assert result.dtype == np.float16
+
+
 def test_templated_dtype():
     """A type spelled with a comma needs PYBIND11_TYPE here."""
     plain, renamed = m.templated_dtypes()


### PR DESCRIPTION
## Description

Fixes #4061.

`npy_api::constants` mirrors NumPy's `NPY_TYPES`, but stops at `NPY_VOID_` (20) and goes straight into the platform-dependent aliases, so `NPY_HALF_` (23) isn't there:

```cpp
handle ptr = npy_api::get().PyArray_DescrFromType_(npy_api::NPY_HALF_);
// error: no member named 'NPY_HALF_' in 'pybind11::detail::npy_api'; did you mean 'NPY_CHAR_'?
```

Taking that suggestion is worse than the error. `NPY_CHAR_` isn't NumPy's `NPY_CHAR`, it's pybind11's own `is_signed<char> ? NPY_BYTE_ : NPY_UBYTE_`, so it compiles cleanly and truncates float16 to int8.

`py::dtype("half")` already works at runtime. What's missing is the compile-time constant, which is what `npy_format_descriptor<T>::value` needs to specialize a user-defined half type. The workaround in #1776 reads the typenum out of NumPy's own headers, which is the dependency this header exists to avoid.

`= 23` is explicit since 21 and 22 aren't mirrored. `numpy.h` asks for `normalized_dtype_num` to be reviewed alongside this enum: it's sized `[NPY_VOID_ + 1]` and bounds-checked before indexing, so 23 falls through unchanged, same as a float16 array does today.

No caster or `format_descriptor` for a concrete half type here. Which C++ type that should be is #4627.

Test specializes `npy_format_descriptor` for a 2-byte POD and round-trips it as `numpy.float16`; without the enumerator the test module doesn't compile. Suite passes on macOS arm64 with `PYBIND11_WERROR=ON`. No Linux or Windows box to hand, so those are down to CI.

## Suggested changelog entry:

* Added NumPy's `float16` typenum to `py::detail::npy_api::constants` as `NPY_HALF_`, so a user-defined half type can specialize `npy_format_descriptor` without hardcoding the value.
