### PR TITLE
fix: do not run keep_alive for an overload that failed argument conversion

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3356,6 +3356,15 @@ PYBIND11_NOINLINE void keep_alive_impl(handle nurse, handle patient) {
 
 PYBIND11_NOINLINE void
 keep_alive_impl(size_t Nurse, size_t Patient, function_call &call, handle ret) {
+    // The overload bailed out of `load_args` before running, so `ret` is the
+    // PYBIND11_TRY_NEXT_OVERLOAD sentinel ((PyObject *) 1) rather than an object. There is no
+    // call and therefore no relationship to establish; the dispatcher will try the next
+    // overload. Checked here because the sentinel is neither null nor `Py_None`, so it passes
+    // straight through the guards below and is dereferenced.
+    if (ret.ptr() == PYBIND11_TRY_NEXT_OVERLOAD) {
+        return;
+    }
+
     auto get_arg = [&](size_t n) {
         if (n == 0) {
             return ret;

--- a/tests/test_call_policies.cpp
+++ b/tests/test_call_policies.cpp
@@ -9,6 +9,8 @@
 
 #include "pybind11_tests.h"
 
+#include <string>
+
 struct CustomGuard {
     static bool enabled;
 
@@ -110,4 +112,19 @@ TEST_SUBMODULE(call_policies, m) {
     m.def("with_gil", report_gil_status);
     m.def("without_gil", report_gil_status, py::call_guard<py::gil_scoped_release>());
 #endif
+
+    // A keep_alive whose nurse or patient is the return value runs in postcall, which
+    // the dispatcher invokes even when the overload bailed out of load_args. `ret` is then the
+    // PYBIND11_TRY_NEXT_OVERLOAD sentinel rather than an object, and dereferencing it crashed.
+    // Reaching the SECOND overload is what exercises the failed first attempt.
+    struct KeepAliveOverload {};
+    py::class_<KeepAliveOverload>(m, "KeepAliveOverload").def(py::init<>());
+    m.def(
+        "keep_alive_overload",
+        [](KeepAliveOverload *self, int) { return self; },
+        py::keep_alive<0, 1>());
+    m.def(
+        "keep_alive_overload",
+        [](KeepAliveOverload *self, const std::string &) { return self; },
+        py::keep_alive<0, 1>());
 }

--- a/tests/test_call_policies.py
+++ b/tests/test_call_policies.py
@@ -254,3 +254,16 @@ def test_call_guard():
     if hasattr(m, "with_gil"):
         assert m.with_gil() == "GIL held"
         assert m.without_gil() == "GIL released"
+
+
+def test_keep_alive_failed_overload():
+    """A keep_alive on an overload that fails argument conversion must not fire.
+
+    The dispatcher invokes postcall unconditionally, so a keep_alive<0, N> on the
+    overload that bails out of load_args was handed the PYBIND11_TRY_NEXT_OVERLOAD
+    sentinel as its return value and dereferenced it. Calling the second overload is
+    what makes the first one fail first.
+    """
+    obj = m.KeepAliveOverload()
+    assert m.keep_alive_overload(obj, 1) is obj
+    assert m.keep_alive_overload(obj, "x") is obj


### PR DESCRIPTION
## Description

Calling an overloaded function bound with `py::keep_alive<0, N>` segfaults whenever the call is not matched by the first overload tried. Minimal reproducer:

```cpp
struct Tensor {};
struct Holder {
    Tensor t;
    Tensor &from_int(int)            { return t; }
    Tensor &from_string(std::string) { return t; }
};

PYBIND11_MODULE(min, m) {
    py::class_<Tensor>(m, "Tensor");
    py::class_<Holder>(m, "Holder")
        .def(py::init<>())
        .def("make", &Holder::from_int,    py::return_value_policy::reference, py::keep_alive<0, 1>())
        .def("make", &Holder::from_string, py::return_value_policy::reference, py::keep_alive<0, 1>());
}
```

```
>>> h.make(1)     # <min.Tensor object at 0x...>
>>> h.make("x")   # Segmentation fault
```

The crash is `EXC_BAD_ACCESS` in `_Py_TYPE(ob=0x1)`. Swapping the registration order swaps which call crashes, so it is always the call that reaches an overload after an earlier one failed argument conversion. `return_value_policy::reference` is not required to trigger it, and removing `keep_alive` makes it go away.

## Cause

The dispatch lambda in `cpp_function::initialize` runs the post-call hook unconditionally (`pybind11.h:596-603`):

```cpp
auto result = call_impl<...>(call, ...);
process_attributes<Extra...>::postcall(call, result);
```

`call_impl` bails out at `pybind11.h:504` when argument loading fails:

```cpp
if (!args_converter.load_args(call)) { return PYBIND11_TRY_NEXT_OVERLOAD; }
```

and that sentinel is `((PyObject *) 1)` (`detail/common.h:367`). For a `keep_alive` whose nurse or patient is index 0 the work happens in `postcall`, so `keep_alive_impl` receives the sentinel as `ret`, `get_arg(0)` returns it, and `_Py_TYPE` dereferences it.

The existing guards do not catch this. The sentinel is neither null nor `Py_None`, so it passes straight through the checks added in #341.

## Fix

A single guard inside `keep_alive_impl`, beside those checks.

On scope: only the `Nurse == 0 || Patient == 0` specialization does its work in `postcall`. The other specialization runs in `precall`, against a fully populated `call.args`, and I verified that `keep_alive<1, 2>` on the same setup is unaffected. `keep_alive` is also the only call policy with a non-trivial `postcall`; the other three in `attr.h` have empty bodies. So this guard covers every path that can observe the sentinel.

An alternative would be to guard the `postcall` call site so that no policy runs on the bail-out path. That may be more correct in general, since running a post-call hook for a call that never happened is questionable on its own terms, but it changes behaviour for call policies broadly. I went with the narrow fix and am happy to switch if you prefer the other.

## Tests

Added to `test_call_policies`. The new test crashes the interpreter without the fix, which is rather the point: pybind11 currently has no test that exercises a call policy on a failing overload, and that gap is the likely reason this went unnoticed for so long.

Full suite on macOS/arm64, clang, Python 3.14, against master `5e9611a`:

| | result |
| --- | --- |
| master (baseline) | 1326 passed, 23 skipped, 2 xfailed, 1 xpassed |
| this PR | 1327 passed, 23 skipped, 2 xfailed, 1 xpassed |

## Notes

Reproduces on both v3.1.0 and current master. I could not find an existing issue or PR for this. I searched issues and PRs for `keep_alive`, `postcall`, and `TRY_NEXT_OVERLOAD`, and grepped the diffs of all 39 open PRs that touch `pybind11.h`.
