### PR TITLE
fix: remove `static` from `type_has_shared_from_this`

### DIFF
--- a/include/pybind11/detail/struct_smart_holder.h
+++ b/include/pybind11/detail/struct_smart_holder.h
@@ -68,14 +68,14 @@ static constexpr bool type_has_shared_from_this(...) { return false; }
 // This overload uses SFINAE to skip enable_shared_from_this checks when the
 // base is inaccessible (e.g. private inheritance).
 template <typename T>
-static auto type_has_shared_from_this(const T *ptr)
+auto type_has_shared_from_this(const T *ptr)
     -> decltype(static_cast<const std::enable_shared_from_this<T> *>(ptr), true) {
     return true;
 }
 
 // Inaccessible base → substitution failure → fallback overload selected
 template <typename T>
-static constexpr bool type_has_shared_from_this(const void *) {
+constexpr bool type_has_shared_from_this(const void *) {
     return false;
 }
 


### PR DESCRIPTION
I hit the following warning when trying to build SciPy with clang-23 in https://github.com/scipy/scipy/pull/26041:

```
In file included from /home/runner/work/scipy/scipy/.pixi/envs/build-clang-23/include/pybind11/trampoline_self_life_support.h:8:
In file included from /home/runner/work/scipy/scipy/.pixi/envs/build-clang-23/include/pybind11/detail/using_smart_holder.h:8:
/home/runner/work/scipy/scipy/.pixi/envs/build-clang-23/include/pybind11/detail/struct_smart_holder.h:71:13: error: unused function template 'type_has_shared_from_this' [-Werror,-Wunused-template]
   71 | static auto type_has_shared_from_this(const T *ptr)
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
```

Claude code says that these `static` qualifiers are incorrect, since including them on a function at namespace scope implies that they are only visible in this translation unit.