### PR TITLE
fix: unused-template warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
             container_suffix: "-bullseye"
           - clang: 18
             std: 20
-            cxx_flags: "-Werror -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls"
+            cxx_flags: "-Werror -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wunused-template"
             container_suffix: "-bookworm"
 
     name: "🐍 3 • Clang ${{ matrix.clang }} • C++${{ matrix.std }} • x64${{ matrix.cxx_flags && ' • cxx_flags' || '' }}"

--- a/include/pybind11/detail/struct_smart_holder.h
+++ b/include/pybind11/detail/struct_smart_holder.h
@@ -73,12 +73,6 @@ auto type_has_shared_from_this(const T *ptr)
     return true;
 }
 
-// Inaccessible base → substitution failure → fallback overload selected
-template <typename T>
-static constexpr bool type_has_shared_from_this(const void *) {
-    return false;
-}
-
 struct guarded_delete {
     // NOTE: PYBIND11_INTERNALS_VERSION needs to be bumped if changes are made to this struct.
     std::weak_ptr<void> released_ptr;    // Trick to keep the smart_holder memory footprint small.

--- a/include/pybind11/detail/struct_smart_holder.h
+++ b/include/pybind11/detail/struct_smart_holder.h
@@ -68,7 +68,7 @@ static constexpr bool type_has_shared_from_this(...) { return false; }
 // This overload uses SFINAE to skip enable_shared_from_this checks when the
 // base is inaccessible (e.g. private inheritance).
 template <typename T>
-static auto type_has_shared_from_this(const T *ptr)
+auto type_has_shared_from_this(const T *ptr)
     -> decltype(static_cast<const std::enable_shared_from_this<T> *>(ptr), true) {
     return true;
 }

--- a/include/pybind11/detail/typeid.h
+++ b/include/pybind11/detail/typeid.h
@@ -68,7 +68,7 @@ PYBIND11_NAMESPACE_END(detail)
 
 /// Return a string representation of a C++ type
 template <typename T>
-static std::string type_id() {
+std::string type_id() {
     return detail::clean_type_id(typeid(T).name());
 }
 


### PR DESCRIPTION
Analogous to gh-6155.

I hit the following warning when trying to build SciPy with clang-23 in https://github.com/scipy/scipy/pull/26041:

```
In file included from /home/runner/work/scipy/scipy/.pixi/envs/build-clang-23/include/pybind11/detail/type_caster_base.h:21:
/home/runner/work/scipy/scipy/.pixi/envs/build-clang-23/include/pybind11/detail/typeid.h:61:20: error: unused function template 'type_id' [-Werror,-Wunused-template]
   61 | static std::string type_id() {
      |                    ^~~~~~~
```

Claude code says that this `static` qualifiers is incorrect, since including it on a function at namespace scope implies that the function is only visible in this translation unit.

## Suggested changelog entry:

* Fixed Clang 23 builds using `-Wall -Werror` by resolving `-Wunused-template` diagnostics and removing an unreachable `type_has_shared_from_this` overload exposed during the investigation.