### PR TITLE
fix: correct args_convert flags for kw-only args after py::args

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1156,6 +1156,7 @@ protected:
                         // replaced later
                         if (func.has_args && call.args.size() == func.nargs_pos) {
                             call.args.push_back(none());
+                            call.args_convert.push_back(false);
                         }
 
                         call.args.push_back(value);
@@ -1187,10 +1188,11 @@ protected:
                     }
                     if (call.args.size() <= func.nargs_pos) {
                         call.args.push_back(call.args_ref);
+                        call.args_convert.push_back(false);
                     } else {
+                        // The stub pushed in step 2 already has its convert flag.
                         call.args[func.nargs_pos] = call.args_ref;
                     }
-                    call.args_convert.push_back(false);
                 }
 
                 // 4b. If we have a py::kwargs, pass on any remaining kwargs
@@ -1246,7 +1248,8 @@ protected:
                     // The (overloaded) call failed; if the call has at least one argument that
                     // permits conversion (i.e. it hasn't been explicitly specified `.noconvert()`)
                     // then add this call to the list of second pass overloads to try.
-                    for (size_t i = func.is_method ? 1 : 0; i < pos_args; i++) {
+                    // Keyword-only arguments count too, so scan all of the flags.
+                    for (size_t i = func.is_method ? 1 : 0; i < second_pass_convert.size(); i++) {
                         if (second_pass_convert[i]) {
                             // Found one: swap the converting flags back in and store the call for
                             // the second pass.

--- a/tests/test_kwargs_and_defaults.cpp
+++ b/tests/test_kwargs_and_defaults.cpp
@@ -148,6 +148,23 @@ TEST_SUBMODULE(kwargs_and_defaults, m) {
         "j"_a = 3.14159,
         "z"_a = 42);
 
+    // test_args_kwonly_noconvert
+    m.def(
+        "args_kwonly_noconvert",
+        [](const py::args &args, bool x, bool y) { return py::make_tuple(args, x, y); },
+        py::arg("x").noconvert(),
+        py::arg("y"));
+
+    // test_args_kwonly_second_pass
+    m.def(
+        "args_kwonly_second_pass",
+        [](const py::args &, const std::string &s) { return "str: " + s; },
+        "s"_a);
+    m.def(
+        "args_kwonly_second_pass",
+        [](const py::args &, bool b) { return std::string(b ? "bool: True" : "bool: False"); },
+        "b"_a);
+
 // test_args_refcount
 // PyPy needs a garbage collection to get the reference count values to match CPython's behaviour
 // PyPy uses the top few bits for REFCNT_FROM_PYPY & REFCNT_FROM_PYPY_LIGHT, so truncate

--- a/tests/test_kwargs_and_defaults.py
+++ b/tests/test_kwargs_and_defaults.py
@@ -249,6 +249,20 @@ def test_mixed_args_and_kwargs(msg):
     assert m.args_kwonly_kwargs_defaults(5, 6, 7, m=8, z=9) == (5, 6, (7,), 9, {"m": 8})
 
 
+def test_args_kwonly_noconvert():
+    # The noconvert flag must stay on x, the argument it was given for.
+    assert m.args_kwonly_noconvert(1, 2, x=True, y=1) == ((1, 2), True, True)
+    with pytest.raises(TypeError):
+        m.args_kwonly_noconvert(x=1, y=True)
+
+
+def test_args_kwonly_second_pass():
+    # Only the keyword-only argument can convert, so the second pass must run.
+    assert m.args_kwonly_second_pass(s="a") == "str: a"
+    assert m.args_kwonly_second_pass(b=True) == "bool: True"
+    assert m.args_kwonly_second_pass(b=1) == "bool: True"
+
+
 def test_keyword_only_args(msg):
     assert m.kw_only_all(i=1, j=2) == (1, 2)
     assert m.kw_only_all(j=1, i=2) == (2, 1)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Description

Two related problems in the function dispatcher, items 1 and 2 of #6159.

When named arguments follow `py::args`, the dispatcher pushes a stub for the `*args` tuple into `call.args` in step 2, but appended its convert flag at the end in step 4a. Each keyword-only argument thus got the convert flag of the next argument, so `py::arg("x").noconvert()` applied to the wrong argument. The flag is now pushed together with the stub, and step 4a appends a flag only when it appends the tuple itself.

The second-pass scan stopped at `pos_args`. An overload whose only convertible arguments are keyword-only was thus never retried with conversion permitted. The scan now examines all of the flags.

Both problems have new tests in `tests/test_kwargs_and_defaults`.

## Suggested changelog entry:

* Fixed the ``noconvert`` flags and the overload second pass for keyword-only arguments that follow ``py::args``.
