### PR TITLE
test: assert line numbers of evaluated source

### DIFF
--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -87,6 +87,30 @@ TEST_SUBMODULE(eval_, m) {
         return false;
     });
 
+    // Line numbers reported from evaluated source must match the source as given;
+    // before #6089 a prepended coding cookie shifted them by one.
+    m.def("test_eval_line_numbers", []() {
+        int syntax_lineno = -1;
+        try {
+            py::exec("x = 1\nx = = 2\n");
+            throw std::runtime_error("py::exec did not raise SyntaxError");
+        } catch (py::error_already_set &e) {
+            syntax_lineno = e.value().attr("lineno").cast<int>();
+        }
+        int traceback_lineno = -1;
+        try {
+            py::exec("x = 1\nraise RuntimeError('line two')\n");
+            throw std::runtime_error("py::exec did not raise RuntimeError");
+        } catch (py::error_already_set &e) {
+            py::object tb = e.trace();
+            for (py::object next = tb.attr("tb_next"); !next.is_none(); next = tb.attr("tb_next")) {
+                tb = std::move(next);
+            }
+            traceback_lineno = tb.attr("tb_lineno").cast<int>();
+        }
+        return py::make_tuple(syntax_lineno, traceback_lineno);
+    });
+
     // test_eval_empty_globals
     m.def("eval_empty_globals", [](py::object global) {
         if (global.is_none()) {

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -103,7 +103,8 @@ TEST_SUBMODULE(eval_, m) {
             throw std::runtime_error("py::exec did not raise RuntimeError");
         } catch (py::error_already_set &e) {
             py::object tb = e.trace();
-            for (py::object next = tb.attr("tb_next"); !next.is_none(); next = tb.attr("tb_next")) {
+            for (py::object next = tb.attr("tb_next"); !next.is_none();
+                 next = tb.attr("tb_next")) {
                 tb = std::move(next);
             }
             traceback_lineno = tb.attr("tb_lineno").cast<int>();

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -27,6 +27,10 @@ def test_eval_file():
     assert m.test_eval_file_failure()
 
 
+def test_eval_line_numbers():
+    assert m.test_eval_line_numbers() == (2, 2)
+
+
 def test_eval_empty_globals():
     assert "__builtins__" in m.eval_empty_globals(None)
 


### PR DESCRIPTION
## Description

Adds regression coverage for #6089: a `SyntaxError` and an exception traceback originating on line 2 of evaluated source must both report line 2.

Checked with pybind11's own test target (`PYBIND11_TEST_OVERRIDE=test_eval.cpp`, CPython 3.12.13, macOS arm64, Apple clang 21): `test_eval` passes at current master, and with `eval.h` from `f00aa6fe` (the parent of #6089) only the new test fails, reporting `(3, 3)`.
