### PR TITLE
docs: clarify where to run the "Compiling the test cases" commands

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -11,6 +11,12 @@ included set of test cases.
 Compiling the test cases
 ========================
 
+The commands below are meant to be run from the root of a source checkout
+of the pybind11 repository. They compile and run the test suite bundled in
+the :file:`tests` directory, which is included in the repository but not in
+the pybind11 wheels on PyPI. If you installed pybind11 with ``pip``, start
+from a git checkout of the repository instead (see :ref:`installing`).
+
 Linux/macOS
 -----------
 


### PR DESCRIPTION
### What
The First Steps page currently shows the "Compiling the test cases" commands
(`mkdir build && cd build && cmake .. && make check`) right after telling new
users they can install pybind11 via `pip install`, with no hint that the
commands are only meaningful from the root of a *source checkout* of the
pybind11 repository, nor that the pip wheels do not contain the bundled
tests.

This adds three sentences to `docs/basics.rst` clarifying that:
- the commands must be run from the root of a source checkout of pybind11,
- they compile and run the test suite bundled in the repository's `tests/`
  directory,
- wheels installed via `pip install pybind11` don't include those tests, so
  pip users should start from a git checkout instead (cross-linked to the
  installing page).

### Why
Closes #3871. The reporter followed the page after a pip install and there
was no context about where to run the commands or where the test cases live;
the maintainer's reply in the thread invited exactly this kind of wording
(e.g. "starting with a git checkout").

### How verified
- `docutils` parse of `docs/basics.rst`: no structural errors, baseline vs.
  modified compared (only expected Sphinx-role noise).
- `git diff --check`: clean.
- No other sections or version numbers touched; this is a pure docs change.

Suggested changelog entry:
- Docs: clarify that the "Compiling the test cases" commands on the First
  Steps page must be run from the root of a source checkout of pybind11,
  since pip wheels don't include the bundled test suite.

<!-- readthedocs-preview pybind11 start -->
----
📚 Documentation preview 📚: https://pybind11--6170.org.readthedocs.build/

<!-- readthedocs-preview pybind11 end -->